### PR TITLE
fixes HH armor + cleaving saw nerf + Tribal slight rebalance

### DIFF
--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -705,9 +705,9 @@
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_DOWN_LASER_T2)
 
 /obj/item/clothing/suit/hooded/cloak/shunter
-	name = "Quickclaw armour"
+	name = "quickclaw armour"
 	desc = "A suit of armour fashioned out of the remains of a legendary deathclaw, this one has been crafted to remove a good portion of its protection to improve on speed and trekking."
-	icon_state = "birdarmor_t"
+	icon_state = "birdarmor"
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/shunter
 	heat_protection = CHEST|GROIN|LEGS|ARMS|HANDS
 	// body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
@@ -717,8 +717,8 @@
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_DOWN_LASER_T2)
 
 /obj/item/clothing/head/hooded/cloakhood/shunter
-	name = "Quickclaw hood"
-	desc = "A hood madde of deathclaw hides, light while also being comfortable to wear, designed for speed."
+	name = "quickclaw hood"
+	desc = "A hood made of deathclaw hides, light while also being comfortable to wear, designed for speed."
 	icon_state = "birdhood"
 	heat_protection = HEAD
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -34,16 +34,43 @@
 		return
 	ADD_TRAIT(H, TRAIT_TRIBAL, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_TRAPPER, src)
 	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
+	ADD_TRAIT(H, TRAIT_AUTO_DRAW, src)
+	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	H.grant_language(/datum/language/tribal)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/punji_sticks)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribal_combat_armor)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribal_combat_armor_helmet)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribal_pa)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribal_pa_helmet)
-
+	var/list/recipes = list(
+		/datum/crafting_recipe/tribal_pa,
+		/datum/crafting_recipe/tribal_pa_helmet,
+		/datum/crafting_recipe/tribal_combat_armor,
+		/datum/crafting_recipe/tribal_combat_armor_helmet,
+		/datum/crafting_recipe/tribal_r_combat_armor,
+		/datum/crafting_recipe/tribal_r_combat_armor_helmet,
+		/datum/crafting_recipe/tribalwar/chitinarmor,
+		/datum/crafting_recipe/tribalwar/lightcloak,
+		/datum/crafting_recipe/warmace,
+		/datum/crafting_recipe/tribalwar/lighttribe,
+		/datum/crafting_recipe/tribalwar/heavytribe,
+		/datum/crafting_recipe/tribalwar/legendaryclawcloak,
+		/datum/crafting_recipe/warpaint,
+		/datum/crafting_recipe/tribalradio,
+		/datum/crafting_recipe/tribalwar/goliathcloak,
+		/datum/crafting_recipe/tribalwar/bonebow,
+		/datum/crafting_recipe/tribalwar/tribe_bow,
+		/datum/crafting_recipe/tribalwar/sturdybow,
+		/datum/crafting_recipe/tribalwar/warclub,
+		/datum/crafting_recipe/tribalwar/silverbow,
+		/datum/crafting_recipe/tribalwar/arrowbone,
+		/datum/crafting_recipe/tribalwar/bonespear,
+		/datum/crafting_recipe/tribalwar/bonecodpiece,
+		/datum/crafting_recipe/tribalwar/bracers,
+		/datum/crafting_recipe/tribal/bonetalisman,
+		/datum/crafting_recipe/healpoultice,
+		/datum/crafting_recipe/healpoultice5,
+		/datum/crafting_recipe/tribal/bonebag
+	)
+	for(var/datum/crafting_recipe/recipe as() in recipes)
+		H.mind.teach_crafting_recipe(recipe)
 
 /*
 Tribal Chief
@@ -147,7 +174,8 @@ Tribal Shaman
 		/obj/item/reagent_containers/glass/mortar=1,
 		/obj/item/pestle=1,
 		/obj/item/reagent_containers/glass/primitive_chem_isolator=1,
-		/obj/item/reagent_containers/pill/patch/healpoultice=2
+		/obj/item/reagent_containers/pill/patch/healpoultice=2,
+		/obj/item/flashlight/lantern = 1,
 	)
 
 /datum/outfit/job/tribal/f13shaman/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -217,12 +245,12 @@ Tribal Head Hunter
 	belt = 		/obj/item/melee/transforming/cleaving_saw
 	id = 		/obj/item/card/id/tribetattoo
 	backpack_contents = list(
-		/obj/item/restraints/legcuffs/bola=1,
 		/obj/item/reagent_containers/pill/healingpowder=2,
 		/obj/item/warpaint_bowl=1,
 		/obj/item/stack/medical/gauze=1,
 		/obj/item/restraints/legcuffs/bola/tactical=2,
-		/obj/item/flashlight/flare/torch=1)
+		/obj/item/flashlight/flare/torch=1,
+		/obj/item/flashlight/lantern = 1)
 
 /*
 Druid

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -762,8 +762,8 @@
 /obj/item/melee/transforming/cleaving_saw
 	name = "cleaving saw"
 	desc = "This saw is the tool of choice for the Head Hunter. Capable of switching its reach and attack speed on the fly, it's an incredibly useful weapon for slaying the denizens of the wastes. Animal or human, the saw doesn't judge."
-	force = 30
-	force_on = 60 //force when active
+	force = 25
+	force_on = 40 //force when active
 	throwforce = 20
 	throwforce_on = 20
 	max_reach = 1
@@ -782,8 +782,8 @@
 	hitsound_on = 'sound/weapons/bladeslice.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_EDGED
-	faction_bonus_force = 30
-	nemesis_factions = list("mining", "boss")
+	faction_bonus_force = 5
+	nemesis_factions = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 	var/transform_cooldown
 	var/swiping = FALSE
 	var/bleed_stacks_per_hit = 3


### PR DESCRIPTION
## About The Pull Request
Basially this PR does is fix the head hunter aka quickclaw armor. So that way its just not a big error if you put on the hood. This also rebalances the cleaving saw and placing it at 20-40, so that way it isnt 30-60. If this PR didnt nerf the cleaving saw it would of ended up removed. 20-40 is a perfect way of it, and also if you attack mobs you get five extra damage on it. So like an claw you attacking an claw is 45 damage in total compared to 40. 20-40 is basially on pvping in a way, so its still the PVE killer. 
This also rebalances the tribals traits and recipes placing them much in line with the wastelander ones. 🙏 
PR takes the fixes from quickclaw armor from this PR. https://github.com/fortune13-ss13/thewasteland/pull/737

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tribal faction loadouts, all heads get lanterns. Remove of regular bola from the Head hunter.
add: Tribal faction gets autodraw and all the traits a regular wasteland tribal gets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
