### PR TITLE
Fences can be attacked! New product lineup: ExploitBGone - Sprint!

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -23,6 +23,8 @@
 	var/hole_size= NO_HOLE
 	var/invulnerable = FALSE
 	var/hole_visuals = TRUE //Whether the fence piece has visuals for being cut. Used in update_cut_status()
+	max_integrity = 300 // juuuust about lower health than a door is.
+
 
 /obj/structure/fence/Initialize()
 	. = ..()
@@ -93,6 +95,8 @@
 						W.play_tool_sound(user, 20)
 
 				update_cut_status()
+				return TRUE
+		return FALSE
 
 		
 	if(istype(W, /obj/item/stack/rods))
@@ -125,8 +129,9 @@
 					hole_size = MEDIUM_HOLE
 
 		update_cut_status()
+		return TRUE
 
-	return TRUE
+	return ..()
 
 /obj/structure/fence/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -154,8 +154,8 @@
 	var/stambufferregentime
 
 	//Sprint buffer---
-	var/sprint_buffer = 42					//Tiles
-	var/sprint_buffer_max = 42
+	var/sprint_buffer = 43					//Tiles
+	var/sprint_buffer_max = 43
 	var/sprint_buffer_regen_ds = 0.1		//Tiles per world.time decisecond
 	var/sprint_buffer_regen_last = 0		//last world.time this was regen'd for math.
 	var/sprint_stamina_cost = 0.70			//stamina loss per tile while insufficient sprint buffer.

--- a/code/modules/mob/living/living_sprint.dm
+++ b/code/modules/mob/living/living_sprint.dm
@@ -72,6 +72,11 @@
 		if((m_intent == MOVE_INTENT_RUN) && CHECK_ALL_MOBILITY(src, MOBILITY_STAND|MOBILITY_MOVE))
 			playsound_local(src, 'sound/misc/sprintactivate.ogg', 50, FALSE, pressure_affected = FALSE)
 
+		if(iscarbon(src))
+			var/mob/living/carbon/C = src
+			C.doSprintLossTiles(1) // Makes it drain 1 movement of stamina loss when you spam the sprint key.
+
+
 /mob/living/proc/sprint_hotkey(targetstatus)
 	if(targetstatus != FORCE_BOOLEAN(combat_flags & COMBAT_FLAG_SPRINT_ACTIVE))
 		default_toggle_sprint()


### PR DESCRIPTION
Dingaling, there you go.
Stops the exploit from being able to juice out all the stamina bitties from spamming spacebar.Because of this, had to add 1 extra tile to the buffer to retain vanilla sprint distance with the buffer (42 tiles)
Fences can now be damaged again! They hadn't called ..() on the proc to allow you to hit it with anything other than wirecutters or metal rods.

No checkbox this time cause I playtested before making the PR and it's good to go 👍 