### PR TITLE
Fixes the yao gui gauntlet

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -816,7 +816,6 @@ obj/item/melee/unarmed/punchdagger/cyborg
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
-//Yao Guai Gauntlet	Keywords: Damage 30, Fast, "Saw Bleed" Effect
 /obj/item/melee/unarmed/yaoguaigauntlet
 	name = "yao guai gauntlet"
 	desc = "The severed hand of a yao guai, the hide cured, the muscles and bone removed, and given a harness to turn it into a deadly gauntlet. Usually seen around the hands of the Sorrows tribe."
@@ -831,11 +830,10 @@ obj/item/melee/unarmed/punchdagger/cyborg
 	attack_speed = CLICK_CD_MELEE * 0.7
 
 /obj/item/melee/unarmed/yaoguaigauntlet/attack(mob/living/target, mob/living/user)
-	if(isliving(target))
-		target.apply_status_effect(/datum/status_effect/stacking/saw_bleed/yaoguaigauntlet)
-	else
+	. = ..()
+	if(!isliving(target))
 		return
-
+	target.apply_status_effect(/datum/status_effect/stacking/saw_bleed/yaoguaigauntlet)
 
 ///////////
 // TOOLS //

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -32,7 +32,7 @@
 							"<span class='userdanger'>[M] [response_harm_continuous] you!</span>", null, COMBAT_MESSAGE_RANGE, null, \
 							M, "<span class='danger'>You [response_harm_simple] [src]!</span>")
 			playsound(loc, attacked_sound, 25, 1, -1)
-			attack_threshold_check(harm_intent_damage)
+			attack_threshold_check(M.dna?.species.punchdamagehigh)
 			log_combat(M, src, "attacked")
 			updatehealth()
 			return TRUE


### PR DESCRIPTION
Pull #221 from Sunset

"Fixes the Yao Guai gauntlet to actually do any damage at all. Also makes it so simplemobs take damage equal to your unarmed damage then you punch them instead of some random arbitrary number, making unarmed weapons work on them without having to hold them in your hands."
