### PR TITLE
Nerfs radroaches but makes them able to swarm, smooth mob movement, support for nests spawning more than one mob, long PR title

### DIFF
--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -21,6 +21,7 @@
 	var/spawnsound //specify an audio file to play when a mob emerges from the spawner
 	var/spawn_once
 	var/infinite = FALSE
+	var/mobs_to_spawn = 1 //number of mobs to spawn at once, for swarms
 
 /obj/structure/nest/Initialize()
 	. = ..()
@@ -47,12 +48,15 @@
 		return FALSE
 	toggle_fire(FALSE)
 	addtimer(CALLBACK(src, .proc/toggle_fire), spawn_time)
-	var/chosen_mob_type = pickweight(mob_types)
-	var/mob/living/simple_animal/L = new chosen_mob_type(src.loc)
-	L.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)	//If we were admin spawned, lets have our children count as that as well.
-	spawned_mobs += L
-	L.nest = src
-	visible_message("<span class='danger'>[L] [spawn_text] [src].</span>")
+	var/chosen_mob_type
+	var/mob/living/simple_animal/L
+	for(var/i = 1 to mobs_to_spawn)
+		chosen_mob_type = pickweight(mob_types)
+		L = new chosen_mob_type(src.loc)
+		L.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)	//If we were admin spawned, lets have our children count as that as well.
+		spawned_mobs += L
+		L.nest = src
+		visible_message("<span class='danger'>[L] [spawn_text] [src].</span>")
 	if(spawnsound)
 		playsound(src, spawnsound, 30, 1)
 	if(!infinite)
@@ -208,7 +212,8 @@
 
 /obj/structure/nest/radroach
 	name = "radroach nest"
-	max_mobs = 5
+	max_mobs = 15
+	mobs_to_spawn = 3
 	mob_types = list(/mob/living/simple_animal/hostile/radroach = 1)
 
 /obj/structure/nest/fireant

--- a/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
@@ -470,7 +470,3 @@
 	aggrosound = list('sound/creatures/radroach_chitter.ogg',)
 	idlesound = list('sound/f13npc/roach/idle1.ogg', 'sound/f13npc/roach/idle2.ogg', 'sound/f13npc/roach/idle3.ogg',)
 	death_sound = 'sound/f13npc/roach/roach_death.ogg'
-
-/mob/living/simple_animal/hostile/radroach/Initialize()
-	. = ..()
-	AddComponent(/datum/component/swarming)

--- a/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
@@ -440,12 +440,12 @@
 	icon_gib = "radroach_gib"
 
 	speed = 1
-	maxHealth = 40
-	health = 40
+	maxHealth = 20
+	health = 20
 	harm_intent_damage = 8
 	obj_damage = 20
-	melee_damage_lower = 10
-	melee_damage_upper = 10
+	melee_damage_lower = 5
+	melee_damage_upper = 8
 
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	speak_chance = 0
@@ -462,8 +462,15 @@
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	faction = list("gecko")
 	a_intent = INTENT_HARM
+	pass_flags = PASSTABLE | PASSMOB
+	density = FALSE
 	gold_core_spawnable = HOSTILE_SPAWN
+	randpixel = 12
 
 	aggrosound = list('sound/creatures/radroach_chitter.ogg',)
 	idlesound = list('sound/f13npc/roach/idle1.ogg', 'sound/f13npc/roach/idle2.ogg', 'sound/f13npc/roach/idle3.ogg',)
 	death_sound = 'sound/f13npc/roach/roach_death.ogg'
+
+/mob/living/simple_animal/hostile/radroach/Initialize()
+	. = ..()
+	AddComponent(/datum/component/swarming)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -337,6 +337,7 @@
 			return 1
 		if(retreat_distance != null) //If we have a retreat distance, check if we need to run from our target
 			if(target_distance <= retreat_distance) //If target's closer than our retreat distance, run
+				set_glide_size(DELAY_TO_GLIDE_SIZE(move_to_delay))
 				walk_away(src,target,retreat_distance,move_to_delay)
 			else
 				Goto(target,move_to_delay,minimum_distance) //Otherwise, get to our minimum distance so we chase them
@@ -370,6 +371,7 @@
 		approaching_target = TRUE
 	else
 		approaching_target = FALSE
+	set_glide_size(DELAY_TO_GLIDE_SIZE(move_to_delay))
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -151,6 +151,8 @@
 	var/sharpness = SHARP_NONE
 	//Generic flags
 	var/simple_mob_flags = NONE
+	//Mob may be offset randomly on both axes by this much
+	var/randpixel = 0
 
 /mob/living/simple_animal/Initialize()
 	. = ..()
@@ -166,6 +168,8 @@
 		AddComponent(/datum/component/personal_crafting)
 	if(footstep_type)
 		AddComponent(/datum/component/footstep, footstep_type)
+	pixel_x = rand(-randpixel, randpixel)
+	pixel_y = rand(-randpixel, randpixel)
 
 /mob/living/simple_animal/Destroy()
 	GLOB.simple_animals[AIStatus] -= src


### PR DESCRIPTION
## About The Pull Request

Radroach HP halved, damage lowered to 5-8 from 10 (like bloatflies)
Radroach nests spawn three roaches instead of just one
Radroaches can now move through other mobs, including other roaches
Radroaches and Bloatflies can move through tables
Mob movement is now s m o o t h
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
