### PR TITLE
Adjusted stimjuice depletion rate

### DIFF
--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -11,7 +11,7 @@
 	reagent_state = LIQUID
 	color = "#eb0000"
 	taste_description = "numbness"
-	metabolization_rate = 2.5 * REAGENTS_METABOLISM
+	metabolization_rate = 5 * REAGENTS_METABOLISM
 	overdose_threshold = 60
 	value = REAGENT_VALUE_COMMON
 	ghoulfriendly = TRUE


### PR DESCRIPTION
## About The Pull Request

It was originally intended for stimfluid to deplete this quickly, to work with how much stimpaks are designed to heal.