### PR TITLE
Belt and suit storage changes

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
@@ -35594,7 +35594,7 @@
 	pixel_y = 32
 	},
 /obj/item/broom,
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
@@ -5401,7 +5401,7 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -29843,7 +29843,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},

--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -3970,7 +3970,7 @@
 	pixel_y = 32
 	},
 /obj/item/broom,
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -7774,8 +7774,8 @@
 /area/f13/village)
 "aBw" = (
 /obj/structure/rack,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
+/obj/item/storage/belt/fannypack,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aBx" = (
@@ -60168,7 +60168,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -10771,7 +10771,7 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -22567,7 +22567,7 @@
 "wdS" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/biogenerator,
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
@@ -30274,7 +30274,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
@@ -35669,7 +35669,7 @@
 	pixel_y = 32
 	},
 /obj/item/broom,
-/obj/item/storage/belt,
+/obj/item/storage/belt/fannypack,
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -266,6 +266,9 @@ GLOBAL_LIST_INIT(default_all_armor_slot_allowed, typecacheof(list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
 	/obj/item/storage/bag,
+	/obj/item/storage/box,
+	/obj/item/storage/survivalkit_triple_empty,
+	/obj/item/storage/belt,
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/flashlight,
 	/obj/item/gun,
@@ -280,7 +283,6 @@ GLOBAL_LIST_INIT(default_all_armor_slot_allowed, typecacheof(list(
 ///extra things light armor can hold in their slot by default
 GLOBAL_LIST_INIT(light_armor_allowed, typecacheof(list(
 	/obj/item/storage/box,
-	/obj/item/storage/backpack,
 	/obj/item/storage/wallet,
 	/obj/item/melee/smith)))
 
@@ -358,8 +360,6 @@ GLOBAL_LIST_INIT(armor_allow_guns_and_melee, typecacheof(list(
 ///extra things medium armor can hold in their slot by default
 ///Basically most items, plus a box/belt
 GLOBAL_LIST_INIT(medium_armor_allowed, typecacheof(list(
-	/obj/item/storage/box,
-	/obj/item/storage/belt,
 	/obj/item/storage/wallet,
 	/obj/item/melee,
 	/obj/item/gun,
@@ -373,6 +373,205 @@ GLOBAL_LIST_INIT(medium_armor_allowed, typecacheof(list(
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/throwing_star/spear,
 	/obj/item/restraints/legcuffs/bola)))
+
+/// Things allowed in a toolbelt
+GLOBAL_LIST_INIT(toolbelt_allowed, typecacheof(list(
+	/obj/item/crowbar,
+	/obj/item/screwdriver,
+	/obj/item/weldingtool,
+	/obj/item/wirecutters,
+	/obj/item/wrench,
+	/obj/item/multitool,
+	/obj/item/inducer,
+	/obj/item/flashlight,
+	/obj/item/stack/cable_coil,
+	/obj/item/stack/sheet,
+	/obj/item/stock_parts,
+	/obj/item/twohanded/chainsaw,
+	/obj/item/melee/smith/hammer,
+	/obj/item/t_scanner,
+	/obj/item/analyzer,
+	/obj/item/geiger_counter,
+	/obj/item/extinguisher/mini,
+	/obj/item/radio,
+	/obj/item/lightreplacer,
+	/obj/item/rcd_ammo,
+	/obj/item/resonator,
+	/obj/item/mining_scanner,
+	/obj/item/pickaxe,
+	/obj/item/lighter,
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/reagent_containers/food/drinks/bottle,
+	/obj/item/kitchen/knife,
+	/obj/item/gps,
+	/obj/item/storage/bag/ore,
+	/obj/item/survivalcapsule,
+	/obj/item/t_scanner/adv_mining_scanner,
+	/obj/item/stack/ore,
+	/obj/item/reagent_containers/food/drinks,
+	/obj/item/organ/regenerative_core,
+	/obj/item/wormhole_jaunter,
+	/obj/item/stack/marker_beacon,
+	/obj/item/reagent_containers/food/snacks/donut,
+	/obj/item/flashlight/seclite,
+	/obj/item/grenade/chem_grenade/metalfoam,
+	/obj/item/grenade/chem_grenade/smart_metal_foam,
+	/obj/item/construction,
+	/obj/item/circuitboard,
+	/obj/item/clothing/gloves,
+	/obj/item/clothing/mask/gas/welding,
+	/obj/item/clothing/glasses/welding,
+	/obj/item/clothing/head/welding,
+	/obj/item/clothing/head/helmet/f13/raider/arclight,
+	/obj/item/holosign_creator,
+	/obj/item/assembly/signaler)))
+
+/// Things allowed in a jannibelt
+GLOBAL_LIST_INIT(janibelt_allowed, typecacheof(list(
+	/obj/item/grenade/chem_grenade,
+	/obj/item/lightreplacer,
+	/obj/item/flashlight,
+	/obj/item/reagent_containers/glass/beaker,
+	/obj/item/reagent_containers/glass/bottle,
+	/obj/item/reagent_containers/spray,
+	/obj/item/soap,
+	/obj/item/holosign_creator,
+	/obj/item/forcefield_projector,
+	/obj/item/key/janitor,
+	/obj/item/clothing/gloves,
+	/obj/item/melee/flyswatter,
+	/obj/item/broom,
+	/obj/item/paint/paint_remover,
+	/obj/item/assembly/mousetrap,
+	/obj/item/screwdriver,
+	/obj/item/stack/cable_coil
+	)))
+
+/// Things allowed in a botanybelt
+GLOBAL_LIST_INIT(plantbelt_allowed, typecacheof(list(
+	/obj/item/shovel/spade,
+	/obj/item/cultivator,
+	/obj/item/hatchet,
+	/obj/item/reagent_containers/spray,
+	/obj/item/book/manual/advice_farming,
+	/obj/item/reagent_containers/glass/bottle,
+	/obj/item/reagent_containers/glass/bucket,
+	/obj/item/reagent_containers/glass/beaker,
+	/obj/item/reagent_containers/food/drinks/flask,
+	/obj/item/storage/bag/plants, // remove if it gets abused to breaking somehow
+	/obj/item/plant_analyzer, // out of place but mechanically useful for the foreseeable future, so included for QoL
+	)))
+
+/// Things allowed in a medibelt
+GLOBAL_LIST_INIT(medibelt_allowed, typecacheof(list(
+	/obj/item/healthanalyzer,
+	/obj/item/dnainjector,
+	/obj/item/reagent_containers/dropper,
+	/obj/item/reagent_containers/glass/beaker,
+	/obj/item/reagent_containers/glass/bottle,
+	/obj/item/reagent_containers/pill,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/reagent_containers/medspray,
+	/obj/item/reagent_containers/hypospray,
+	/obj/item/reagent_containers/chem_pack,
+	/obj/item/lighter,
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/storage/pill_bottle,
+	/obj/item/stack/medical,
+	/obj/item/flashlight/pen,
+	/obj/item/extinguisher/mini,
+	/obj/item/hypospray/mkii,
+	/obj/item/sensor_device,
+	/obj/item/radio,
+	/obj/item/clothing/gloves,
+	/obj/item/lazarus_injector,
+	/obj/item/clothing/mask/surgical,
+	/obj/item/clothing/mask/breath,
+	/obj/item/surgical_drapes, //for true paramedics
+	/obj/item/bedsheet, //for true hobos
+	/obj/item/scalpel,
+	/obj/item/circular_saw,
+	/obj/item/bonesetter,
+	/obj/item/surgicaldrill,
+	/obj/item/retractor,
+	/obj/item/cautery,
+	/obj/item/hemostat,
+	/obj/item/geiger_counter,
+	/obj/item/clothing/neck/stethoscope,
+	/obj/item/stamp,
+	/obj/item/razor,
+	/obj/item/clothing/glasses,
+	/obj/item/wrench/medical,
+	/obj/item/clothing/mask/muzzle,
+	/obj/item/storage/bag/chemistry,
+	/obj/item/storage/bag/bio,
+	/obj/item/reagent_containers/blood,
+	/obj/item/tank/internals/emergency_oxygen,
+	/obj/item/implantcase,
+	/obj/item/implant,
+	/obj/item/implanter,
+	/obj/item/pinpointer/crew,
+	/obj/item/weldingtool,
+	/obj/item/gun/ballistic/revolver/needler, // the healing is not as rewarding as the hurting
+	/obj/item/ammo_box/needle,
+	/obj/item/tele_iv,
+	/obj/item/stack/sticky_tape, //surgical tape
+	/obj/item/handsaw)))
+
+/// Things allowed in a holster (more of a secbelt)
+GLOBAL_LIST_INIT(gunbelt_allowed, typecacheof(list(
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/gun,
+	/obj/item/reagent_containers/spray/pepper,
+	/obj/item/melee/onehanded/knife/hunting,
+	/obj/item/melee/baton,
+	/obj/item/melee/classic_baton/telescopic,
+	/obj/item/restraints/handcuffs,
+	/obj/item/tank/internals,
+	/obj/item/restraints/legcuffs/bola,
+	/obj/item/toy)))
+
+/// Things allowed in a bandolier
+GLOBAL_LIST_INIT(ammobelt_allowed, typecacheof(list(
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/ammo_box,
+	/obj/item/ammo_casing,
+	/obj/item/grenade,
+	/obj/item/reagent_containers/spray/pepper,
+	/obj/item/restraints/handcuffs,
+	/obj/item/tank/internals,
+	/obj/item/restraints/legcuffs/bola,
+	/obj/item/toy)))
+
+/// Things allowed in a scabbard
+GLOBAL_LIST_INIT(knifebelt_allowed, typecacheof(list(
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/melee,
+	/obj/item/reagent_containers/spray/pepper,
+	/obj/item/restraints/handcuffs,
+	/obj/item/tank/internals,
+	/obj/item/restraints/legcuffs/bola,
+	/obj/item/toy)))
+
+/// How many items total fit in a holster
+#define STORAGE_HOLSTER_MAX_ITEMS 7
+/// How much volume fits in a holster
+#define STORAGE_HOLSTER_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_HOLSTER_MAX_ITEMS
+
+/// How many items total fit in a belt
+#define STORAGE_BELT_MAX_ITEMS 14
+/// How much volume fits in a belt
+#define STORAGE_BELT_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_BELT_MAX_ITEMS
+
+/// How many items total fit in a belt
+#define STORAGE_FANNYPACK_MAX_ITEMS 7
+/// How much volume fits in a belt
+#define STORAGE_FANNYPACK_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_FANNYPACK_MAX_ITEMS
+
+/// How many items total fit in a large survival kit
+#define STORAGE_TRIPLEKIT_MAX_ITEMS 21
+/// How much volume fits in a belt
+#define STORAGE_TRIPLEKIT_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_FANNYPACK_MAX_ITEMS
 
 //Internals checker
 #define GET_INTERNAL_SLOTS(C) list(C.head, C.wear_mask)

--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -5,7 +5,9 @@
 /datum/crafting_recipe/bandolier
 	name = "Bandolier"
 	result = /obj/item/storage/belt/bandolier
-	reqs = list(/obj/item/stack/sheet/hay = 3,
+	reqs = list(/obj/item/stack/sheet/metal = 3,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/sheet/leather = 4)
 	tools = list(TOOL_WORKBENCH)
 	time = 40
@@ -13,9 +15,11 @@
 	subcategory = CAT_BELTS
 
 /datum/crafting_recipe/belt
-	name = "Belt"
-	result = /obj/item/storage/belt
-	reqs = list(/obj/item/stack/sheet/hay = 3,
+	name = "Fannypack"
+	result = /obj/item/storage/belt/fannypack
+	reqs = list(/obj/item/stack/sheet/metal = 3,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/sheet/leather = 3)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
@@ -27,6 +31,8 @@
 	result = /obj/item/storage/belt/military
 	tools = list(TOOL_AWORKBENCH)
 	reqs = list(/obj/item/stack/sheet/plastic = 2,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/sheet/leather = 3)
 	time = 30
 	category = CAT_CLOTHING
@@ -36,6 +42,8 @@
 	name = "Webbing"
 	result = /obj/item/storage/belt/military/alt
 	reqs = list(/obj/item/stack/sheet/leather = 3,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/sheet/cloth = 2)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
@@ -46,7 +54,9 @@
 	name = "Shoulder Holster"
 	result = /obj/item/storage/belt/holster
 	reqs = list(/obj/item/stack/sheet/leather = 2,
-				/obj/item/stack/sheet/hay = 3)
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/cloth = 2,
+				/obj/item/stack/sheet/metal = 3)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_CLOTHING
@@ -56,7 +66,9 @@
 	name = "Leg Holster"
 	result = /obj/item/storage/belt/holster/legholster
 	reqs = list(/obj/item/stack/sheet/leather = 2,
-				/obj/item/stack/sheet/hay = 3)
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/cloth = 2,
+				/obj/item/stack/sheet/metal = 3)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_CLOTHING
@@ -66,8 +78,9 @@
 	name = "Medolier"
 	result =  /obj/item/storage/belt/medolier
 	reqs = list(/obj/item/stack/sheet/metal = 2,
-	/obj/item/stack/sheet/cloth = 3,
-	/obj/item/stack/sheet/plastic = 4)
+				/obj/item/stack/sheet/cloth = 3,
+				/obj/item/stack/crafting/metalparts = 2,
+				/obj/item/stack/sheet/plastic = 4)
 	time = 30
 	category = CAT_CLOTHING
 	subcategory = CAT_BELTS
@@ -105,7 +118,7 @@
 /datum/crafting_recipe/heavysheath
 	name = "Heavy-Duty Sheath"
 	result = /obj/item/storage/belt/sabre/heavy
-	reqs = list(/obj/item/stack/sheet/hay = 1,
+	reqs = list(/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/sheet/leather = 3,
 				/obj/item/stack/crafting/metalparts = 2)
 	tools = list(TOOL_WORKBENCH)
@@ -116,7 +129,7 @@
 /datum/crafting_recipe/twinsheath
 	name = "Twin Sheath"
 	result = /obj/item/storage/belt/sword/twin
-	reqs = list(/obj/item/stack/sheet/hay = 1,
+	reqs = list(/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/sheet/leather = 3,
 				/obj/item/stack/crafting/metalparts = 2)
 	tools = list(TOOL_WORKBENCH)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -118,7 +118,7 @@
 	icon_state = "gardener"
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 
-/obj/item/storage/belt/utility/gardener/ComponentInitialize() /// AAAAAAAAAAAAAAAAAAAAAAAA
+/obj/item/storage/belt/utility/gardener/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
@@ -150,7 +150,7 @@
 	item_state = "bandolier"
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
-/obj/item/storage/belt/bandolier/ComponentInitialize()// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+/obj/item/storage/belt/bandolier/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
@@ -211,7 +211,7 @@
 	item_state = "security"//Could likely use a better one.
 	content_overlays = TRUE
 
-/obj/item/storage/belt/security/ComponentInitialize() /// combine with bandolier
+/obj/item/storage/belt/security/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
@@ -391,7 +391,7 @@
 	resistance_flags = FIRE_PROOF
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE //If normal belts get this, the upgraded version should too
 
-/obj/item/storage/belt/durathread/ComponentInitialize() /// AAAAAAAAAAAAAAAAAAA combine with toolbelt
+/obj/item/storage/belt/durathread/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -9,6 +9,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
+	w_class = WEIGHT_CLASS_BULKY // keep out of backpack!
 	var/content_overlays = FALSE //If this is true, the belt will gain overlays based on what it's holding
 	var/onmob_overlays = FALSE //worn counterpart of the above.
 
@@ -49,26 +50,10 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/multitool,
-		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
-		/obj/item/t_scanner,
-		/obj/item/analyzer,
-		/obj/item/geiger_counter,
-		/obj/item/extinguisher/mini,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/holosign_creator,
-		/obj/item/forcefield_projector,
-		/obj/item/assembly/signaler
-		))
-	STR.can_hold = can_hold
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.toolbelt_allowed
 
 /obj/item/storage/belt/utility/chief
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
@@ -103,29 +88,6 @@
 	name = "wastelander toolbelt"
 	desc = "Holds a collection of simple tools."
 
-/obj/item/storage/belt/utility/waster/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_BULKY
-	var/static/list/can_hold = typecacheof(list(
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/multitool,
-		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
-		/obj/item/analyzer,
-		/obj/item/geiger_counter,
-		/obj/item/extinguisher/mini,
-		/obj/item/radio,
-		/obj/item/assembly/signaler,
-		/obj/item/twohanded/chainsaw,
-		/obj/item/melee/smith/hammer,
-		))
-	STR.can_hold = can_hold
-
 /obj/item/storage/belt/utility/waster/PopulateContents()
 	new /obj/item/crowbar(src)
 	new /obj/item/wrench(src)
@@ -138,7 +100,6 @@
 /obj/item/storage/belt/utility/waster/forgemaster
 	name = "forgemasters toolbelt"
 	desc = "Has a collection of basic tools and a hook rigging to sling a chainsaw from."
-	var/max_combined_w_class = WEIGHT_CLASS_SMALL * 8
 
 /obj/item/storage/belt/utility/waster/forgemaster/PopulateContents()
 	new /obj/item/crowbar(src)
@@ -157,21 +118,13 @@
 	icon_state = "gardener"
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 
-/obj/item/storage/belt/utility/gardener/ComponentInitialize()
+/obj/item/storage/belt/utility/gardener/ComponentInitialize() /// AAAAAAAAAAAAAAAAAAAAAAAA
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
-		/obj/item/shovel/spade,
-		/obj/item/cultivator,
-		/obj/item/hatchet,
-		/obj/item/book/manual/advice_farming,
-		/obj/item/reagent_containers/glass/bottle/nutrient,
-		/obj/item/reagent_containers/glass/bottle/killer,
-		/obj/item/reagent_containers/food/drinks/flask,
-		/obj/item/storage/bag/plants, // remove if it gets abused to breaking somehow
-		/obj/item/plant_analyzer, // out of place but mechanically useful for the foreseeable future, so included for QoL
-		))
-	STR.can_hold = can_hold
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.plantbelt_allowed
 
 // Primitive medical belt, meant to be part of a ghetto surgery improvement at some point
 /obj/item/storage/belt/medical/primitive
@@ -197,19 +150,13 @@
 	item_state = "bandolier"
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
-/obj/item/storage/belt/bandolier/ComponentInitialize()
+/obj/item/storage/belt/bandolier/ComponentInitialize()// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 3
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
-		/obj/item/ammo_box/shotgun,
-		/obj/item/ammo_box/lasmusket,
-		/obj/item/reagent_containers/food/drinks/flask,
-		/obj/item/grenade/f13,
-		/obj/item/reagent_containers/food/drinks/bottle/molotov,
-		/obj/item/grenade/homemade
-		))
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.ammobelt_allowed
 
 
 // END OF FALLOUT BELTS
@@ -234,59 +181,9 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
-		/obj/item/healthanalyzer,
-		/obj/item/dnainjector,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/glass/beaker,
-		/obj/item/reagent_containers/glass/bottle,
-		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/reagent_containers/medspray,
-		/obj/item/lighter,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/storage/pill_bottle,
-		/obj/item/stack/medical,
-		/obj/item/flashlight/pen,
-		/obj/item/extinguisher/mini,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/hypospray/mkii,
-		/obj/item/sensor_device,
-		/obj/item/radio,
-		/obj/item/clothing/gloves/,
-		/obj/item/lazarus_injector,
-		/obj/item/clothing/mask/surgical,
-		/obj/item/clothing/mask/breath,
-		/obj/item/clothing/mask/breath/medical,
-		/obj/item/surgical_drapes, //for true paramedics
-		/obj/item/scalpel,
-		/obj/item/circular_saw,
-		/obj/item/bonesetter,
-		/obj/item/surgicaldrill,
-		/obj/item/retractor,
-		/obj/item/cautery,
-		/obj/item/hemostat,
-		/obj/item/geiger_counter,
-		/obj/item/clothing/neck/stethoscope,
-		/obj/item/stamp,
-		/obj/item/clothing/glasses,
-		/obj/item/wrench/medical,
-		/obj/item/clothing/mask/muzzle,
-		/obj/item/storage/bag/chemistry,
-		/obj/item/storage/bag/bio,
-		/obj/item/reagent_containers/blood,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/implantcase,
-		/obj/item/implant,
-		/obj/item/implanter,
-		/obj/item/pinpointer/crew,
-		/obj/item/reagent_containers/chem_pack,
-		/obj/item/weldingtool/basic,
-		/obj/item/stack/sticky_tape, //surgical tape
-		/obj/item/handsaw
-		))
-
-
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.medibelt_allowed
 
 /obj/item/storage/belt/medical/surgery_belt_adv
 	name = "surgical supply belt"
@@ -298,6 +195,14 @@
 	new /obj/item/retractor/advanced(src)
 	new /obj/item/surgicaldrill/advanced(src)
 	new /obj/item/surgical_drapes/advanced(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/reagent_containers/medspray/sterilizine(src)
+	new /obj/item/razor(src)
+	new /obj/item/stack/sticky_tape/surgical(src)
+	new /obj/item/stack/sticky_tape/surgical(src)
+	new /obj/item/stack/medical/bone_gel(src)
+	new /obj/item/stack/medical/bone_gel(src)
 
 /obj/item/storage/belt/security
 	name = "security belt"
@@ -306,29 +211,13 @@
 	item_state = "security"//Could likely use a better one.
 	content_overlays = TRUE
 
-/obj/item/storage/belt/security/ComponentInitialize()
+/obj/item/storage/belt/security/ComponentInitialize() /// combine with bandolier
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 5
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
-		/obj/item/melee/baton,
-		/obj/item/melee/classic_baton,
-		/obj/item/grenade,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/assembly/flash/handheld,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
-		/obj/item/reagent_containers/food/snacks/donut,
-		/obj/item/melee/onehanded/knife/hunting,
-		/obj/item/flashlight/seclite,
-		/obj/item/melee/classic_baton/telescopic,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/restraints/legcuffs/bola
-		))
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_HOLSTER_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_HOLSTER_MAX_VOLUME
+	STR.can_hold = GLOB.gunbelt_allowed
 
 /obj/item/storage/belt/security/full/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -348,63 +237,10 @@
 /obj/item/storage/belt/mining/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.max_combined_w_class = 20
-	STR.can_hold = typecacheof(list(
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/multitool,
-		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
-		/obj/item/analyzer,
-		/obj/item/extinguisher/mini,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/resonator,
-		/obj/item/mining_scanner,
-		/obj/item/pickaxe,
-		/obj/item/stack/sheet/animalhide,
-		/obj/item/stack/sheet/sinew,
-		/obj/item/stack/sheet/bone,
-		/obj/item/lighter,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/reagent_containers/food/drinks/bottle,
-		/obj/item/stack/medical,
-		/obj/item/kitchen/knife,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/gps,
-		/obj/item/storage/bag/ore,
-		/obj/item/survivalcapsule,
-		/obj/item/t_scanner/adv_mining_scanner,
-		/obj/item/reagent_containers/pill,
-		/obj/item/storage/pill_bottle,
-		/obj/item/stack/ore,
-		/obj/item/reagent_containers/food/drinks,
-		/obj/item/organ/regenerative_core,
-		/obj/item/wormhole_jaunter,
-		/obj/item/storage/bag/plants,
-		/obj/item/stack/marker_beacon,
-		/obj/item/melee/baton,
-		/obj/item/melee/classic_baton,
-		/obj/item/grenade,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/restraints/handcuffs,
-		/obj/item/assembly/flash/handheld,
-		/obj/item/clothing/glasses,
-		/obj/item/ammo_casing/shotgun,
-		/obj/item/ammo_box,
-		/obj/item/reagent_containers/food/snacks/donut,
-		/obj/item/flashlight/seclite,
-		/obj/item/melee/classic_baton/telescopic,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/restraints/legcuffs/bola
-		))
-
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.toolbelt_allowed
 
 /obj/item/storage/belt/mining/vendor
 	contents = newlist(/obj/item/survivalcapsule)
@@ -418,11 +254,6 @@
 	desc = "A versatile belt, woven from sinew."
 	icon_state = "ebelt"
 	item_state = "ebelt"
-
-/obj/item/storage/belt/mining/primitive/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 5
 
 /obj/item/storage/belt/champion
 	name = "championship belt"
@@ -449,7 +280,10 @@
 /obj/item/storage/belt/military/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.ammobelt_allowed
 
 /obj/item/storage/belt/military/snack
 	name = "tactical snack rig"
@@ -462,14 +296,13 @@
 /obj/item/storage/belt/military/snack/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
+	STR.max_items = 21
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.can_hold = typecacheof(list(
-		/obj/item/reagent_containers/food/snacks,
-		/obj/item/reagent_containers/food/drinks
+		/obj/item/reagent_containers/food
 		))
 
-	var/amount = 5
+	var/amount = 21
 	var/rig_snacks
 	while(contents.len <= amount)
 		rig_snacks = pick(list(
@@ -506,6 +339,14 @@
 	icon_state = "belt"
 	item_state = "security"
 
+/obj/item/storage/belt/military/abductor/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.toolbelt_allowed
+
 /obj/item/storage/belt/military/abductor/full/PopulateContents()
 	new /obj/item/screwdriver/abductor(src)
 	new /obj/item/wrench/abductor(src)
@@ -521,17 +362,19 @@
 	icon_state = "grenadebeltold"
 	item_state = "security"
 
+/obj/item/storage/belt/military/assault/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.ammobelt_allowed
+
 /obj/item/storage/belt/military/assault
 	name = "assault belt"
 	desc = "A tactical assault belt."
 	icon_state = "assaultbelt"
 	item_state = "security"
-
-/obj/item/storage/belt/military/assault/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 7
-
 
 /obj/item/storage/belt/military/army/military/followers/PopulateContents()
 	new /obj/item/reagent_containers/spray/pepper(src)
@@ -542,44 +385,19 @@
 
 /obj/item/storage/belt/durathread
 	name = "durathread toolbelt"
-	desc = "A toolbelt made out of durathread, it seems robust enough to hold bigger tools like RCDs or RPDs, with enough pouches to hold more gear than a normal belt."
+	desc = "A toolbelt made out of durathread. Aside from the material being fireproof, this is virtually identical to a leather toolbelt."
 	icon_state = "webbing-durathread"
 	item_state = "webbing-durathread"
 	resistance_flags = FIRE_PROOF
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE //If normal belts get this, the upgraded version should too
 
-/obj/item/storage/belt/durathread/ComponentInitialize()
+/obj/item/storage/belt/durathread/ComponentInitialize() /// AAAAAAAAAAAAAAAAAAA combine with toolbelt
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 14
-	STR.max_combined_w_class = 32
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/multitool,
-		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
-		/obj/item/t_scanner,
-		/obj/item/analyzer,
-		/obj/item/geiger_counter,
-		/obj/item/extinguisher,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/holosign_creator,
-		/obj/item/forcefield_projector,
-		/obj/item/assembly/signaler,
-		/obj/item/lightreplacer,
-		/obj/item/rcd_ammo,
-		/obj/item/construction,
-		/obj/item/stack/rods,
-		/obj/item/stack/tile/plasteel,
-		/obj/item/grenade/chem_grenade/metalfoam,
-		/obj/item/grenade/chem_grenade/smart_metal_foam
-		))
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.toolbelt_allowed
 
 /obj/item/storage/belt/grenade
 	name = "grenadier belt"
@@ -643,38 +461,10 @@
 /obj/item/storage/belt/janitor/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
-	STR.max_w_class = WEIGHT_CLASS_BULKY // Set to this so the  light replacer can fit.
-	STR.can_hold = typecacheof(list(
-		/obj/item/grenade/chem_grenade,
-		/obj/item/lightreplacer,
-		/obj/item/flashlight,
-		/obj/item/reagent_containers/glass/beaker,
-		/obj/item/reagent_containers/glass/bottle,
-		/obj/item/reagent_containers/spray,
-		/obj/item/soap,
-		/obj/item/holosign_creator,
-		/obj/item/forcefield_projector,
-		/obj/item/key/janitor,
-		/obj/item/clothing/gloves,
-		/obj/item/melee/flyswatter,
-		/obj/item/broom,
-		/obj/item/paint/paint_remover,
-		/obj/item/assembly/mousetrap,
-		/obj/item/screwdriver,
-		/obj/item/stack/cable_coil
-		))
-
-
-
-/obj/item/storage/belt/utility
-	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
-	desc = "Holds tools."
-	icon_state = "utilitybelt"
-	item_state = "utility"
-	content_overlays = TRUE
-	custom_premium_price = 300
-
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.janibelt_allowed
 
 /obj/item/storage/belt/bandolier/durathread
 	name = "durathread bandolier"
@@ -686,11 +476,10 @@
 /obj/item/storage/belt/bandolier/durathread/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 32
-	STR.display_numerical_stacking = TRUE
-	STR.can_hold = typecacheof(list(
-		/obj/item/ammo_casing
-		))
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_BELT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_BELT_MAX_VOLUME
+	STR.can_hold = GLOB.ammobelt_allowed
 
 //CIT QUIVER
 /*/obj/item/storage/belt/quiver
@@ -757,45 +546,15 @@
 	icon_state = "holster_shoulder"
 	item_state = "holster_shoulder"
 	alternate_worn_layer = UNDER_SUIT_LAYER
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/storage/belt/holster/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 4
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/ammo_box/magazine,
-		/obj/item/ammo_box/tube,
-		/obj/item/ammo_box/a357,
-		/obj/item/ammo_box/c38,
-		/obj/item/ammo_box/l10mm,
-		/obj/item/ammo_box/a762,
-		/obj/item/ammo_box/shotgun,
-		/obj/item/ammo_box/m44,
-		/obj/item/ammo_box/a762,
-		/obj/item/ammo_box/a556/stripper,
-		/obj/item/ammo_box/needle,
-		/obj/item/ammo_box/a308,
-		/obj/item/ammo_box/c4570,
-		/obj/item/ammo_box/a50MG,
-		/obj/item/ammo_box/c45rev,
-		/obj/item/ammo_box/a45lcrev,
-		/obj/item/gun/energy/laser/solar,
-		/obj/item/gun/energy/laser/pistol,
-		/obj/item/gun/energy/laser/auto,
-		/obj/item/gun/energy/laser/complianceregulator,
-		/obj/item/gun/energy/laser/plasma/pistol,
-		/obj/item/gun/energy/laser/plasma/glock,
-		/obj/item/gun/energy/laser/plasma/glock/extended,
-		/obj/item/gun/energy/laser/wattz,
-		/obj/item/gun/energy/laser/wattz/magneto,
-		/obj/item/gun/energy/laser/plasma/pistol/alien,
-		/obj/item/stock_parts/cell/ammo/ec,
-		/obj/item/stock_parts/cell/ammo/ecp,
-		))
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_items = STORAGE_HOLSTER_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_HOLSTER_MAX_VOLUME
+	STR.can_hold = GLOB.gunbelt_allowed
 
 /obj/item/storage/belt/holster/full/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/detective(src)
@@ -857,8 +616,9 @@
 /obj/item/storage/belt/fannypack/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 3
-	STR.max_w_class = WEIGHT_CLASS_SMALL
+	STR.max_w_class = WEIGHT_CLASS_TINY
+	STR.max_items = STORAGE_FANNYPACK_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_FANNYPACK_MAX_VOLUME
 
 /obj/item/storage/belt/fannypack/black
 	name = "black fannypack"
@@ -890,10 +650,10 @@
 /obj/item/storage/belt/sabre/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 1
-	STR.rustle_sound = FALSE
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(fitting_swords)
+	STR.max_items = STORAGE_HOLSTER_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_HOLSTER_MAX_VOLUME
+	STR.can_hold = GLOB.knifebelt_allowed
 	STR.quickdraw = TRUE
 
 /obj/item/storage/belt/sabre/examine(mob/user)
@@ -912,7 +672,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	content_overlays = TRUE
 	onmob_overlays = TRUE
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_BELT
 	fitting_swords = list(/obj/item/melee/smith/machete,
 	/obj/item/melee/smith/machete/reforged,
 	/obj/item/melee/smith/wakizashi,
@@ -1014,21 +774,11 @@
 	icon_state = "reconbandolier"
 	item_state = "reconbandolier"
 
-/obj/item/storage/belt/military/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_SMALL
-
 /obj/item/storage/belt/military/NCR_Bandolier
 	name = "NCR bandolier"
 	desc = "A standard issue NCR bandolier."
 	icon_state = "ncr_bandolier"
 	item_state = "ncr_bandolier"
-
-/obj/item/storage/belt/military/NCR_Bandolier/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 7
 
 //Regular Quiver
 /obj/item/storage/belt/tribe_quiver
@@ -1040,7 +790,7 @@
 /obj/item/storage/belt/tribe_quiver/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 8
+	STR.max_items = 14
 	STR.can_hold = typecacheof(list(/obj/item/ammo_casing/caseless/arrow))
 	STR.max_w_class = 3
 	STR.max_combined_w_class = 24

--- a/code/game/objects/items/storage/survivalkit.dm
+++ b/code/game/objects/items/storage/survivalkit.dm
@@ -129,15 +129,16 @@
 
 /obj/item/storage/survivalkit_triple_empty
 	name = "large survival kit"
-	desc = "A large, robust leather pouch containing the essentials for wasteland survival. This one won't fit in your pocket, but holds three times as much."
-	icon_state = "survivalkit_triple"
-	w_class = WEIGHT_CLASS_NORMAL
+	desc = "A large, robust set of leather pouches tailored to hold lots and lots of tiny things. This one won't fit in your pocket, but it comes with straps that'll attach to most armors."
+	icon_state = "survivalkit"
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/survivalkit_triple_empty/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 21
-	STR.max_combined_w_class = 42
+	STR.max_w_class = WEIGHT_CLASS_TINY
+	STR.max_items = STORAGE_TRIPLEKIT_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_TRIPLEKIT_MAX_VOLUME
 
 /obj/item/storage/survivalkit_empty/PopulateContents()
 	. = ..()

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -310,7 +310,7 @@
 	new /obj/item/gun/ballistic/automatic/smg/greasegun(src)
 	new /obj/item/ammo_box/magazine/greasegun(src)
 	new /obj/item/clothing/head/helmet/armyhelmet(src)
-	new /obj/item/storage/belt(src)
+	new /obj/item/storage/belt/fannypack(src)
 	new /obj/item/clothing/under/f13/army(src)
 	new /obj/item/gun/ballistic/automatic/pistol/m1911(src)
 	new /obj/item/grenade/frag(src)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -320,7 +320,7 @@ Head Knight
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
 	accessory =		/obj/item/clothing/accessory/bos/knightcaptain
 	belt =			/obj/item/storage/belt/security/full
-	neck =			/obj/item/storage/belt/holster
+	l_pocket =			/obj/item/storage/belt/holster
 	mask =			/obj/item/clothing/mask/gas/sechailer
 	head =			/obj/item/clothing/head/helmet/f13/combat/brotherhood/captain
 	id =			/obj/item/card/id/dogtag
@@ -751,7 +751,7 @@ Senior Knight
 	glasses =       /obj/item/clothing/glasses/night
 	mask =			/obj/item/clothing/mask/gas/sechailer
 	belt = 			/obj/item/storage/belt/military/assault
-	neck =			/obj/item/storage/belt/holster
+	l_pocket =			/obj/item/storage/belt/holster
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior
 	id = 			/obj/item/card/id/dogtag
 	gunsmith_one = TRUE
@@ -860,7 +860,7 @@ Knight
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
 	mask =			/obj/item/clothing/mask/gas/sechailer
 	belt = 			/obj/item/storage/belt/military/assault
-	neck =			/obj/item/storage/belt/holster
+	l_pocket =			/obj/item/storage/belt/holster
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood
 	id = 			/obj/item/card/id/dogtag
 	gunsmith_one = TRUE

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -20,7 +20,7 @@
 /datum/outfit/job/enclave/peacekeeper
 	id = /obj/item/card/id/dogtag/enclave/trooper
 	mask = /obj/item/clothing/mask/gas/enclave
-	neck = /obj/item/storage/belt/holster/legholster
+	l_pocket = /obj/item/storage/belt/holster/legholster
 	backpack = /obj/item/storage/backpack/enclave
 	satchel = /obj/item/storage/backpack/satchel/enclave
 	belt = /obj/item/storage/belt/military/assault/enclave

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -369,7 +369,7 @@ Follower Volunteer
 	head =	/obj/item/clothing/head/helmet/riot/vaultsec
 	glasses =	/obj/item/clothing/glasses/sunglasses
 	shoes =	/obj/item/clothing/shoes/combat
-	neck =	/obj/item/storage/belt/holster
+	l_pocket =	/obj/item/storage/belt/holster
 	backpack =	/obj/item/storage/backpack/explorer
 	satchel =	/obj/item/storage/backpack/satchel/explorer
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/khan.dm
+++ b/code/modules/jobs/job_types/khan.dm
@@ -135,7 +135,7 @@
 	name = "Prospector"
 	r_hand = /obj/item/gun/ballistic/automatic/pistol/m1911/custom
 	l_hand = /obj/item/weldingtool/largetank
-	belt = /obj/item/storage/belt
+	belt = /obj/item/storage/belt/fannypack
 	mask = /obj/item/clothing/mask/gas/welding
 	backpack_contents = list(
 		/obj/item/wrench = 1,
@@ -257,7 +257,7 @@
 	head = /obj/item/clothing/head/collectable/petehat/gang
 	r_hand = /obj/item/gun/ballistic/revolver/colt357/lucky
 	l_hand = /obj/item/twohanded/baseball/louisville
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/ammo_box/a357 = 3,
 		/obj/item/clipboard = 1,
@@ -268,7 +268,7 @@
 	name = "Tax Collector"
 	glasses = /obj/item/clothing/glasses/sunglasses
 	r_hand = /obj/item/gun/ballistic/revolver/hunting
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/ammo_box/c4570 = 3,
 		/obj/item/twohanded/baseball = 1,
@@ -309,7 +309,7 @@
 	head = /obj/item/clothing/head/helmet/f13/khan/fullhelm
 	suit = /obj/item/clothing/suit/toggle/labcoat/khan_jacket/coat
 	glasses = /obj/item/clothing/glasses/sunglasses
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/ammo_box/c45rev = 3,
 		/obj/item/restraints/legcuffs/bola/tactical = 1,

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -153,7 +153,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13orator	// .357 Revolver, Spatha
 	name = "Orator"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13orator
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	suit = /obj/item/clothing/suit/armor/legion/orator
 	head = /obj/item/clothing/head/helmet/f13/legion/orator
@@ -313,7 +313,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	id = /obj/item/card/id/dogtag/legveteran
 	suit = /obj/item/clothing/suit/armor/legion/heavy
 	mask = /obj/item/clothing/mask/bandana/legion/legdecan
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	gloves = /obj/item/clothing/gloves/legion/plated
 	ears = /obj/item/radio/headset/headset_legion/cent
 	glasses = /obj/item/clothing/glasses/sunglasses/big
@@ -417,7 +417,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit = /obj/item/clothing/suit/armor/legion/prime/decan
 	head = /obj/item/clothing/head/helmet/f13/legion/prime/decan
 	mask = /obj/item/clothing/mask/bandana/legion/legdecan
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	glasses = /obj/item/clothing/glasses/legiongoggles
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	r_pocket = /obj/item/flashlight/lantern
@@ -508,7 +508,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	suit = /obj/item/clothing/suit/armor/legion/recruit/decan
 	head = /obj/item/clothing/head/helmet/f13/legion/recruit/decan
 	mask = /obj/item/clothing/mask/bandana/legion/legdecan
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	glasses = /obj/item/clothing/glasses/legiongoggles
 	r_pocket = /obj/item/flashlight/lantern
 	l_pocket = /obj/item/storage/survivalkit_tribal
@@ -591,7 +591,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	id = /obj/item/card/id/dogtag/legveteran
 	suit = /obj/item/clothing/suit/armor/legion/vet/vexil
 	mask = /obj/item/clothing/mask/bandana/legion/legvet
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	glasses = /obj/item/clothing/glasses/sunglasses
 	gloves = /obj/item/clothing/gloves/legion/plated
 	r_pocket = /obj/item/flashlight/lantern
@@ -675,7 +675,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	id = /obj/item/card/id/dogtag/legprime
 	suit = /obj/item/clothing/suit/armor/legion/vet/explorer
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/explorer
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	r_pocket = /obj/item/flashlight
 	l_pocket = /obj/item/binoculars
 	backpack_contents = list(
@@ -759,7 +759,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	id = /obj/item/card/id/dogtag/legveteran
 	mask = /obj/item/clothing/mask/bandana/legion/legvet
 	head = /obj/item/clothing/head/helmet/f13/legion/vet
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	suit = /obj/item/clothing/suit/armor/legion/vet
 	glasses = /obj/item/clothing/glasses/sunglasses
 	shoes = /obj/item/clothing/shoes/f13/military/plated
@@ -858,7 +858,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	id = /obj/item/card/id/dogtag/legprime
 	mask = /obj/item/clothing/mask/bandana/legion/legprime
 	head = /obj/item/clothing/head/helmet/f13/legion/prime
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	suit = /obj/item/clothing/suit/armor/legion/prime
 	glasses = /obj/item/clothing/glasses/legiongoggles
 	r_pocket = /obj/item/flashlight/lantern
@@ -1147,7 +1147,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Opifex (Artisan)"
 	neck = /obj/item/clothing/neck/apron/labor/forge
 	gloves = /obj/item/clothing/gloves/legion/forgemaster
-	belt = /obj/item/storage/belt
+	belt = /obj/item/storage/belt/fannypack
 	glasses = /obj/item/clothing/glasses/welding
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 	r_pocket = /obj/item/flashlight/lantern
@@ -1287,7 +1287,7 @@ Venator  - Zero slots, role built on cloning vet ranger, linear just vastly bett
 	suit = /obj/item/clothing/suit/armor/legion/venator
 	head = /obj/item/clothing/head/helmet/f13/legion/venator
 	mask = /obj/item/clothing/mask/bandana/legion/legdecan
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	glasses = /obj/item/clothing/glasses/night/polarizing
 	ears = /obj/item/radio/headset/headset_legion
 	r_pocket = /obj/item/binoculars

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -82,7 +82,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr
 	head = /obj/item/clothing/head/beret/ncr/ncr_sof
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	gloves = /obj/item/clothing/gloves/f13/leather
 	suit = /obj/item/clothing/suit/armor/power_armor/t45d/sierra
@@ -121,7 +121,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	accessory = /obj/item/clothing/accessory/ncr/CPL
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	head = /obj/item/clothing/head/f13/ncr
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
 	suit = /obj/item/clothing/suit/armor/ncrarmor/captain
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/deagle
@@ -182,7 +182,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr/CPT
 	mask = /obj/item/clothing/mask/cigarette/pipe
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	r_pocket = /obj/item/binoculars
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncr = 1,
@@ -250,7 +250,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes =	/obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	accessory = /obj/item/clothing/accessory/ncr/LT1
 	head = /obj/item/clothing/head/beret/ncr
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/night/ncr
 	gloves = /obj/item/clothing/gloves/f13/leather
 	ears = /obj/item/radio/headset/headset_ncr_com
@@ -325,7 +325,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	accessory = /obj/item/clothing/accessory/ncr/SGT
 	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
 	suit = /obj/item/clothing/suit/armor/ncrarmor/mantle/reinforced
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	backpack_contents = list(
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
 		/obj/item/grenade/f13/frag = 1,
@@ -409,7 +409,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_officer_boots
 	glasses	= /obj/item/clothing/glasses/sunglasses
 	head = /obj/item/clothing/head/f13/ncr/ncr_campaign
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/bayonet = 1,
 		/obj/item/storage/bag/money/small/ncrofficers = 1,
@@ -484,7 +484,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	uniform = /obj/item/clothing/under/f13/ncr/ncr_dress
 	jobtype	= /datum/job/ncr/f13representative
 	id = /obj/item/card/id/dogtag/ncrrep
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	backpack = /obj/item/storage/backpack/satchel/leather
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/revolver45 = 1,
@@ -572,7 +572,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	gloves = /obj/item/clothing/gloves/rifleman
 	shoes =	/obj/item/clothing/shoes/f13/military/leather
 	glasses	= /obj/item/clothing/glasses/sunglasses
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	ears = /obj/item/radio/headset/headset_ranger
 	mask = /obj/item/clothing/mask/gas/ranger
 	r_pocket = /obj/item/binoculars
@@ -666,10 +666,9 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	gloves = /obj/item/clothing/gloves/patrol
 	shoes = /obj/item/clothing/shoes/f13/military/leather
 	glasses	= /obj/item/clothing/glasses/sunglasses
-	belt = null
 	ears = /obj/item/radio/headset/headset_ranger
 	r_pocket = /obj/item/binoculars
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
@@ -776,7 +775,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	accessory =	/obj/item/clothing/accessory/ncr/SGT
 	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
 	head = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/ncr
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	suit = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/ncr
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
@@ -929,7 +928,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	name = "NCR Military Police"
 	jobtype	= /datum/job/ncr/f13mp
 	id = /obj/item/card/id/dogtag/ncrsergeant
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	accessory = /obj/item/clothing/accessory/armband/black
 	glasses	= /obj/item/clothing/glasses/sunglasses/big
 	head = /obj/item/clothing/head/f13/ncr/steelpot_mp
@@ -1065,7 +1064,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	name = "Squad Ranged Support"
 	suit = /obj/item/clothing/suit/armor/ncrarmor/mantle
 	head = /obj/item/clothing/head/f13/ncr/steelpot_bandolier
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	suit_store = /obj/item/gun/ballistic/automatic/marksman
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m556/rifle = 2,
@@ -1099,7 +1098,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	name = "Squad Pathfinder"
 	suit = /obj/item/clothing/suit/armor/ncrarmor/mantle
 	suit_store = /obj/item/gun/ballistic/automatic/m1carbine/compact
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	head = /obj/item/clothing/head/f13/ncr/steelpot_goggles
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
@@ -1273,7 +1272,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	shoes =	/obj/item/clothing/shoes/f13/military/ncr
 	accessory =	/obj/item/clothing/accessory/ncr/LT2
 	head = /obj/item/clothing/head/beret/ncr/ncr_medic
-	neck = /obj/item/storage/belt/holster/legholster
+	l_pocket = /obj/item/storage/belt/holster/legholster
 	glasses = /obj/item/clothing/glasses/hud/health/f13
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	ears = /obj/item/radio/headset/headset_ncr_com
@@ -1351,7 +1350,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	uniform	= /obj/item/clothing/under/f13/ncr/ncr_officer
 	accessory = /obj/item/clothing/accessory/ncr/LT2
 	head = /obj/item/clothing/head/beret/ncr/ncr_sapper
-	neck = /obj/item/storage/belt/holster/legholster
+	l_pocket = /obj/item/storage/belt/holster/legholster
 	suit = /obj/item/clothing/suit/armor/utilityvest/logisticsofficer
 	glasses	= /obj/item/clothing/glasses/welding
 	belt = /obj/item/storage/belt/military/assault/ncr/engineer
@@ -1448,7 +1447,7 @@ Weapons		Service Rifle, Grease Gun, 9mm pistol, all good.
 	suit = /obj/item/clothing/suit/armor/utilityvest
 	belt = /obj/item/storage/belt/medical
 	gloves = /obj/item/clothing/gloves/f13/leather/fingerless
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 		/obj/item/ammo_box/magazine/m9mmds = 2,

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -271,7 +271,7 @@ Mayor
 	name = "The Law Man"
 	suit = /obj/item/clothing/suit/armor/town/sheriff
 	head = /obj/item/clothing/head/f13/town/sheriff
-	neck = /obj/item/storage/belt/holster
+	l_pocket = /obj/item/storage/belt/holster
 	r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
 	belt = /obj/item/gun/ballistic/revolver/m29/peacekeeper
 	backpack_contents = list(
@@ -284,7 +284,7 @@ Mayor
 	uniform = /obj/item/clothing/under/f13/police/formal
 	suit = /obj/item/clothing/suit/armor/town/chief
 	head = /obj/item/clothing/head/f13/town/chief
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	shoes = /obj/item/clothing/shoes/jackboots
 	r_hand = /obj/item/gun/energy/laser/aer9
 
@@ -353,7 +353,7 @@ Mayor
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	belt = /obj/item/storage/belt/military/assault
 	suit = /obj/item/clothing/suit/armor/heavy/vest/bulletproof
-	neck = /obj/item/storage/belt/holster/legholster/police
+	suit_store = /obj/item/storage/belt/holster/legholster/police
 	l_pocket = /obj/item/storage/bag/money/small/settler
 	r_pocket = /obj/item/flashlight/flare
 	shoes = /obj/item/clothing/shoes/f13/explorer
@@ -368,7 +368,7 @@ Mayor
 	name = "Frontier Justice"
 	suit = /obj/item/clothing/suit/armor/town/deputy
 	head = /obj/item/clothing/head/f13/town/deputy
-	neck =	/obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 	r_hand = /obj/item/gun/ballistic/rifle/repeater/trail
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/m44 = 2,
@@ -381,7 +381,7 @@ Mayor
 	uniform = /obj/item/clothing/under/f13/police/officer
 	suit = /obj/item/clothing/suit/armor/heavy/vest/bulletproof
 	head = /obj/item/clothing/head/f13/town/officer
-	neck = /obj/item/storage/belt/holster/legholster
+	belt = /obj/item/storage/belt/holster/legholster
 	r_hand = /obj/item/gun/ballistic/shotgun/police
 	shoes = /obj/item/clothing/shoes/jackboots
 	backpack_contents = list(
@@ -730,7 +730,7 @@ Mayor
 /datum/outfit/loadout/groundskeeper
 	name = "Groundskeeper"
 	head = /obj/item/clothing/head/soft/grey
-	belt = /obj/item/storage/belt
+	belt = /obj/item/storage/belt/fannypack
 	suit = /obj/item/clothing/under/f13/mechanic
 	gloves = /obj/item/clothing/gloves/color/yellow
 	backpack_contents = list(/obj/item/storage/bag/trash = 1, /obj/item/reagent_containers/spray/cleaner = 1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -431,7 +431,7 @@ Raider
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	r_hand = /obj/item/storage/backpack/duffelbag/scavengers
 	l_hand = /obj/item/pickaxe/drill
-	belt = /obj/item/storage/belt
+	belt = /obj/item/storage/belt/fannypack
 	backpack_contents = list(/obj/item/mining_scanner=1,
 							/obj/item/metaldetector=1,
 							/obj/item/shovel=1,
@@ -443,7 +443,7 @@ Raider
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	r_hand = /obj/item/hatchet
 	l_hand = /obj/item/gun/ballistic/automatic/pistol/n99
-	belt = /obj/item/storage/belt
+	belt = /obj/item/storage/belt/fannypack
 	backpack_contents = list(
 		/obj/item/stack/sheet/metal = 50,
 		/obj/item/stack/sheet/mineral/wood = 50,

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -274,7 +274,7 @@ obj/effect/mob_spawn/human/corpse/raiderbossalt
 
 /obj/effect/mob_spawn/human/corpse/chineseremnant/pistol
 	name = "Chinese Remnant Pistoleer Corpse"
-	neck = /obj/item/storage/belt/holster
+	belt = /obj/item/storage/belt/holster
 
 /obj/effect/mob_spawn/human/corpse/chineseremnant/assault
 	name = "Chinese Remnant Assault Corpse"


### PR DESCRIPTION
## About The Pull Request

So first thing's first, you cant store a backpack on your suit anymore. I know, it was great, and it'll be back when i can get it to have some slowdown in that slot, but it was just too much loot hoarding for too little drawback.

Most specialized belts now hold a lot more. For instance, toolbelts can hold 14 items, and can also hold stuff that would fit in a mining belt, along with components, boards, mats, welding goggles, basically anything even vaguely tool-like. Also a chainsaw.

Also mining belts (and sinew belts) are essentially reskinned toolbelts. 

medibelts also hold 14 items, and can also hold a folded up IV stand, a needler and ammo, and a razor.

Holsters can hold a total of 7 guns, including rifles. However, bigger guns take up more room, meaning you can only hold *one* large gun in there, alongside a couple other tiny guns. Also, they can't hold ammo, but they can hold batons. Some holsters spawn with ammo in them, but that'll change when I figure out a better solution for the loadout spawns.

Bandoliers can hold a total of 14 ammoboxes or magazines.

Chest rigs now work like bandoliers, as do army and assault belts.

Snack rigs can hold 21 snacks in them, and come with a lot more snack.

Also, belts are now bulky, so you'll want to wear the darn thing. or carry it in a trashbin. either work!

Fixed the large survival kit's icon, and made it hold 21 tiny items. It also fits in your suit slot, for additional loot goblining.

Replaced most generic belt spawns with fannypacks, and made fannypacks fit as much as an old belt did.

Belt and holster crafting now uses a lot more metal and cloth instead of grass.

Holsters no longer go in the neck slot.