### PR TITLE
Observer blindening + Fixes Observers not being able to move around when non-admin

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -24,7 +24,7 @@
 #define FIELD_OF_VISION_LAYER 17 //used to place the visual (not the mask) shadow cone above any other floor plane stuff.
 
 #define GAME_PLANE -4
-
+#define OBJITEM_PLANE -3 // Used for obj/items rendering.
 #define FIELD_OF_VISION_VISUAL_PLANE -2 //Yea, FoV does require quite a few planes to work with 513 filters to a decent degree.
 
 #define CHAT_PLANE -1 //We don't want heard messages to be hidden by FoV.

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -84,6 +84,7 @@
 	if(check_rights(R_ADMIN))
 		return
 	plane_masters["[OBJITEM_PLANE]"].Hide()
+	mymob.client.show_popup_menus = 0
 
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
 	// don't show this HUD if observing; show the HUD of the observee

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -78,11 +78,19 @@
 	using.hud = src
 	static_inventory += using
 
+	HandlePlanes()
+
+/datum/hud/ghost/proc/HandlePlanes()
+	if(check_rights(R_ADMIN))
+		return
+	plane_masters["[OBJITEM_PLANE]"].Hide()
+
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)
 	// don't show this HUD if observing; show the HUD of the observee
 	var/mob/dead/observer/O = mymob
 	if (istype(O) && O.observetarget)
 		plane_masters_update()
+		HandlePlanes()
 		return FALSE
 
 	. = ..()

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -93,6 +93,12 @@
 	else
 		remove_filter("ambient_occlusion")
 
+/obj/screen/plane_master/objitem
+	name = "obj item plane master"
+	plane = OBJITEM_PLANE
+	appearance_flags = PLANE_MASTER //should use client color
+	blend_mode = BLEND_OVERLAY
+
 //Reserved to chat messages, so they are still displayed above the field of vision masking.
 /obj/screen/plane_master/chat_messages
 	name = "chat messages plane master"

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -10,7 +10,7 @@
 
 	// Otherwise jump
 	else if(A.loc)
-		forceMove(get_turf(A))
+		abstract_move(get_turf(A))
 		update_parallax_contents()
 
 /mob/dead/observer/ClickOn(atom/A, params)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -12,6 +12,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	icon = 'icons/obj/items_and_weapons.dmi'
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
+	plane = OBJITEM_PLANE
+
 	attack_hand_speed = 0
 	attack_hand_is_action = FALSE
 	attack_hand_unwieldlyness = 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2818,9 +2818,11 @@ Records disabled until a use for them is found
 					ambientocclusion = !ambientocclusion
 					if(parent && parent.screen && parent.screen.len)
 						var/obj/screen/plane_master/game_world/G = parent.mob.hud_used.plane_masters["[GAME_PLANE]"]
+						var/obj/screen/plane_master/objitem/OI = parent.mob.hud_used.plane_masters["[OBJITEM_PLANE]"]
 						var/obj/screen/plane_master/above_wall/A = parent.mob.hud_used.plane_masters["[ABOVE_WALL_PLANE]"]
 						var/obj/screen/plane_master/wall/W = parent.mob.hud_used.plane_masters["[WALL_PLANE]"]
 						G.backdrop(parent.mob)
+						OI.backdrop(parent.mob)
 						A.backdrop(parent.mob)
 						W.backdrop(parent.mob)
 

--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -492,7 +492,7 @@
 /datum/reagent/consumable/ethanol/nukaxtreme/on_mob_life(mob/living/carbon/M)
 	if(M.hud_used)
 		if(current_cycle >= 20 && current_cycle%20 == 0)
-			var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"],
+			var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[OBJITEM_PLANE]"],
 									M.hud_used.plane_masters["[LIGHTING_PLANE]"], M.hud_used.plane_masters["[WALL_PLANE]"],
 									M.hud_used.plane_masters["[ABOVE_WALL_PLANE]"])
 			var/rotation = min(round(current_cycle/20), 89) // By this point the player is probably puking and quitting anyway
@@ -505,7 +505,7 @@
 	REMOVE_TRAIT(M, TRAIT_IRONFIST, "[type]")
 	REMOVE_TRAIT(M, TRAIT_SLEEPIMMUNE, "[type]")
 	if(M && M.hud_used)
-		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
+		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[OBJITEM_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
 		for(var/whole_screen in screens)
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	if(rage)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -666,6 +666,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(check_rights(R_ADMIN))
 		return
 	hud_used.plane_masters["[OBJITEM_PLANE]"].Hide()
+	if(client)
+		client.show_popup_menus = 0
 
 /proc/updateallghostimages()
 	listclearnulls(GLOB.ghost_images_default)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -115,7 +115,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 		else
 			T = SSmapping.get_station_center()
 
-		forceMove(T)
+		abstract_move(T)
 
 	if(!name)							//To prevent nameless ghosts
 		name = random_unique_name(gender)
@@ -494,7 +494,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, "No area available.")
 		return
 
-	usr.forceMove(pick(L))
+	usr.abstract_move(pick(L))
 	update_parallax_contents()
 
 /mob/dead/observer/proc/view_gas()
@@ -573,7 +573,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/turf/T = get_turf(M) //Turf of the destination mob
 
 			if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
-				A.forceMove(T)
+				A.abstract_move(T)
 				A.update_parallax_contents()
 			else
 				to_chat(A, "This mob is not located in the game world.")
@@ -657,9 +657,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		see_invisible = SEE_INVISIBLE_OBSERVER
 
