### PR TITLE
First pass of smithing changed

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define TOTAL_MASS_GIGANTIC_ITEM	7.5
 
 #define TOTAL_MASS_HAND_REPLACEMENT	5 //standard punching stamina cost. most hand replacements are huge items anyway.
-#define TOTAL_MASS_MEDIEVAL_WEAPON	3.6 //very, very generic average sword/warpick/etc. weight in pounds.
+#define TOTAL_MASS_MEDIEVAL_WEAPON	15 //very, very generic average sword/warpick/etc. weight in pounds.
 #define TOTAL_MASS_TOY_SWORD 1.5
 
 //stamina cost defines.

--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -11,3 +11,50 @@
 #define MARTIALART_BERSERKER "berserker"
 #define MARTIALART_RISINGBASS "rising bass"
 #define MARTIALART_RANGERTAKEDOWN "ranger takedown"
+
+/// Melee item defines
+/// Base forces!
+/// A small, generic tool
+#define WEAPON_FORCE_TOOL_SMALL 5
+/// A large, generic tool
+#define WEAPON_FORCE_TOOL_LARGE 10
+
+/// An axe designed as a tool
+#define WEAPON_FORCE_AXE_TOOL 15
+/// A small hatchet
+#define WEAPON_FORCE_AXE_SMALL 18
+/// A big axe
+#define WEAPON_FORCE_AXE_LARGE 20
+/// Two-handed axe multiplier
+#define WEAPON_AXE_TWOHAND_MULT 1.5
+
+/// A cutting thing designed as a tool (wirecutters)
+#define WEAPON_FORCE_SLASH_TOOL 5
+/// A small knife
+#define WEAPON_FORCE_SLASH_SMALL 10
+/// A large blade
+#define WEAPON_FORCE_SLASH_LARGE 15
+/// Two-handed blade multiplier
+#define WEAPON_SLASH_TWOHAND_MULT 1.5
+/// Slash wound addition
+#define WEAPON_SLASH_WOUND_ADD 50
+
+/// A pointed thing designed as a tool (screwdriver)
+#define WEAPON_FORCE_PIERCE_TOOL 5
+/// A small dagger
+#define WEAPON_FORCE_PIERCE_SMALL 7
+/// A long spear
+#define WEAPON_FORCE_PIERCE_LARGE 10
+/// Two-handed blade multiplier
+#define WEAPON_PIERCE_TWOHAND_MULT 1
+
+/// A blunt thing designed as a tool (wrench)
+#define WEAPON_FORCE_BLUNT_TOOL 5
+/// A small baton
+#define WEAPON_FORCE_BLUNT_SMALL 10
+/// A huge club
+#define WEAPON_FORCE_BLUNT_LARGE 15
+/// Two-handed blade multiplier
+#define WEAPON_BLUNT_TWOHAND_MULT 1
+/// Blunt wound addition
+#define WEAPON_BLUNT_WOUND_ADD 100 // limb wrecker

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -63,9 +63,9 @@
 	icon_state = "knife_kitchen"
 	item_state = "knife"
 	flags_1 = CONDUCT_1
-	force = 15
+	force = WEAPON_FORCE_SLASH_SMALL
 	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 15
+	throwforce = WEAPON_FORCE_SLASH_SMALL
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throw_speed = 3
 	throw_range = 6

--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -28,15 +28,43 @@
 #define RECIPE_THROWING "dbd" //draw bend draw
 
 //Tablevil specific
-#define RECIPE_MACHREFORG "fdf" //fold punch punch
-#define RECIPE_SCRAP "udsp" //upset draw shrink punch
-#define RECIPE_UNITOOL "bbb"  //bend bend bend
+#define RECIPE_MACHREFORG "fddf" //fold punch punch
+#define RECIPE_SCRAP "udpp" //upset draw shrink punch
+#define RECIPE_UNITOOL "bbu"  //bend bend upset
 
 //Legion specific
