### PR TITLE
Raiders and Ghouls drop caps

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -844,24 +844,15 @@ GLOBAL_LIST_INIT(loot_material, list(
 ))
 
 GLOBAL_LIST_INIT(loot_t1_money, list(
-	/obj/item/stack/f13Cash/random/low,
-	/obj/item/stack/f13Cash/random/ncr/low,
-	/obj/item/stack/f13Cash/random/denarius/low,
-	/obj/item/stack/f13Cash/random/aureus/low
+	/obj/item/stack/f13Cash/random/low
 ))
 
 GLOBAL_LIST_INIT(loot_t2_money, list(
-	/obj/item/stack/f13Cash/random/med,
-	/obj/item/stack/f13Cash/random/ncr/med,
-	/obj/item/stack/f13Cash/random/denarius/med,
-	/obj/item/stack/f13Cash/random/aureus/med
+	/obj/item/stack/f13Cash/random/med
 ))
 
 GLOBAL_LIST_INIT(loot_t3_money, list(
-	/obj/item/stack/f13Cash/random/high,
-	/obj/item/stack/f13Cash/random/ncr/high,
-	/obj/item/stack/f13Cash/random/denarius/high,
-	/obj/item/stack/f13Cash/random/aureus/high
+	/obj/item/stack/f13Cash/random/high
 ))
 
 GLOBAL_LIST_INIT(loot_skillbook, list(

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -119,10 +119,12 @@
 	var/money_type = /obj/item/stack/f13Cash/caps
 	var/min_qty = LOW_MIN
 	var/max_qty = LOW_MAX
+	var/spawn_nothing_chance = 0 //chance no money at all spawns
 
 /obj/item/stack/f13Cash/random/Initialize()
 	..()
-	spawn_money()
+	if(!prob(spawn_nothing_chance))
+		spawn_money()
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/stack/f13Cash/random/proc/spawn_money()
@@ -150,6 +152,12 @@
 /obj/item/stack/f13Cash/random/low
 	min_qty = LOW_MIN / CASH_CAP
 	max_qty = LOW_MAX / CASH_CAP
+
+/obj/item/stack/f13Cash/random/low/lowchance
+	spawn_nothing_chance = 75
+
+/obj/item/stack/f13Cash/random/low/medchance
+	spawn_nothing_chance = 50
 
 /obj/item/stack/f13Cash/random/med
 	min_qty = MED_MIN / CASH_CAP

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -50,6 +50,7 @@
 	aggrosound = list('sound/f13npc/ghoul/aggro1.ogg', 'sound/f13npc/ghoul/aggro2.ogg')
 	idlesound = list('sound/f13npc/ghoul/idle.ogg')
 	death_sound = 'sound/f13npc/ghoul/ghoul_death.ogg'
+	loot = list(/obj/item/stack/f13Cash/random/low/lowchance)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 
 
@@ -66,6 +67,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 
 /mob/living/simple_animal/hostile/ghoul/reaver/Initialize()
@@ -104,6 +106,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 
 //Frozen Feral Ghoul
@@ -119,6 +122,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	
 //Legendary Ghoul
@@ -138,6 +142,7 @@
 	mob_size = 5
 	wound_bonus = 0
 	bare_wound_bonus = 0
+	loot = list(/obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	
 //Glowing Ghoul
@@ -193,6 +198,7 @@
 	icon_gib = "syndicate_gib"
 	maxHealth = 90
 	health = 90
+	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	
 //Alive Ghoul

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -25,7 +25,7 @@
 	check_friendly_fire = TRUE
 	status_flags = CANPUSH
 	del_on_death = FALSE
-	loot = list(/obj/item/melee/onehanded/knife/survival)
+	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /obj/effect/mob_spawn/human/corpse/raider
@@ -84,7 +84,7 @@
 	minimum_distance = 6
 	projectiletype = /obj/item/projectile/bullet/c9mm/op
 	projectilesound = 'sound/f13weapons/ninemil.ogg'
-	loot = list(/obj/effect/spawner/lootdrop/f13/npc_raider)
+	loot = list(/obj/effect/spawner/lootdrop/f13/npc_raider, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // LEGENDARY MELEE RAIDER
@@ -97,7 +97,7 @@
 	speed = 1.2
 	obj_damage = 300
 	aggro_vision_range = 15
-	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/reagent_containers/food/snacks/kebab/human)
+	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/reagent_containers/food/snacks/kebab/human, /obj/item/stack/f13Cash/random/high)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // LEGENDARY RANGED RAIDER
@@ -114,7 +114,7 @@
 	extra_projectiles = 1
 	aggro_vision_range = 15
 	obj_damage = 300
-	loot = list(/obj/item/gun/ballistic/revolver/m29)
+	loot = list(/obj/item/gun/ballistic/revolver/m29, /obj/item/stack/f13Cash/random/high)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // RAIDER BOSS
@@ -127,7 +127,7 @@
 	health = 170
 	extra_projectiles = 3
 	projectiletype = /obj/item/projectile/bullet/c45/op
-	loot = list(/obj/item/gun/ballistic/automatic/smg/greasegun, /obj/item/clothing/head/helmet/f13/combat/mk2/raider, /obj/item/clothing/suit/armor/medium/combat/mk2/raider, /obj/item/clothing/under/f13/ravenharness)
+	loot = list(/obj/item/gun/ballistic/automatic/smg/greasegun, /obj/item/clothing/head/helmet/f13/combat/mk2/raider, /obj/item/clothing/suit/armor/medium/combat/mk2/raider, /obj/item/clothing/under/f13/ravenharness, /obj/item/stack/f13Cash/random/high)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /mob/living/simple_animal/hostile/raider/ranged/boss/Aggro()
@@ -144,7 +144,7 @@
 	health = 180
 	projectiletype = /obj/item/projectile/bullet/c45/op
 	projectilesound = 'sound/weapons/gunshot.ogg'
-	loot = list(/obj/item/gun/ballistic/automatic/pistol/m1911/custom, /obj/item/clothing/suit/armor/heavy/metal/reinforced, /obj/item/clothing/head/helmet/f13/metalmask/mk2)
+	loot = list(/obj/item/gun/ballistic/automatic/pistol/m1911/custom, /obj/item/clothing/suit/armor/heavy/metal/reinforced, /obj/item/clothing/head/helmet/f13/metalmask/mk2, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // FIREFIGHTER RAIDER
@@ -152,7 +152,7 @@
 	icon_state = "firefighter_raider"
 	icon_living = "firefighter_raider"
 	icon_dead = "firefighter_raider_dead"
-	loot = list(/obj/item/twohanded/fireaxe)
+	loot = list(/obj/item/twohanded/fireaxe, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // BIKER RAIDER
@@ -167,7 +167,7 @@
 	projectiletype = /obj/item/projectile/bullet/a556/match
 	projectilesound = 'sound/f13weapons/magnum_fire.ogg'
 	casingtype = /obj/item/ammo_casing/a556
-	loot = list(/obj/item/gun/ballistic/revolver/thatgun, /obj/item/clothing/suit/armor/medium/combat/rusted, /obj/item/clothing/head/helmet/f13/raidercombathelmet)
+	loot = list(/obj/item/gun/ballistic/revolver/thatgun, /obj/item/clothing/suit/armor/medium/combat/rusted, /obj/item/clothing/head/helmet/f13/raidercombathelmet, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /obj/effect/mob_spawn/human/corpse/raider/ranged/biker
@@ -191,7 +191,7 @@
 	melee_damage_upper = 40
 	maxHealth = 200
 	health = 200
-	loot = list(/obj/item/twohanded/baseball)
+	loot = list(/obj/item/twohanded/baseball, /obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 
@@ -236,7 +236,7 @@
 	health = 220
 	melee_damage_lower = 40
 	melee_damage_upper = 55
-	loot = list(/obj/item/locked_box/misc/money/all/low)
+	loot = list(/obj/item/stack/f13Cash/random/med)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /////////////
@@ -254,7 +254,6 @@
 	health = 220
 	melee_damage_lower = 40
 	melee_damage_upper = 55
-	loot = null
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker
@@ -337,5 +336,6 @@
 	ranged_cooldown_time = 15
 	projectiletype = /obj/item/projectile/bullet/shrapnel
 	projectilesound = 'sound/f13weapons/auto5.ogg'
+	loot = list(/obj/item/stack/f13Cash/random/high)
 	footstep_type = FOOTSTEP_MOB_SHOE
 

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -134,7 +134,7 @@
 	minimum_distance = 6
 	projectiletype = /obj/item/projectile/bullet/a762/sport/simple
 	projectilesound = 'sound/f13weapons/hunting_rifle.ogg'
-	loot = list(/obj/item/ammo_box/a308)
+	loot = list(/obj/item/ammo_box/a308, /obj/item/gun/ballistic/rifle/hunting)
 	footstep_type = FOOTSTEP_MOB_HEAVY
 
 /mob/living/simple_animal/hostile/supermutant/rangedmutant/death(gibbed)


### PR DESCRIPTION
## About The Pull Request

Raiders drop some caps on death (bosses drop more)
Ghouls will SOMETIMES drop some caps when they die
Supermutants carrying hunting rifles now drop the hunting rifles after dying
The time travellers bringing NCR dollars and Legion coins from the future have been dealt with
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Raiders and ghouls are now carrying some caps on themselves
add: Supermutant-made rifles no longer disintegrate after their owner dies
fix: Legion and NCR money is no longer in the loot lists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
