### PR TITLE
Tweaked Peacekeeper's firemode

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -389,10 +389,11 @@
 
 /* * * * * * * * * * *
  * Peacekeeper revolver
- * Fullauto? heavier revolver
+ * Quickfire heavier revolver
  * .44 magnum
  * Scope!
- * Full-auto?
+ * Quick fire
+ * Heavy recoil
  * Unique
  * * * * * * * * * * */
 
@@ -407,16 +408,16 @@
 	weapon_weight = GUN_ONE_HAND_AKIMBO
 	draw_time = GUN_DRAW_QUICK
 	recoil_multiplier = GUN_RECOIL_REVOLVER_HEAVY * 2
-	recoil_cooldown_time = GUN_RECOIL_TIMEOUT_NORMAL * 2
+	recoil_cooldown_time = GUN_RECOIL_TIMEOUT_NORMAL
 	spread = GUN_SPREAD_ACCURATE
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_FASTEST
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	gun_damage_multiplier = GUN_EXTRA_DAMAGE_0
 
-	automatic = 1
-	autofire_shot_delay = 1
+	automatic = 0
+	autofire_shot_delay = 0
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_scope = FALSE
 


### PR DESCRIPTION
## About The Pull Request

Instead of the Peacekeeper being full-auto, it is now semi-automatic, but able to shoot really quickly. Careful, it has a kick!

#371

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Peacekeeper is no longer automatic. Instead, it can be fired semi-automatically really quickly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