-#define RECIPE_LANCE "ddbf" //draw draw fold fold
-#define RECIPE_GLADIUS "fdf" //fold draw fold
-#define RECIPE_SPATHA "ffdf" // fold fold draw fold
-#define RECIPE_WARHONED "udsp" //upset draw shrink punch
+#define RECIPE_LANCE "dbdf" //draw bend fold fold
+#define RECIPE_GLADIUS "fbf" //fold bend fold
+#define RECIPE_SPATHA "ffbf" // fold fold bend fold
+#define RECIPE_WARHONED "udup" //upset draw upset punch
+
+GLOBAL_LIST_INIT(anvil_recipes, list(
+	RECIPE_HAMMER = /obj/item/smithing/hammerhead,
+	RECIPE_SHOVEL = /obj/item/smithing/shovelhead,
+	RECIPE_PICKAXE = /obj/item/smithing/pickaxehead,
+	RECIPE_PROSPECTPICK = /obj/item/smithing/prospectingpickhead,
+	RECIPE_KITCHENKNIFE = /obj/item/smithing/knifeblade,
+	RECIPE_CROWBAR = /obj/item/smithing/crowbar,
+	RECIPE_RING = /obj/item/smithing/special/jewelry/ring,
+	RECIPE_BALLANDCHAIN = /obj/item/smithing/ballandchain,
+	RECIPE_DAGGER = /obj/item/smithing/daggerblade,
+	RECIPE_MACHETE = /obj/item/smithing/macheteblade,
+	RECIPE_SWORD = /obj/item/smithing/swordblade,
+	RECIPE_SABRE = /obj/item/smithing/sabreblade,
+	RECIPE_WAKI = /obj/item/smithing/wakiblade,
+	RECIPE_KATANA = /obj/item/smithing/katanablade,
+	RECIPE_MACE = /obj/item/smithing/macehead,
+	RECIPE_AXE = /obj/item/smithing/axehead,
+	RECIPE_SPEAR = /obj/item/smithing/spearhead,
+	RECIPE_JAVELIN = /obj/item/smithing/javelinhead,
+	RECIPE_THROWING = /obj/item/smithing/throwingknife,
+	RECIPE_UNITOOL = /obj/item/smithing/unitool,
+	RECIPE_MACHREFORG = /obj/item/smithing/macheterblade,
+	RECIPE_SCRAP = /obj/item/smithing/scrapblade,
+	RECIPE_GLADIUS =  /obj/item/smithing/gladiusblade,
+	RECIPE_SPATHA = /obj/item/smithing/spathablade,
+	RECIPE_WARHONED = /obj/item/smithing/warhonedhead,
+	RECIPE_LANCE = /obj/item/smithing/lancehead))
 
 // Logic of smithing recipes: Tools start with bend and have 3 steps. 1h weapons have 3-4 steps. 2h weapons have 4-5 steps. Bigger bladed stuff start with a fold. Pointy stuff generally start with a draw. Unusual stuff migth start with upset.
 // Point of having a structure is obviously to help remember, not just keeping every recipe as pure rote memory with no internal logic. If you add more stuff and fuck this up and don't read comments I hope you get a prolapse. - Pebbles
@@ -64,26 +92,7 @@
 	var/debug = FALSE //vv this if you want an artifact
 	var/artifactrolled = FALSE
 	var/itemqualitymax = 8
-	var/list/smithrecipes = list(RECIPE_HAMMER = /obj/item/smithing/hammerhead,
-	RECIPE_SHOVEL = /obj/item/smithing/shovelhead,
-	RECIPE_PICKAXE = /obj/item/smithing/pickaxehead,
-	RECIPE_PROSPECTPICK = /obj/item/smithing/prospectingpickhead,
-	RECIPE_KITCHENKNIFE = /obj/item/smithing/knifeblade,
-	RECIPE_CROWBAR = /obj/item/smithing/crowbar,
-	RECIPE_RING = /obj/item/smithing/special/jewelry/ring,
-	RECIPE_BALLANDCHAIN = /obj/item/smithing/ballandchain,
-	RECIPE_DAGGER = /obj/item/smithing/daggerblade,
-	RECIPE_MACHETE = /obj/item/smithing/macheteblade,
-	RECIPE_SWORD = /obj/item/smithing/swordblade,
-	RECIPE_SABRE = /obj/item/smithing/sabreblade,
-	RECIPE_WAKI = /obj/item/smithing/wakiblade,
-	RECIPE_KATANA = /obj/item/smithing/katanablade,
-	RECIPE_MACE = /obj/item/smithing/macehead,
-	RECIPE_AXE = /obj/item/smithing/axehead,
-	RECIPE_SPEAR = /obj/item/smithing/spearhead,
-	RECIPE_JAVELIN = /obj/item/smithing/javelinhead,
-	RECIPE_THROWING = /obj/item/smithing/throwingknife,
-)
+
 
 /obj/structure/anvil/Initialize()
 	. = ..()