+	HandlePlanes()
 
 	updateghostimages()
 	..()
+
+/mob/dead/observer/proc/HandlePlanes()
+	if(check_rights(R_ADMIN))
+		return
+	hud_used.plane_masters["[OBJITEM_PLANE]"].Hide()
 
 /proc/updateallghostimages()
 	listclearnulls(GLOB.ghost_images_default)
@@ -909,6 +915,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			mob_eye.observers |= src
 			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
 			observetarget = mob_eye
+			HandlePlanes()
+
 
 /mob/dead/observer/verb/register_pai_candidate()
 	set category = "Ghost"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -502,9 +502,3 @@
 	if(zMove(DOWN, z_move_flags = ZMOVE_FLIGHT_FLAGS|ZMOVE_FEEDBACK|ventcrawling_flag))
 		to_chat(src, span_notice("You move down."))
 	return FALSE
-
-/mob/abstract_move(atom/destination)
-	var/turf/new_turf = get_turf(destination)
-	if(new_turf && !client?.holder)
-		return
-	return ..()

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -88,7 +88,7 @@
 /mob/proc/add_eyeblur()
 	if(!client)
 		return
-	var/list/screens = list(hud_used.plane_masters["[GAME_PLANE]"], hud_used.plane_masters["[FLOOR_PLANE]"],
+	var/list/screens = list(hud_used.plane_masters["[GAME_PLANE]"], hud_used.plane_masters["[OBJITEM_PLANE]"], hud_used.plane_masters["[FLOOR_PLANE]"],
 							hud_used.plane_masters["[WALL_PLANE]"], hud_used.plane_masters["[ABOVE_WALL_PLANE]"])
 	for(var/A in screens)
 		var/obj/screen/plane_master/P = A
@@ -97,7 +97,7 @@
 /mob/proc/remove_eyeblur()
 	if(!client)
 		return
-	var/list/screens = list(hud_used.plane_masters["[GAME_PLANE]"], hud_used.plane_masters["[FLOOR_PLANE]"],
+	var/list/screens = list(hud_used.plane_masters["[GAME_PLANE]"], hud_used.plane_masters["[OBJITEM_PLANE]"], hud_used.plane_masters["[FLOOR_PLANE]"],
 							hud_used.plane_masters["[WALL_PLANE]"], hud_used.plane_masters["[ABOVE_WALL_PLANE]"])
 	for(var/A in screens)
 		var/obj/screen/plane_master/P = A

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -857,7 +857,7 @@
 /datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/M)
 	if(M.hud_used)
 		if(current_cycle >= 20 && current_cycle%20 == 0)
-			var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"],
+			var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[OBJITEM_PLANE]"],
 									M.hud_used.plane_masters["[LIGHTING_PLANE]"], M.hud_used.plane_masters["[WALL_PLANE]"],
 									M.hud_used.plane_masters["[ABOVE_WALL_PLANE]"])
 			var/rotation = min(round(current_cycle/20), 89) // By this point the player is probably puking and quitting anyway
@@ -868,7 +868,7 @@
 
 /datum/reagent/toxin/rotatium/on_mob_end_metabolize(mob/living/M)
 	if(M && M.hud_used)
-		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
+		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[OBJITEM_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
 		for(var/whole_screen in screens)
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()
@@ -907,7 +907,7 @@
 
 /datum/reagent/toxin/skewium/on_mob_end_metabolize(mob/living/M)
 	if(M && M.hud_used)
-		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
+		var/list/screens = list(M.hud_used.plane_masters["[FLOOR_PLANE]"], M.hud_used.plane_masters["[GAME_PLANE]"], M.hud_used.plane_masters["[OBJITEM_PLANE]"], M.hud_used.plane_masters["[LIGHTING_PLANE]"])
 		for(var/whole_screen in screens)
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()

--- a/modular_citadel/code/modules/client/client_procs.dm
+++ b/modular_citadel/code/modules/client/client_procs.dm
@@ -55,5 +55,6 @@
 	set name = "Toggle Rightclick"
 	set desc = "Did the context menu get stuck on or off? Press this button."
 
-	show_popup_menus = !show_popup_menus
-	to_chat(src, "<span class='notice'>The right-click context menu is now [show_popup_menus ? "enabled" : "disabled"].</span>")
+	if(check_rights(R_ADMIN))
+		show_popup_menus = !show_popup_menus
+		to_chat(src, "<span class='notice'>The right-click context menu is now [show_popup_menus ? "enabled" : "disabled"].</span>")


### PR DESCRIPTION
oops! complete oversight with that movement code. Fixed it <3

Anyway, added in the feature to stop non-admin ghosts from seeing obj/items. This prevents unintentional metagaming and also removes that worry that we may have if some cheeky buggers observe first to find all that loot while no admins are active/aware of it.

Because of this, I had to seperate all the obj/items on your screen to be rendered seperately. You know what this means? I can fuck with all the items you can click on. Do you know the power you gave me? How I can make every item you come across SPEEN? AND HOW YOU WON'T EVER BE ABLE TO CLICK IT BECAUSE OF THE PAINFUL SPIN IT HAS ROTATING ACROSS YOUR SCREEN???
perish.

Here's some pics.
https://user-images.githubusercontent.com/68038883/178081365-628e60b4-fbb0-4be1-bdd4-d653190ce31e.mp4
https://i.gyazo.com/8dba8b28186172bfbb47f94b42128fed.gif



This is safe to merge once this checkbox is ticked <3
- [x] good to go & tested!