### PR TITLE
Revert "disables failing linter for now"

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -62,7 +62,7 @@
 #include "surgeries.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
-//#include "_coyote_tests.dm"
+#include "_coyote_tests.dm"
 
 #undef TEST_ASSERT
 #undef TEST_ASSERT_EQUAL


### PR DESCRIPTION
makes the error worse, so...guess its better than a pure linter fail