@@ -283,10 +292,10 @@
 		return SetBusy(FALSE, user) 
 	
 	// IF YOU DIDN'T FUCK UP THE RECIPE
-	for(var/i in smithrecipes) // for each recipes.
+	for(var/i in GLOB.anvil_recipes) // for each recipes.
 		if(i == stepsdone) // if... "cum" == "bbu" idfk what the fuck am I looking at why isnt this a GLOB recipe list...
 
-			var/obj/item/smithing/finisheditem = smithrecipes[stepsdone]
+			var/obj/item/smithing/finisheditem = GLOB.anvil_recipes[stepsdone]
 			finisheditem = new finisheditem(get_turf(src)) // Lets just spawn the item in immediately!
 
 			to_chat(user, "You finish your [finisheditem]!")
@@ -349,27 +358,6 @@
 	currentquality = 1
 	itemqualitymax = 8
 	anchored = TRUE
-	smithrecipes = list(RECIPE_HAMMER = /obj/item/smithing/hammerhead,
-	RECIPE_SHOVEL = /obj/item/smithing/shovelhead,
-	RECIPE_PICKAXE = /obj/item/smithing/pickaxehead,
-	RECIPE_PROSPECTPICK = /obj/item/smithing/prospectingpickhead,
-	RECIPE_KITCHENKNIFE = /obj/item/smithing/knifeblade,
-	RECIPE_CROWBAR = /obj/item/smithing/crowbar,
-	RECIPE_RING = /obj/item/smithing/special/jewelry/ring,
-	RECIPE_BALLANDCHAIN = /obj/item/smithing/ballandchain,
-	RECIPE_DAGGER = /obj/item/smithing/daggerblade,
-	RECIPE_GLADIUS =  /obj/item/smithing/gladiusblade,
-	RECIPE_SPATHA = /obj/item/smithing/spathablade,
-	RECIPE_SABRE = /obj/item/smithing/sabreblade,
-	RECIPE_WAKI = /obj/item/smithing/wakiblade,
-	RECIPE_KATANA = /obj/item/smithing/katanablade,
-	RECIPE_MACE = /obj/item/smithing/macehead,
-	RECIPE_WARHONED = /obj/item/smithing/warhonedhead,
-	RECIPE_LANCE = /obj/item/smithing/lancehead,
-	RECIPE_JAVELIN = /obj/item/smithing/javelinhead,
-	RECIPE_THROWING = /obj/item/smithing/throwingknife,
-)
-
 
 // Decent makeshift anvil, can break, mobile. Gets the exclusive scrap version of the machete and 2h chopper, as well as the universal tool instead of a crowbar
 /obj/structure/anvil/obtainable/table
@@ -378,26 +366,6 @@
 	icon_state = "tablevil"
 	currentquality = 0
 	itemqualitymax = 7
-	smithrecipes = list(RECIPE_HAMMER = /obj/item/smithing/hammerhead,
-	RECIPE_SHOVEL = /obj/item/smithing/shovelhead,
-	RECIPE_PICKAXE = /obj/item/smithing/pickaxehead,
-	RECIPE_PROSPECTPICK = /obj/item/smithing/prospectingpickhead,
-	RECIPE_KITCHENKNIFE = /obj/item/smithing/knifeblade,
-	RECIPE_UNITOOL = /obj/item/smithing/unitool,
-	RECIPE_RING = /obj/item/smithing/special/jewelry/ring,
-	RECIPE_BALLANDCHAIN = /obj/item/smithing/ballandchain,
-	RECIPE_DAGGER = /obj/item/smithing/daggerblade,
-	RECIPE_MACHREFORG = /obj/item/smithing/macheterblade,
-	RECIPE_SWORD = /obj/item/smithing/swordblade,
-	RECIPE_SABRE = /obj/item/smithing/sabreblade,
-	RECIPE_WAKI = /obj/item/smithing/wakiblade,
-	RECIPE_KATANA = /obj/item/smithing/katanablade,
-	RECIPE_MACE = /obj/item/smithing/macehead,
-	RECIPE_SPEAR = /obj/item/smithing/spearhead,
-	RECIPE_SCRAP = /obj/item/smithing/scrapblade,
-	RECIPE_JAVELIN = /obj/item/smithing/javelinhead,
-	RECIPE_THROWING = /obj/item/smithing/throwingknife,
-)
 
 /obj/structure/anvil/obtainable/table/wrench_act(mob/living/user, obj/item/I)
 	..()

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -10,13 +10,13 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON //yeah ok
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 6
+	force = WEAPON_FORCE_TOOL_SMALL
 	obj_flags = UNIQUE_RENAME
 	var/quality
 	var/overlay_state = "stick"
 	var/mutable_appearance/overlay
 	var/wielded_mult = 1
