### PR TITLE
Dungeon removal, and some small map changes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -293,13 +293,6 @@
 /obj/item/clothing/suit/armor/f13/leatherarmor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"abi" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "mine"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "abj" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/armor/f13/raider/yankee,
@@ -16712,14 +16705,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"baw" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "NCR"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/caves)
 "bax" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
@@ -27732,9 +27717,6 @@
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
-"dze" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/caves)
 "dzg" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/ground/outside/dirt{
@@ -29189,9 +29171,6 @@
 	health = 600
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"emb" = (
-/turf/closed/indestructible/opshuttle,
 /area/f13/caves)
 "emi" = (
 /turf/open/floor/f13/wood{
@@ -38479,19 +38458,6 @@
 /obj/item/mining_scanner,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jkh" = (
-/obj/docking_port/stationary{
-	area_type = /area/f13;
-	dir = 8;
-	dwidth = 1;
-	height = 3;
-	id = "South_Ground";
-	name = "Ground";
-	roundstart_template = /datum/map_template/shuttle/southbunker/elevator;
-	width = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/f13/caves)
 "jkj" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13{
@@ -39047,13 +39013,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/mall)
-"jDp" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
 "jDC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
@@ -61990,9 +61949,13 @@
 /obj/item/stack/medical/suture/emergency/five,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/pill/patch/healpoultice,
-/obj/item/reagent_containers/pill/patch/healpoultice,
-/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/pill/patch/healingpowder{
+	pixel_x = -11;
+	pixel_y = 12
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vUN" = (
@@ -77290,7 +77253,7 @@ aae
 ajD
 alW
 aqx
-baw
+qMi
 clT
 xLa
 amg
@@ -93723,12 +93686,12 @@ ygp
 rkl
 rkl
 aae
-emb
-emb
-emb
-emb
-emb
-emb
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (108,1,1) = {"
@@ -93980,12 +93943,12 @@ vgJ
 xby
 rkl
 aae
-emb
-dze
-dze
-dze
-dze
-emb
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (109,1,1) = {"
@@ -94237,12 +94200,12 @@ acl
 acg
 rkl
 aae
-emb
-dze
-dze
-dze
-dze
-emb
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (110,1,1) = {"
@@ -94494,12 +94457,12 @@ xPI
 acg
 rkl
 aae
-emb
-dze
-dze
-jkh
-dze
-emb
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (111,1,1) = {"
@@ -94751,12 +94714,12 @@ pAi
 oVn
 rkl
 aae
-emb
-emb
-jDp
-jDp
-emb
-emb
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (112,1,1) = {"
@@ -95269,7 +95232,7 @@ aaa
 aaB
 aaB
 hEt
-aaB
+elW
 aaa
 aaa
 "}
@@ -97340,7 +97303,7 @@ aae
 aaB
 bjo
 bjo
-abi
+bjo
 bjo
 adz
 acr


### PR DESCRIPTION
Removed Sunsets dungeons, they can still be found in the older map files folder for future reference.  For now they were just taking up space, and don't fit with what we want moving forward.

Also removed their dungeon elevators from the main map.

Dungeon Z was overhauled entirely, setting it up for moving forward with an area for the Texarkana Mall.  The Enclave Bunker/BOS Bunkers are placed down with future plans to make them easy to setup for events.

Also also added a few things to the vault, and poked about in it to straighten some stuff out.  Mostly added just a few things to the armory.

