### PR TITLE
Spears and other two-handers fit in suit storages now

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -273,6 +273,8 @@ GLOBAL_LIST_INIT(default_all_armor_slot_allowed, typecacheof(list(
 	/obj/item/flashlight,
 	/obj/item/gun,
 	/obj/item/melee,
+	/obj/item/twohanded,
+	/obj/item/throwing_star,
 	/obj/item/reagent_containers/spray/pepper,
 	/obj/item/restraints/handcuffs,
 	/obj/item/tank/internals,


### PR DESCRIPTION
## About The Pull Request

Most armor can hold spears and two-handed melee weapons.