-	var/wield_force = 15
+	var/wield_force = 15 // does nothing
 
 /obj/item/melee/smith/Initialize()
 	..()
@@ -36,8 +36,8 @@
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	force = 10
-	wielded_mult = 1.8
+	force = WEAPON_FORCE_TOOL_LARGE
+	wielded_mult = WEAPON_SLASH_TWOHAND_MULT
 	w_class = WEIGHT_CLASS_BULKY
 	var/icon_prefix = null
 	var/wielded = FALSE
@@ -168,7 +168,7 @@
 	icon_state = "crowbar_smith"
 	item_state = "crowbar"
 	toolspeed = 0.8
-	force = 15
+	force = WEAPON_FORCE_TOOL_LARGE
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
 /obj/item/crowbar/smithed/Initialize()
@@ -181,15 +181,15 @@
 
 // Crowbar-axe. Just a crowbar with more force and a homemade vibe.
 /obj/item/crowbar/smithedunitool
-	name = "universal tool"
+	name = "crowbaxe"
 	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
 	icon_state = "unitool_smith"
 	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
 	item_state = "unitool_smith"
-	sharpness = SHARP_POINTY
+	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	force = 28
+	force = WEAPON_FORCE_AXE_TOOL
 
 /obj/item/crowbar/smithedunitool/Initialize()
 	..()
@@ -208,45 +208,41 @@
 //////////////////////////
 
 /obj/item/melee/smith/sword
-	name = "sword"
+	name = "scrap sword"
 	icon_state = "sword_smith"
 	item_state = "sword_smith"
 	overlay_state = "hilt_sword"
 	armour_penetration = 0.1
-	force = 25
+	force = WEAPON_FORCE_SLASH_LARGE
 	sharpness = SHARP_EDGED
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/captain_saber
 	w_class = WEIGHT_CLASS_BULKY
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
-	wound_bonus = 20
-	block_chance = 50
+	wound_bonus = WEAPON_SLASH_WOUND_ADD
+	//block_chance = 50
 
 /obj/item/melee/smith/sword/spatha
-	name = "spatha"
+	name = "papercutter"
 	icon_state = "spatha_smith"
 	item_state = "spatha_smith"
 	overlay_state = "hilt_spatha"
-	block_chance = 60
 
 /obj/item/melee/smith/sword/sabre
-	name = "sabre"
+	name = "bumper sabre"
 	icon_state = "sabre_smith"
 	item_state = "sabre_smith"
 	overlay_state = "hilt_sabre"
-	armour_penetration = 0.15
-	force = 24
-	block_chance = 55
 
 // go for the eyes Boo
 /obj/item/melee/smith/dagger
-	name = "dagger"
+	name = "shiv"
 	icon_state = "dagger_smith"
 	overlay_state = "hilt_dagger"
 	w_class = WEIGHT_CLASS_SMALL
-	sharpness = SHARP_EDGED
-	force = 24
+	sharpness = SHARP_POINTY
+	force = WEAPON_FORCE_PIERCE_SMALL
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
 /obj/item/melee/smith/dagger/attack(mob/living/carbon/M, mob/living/carbon/user)
@@ -262,31 +258,32 @@
 	name = "machete"
 	icon_state = "machete_smith"
 	overlay_state = "hilt_machete"
-	force = 24
+	force = WEAPON_FORCE_SLASH_LARGE
 	sharpness = SHARP_EDGED
-	wound_bonus = 30
-	block_chance = 20
+	wound_bonus = WEAPON_SLASH_WOUND_ADD
 
 /obj/item/melee/smith/machete/gladius
