### PR TITLE
Fixed Nothing in Ghoul Fort

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -14425,7 +14425,9 @@
 /area/f13/wasteland)
 "lGq" = (
 /obj/structure/simple_door/bunker,
-/turf/open/space/basic,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
 /area/f13/city)
 "lHJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22289,13 +22291,8 @@
 /area/f13/wasteland)
 "spo" = (
 /obj/structure/simple_door/bunker,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
 	},
 /area/f13/city)
 "spt" = (
@@ -24766,7 +24763,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/space/basic,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
 /area/f13/city)
 "unX" = (
 /obj/structure/spacevine,
@@ -29141,10 +29140,6 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/city)
-"ykp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/space/basic,
 /area/f13/city)
 "ykJ" = (
 /obj/structure/wreck/trash/two_tire,
@@ -65275,7 +65270,7 @@ jXj
 jSg
 pyl
 fQz
-ykp
+pbw
 ode
 lVj
 iLx
@@ -65532,7 +65527,7 @@ jSg
 wms
 bDe
 shz
-ykp
+pbw
 iLx
 iLx
 bcS


### PR DESCRIPTION
Nothing Tiles in Fort Ghussy Removed

## About The Pull Request
Nothing Tiles in Fort Ghussy Removed


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Replaced Floor Tiles in Fort Ghusy so they aren't portals the the dark abyss of forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
