### PR TITLE
Fixed matrix tiles turning permanently green once they've been used

### DIFF
--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -303,10 +303,10 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 	update_icon()
 	in_use = TRUE
 	if(!do_after(user, 50, target = src))
-		icon_state = "matrix"
+		icon_state = initial(matrix)
 		in_use = FALSE
 		return
-	icon_state = "matrix"
+	icon_state = initial(matrix)
 	in_use = FALSE
 	update_icon()
 	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -303,10 +303,10 @@ turf/closed/wall/f13/wood/house/update_damage_overlay()
 	update_icon()
 	in_use = TRUE
 	if(!do_after(user, 50, target = src))
-		icon_state = initial(matrix)
+		icon_state = initial(icon_state)
 		in_use = FALSE
 		return
-	icon_state = initial(matrix)
+	icon_state = initial(icon_state)
 	in_use = FALSE
 	update_icon()
 	var/dat = "[key_name(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"

--- a/tgui/.gitignore
+++ b/tgui/.gitignore
@@ -16,6 +16,9 @@ package-lock.json
 /public/.tmp/**/*
 /public/**/*
 !/public/*.html
+!/public/*.css
+!/public/tgui-polyfill.min.js
+/coverage
 
 ## Previously ignored locations that are kept to avoid confusing git
 ## while transitioning to a new project structure.


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Bit scuffed but it only turns green when you're transitioning, cba making a new sprite just in blue for it to transition, but hey! It  goes back to bloo.

Also added some stuff to gitignore.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Icon for matrix tiles go back to their original icon after you leave the round with them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