-	name = "gladius"
+	name = "razorbar"
 	icon_state = "gladius_smith"
 	overlay_state = "hilt_gladius"
 
 /obj/item/melee/smith/machete/reforged
-	name = "reforged machete"
+	name = "mowerchete"
 	icon_state = "macheter_smith"
 	overlay_state = "hilt_macheter"
 
 /obj/item/melee/smith/wakizashi
-	name = "wakizashi"
+	name = "weedwhacker"
 	icon_state = "waki_smith"
 	overlay_state = "hilt_waki"
-	sharpness = SHARP_EDGED
-	force = 24
 	item_flags = NEEDS_PERMIT | ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/waki
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	block_chance = 60
+
+/obj/item/melee/smith/wakizashi/Initialize()
+	if(prob(1))
+		name = pick("weebwhacker", "weedhacker", "weebhacker", "weewhacker")
+	. = ..()
 
 /datum/block_parry_data/waki //like longbokken but worse reflect
 	parry_stamina_cost = 6
@@ -304,10 +301,11 @@
 
 // Mace - low damage, high AP (25, 0,4)
 /obj/item/melee/smith/mace
-	name = "mace"
+	name = "club"
 	icon_state = "mace_smith"
 	overlay_state = "handle_mace"
-	force = 15
+	force = WEAPON_FORCE_BLUNT_LARGE
+	wound_bonus = WEAPON_BLUNT_WOUND_ADD
 
 /obj/item/melee/smith/mace/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -323,19 +321,18 @@
 //////////////////////////
 
 /obj/item/melee/smith/twohand/katana
-	name = "katana"
+	name = "scraptana"
 	icon_state = "katana_smith"
 	icon_prefix = "katana_smith"
 	overlay_state = "hilt_katana"
-	force = 22
-	wielded_mult = 1.5
+	force = WEAPON_FORCE_SLASH_LARGE
+	wielded_mult = WEAPON_SLASH_TWOHAND_MULT
 	item_flags = ITEM_CAN_PARRY | NEEDS_PERMIT
 	block_parry_data = /datum/block_parry_data/smithrapier
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	slot_flags = ITEM_SLOT_BELT
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
-	block_chance = 50
 
 /datum/block_parry_data/smithrapier //Old rapier code reused. parry into riposte. i am pretty sure this is going to be nearly fucking impossible to land.
 	parry_stamina_cost = 12 //dont miss
@@ -354,80 +351,48 @@
 
 // Heavy axe, 2H focused chopper 27/54. Can be worn on your back.
 /obj/item/melee/smith/twohand/axe
-	name = "heavy axe"
+	name = "woodsplitter"
 	icon_state = "axe_smith"
 	icon_prefix = "axe_smith"
 	overlay_state = "shaft_axe"
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
-	force = 18
-	wielded_mult = 2
+	force = WEAPON_FORCE_AXE_LARGE
+	wielded_mult = WEAPON_AXE_TWOHAND_MULT
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	layer = MOB_UPPER_LAYER
-	wound_bonus = 10
-	bare_wound_bonus = 10
 
 /obj/item/melee/smith/twohand/axe/afterattack(atom/A, mob/living/user, proximity)
 	. = ..()
 	if(!proximity || !wielded || IS_STAMCRIT(user))
 		return
-	if(istype(A, /obj/machinery/door))
+	if(istype(A, /obj/machinery/door) || istype(A, /obj/structure/simple_door) || istype(A, /obj/structure/barricade))
 		var/obj/machinery/door/D = A
-		D.take_damage(20, BRUTE, "melee", 0)
-	else if(istype(A, /obj/structure/simple_door))
-		var/obj/structure/simple_door/M = A
-		M.take_damage(20, BRUTE, "melee", 0)
+		D.take_damage(force, BRUTE, "melee", 0) // DOORFUCKER 9000
 
-
-// Legion axe
 /obj/item/melee/smith/twohand/axe/warhoned
-	name = "war honed axe"
+	name = "sledge axe"
 	icon_state = "warhoned_smith"
 	icon_prefix = "warhoned_smith"
 	overlay_state = "shaft_warhoned"
 
