### PR TITLE
Fixes bandage eyepatch crashing craft menu

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -458,7 +458,7 @@ datum/crafting_recipe/tribalwar/bone
 				/obj/item/clothing/head/helmet/skull = 1)
 
 //Cloth Eyepatch
-/datum/crafting_recipe/eyepatch
+/datum/crafting_recipe/tribal/eyepatch
 	name = "Bandage Eyepatch"
 	result = /obj/item/clothing/glasses/f13/tribaleyepatch
 	time = 10


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This fixes craft menu crashing due bandage eyepatch not having proper category (and subcategory) variables. It should now appear in tribal tab.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Anonymous
fix: Fixes eyepatch bandage crashing menu due not having proper category set.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