-/obj/item/melee/smith/twohand/axe/warhoned/afterattack(atom/A, mob/living/user, proximity)
-	. = ..()
-	if(!proximity || !wielded || IS_STAMCRIT(user))
-		return
-	if(istype(A, /obj/machinery/door))
-		var/obj/machinery/door/D = A
-		D.take_damage(20, BRUTE, "melee", 0)
-	else if(istype(A, /obj/structure/simple_door))
-		var/obj/structure/simple_door/M = A
-		M.take_damage(20, BRUTE, "melee", 0)
-
-// Scrap blade. 1/2 H chopper, variant on the axe basically 32/48. Can be worn on your back.
 /obj/item/melee/smith/twohand/axe/scrapblade
-	name = "scrap blade"
+	name = "homewrecker"
 	icon_state = "scrap_smith"
 	icon_prefix = "scrap_smith"
 	overlay_state = "hilt_scrap"
-	force = 21
-	wielded_mult = 1.5
-
-/obj/item/melee/smith/twohand/axe/scrapblade/afterattack(atom/A, mob/living/user, proximity)
-	. = ..()
-	if(!proximity || !wielded || IS_STAMCRIT(user))
-		return
-	if(istype(A, /obj/machinery/door))
-		var/obj/machinery/door/D = A
-		D.take_damage(20, BRUTE, "melee", 0)
-	else if(istype(A, /obj/structure/simple_door))
-		var/obj/structure/simple_door/M = A
-		M.take_damage(20, BRUTE, "melee", 0)
 
 /obj/item/melee/smith/twohand/spear
-	name = "spear"
+	name = "rebar spear"
 	icon_state = "spear_smith"
 	icon_prefix = "spear_smith"
 	overlay_state = "shaft_spear"
 	max_reach = 2
-	force = 10
+	force = WEAPON_FORCE_PIERCE_LARGE
 	sharpness = SHARP_POINTY
 
 /obj/item/melee/smith/twohand/spear/lance
-	name = "legion lance"
+	name = "rebar lance"
 	icon_state = "lance_smith"
 	icon_prefix = "lance_smith"
 	overlay_state = "shaft_lance"
@@ -442,24 +407,24 @@
 
 // Good throwing, thats about it (27, 40)
 /obj/item/melee/smith/javelin 
-	name = "javelin"
+	name = "rebar throwing spike"
 	icon_state = "javelin_smith"
 	overlay_state = "shaft_javelin"
 	item_state = "javelin_smith"
 	sharpness = SHARP_POINTY
 	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 15
-	armour_penetration = 0.10
+	force = WEAPON_FORCE_PIERCE_LARGE
+	sharpness = SHARP_POINTY
 
 // Smaller weaker javelin, easier to store/carry, less effective
 /obj/item/melee/smith/throwingknife
-	name = "throwing knife"
+	name = "mower blade"
 	icon_state = "throwing_smith"
 	overlay_state = "handle_throwing"
 	item_state = "dagger_smith"
 	embedding = list("pain_mult" = 2, "embed_chance" = 50, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
-	force = 14
-	w_class = WEIGHT_CLASS_SMALL
+	force = WEAPON_FORCE_PIERCE_SMALL
+	sharpness = SHARP_POINTY
 
 
 // TG stuff

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -107,15 +107,15 @@
 		if(-1 to 1)
 			qualname = "normal"
 		if(10 to INFINITY)
-			qualname = "legendary"
-		if(7.5 to 10)
-			qualname = "masterwork"
-		if(5.5 to 7.5)
-			qualname = "excellent"
-		if(3.5 to 5.5)
 			qualname = "good"
+		if(7.5 to 10)
+			qualname = "fair"
+		if(5.5 to 7.5)
+			qualname = "makeshift"
+		if(3.5 to 5.5)
+			qualname = "crude"
 		if(0 to 3.5)
-			qualname = "above-average"
+			qualname = "improvised"
 	var/datum/material/mat = custom_materials[1]
 	finalitem.set_custom_materials(custom_materials)
 	mat = mat.name
@@ -247,7 +247,8 @@
 		finalforreal.toolspeed = max(0.05,(1-(quality/10)))
 	else
 		finalforreal.toolspeed *= max(1, (quality * -1))
-	switch(quality)
+	finalforreal.digrange = 1
+/* 	switch(quality)
 		if(10 to INFINITY)
 			finalforreal.digrange = 2
 		if(5 to 9)
@@ -255,7 +256,7 @@
 		if(3,4)
 			finalforreal.digrange = 1
 		else
-			finalforreal.digrange = 1
+			finalforreal.digrange = 1 */
 	finalitem = finalforreal
 	..()
 
@@ -296,7 +297,7 @@
 
 // Does not produce the expected result with force dependent on quality, instead just uses the base one. The finished item is a placeholder, it works though.
 /obj/item/smithing/unitool
-	name = "unwrapped universal tool"
+	name = "unwrapped crowbaxe"
 	desc = "Add leather strips."
 	icon_state = "unitool_smith"
 	finishingitem = /obj/item/stack/sheet/leatherstrips
@@ -318,7 +319,7 @@
 /obj/item/smithing/knifeblade/startfinish()
 	var/obj/item/smithing/knifeblade/finalforreal = new /obj/item/smithing/knifeblade(src)
 	finalitem = new /obj/item/kitchen/knife(src)
-	finalforreal.force += quality*3
+	finalforreal.force += quality*2
 	finalitem = finalforreal
 	finalitem.icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
 	finalitem.icon_state = "knife_smith"
@@ -418,46 +419,46 @@
 ///////////////
 
 /obj/item/smithing/swordblade
-	name = "smithed swordblade"
+	name = "sharpened longblade"
 	icon_state = "sword_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/sword
 
 /obj/item/smithing/swordblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sword(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 /obj/item/smithing/sabreblade
-	name = "smithed sabre blade"
+	name = "scrap sabre blade"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/sword/sabre
 	icon_state = "sabre_smith"
 
 /obj/item/smithing/sabreblade/startfinish()
 	finalitem = new /obj/item/melee/smith/sword/sabre(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 /obj/item/smithing/spathablade
-	name = "smithed spathablade"
+	name = "papercutter blade"
 	icon_state = "spatha_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/sword/spatha
 
 /obj/item/smithing/spathablade/startfinish()
 	finalitem = new /obj/item/melee/smith/sword/spatha(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 /obj/item/smithing/spearhead
-	name = "smithed spearhead"
+	name = "sharpened length of rebar"
 	finalitem = /obj/item/melee/smith/twohand/spear
 	icon_state = "spear_smith"
 
 /obj/item/smithing/spearhead/startfinish()
 	var/obj/item/melee/smith/twohand/spear/finalforreal = new /obj/item/melee/smith/twohand/spear(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalforreal.throwforce = finalforreal.force/10
@@ -466,13 +467,13 @@
 
 
 /obj/item/smithing/lancehead
-	name = "smithed lancehead"
+	name = "pointy length of rebar"
 	finalitem = /obj/item/melee/smith/twohand/spear/lance
 	icon_state = "lance_smith"
 
 /obj/item/smithing/lancehead/startfinish()
 	var/obj/item/melee/smith/twohand/spear/lance/finalforreal = new /obj/item/melee/smith/twohand/spear/lance(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalforreal.throwforce = finalforreal.force/10
@@ -487,34 +488,34 @@
 
 /obj/item/smithing/axehead/startfinish()
 	var/obj/item/melee/smith/twohand/axe/finalforreal = new /obj/item/melee/smith/twohand/axe(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalitem = finalforreal
 	..()
 
 /obj/item/smithing/warhonedhead
-	name = "smithed axehead"
+	name = "sharpened wedge"
 	icon_state = "warhoned_smith"
 	finalitem = /obj/item/melee/smith/twohand/axe/warhoned
 
 /obj/item/smithing/warhonedhead/startfinish()
 	var/obj/item/melee/smith/twohand/axe/warhoned/finalforreal = new /obj/item/melee/smith/twohand/axe/warhoned(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalitem = finalforreal
 	..()
 
 /obj/item/smithing/scrapblade
-	name = "smithed scrap blade"
+	name = "jagged wedge"
 	icon_state = "scrap_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/twohand/axe/scrapblade
 
 /obj/item/smithing/scrapblade/startfinish()
 	var/obj/item/melee/smith/twohand/axe/scrapblade/finalforreal = new /obj/item/melee/smith/twohand/axe/scrapblade(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalitem = finalforreal
@@ -522,88 +523,88 @@
 
 
 /obj/item/smithing/daggerblade
-	name = "smithed dagger blade"
+	name = "spike"
 	icon_state = "dagger_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/dagger
 
 /obj/item/smithing/daggerblade/startfinish()
 	finalitem = new /obj/item/melee/smith/dagger(src)
-	finalitem.force += quality*1.5
-	finalitem.armour_penetration += quality*0.0375
+	finalitem.force += quality
+	//finalitem.armour_penetration += quality*0.0375
 	..()
 
 
 /obj/item/smithing/macheteblade
-	name = "smithed machete blade"
+	name = "sharpened blade"
 	icon_state = "machete_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/machete
 
 /obj/item/smithing/macheteblade/startfinish()
 	finalitem = new /obj/item/melee/smith/machete(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 
 /obj/item/smithing/gladiusblade
-	name = "smithed gladius blade"
+	name = "razorbar"
 	icon_state = "gladius_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/machete/gladius
 
 /obj/item/smithing/gladiusblade/startfinish()
 	finalitem = new /obj/item/melee/smith/machete/gladius(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 
 /obj/item/smithing/macheterblade
-	name = "reforged machete blade"
+	name = "welded together lawnmower blades"
 	icon_state = "macheter_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/machete/reforged
 
 /obj/item/smithing/macheterblade/startfinish()
 	finalitem = new /obj/item/melee/smith/machete/reforged(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 /obj/item/smithing/macehead
-	name = "smithed macehead"
+	name = "heavy lump"
 	icon_state = "mace_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/mace
 
 /obj/item/smithing/macehead/startfinish()
 	finalitem = new /obj/item/melee/smith/mace(src)
-	finalitem.force += quality*1.5
-	finalitem.armour_penetration += quality*0.05
+	finalitem.force += quality
+	//finalitem.armour_penetration += quality*0.05
 	..()
 
 
 
 /obj/item/smithing/wakiblade
-	name = "smithed wakizashi blade"
+	name = "shortblade"
 	icon_state = "waki_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/wakizashi
 
 /obj/item/smithing/wakiblade/startfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
-	finalitem.force += quality*1.5
+	finalitem.force += quality
 	..()
 
 
 /obj/item/smithing/katanablade
-	name = "smithed katana blade"
+	name = "longblade"
 	icon_state = "katana_smith"
 	finishingitem = /obj/item/blacksmith/swordhandle
 	finalitem = /obj/item/melee/smith/twohand/katana
 
 /obj/item/smithing/katanablade/startfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.wield_force = finalforreal.force*finalforreal.wielded_mult
 	finalforreal.AddComponent(/datum/component/two_handed, force_unwielded=finalforreal.force, force_wielded=finalforreal.wield_force, icon_wielded="[icon_state]2")
 	finalitem = finalforreal
@@ -611,20 +612,20 @@
 
 
 /obj/item/smithing/javelinhead
-	name = "smithed javelin head"
+	name = "streamlined rebar spike"
 	icon_state = "javelin_smith"
 	finalitem = /obj/item/melee/smith/javelin
 
 /obj/item/smithing/javelinhead/startfinish()
 	var/obj/item/melee/smith/javelin/finalforreal = new /obj/item/melee/smith/javelin(src)
-	finalforreal.force += quality*1.5
+	finalforreal.force += quality
 	finalforreal.throwforce = finalforreal.force*1.5
 	finalitem = finalforreal
 	..()
 
 
 /obj/item/smithing/throwingknife
-	name = "unfinished throwing knife"
+	name = "shortened lawnmower blade"
 	desc = "Add leather strips."
 	icon_state = "throwing_smith"
 	finishingitem = /obj/item/stack/sheet/leatherstrips
@@ -632,7 +633,7 @@
 
 /obj/item/smithing/throwingknife/startfinish()
 	var/obj/item/melee/smith/throwingknife/finalforreal = new /obj/item/melee/smith/throwingknife(src)
-	finalforreal.force += quality*1.4
+	finalforreal.force += quality
 	finalforreal.throwforce = finalforreal.force*1.4
 	finalitem = finalforreal
 	..()


### PR DESCRIPTION
## About The Pull Request

Some crude changes to smithing.

First, just about every smithed weapon has been nerfed in some way. Swords all do roughly the same thing, (15 *1.1) + 8 damage, + 50% when wielded if available. They also do a lot of wounding damage, if you want to PVP with it.

Maces do a lot of fracture damage.

Axes do a shitload of damage to most doors and barricades.

Removed blockchance on all smithed weapons.

All recipes are available on all anvils.

Reflavored the weapons that are craftable.

AS WITH ALL THINGS these are subject to change!