### PR TITLE
Texarkana General Generators

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -127,10 +127,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ach" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "acX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -151,6 +147,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"adx" = (
+/obj/structure/table/reinforced,
+/obj/item/blueprint/research,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "adz" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
@@ -290,12 +294,6 @@
 "alc" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"alA" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "alI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -347,6 +345,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
+"aoa" = (
+/obj/structure/nest/supermutant,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "aon" = (
 /turf/closed/wall/rust,
 /area/f13/ncr)
@@ -502,6 +507,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/caves)
+"awR" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "axw" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -977,14 +989,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
-"bbX" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
@@ -999,15 +1003,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"bge" = (
-/obj/structure/filingcabinet,
+"bgb" = (
+/obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "bgr" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -1043,6 +1046,14 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"bhq" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "bhH" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -1111,6 +1122,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"bjf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "bjZ" = (
 /obj/effect/spawner/lootdrop/f13/medical/random_fev,
 /turf/open/water,
@@ -1454,12 +1471,6 @@
 /mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bAN" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "bAY" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -4876,17 +4887,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"bUO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "bUZ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -4930,6 +4930,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"bVE" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "bVK" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
@@ -5770,13 +5783,6 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"cmk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "cmy" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -5956,10 +5962,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"cpY" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "cqh" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars,
@@ -6033,11 +6035,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
-"cun" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "cuv" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -6379,6 +6376,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"cHS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "cJp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -6592,14 +6598,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
-"cYc" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "cYz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
@@ -6683,16 +6681,6 @@
 	dir = 10
 	},
 /area/f13/caves)
-"dbl" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/item/stack/sheet/animalhide/human,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "dbr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -6801,20 +6789,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"dig" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "djs" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
@@ -7160,6 +7134,10 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"dAT" = (
+/obj/effect/spawner/lootdrop/f13/medical/random_fev,
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "dBy" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -7222,12 +7200,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dEX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/closed/wall/f13/store,
 /area/f13/building/hospital)
 "dFj" = (
 /obj/machinery/light{
@@ -7351,17 +7324,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"dKt" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "dKz" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance/underground,
@@ -7447,6 +7409,16 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"dQf" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "dQn" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -7538,6 +7510,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"dUy" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "dUQ" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7631,17 +7609,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"dYI" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "dYU" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/turf_decal/weather/dirt{
@@ -7762,14 +7729,6 @@
 /mob/living/simple_animal/hostile/fireant,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"efp" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "egj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -7796,9 +7755,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"eij" = (
-/turf/closed/wall/f13/store,
-/area/f13/building/hospital)
 "eik" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry,
@@ -7853,6 +7809,13 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"elc" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "elZ" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
@@ -7906,6 +7869,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"eoT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "eoU" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -7976,11 +7950,6 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"esd" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "esI" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/outside/ruins,
@@ -8175,11 +8144,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"ezK" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "ezZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8197,10 +8161,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"eAn" = (
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building/hospital)
 "eAA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel{
@@ -8395,16 +8355,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
-"eJE" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "eJI" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorybasement";
@@ -8552,6 +8502,13 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
+"eQX" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "eRG" = (
 /obj/structure/bed/old,
 /obj/structure/sign/poster/contraband/tools{
@@ -8571,6 +8528,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"eSA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/breathing_tanks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "eSR" = (
 /obj/structure/sink{
 	dir = 1;
@@ -8601,15 +8567,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"eUu" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/breathing_tanks,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "eUw" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plasteel/f13{
@@ -8719,14 +8676,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"eZX" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fae" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8734,10 +8683,6 @@
 "fap" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
-"faE" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fbR" = (
 /obj/structure/chair/left,
 /turf/open/floor/f13/wood,
@@ -9050,16 +8995,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/sewer)
-"fwz" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "fwD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9077,11 +9012,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"fxZ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/rndboards,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fyj" = (
 /obj/structure/lattice{
 	layer = 3
@@ -9186,15 +9116,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"fDo" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fET" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9214,10 +9135,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/caves)
-"fGE" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fHO" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -9227,6 +9144,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"fIf" = (
+/obj/structure/nest/ghoul,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fIt" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
@@ -9321,6 +9245,13 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"fNb" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fNr" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old";
@@ -9437,11 +9368,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fUd" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "fVh" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -9602,15 +9528,6 @@
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/grass,
 /area/f13/caves)
-"ggM" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "ghn" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
@@ -9692,6 +9609,11 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"gkC" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "gkH" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -9725,15 +9647,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"gmF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "gmM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -9745,15 +9658,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gnh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "gns" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9821,20 +9725,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"gtD" = (
-/obj/item/bodypart/l_arm,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbear1"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "gtH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -9896,12 +9786,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"gwG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "gwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -9998,10 +9882,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gAt" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "gAQ" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -10262,6 +10142,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"gRt" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "gRv" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -10434,6 +10325,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"hfs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "hfO" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	icon_living = "pvtgutsy";
@@ -10598,6 +10498,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"hoy" = (
+/obj/item/clothing/head/hooded/human_head{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "hoD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -10622,11 +10536,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"hpx" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/breathing_masks,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "hqo" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -10648,19 +10557,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
-"hqM" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "hrd" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -10840,6 +10736,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"hBJ" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "hCA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -11347,13 +11249,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"ifn" = (
-/obj/machinery/door/airlock/medical{
-	name = null;
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "ifE" = (
 /obj/item/clothing/suit/armor/medium/combat/rusted,
 /obj/item/clothing/head/helmet/f13/hoodedmask,
@@ -11522,15 +11417,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
-"iok" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "iol" = (
 /turf/open/floor/f13{
 	icon_state = "purplefull"
@@ -11555,6 +11441,16 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"iqw" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "iqJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11572,6 +11468,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"ira" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "irr" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
@@ -11971,12 +11871,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"iHK" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iIr" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"iIF" = (
+/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iJH" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -12112,19 +12023,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"iOY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building/hospital)
-"iQk" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "iQn" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12189,10 +12087,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"iUh" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "iUK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12220,15 +12114,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"iVD" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "iWp" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -12244,6 +12129,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"iWQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "iXe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12277,11 +12172,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"iYW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/stockparts/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "iZm" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/dirt{
@@ -12460,12 +12350,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
-"jiM" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "jiZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12750,6 +12634,20 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"jBD" = (
+/obj/item/bodypart/l_arm,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "jBV" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/weather/dirt{
@@ -13020,6 +12918,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"jQi" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "jQC" = (
 /obj/structure/nest/deathclaw,
 /turf/open/floor/f13{
@@ -13240,6 +13146,13 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/water,
 /area/f13/tunnel)
+"kfw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "kfE" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -13293,6 +13206,18 @@
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"khs" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "khL" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -13395,6 +13320,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"knX" = (
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "kov" = (
 /obj/item/storage/trash_stack,
 /obj/structure/handrail/g_central{
@@ -13478,6 +13410,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
+"kuo" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "kuy" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
@@ -13508,12 +13445,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"kwd" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "kwC" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -13529,9 +13460,8 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"kxI" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+"kyb" = (
+/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
@@ -13777,6 +13707,22 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"kMM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
+"kNp" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -14072,11 +14018,6 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lem" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "leT" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -14182,6 +14123,13 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"lkl" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "lkD" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -14203,6 +14151,11 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
+"lmd" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "lms" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/f13{
@@ -14228,11 +14181,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"loz" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/plush,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "loD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -14462,6 +14410,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"lAG" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "lAI" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -14706,14 +14666,6 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"lJH" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "lJW" = (
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
@@ -14853,16 +14805,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"lQr" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "lQY" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -15096,6 +15038,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"maa" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mab" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15238,10 +15184,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
-"mga" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "mgI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
@@ -15284,12 +15226,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
-"mkc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "mkG" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars,
@@ -15476,13 +15412,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
-"mvi" = (
-/obj/structure/nest/ghoul,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "mvW" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -15588,6 +15517,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"mAM" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "mBz" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -15615,14 +15551,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"mDA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "mDU" = (
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -15657,6 +15585,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"mIj" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mIM" = (
 /obj/machinery/workbench/mbench,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -15819,16 +15756,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"mQI" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "mRt" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15905,16 +15832,6 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
-"mWD" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "mWL" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -16031,10 +15948,25 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"nbm" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "nbQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nch" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ncC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16042,14 +15974,6 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"ncQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "ndu" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -16193,6 +16117,15 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"nkA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "nkT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -16395,9 +16328,27 @@
 	icon_state = "purplefull"
 	},
 /area/f13/caves)
+"nvA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
+"nxU" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "nyY" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -16408,6 +16359,10 @@
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nzr" = (
+/obj/structure/simple_door/house,
+/turf/closed/wall/f13/store,
+/area/f13/building/hospital)
 "nzz" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -16425,12 +16380,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"nAn" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/bio_suit/hazmat,
-/obj/item/clothing/head/bio_hood/hazmat,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "nAQ" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -16479,16 +16428,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"nDq" = (
-/obj/effect/decal/waste{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "nDw" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -16570,13 +16509,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"nGY" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "nHe" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16643,6 +16575,14 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nKT" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "nMm" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/barricade/wooden,
@@ -16759,12 +16699,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"nRd" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "nRv" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
 	},
 /area/f13/tunnel)
+"nRX" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "nSi" = (
 /obj/structure/closet/crate/bin,
 /obj/item/radio,
@@ -16887,6 +16839,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nYd" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "nYi" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/tunnel,
@@ -16923,13 +16885,6 @@
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nZC" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "nZV" = (
 /obj/structure/nest/ghoul,
 /obj/effect/decal/cleanable/dirt,
@@ -17219,6 +17174,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"oqm" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oqB" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -17391,11 +17352,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"oAa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "oBy" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -17422,6 +17378,10 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/clinic)
+"oDy" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oDA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -17467,6 +17427,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"oFG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/breathing_masks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/nukacolavendfull,
@@ -17555,6 +17520,10 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
+"oLq" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oLw" = (
 /obj/structure/showcase/horrific_experiment{
 	desc = "Some sort of pod. You wonder what could have been in that.";
@@ -17628,10 +17597,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"oOc" = (
-/obj/effect/spawner/lootdrop/f13/medical/random_fev,
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "oOk" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -17667,6 +17632,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"oPJ" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oPK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17716,11 +17685,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
-"oSW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "oTg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18104,13 +18068,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"pkU" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "plp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/medical/ointment/five,
@@ -18157,6 +18114,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"pmI" = (
+/obj/machinery/door/airlock/medical{
+	name = null;
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
+"pmJ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "pno" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag{
@@ -18262,6 +18233,12 @@
 	icon_state = "neutralrusty"
 	},
 /area/f13/tunnel)
+"puP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building/hospital)
 "pvk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old{
@@ -18482,6 +18459,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pFY" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "pGB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18520,6 +18505,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pHG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "pHH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/f13vault{
@@ -18643,10 +18633,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"pNJ" = (
-/obj/structure/simple_door/house,
-/turf/closed/wall/f13/store,
-/area/f13/building/hospital)
 "pOx" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating{
 	name = "plating"
@@ -18691,6 +18677,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"pPS" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "pQk" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -18712,6 +18704,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"pRe" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "pRy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18746,6 +18748,17 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"pTv" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "pTK" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -19006,18 +19019,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
-"qhx" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "qhE" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -19371,6 +19372,11 @@
 	name = "cave"
 	},
 /area/f13/caves)
+"qvD" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "qvL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
@@ -19503,14 +19509,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"qDm" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "qDu" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
@@ -19538,6 +19536,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/sewer)
+"qEQ" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "qES" = (
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -19860,18 +19866,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"qUo" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ultracite,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "qUM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -19930,13 +19924,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"qXK" = (
-/obj/structure/closet,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "qYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -19964,6 +19951,10 @@
 /obj/structure/weightlifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"raz" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "raI" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19984,6 +19975,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"rbm" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "rcf" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -20054,15 +20052,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/tunnel)
-"rgw" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "rhq" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -20138,6 +20127,20 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/caves)
+"rll" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "rlv" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -20149,14 +20152,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"rly" = (
-/obj/structure/table/reinforced,
-/obj/item/blueprint/research,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "rlJ" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -20181,24 +20176,12 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
-"rnV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "rog" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"roz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "roU" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -20206,6 +20189,15 @@
 	dir = 9
 	},
 /area/f13/building/museum)
+"rph" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "rpp" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/trash,
@@ -20414,10 +20406,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/caves)
-"rDO" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "rEX" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20759,6 +20747,15 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
+"rWH" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "rWP" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -20901,6 +20898,13 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"seI" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "seP" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -20958,6 +20962,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"sji" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "sjF" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress3"
@@ -21038,6 +21048,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"sqD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "sqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -21179,18 +21197,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"sxQ" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/structure/fermenting_barrel,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "sxV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
@@ -21372,6 +21378,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"sGc" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "sGj" = (
 /mob/living/simple_animal/hostile/centaur,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -21493,13 +21506,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"sMI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "sNR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21522,6 +21528,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/caves)
+"sOK" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib6-old"
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "sOQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
@@ -21532,11 +21550,8 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
-"sPf" = (
-/obj/structure/nest/supermutant,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+"sPQ" = (
+/obj/structure/nest/ghoul,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "sPZ" = (
@@ -21837,13 +21852,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
-"tcU" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "tdi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -21911,13 +21919,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/tunnel)
-"tgm" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "tha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -21960,6 +21961,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
+"tjr" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tjD" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/outside/ruins,
@@ -22044,17 +22050,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"tmn" = (
-/obj/structure/table,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "tmV" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	desc = "All hail the Chinese Communist Party!"
@@ -22245,13 +22240,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"txl" = (
-/obj/structure/table/reinforced,
-/obj/item/circular_saw,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "txt" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -22264,13 +22252,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"tzi" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "tzw" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22348,6 +22329,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
+"tDQ" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tDX" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -22426,6 +22417,14 @@
 "tGG" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/tunnel)
+"tGK" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tGP" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/structure/decoration/rag{
@@ -22436,6 +22435,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"tHm" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "tHF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -22497,6 +22505,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"tLF" = (
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tNM" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -22570,12 +22586,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
-"tSl" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "tSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -22643,6 +22653,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"tYi" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tYn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -22740,6 +22755,16 @@
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"ucr" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ucB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -23010,6 +23035,17 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"uvu" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "uvv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -23429,17 +23465,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"uRn" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "uRB" = (
 /obj/structure/barricade/bars,
 /obj/structure/disposalpipe/segment{
@@ -23459,20 +23484,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
-"uTv" = (
-/obj/item/clothing/head/hooded/human_head{
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "uTw" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23502,6 +23513,10 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/caves)
+"uUZ" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "uVb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13chair2,
@@ -23579,17 +23594,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"uYP" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "uYT" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/f13{
@@ -23605,10 +23609,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"vaj" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "var" = (
 /obj/structure/nest/fireant{
 	max_mobs = 4;
@@ -23890,14 +23890,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
-"vlk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "vly" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
@@ -24066,6 +24058,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"vuF" = (
+/obj/structure/nest/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vvG" = (
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_x = 32
@@ -24091,6 +24090,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vym" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vyr" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
@@ -24188,6 +24192,10 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"vCF" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building/hospital)
 "vCG" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -24238,16 +24246,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
-"vFq" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/obj/item/organ/heart,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "vFL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -24377,6 +24375,13 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"vLw" = (
+/obj/structure/closet,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vNt" = (
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall/r_wall/f13vault{
@@ -24414,6 +24419,14 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
+"vON" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vPp" = (
 /obj/structure/table,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
@@ -24452,15 +24465,6 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/water,
 /area/f13/tunnel)
-"vSF" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "vSH" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -24502,6 +24506,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"vVN" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "vVY" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -24521,10 +24532,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"vYw" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -24621,6 +24628,10 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"wan" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "waG" = (
 /obj/structure/chair/comfy/brown,
 /obj/item/clothing/head/crown,
@@ -24654,14 +24665,6 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"wdy" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "weh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24715,6 +24718,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"whm" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
+/area/f13/radiation)
 "who" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24994,6 +25001,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wxL" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "wxX" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
@@ -25208,13 +25221,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"wKj" = (
-/obj/effect/spawner/lootdrop/trash,
+"wKp" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/building/hospital)
 "wKJ" = (
 /obj/structure/table/reinforced,
@@ -25319,10 +25335,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"wRM" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "wSA" = (
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -25427,6 +25439,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"wYL" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "wZk" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/inside/subway{
@@ -25454,11 +25471,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
-"xaI" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "xaX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25477,20 +25489,6 @@
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"xbB" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
-	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
-"xcf" = (
-/obj/structure/ladder/unbreakable{
-	id = "followersbasement";
-	height = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "xcj" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -25509,24 +25507,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"xcF" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/hospital)
 "xcJ" = (
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xcQ" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "xcS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
@@ -25648,6 +25632,15 @@
 /obj/structure/fluff/railing,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"xiY" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xkd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25886,15 +25879,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
-"xzi" = (
-/mob/living/simple_animal/hostile/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "xzj" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -25910,6 +25894,14 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"xzy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "xzK" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/poker,
@@ -25999,10 +25991,25 @@
 	icon_state = "2-i"
 	},
 /area/f13/caves)
+"xFT" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "xGL" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xGS" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xHi" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
@@ -26013,6 +26020,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"xHk" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xHG" = (
 /obj/item/stack/ore/iron,
 /turf/open/indestructible/ground/inside/subway{
@@ -26070,15 +26081,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xKA" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "xKU" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/barricade/wooden/strong,
@@ -26157,13 +26159,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"xMA" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "xMJ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -26203,13 +26198,6 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
-"xPG" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/building/hospital)
 "xPT" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meatsalted,
@@ -26466,11 +26454,8 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ycb" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+"ycG" = (
+/obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "ycU" = (
@@ -26503,10 +26488,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"yel" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "yen" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /obj/effect/decal/cleanable/dirt,
@@ -26550,10 +26531,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"ygf" = (
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "ygq" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -26626,6 +26603,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"yjg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
+"yjm" = (
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "yjt" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -26643,10 +26630,23 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"yle" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
+"yjO" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/organ/heart,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
+"ylq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "ylF" = (
 /obj/machinery/porta_turret/syndicate{
@@ -70442,29 +70442,29 @@ aak
 aae
 aae
 aaa
-eij
-eij
-eij
-eij
-eij
-eij
-ifn
-ifn
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+pmI
+pmI
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 aaa
 aae
 aae
@@ -70699,29 +70699,29 @@ aae
 aae
 aae
 aaa
-eij
-rgw
+dEX
+nkA
 kDe
-ach
+raz
 kDe
 kDe
-ygf
+oDy
 kDe
 gYI
 gYI
-vaj
-eij
-iYW
-lem
-fxZ
-eij
-lJH
+ira
+dEX
+qvD
+tYi
+tjr
+dEX
+bhq
 gYI
 kDe
-eij
+dEX
 kDe
-xcf
-eij
+knX
+dEX
 aaa
 aae
 aae
@@ -70956,29 +70956,29 @@ aae
 aae
 aae
 aaa
-eij
+dEX
 gYI
 gYI
-ach
+raz
 gYI
-fDo
-fDo
-fDo
-fDo
-fDo
+mIj
+mIj
+mIj
+mIj
+mIj
 kDe
-eij
+dEX
 gYI
 gYI
-faE
-eij
-rnV
-vSF
-pkU
-eij
+xGS
+dEX
+yjg
+rWH
+vuF
+dEX
 kDe
-esd
-eij
+iIF
+dEX
 aaa
 aae
 aae
@@ -71213,29 +71213,29 @@ aae
 aae
 aae
 aaa
-eij
+dEX
 kDe
-tcU
-iOY
+nbm
+puP
 gYI
-tgm
-vYw
-tgm
-tgm
-tgm
-fGE
-eij
-gYI
-gYI
-ycb
-eij
-loz
+kyb
+uUZ
+kyb
+kyb
+kyb
+ycG
+dEX
 gYI
 gYI
-eij
-rDO
-eij
-eij
+fNb
+dEX
+wYL
+gYI
+gYI
+dEX
+xHk
+dEX
+dEX
 aaa
 aae
 aae
@@ -71470,29 +71470,29 @@ aak
 aak
 aae
 aaa
-eij
+dEX
 kDe
 gYI
-iOY
-gmF
-tgm
-vYw
-tgm
-tgm
-tgm
+puP
+hfs
+kyb
+uUZ
+kyb
+kyb
+kyb
 gYI
-eij
+dEX
 gYI
-tzi
-eZX
-eij
-bge
+nRd
+qEQ
+dEX
+ucr
 gYI
-tcU
-eij
+nbm
+dEX
 kDe
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -71727,29 +71727,29 @@ aae
 aae
 aae
 aaa
-eij
+dEX
 kDe
 gYI
-eij
+dEX
 gYI
-xKA
-mWD
-xKA
-alA
-xKA
+xiY
+tDQ
+xiY
+wxL
+xiY
 gYI
-eij
+dEX
 gYI
-pkU
-iUh
-eij
-xMA
-gYI
-gYI
-pNJ
+vuF
+wan
+dEX
+rbm
 gYI
 gYI
-eij
+nzr
+gYI
+gYI
+dEX
 aaa
 aak
 aak
@@ -71984,29 +71984,29 @@ aae
 aae
 aae
 aaa
-eij
-kwd
+dEX
+oqm
 gYI
-eij
+dEX
 kDe
-vaj
-gYI
-kDe
-kDe
-gYI
-gYI
-rDO
-kDe
-gYI
-vlk
-eij
-gAt
+ira
 gYI
 kDe
-eij
+kDe
 gYI
-wKj
-eij
+gYI
+xHk
+kDe
+gYI
+sqD
+dEX
+oPJ
+gYI
+kDe
+dEX
+gYI
+nch
+dEX
 aaa
 aak
 aae
@@ -72241,29 +72241,29 @@ aae
 aae
 aae
 aaa
-eij
+dEX
 gYI
 kDe
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 kDe
 gYI
-eij
+dEX
 kDe
 kDe
-rly
-eij
-gAt
+adx
+dEX
+oPJ
 gYI
-tSl
-eij
+sji
+dEX
 kDe
-pkU
-eij
+vuF
+dEX
 aaa
 aae
 aak
@@ -72498,29 +72498,29 @@ xwF
 aak
 aak
 aaa
-eij
-tcU
+dEX
+nbm
 kDe
-eij
-qhx
-qDm
-ezK
-xPG
-eij
-rDO
-rDO
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+khs
+nvA
+yjm
+kNp
+dEX
+xHk
+xHk
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 kDe
 gYI
-eij
+dEX
 aaa
 aae
 aak
@@ -72755,29 +72755,29 @@ xwF
 aak
 aak
 aaa
-eij
+dEX
 gYI
 kDe
-eij
-dig
-qDm
-uTv
-xPG
-eij
+dEX
+rll
+nvA
+hoy
+kNp
+dEX
 gYI
 gYI
-eij
+dEX
 kDe
-wdy
-eij
-yle
-bbX
-kxI
-fUd
-eij
+jQi
+dEX
+lmd
+tGK
+vON
+gkC
+dEX
 gYI
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -73012,29 +73012,29 @@ xwF
 xwF
 xwF
 aaa
-eij
+dEX
 gYI
 gYI
-eij
-dbl
-dYI
-qDm
-txl
-eij
+dEX
+nYd
+gRt
+nvA
+vVN
+dEX
 gYI
-sMI
-eij
+kfw
+dEX
 kDe
-ncQ
-eij
-ygf
+pFY
+dEX
+oDy
 gYI
 gYI
 gYI
-eij
-tcU
+dEX
+nbm
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -73269,29 +73269,29 @@ xwF
 xwF
 xwF
 aaa
-eij
-kwd
+dEX
+oqm
 gYI
-eij
-vFq
-qDm
-gtD
-cmk
-eij
+dEX
+yjO
+nvA
+jBD
+pmJ
+dEX
 gYI
 gYI
-rDO
+xHk
 gYI
-iVD
-eij
-rgw
+kMM
+dEX
+nkA
 gYI
-pkU
+vuF
 gYI
-eAn
+vCF
 gYI
-wRM
-eij
+maa
+dEX
 aaa
 aae
 aae
@@ -73526,29 +73526,29 @@ xwF
 aaB
 aaB
 aaa
-eij
+dEX
 kDe
 gYI
-eij
+dEX
 auG
-qDm
-bAN
-eJE
-eij
+nvA
+hBJ
+iWQ
+dEX
 gYI
 gYI
-eij
+dEX
 gYI
-xaI
-eij
+vym
+dEX
 gYI
 gYI
-gYI
-kDe
-eij
 gYI
 kDe
-eij
+dEX
+gYI
+kDe
+dEX
 aaa
 aae
 aae
@@ -73783,29 +73783,29 @@ aak
 aaB
 aaB
 aaa
-eij
+dEX
 gYI
 gYI
-eij
-uRn
-ezK
-uYP
-qDm
-rDO
+dEX
+xFT
+yjm
+wKp
+nvA
+xHk
 kDe
-sPf
-eij
+aoa
+dEX
 gYI
-oSW
-eij
-eUu
-hpx
-oAa
-gwG
-eij
+kuo
+dEX
+eSA
+oFG
+pHG
+iHK
+dEX
 gYI
 kDe
-eij
+dEX
 aaa
 aae
 aae
@@ -74040,29 +74040,29 @@ xwF
 xwF
 aaB
 aaa
-eij
+dEX
 gYI
-tcU
-eij
-uRn
-ezK
-qDm
-ezK
-eij
+nbm
+dEX
+xFT
+yjm
+nvA
+yjm
+dEX
 kDe
 gYI
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 gYI
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -74297,29 +74297,29 @@ xwF
 xwF
 aar
 aaa
-eij
+dEX
 kDe
 gYI
-eij
-uRn
-qDm
-qDm
-xcQ
-eij
+dEX
+xFT
+nvA
+nvA
+mAM
+dEX
 gYI
 gYI
-eij
-fwz
-efp
-hqM
-efp
-fwz
-efp
-hqM
-eij
+dEX
+pRe
+ylq
+bVE
+ylq
+pRe
+ylq
+bVE
+dEX
 gYI
-tcU
-eij
+nbm
+dEX
 aaa
 aak
 aae
@@ -74554,29 +74554,29 @@ xwF
 xwF
 xwF
 aaa
-eij
-rgw
+dEX
+nkA
 gYI
-eij
-nZC
-dKt
-sxQ
-jiM
-eij
+dEX
+seI
+uvu
+sOK
+dUy
+dEX
 kDe
 gYI
-eij
-cun
-xzi
 dEX
+nRX
+tHm
+xzy
+xzy
+xzy
+tHm
+xzy
 dEX
+vuF
+kfw
 dEX
-xzi
-dEX
-eij
-pkU
-sMI
-eij
 aaa
 adz
 adz
@@ -74811,29 +74811,29 @@ xwF
 xwF
 xwF
 aaa
-eij
-gYI
-vaj
-eij
-eij
-eij
-eij
-eij
-eij
-rgw
-gYI
-eij
 dEX
-cun
-dEX
-bUO
-ggM
-dEX
-tmn
-eij
 gYI
-gnh
-eij
+ira
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+nkA
+gYI
+dEX
+xzy
+nRX
+xzy
+eoT
+bgb
+xzy
+pTv
+dEX
+gYI
+rph
+dEX
 aaa
 adz
 adz
@@ -75068,29 +75068,29 @@ aak
 aak
 aak
 aaa
-eij
+dEX
 gYI
 gYI
-eij
-cpY
-lQr
-oOc
-xcF
-eij
+dEX
+whm
+iqw
+dAT
+sGc
+dEX
 gYI
 gYI
-eij
-eij
-eij
-eij
-eij
-eij
-rDO
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+xHk
+dEX
+dEX
 gYI
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -75325,29 +75325,29 @@ xwF
 xwF
 xwF
 aaa
-eij
+dEX
 kDe
 gYI
-eij
-qUo
-cYc
-mQI
-nDq
-rDO
-sPf
+dEX
+lAG
+nKT
+nxU
+dQf
+xHk
+aoa
 gYI
-pNJ
+nzr
 kDe
 kDe
 kDe
-mvi
+fIf
 kDe
 kDe
 kDe
-rDO
+xHk
 gYI
-mga
-eij
+sPQ
+dEX
 aaa
 aae
 aae
@@ -75582,29 +75582,29 @@ xwF
 xwF
 xwF
 aaa
-eij
+dEX
 gYI
 kDe
-eij
-cpY
-xbB
-xcF
-nGY
-eij
+dEX
+whm
+lkl
+sGc
+awR
+dEX
 kDe
 gYI
-eij
+dEX
 kDe
-nAn
-nAn
-qXK
-qXK
-yel
-mDA
-eij
+pPS
+pPS
+vLw
+vLw
+oLq
+tLF
+dEX
 gYI
 kDe
-eij
+dEX
 aaa
 aae
 aae
@@ -75839,29 +75839,29 @@ xwF
 xwF
 xwF
 aaa
-eij
-gmF
+dEX
+hfs
 gYI
-eij
-eij
-eij
-eij
-eij
-eij
-ach
-ach
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+raz
+raz
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 gYI
-roz
-eij
+elc
+dEX
 aaa
 aae
 aae
@@ -76096,13 +76096,13 @@ aaB
 aaB
 aaB
 aaa
-eij
+dEX
 gYI
 gYI
-ach
+raz
 gYI
 gYI
-yel
+oLq
 kDe
 kDe
 kDe
@@ -76110,15 +76110,15 @@ gYI
 gYI
 gYI
 gYI
-vaj
+ira
 gYI
 gYI
-tcU
+nbm
 gYI
-ach
+raz
 gYI
 gYI
-eij
+dEX
 aaa
 aae
 aae
@@ -76353,29 +76353,29 @@ aaB
 ilg
 aaB
 aaa
-eij
-tcU
+dEX
+nbm
 kDe
-iQk
+eQX
 gYI
 gYI
 gYI
 gYI
-iok
+cHS
 gYI
 gYI
-yel
+oLq
 gYI
-mkc
+bjf
 gYI
 gYI
 gYI
 kDe
-iok
-iQk
+cHS
+eQX
 kDe
 kDe
-eij
+dEX
 aaa
 aae
 aak
@@ -76610,29 +76610,29 @@ aaB
 aaB
 yeX
 aaa
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
-eij
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
+dEX
 aaa
 aae
 aak

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -127,6 +127,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ach" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "acX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -286,6 +290,12 @@
 "alc" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"alA" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "alI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -326,14 +336,6 @@
 	},
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
-"anC" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "anY" = (
 /obj/structure/nest/assaultron{
@@ -410,16 +412,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"arl" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/obj/item/organ/heart,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "arY" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -479,7 +471,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
-/area/f13/caves)
+/area/f13/building/hospital)
 "auM" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -532,14 +524,6 @@
 "axS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/ash_rock,
-/area/f13/caves)
-"ayr" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "ayu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -648,18 +632,6 @@
 /area/f13/caves)
 "aGd" = (
 /turf/open/floor/f13/wood,
-/area/f13/caves)
-"aGe" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ultracite,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "aGf" = (
 /obj/machinery/workbench/forge,
@@ -891,11 +863,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"aTU" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/plush,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "aTZ" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -1010,6 +977,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
+"bbX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/museum)
@@ -1024,6 +999,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"bge" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "bgr" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/indestructible/ground/inside/subway,
@@ -1154,10 +1139,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"bmN" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "bmR" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1241,16 +1222,6 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"brP" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "brR" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_0"
@@ -1307,15 +1278,6 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"btU" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "btV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -1358,20 +1320,6 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"bvM" = (
-/obj/item/clothing/head/hooded/human_head{
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "bvU" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -1506,6 +1454,12 @@
 /mob/living/simple_animal/hostile/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"bAN" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "bAY" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -4782,11 +4736,6 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"bSe" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/breathing_masks,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "bSm" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
@@ -4927,6 +4876,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"bUO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "bUZ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -5315,14 +5275,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
-"cgM" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "chj" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -5818,6 +5770,13 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"cmk" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "cmy" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -5997,6 +5956,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"cpY" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "cqh" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars,
@@ -6070,6 +6033,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
+"cun" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "cuv" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -6461,12 +6429,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"cMw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "cML" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -6630,6 +6592,14 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
+"cYc" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "cYz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
@@ -6713,6 +6683,16 @@
 	dir = 10
 	},
 /area/f13/caves)
+"dbl" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "dbr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -6821,6 +6801,20 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"dig" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "djs" = (
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
@@ -7084,16 +7078,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
-"dwI" = (
-/obj/effect/decal/waste{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "dwM" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -7238,8 +7222,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dEX" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "dFj" = (
 /obj/machinery/light{
 	dir = 8
@@ -7285,13 +7274,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"dFS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "dFY" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -7369,6 +7351,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"dKt" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "dKz" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance/underground,
@@ -7403,11 +7396,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"dLy" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "dLI" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -7447,13 +7435,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"dPo" = (
-/obj/structure/table/reinforced,
-/obj/item/circular_saw,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "dPK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/old,
@@ -7650,6 +7631,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"dYI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "dYU" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/turf_decal/weather/dirt{
@@ -7770,6 +7762,14 @@
 /mob/living/simple_animal/hostile/fireant,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"efp" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "egj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -7796,6 +7796,9 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"eij" = (
+/turf/closed/wall/f13/store,
+/area/f13/building/hospital)
 "eik" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/chemistry,
@@ -7850,14 +7853,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"elT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "elZ" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
@@ -7882,14 +7877,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"enW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "eoj" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -7989,6 +7976,11 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"esd" = (
+/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "esI" = (
 /obj/structure/table/booth,
 /turf/open/indestructible/ground/outside/ruins,
@@ -8110,17 +8102,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
-"exk" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "exn" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/ncr/jobguide,
@@ -8194,6 +8175,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"ezK" = (
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "ezZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8211,6 +8197,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"eAn" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building/hospital)
 "eAA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel{
@@ -8405,6 +8395,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
+"eJE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "eJI" = (
 /obj/machinery/door/poddoor/shutters/old{
 	id = "factorybasement";
@@ -8601,6 +8601,15 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"eUu" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/breathing_tanks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "eUw" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plasteel/f13{
@@ -8710,6 +8719,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"eZX" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fae" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8717,6 +8734,10 @@
 "fap" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/caves)
+"faE" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fbR" = (
 /obj/structure/chair/left,
 /turf/open/floor/f13/wood,
@@ -9029,17 +9050,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/sewer)
-"fvL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"fwz" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
+/obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/caves)
+/area/f13/building/hospital)
 "fwD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9057,6 +9077,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"fxZ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fyj" = (
 /obj/structure/lattice{
 	layer = 3
@@ -9126,10 +9151,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
 /area/f13/caves)
-"fBY" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "fCu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9165,6 +9186,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"fDo" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fET" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9184,6 +9214,10 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/caves)
+"fGE" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fHO" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -9403,6 +9437,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fUd" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "fVh" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -9551,13 +9590,6 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"gfC" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ggk" = (
 /obj/structure/table,
 /obj/item/ammo_box/shotgun/slug,
@@ -9570,6 +9602,15 @@
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/grass,
 /area/f13/caves)
+"ggM" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "ghn" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
@@ -9684,6 +9725,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"gmF" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "gmM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -9695,6 +9745,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"gnh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "gns" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -9762,6 +9821,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
+"gtD" = (
+/obj/item/bodypart/l_arm,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "gtH" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -9823,6 +9896,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"gwG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "gwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -9856,14 +9935,6 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
-"gxo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "gxz" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
@@ -9882,10 +9953,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"gyf" = (
-/obj/structure/simple_door/house,
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "gyt" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -9931,6 +9998,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gAt" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "gAQ" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -10251,19 +10322,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"gUQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"gUR" = (
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
 "gUU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -10304,12 +10362,7 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"gYQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
+/area/f13/building/hospital)
 "gZn" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10512,15 +10565,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"hnk" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -10578,6 +10622,11 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
+"hpx" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/breathing_masks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "hqo" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -10599,6 +10648,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
+"hqM" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "hrd" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -10683,14 +10745,6 @@
 /obj/effect/landmark/start/f13/ncrranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"hvS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hvT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -10793,15 +10847,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"hCE" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hCT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10896,11 +10941,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"hHB" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11307,6 +11347,13 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"ifn" = (
+/obj/machinery/door/airlock/medical{
+	name = null;
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ifE" = (
 /obj/item/clothing/suit/armor/medium/combat/rusted,
 /obj/item/clothing/head/helmet/f13/hoodedmask,
@@ -11469,17 +11516,21 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"iod" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "iof" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
+"iok" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iol" = (
 /turf/open/floor/f13{
 	icon_state = "purplefull"
@@ -11578,15 +11629,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"itn" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "itt" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -11688,22 +11730,11 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"iyL" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "iyM" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"iyV" = (
-/obj/structure/ladder/unbreakable{
-	id = "followersbasement";
-	height = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "izf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -12017,10 +12048,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"iMN" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "iMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12085,6 +12112,19 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"iOY" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building/hospital)
+"iQk" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iQn" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12104,14 +12144,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
-"iRM" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "iRN" = (
 /obj/structure/rack,
@@ -12157,6 +12189,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"iUh" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iUK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12184,6 +12220,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"iVD" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iWp" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -12232,6 +12277,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"iYW" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "iZm" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/decal/cleanable/dirt{
@@ -12364,9 +12414,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"jdA" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
 "jdR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
@@ -12413,6 +12460,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
+"jiM" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "jiZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12748,18 +12801,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
-"jEg" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "jFh" = (
@@ -13188,14 +13229,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/caves)
-"kdY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "keb" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -13291,10 +13324,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
-"kkb" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kkd" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -13479,6 +13508,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"kwd" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "kwC" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -13494,6 +13529,14 @@
 /obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"kxI" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "kyk" = (
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
@@ -13553,12 +13596,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"kzE" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kzN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -13594,10 +13631,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/tunnel)
-"kCu" = (
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kCz" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -13618,14 +13651,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "kDe" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
+/area/f13/building/hospital)
 "kDw" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13693,15 +13720,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"kIL" = (
-/mob/living/simple_animal/hostile/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "kJd" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/indestructible/ground/inside/subway,
@@ -13745,14 +13763,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"kLG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kMc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
@@ -13793,16 +13803,6 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
-"kOX" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "kPE" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -13930,13 +13930,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"kVD" = (
-/obj/structure/nest/ghoul,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kVU" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
@@ -14079,6 +14072,11 @@
 /obj/item/clothing/head/hardhat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lem" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "leT" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -14216,15 +14214,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"lmB" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"lmM" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "lmW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14239,12 +14228,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"lnY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/caves)
+"loz" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "loD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -14718,6 +14706,14 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"lJH" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "lJW" = (
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
@@ -14857,6 +14853,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"lQr" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "lQY" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -15232,6 +15238,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/tunnel)
+"mga" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mgI" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
@@ -15274,6 +15284,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
+"mkc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mkG" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars,
@@ -15423,15 +15439,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"mth" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/breathing_tanks,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "mtF" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -15469,6 +15476,13 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/museum)
+"mvi" = (
+/obj/structure/nest/ghoul,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mvW" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13/vault_floor/red{
@@ -15601,6 +15615,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"mDA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mDU" = (
 /obj/structure/closet/crate/medical/anchored,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -15634,20 +15656,6 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"mIL" = (
-/obj/item/bodypart/l_arm,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbear1"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "mIM" = (
 /obj/machinery/workbench/mbench,
@@ -15753,17 +15761,6 @@
 /obj/item/clothing/under/f13/vault/v13,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"mLd" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "mLm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden/strong,
@@ -15822,6 +15819,16 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"mQI" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "mRt" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15898,6 +15905,16 @@
 /obj/structure/timeddoor/sixtyminute,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
+"mWD" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "mWL" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -16
@@ -16014,16 +16031,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"nbB" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "nbQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
@@ -16035,6 +16042,14 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
+"ncQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ndu" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -16383,13 +16398,6 @@
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
-"nxf" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "nyY" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -16417,6 +16425,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"nAn" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "nAQ" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -16465,6 +16479,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"nDq" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "nDw" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -16546,6 +16570,13 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"nGY" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "nHe" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/inside/mountain,
@@ -16560,14 +16591,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"nIz" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "nIE" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -16847,10 +16870,6 @@
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"nXd" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "nXl" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -16904,6 +16923,13 @@
 /obj/item/trash/f13/fancylads,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nZC" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "nZV" = (
 /obj/structure/nest/ghoul,
 /obj/effect/decal/cleanable/dirt,
@@ -17015,13 +17041,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"ohQ" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "oib" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -17055,16 +17074,6 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
-/area/f13/caves)
-"ojE" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "ojM" = (
 /obj/structure/nest/deathclaw{
@@ -17108,12 +17117,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
-/area/f13/caves)
-"ols" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "olP" = (
 /obj/item/trash/f13/dog,
@@ -17223,24 +17226,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"oqQ" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"ord" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "ory" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -17330,19 +17315,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/caves)
-"owG" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "owV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17377,20 +17349,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
-	},
-/area/f13/caves)
-"oyq" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "oyC" = (
@@ -17433,6 +17391,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"oAa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oBy" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -17665,6 +17628,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"oOc" = (
+/obj/effect/spawner/lootdrop/f13/medical/random_fev,
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "oOk" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -17749,6 +17716,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"oSW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "oTg" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18015,12 +17987,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"peT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pfa" = (
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_y = 32
@@ -18138,6 +18104,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"pkU" = (
+/obj/structure/nest/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "plp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/medical/ointment/five,
@@ -18479,26 +18452,11 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/caves)
-"pCX" = (
-/obj/structure/table/reinforced,
-/obj/item/blueprint/research,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pDI" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"pDL" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pDW" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -18524,13 +18482,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pGt" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "pGB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18692,6 +18643,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"pNJ" = (
+/obj/structure/simple_door/house,
+/turf/closed/wall/f13/store,
+/area/f13/building/hospital)
 "pOx" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating{
 	name = "plating"
@@ -19051,6 +19006,18 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
+"qhx" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "qhE" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -19355,10 +19322,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
-"qtH" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "qtU" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -19450,17 +19413,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"qyt" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "qyC" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -19551,6 +19503,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"qDm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "qDu" = (
 /obj/machinery/sleeper,
 /obj/machinery/light{
@@ -19558,16 +19518,6 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
-"qDE" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/item/stack/sheet/animalhide/human,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "qDL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19910,6 +19860,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"qUo" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "qUM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -19968,6 +19930,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"qXK" = (
+/obj/structure/closet,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "qYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -20085,6 +20054,15 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/tunnel)
+"rgw" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "rhq" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -20106,10 +20084,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/tunnel)
-"riX" = (
-/obj/effect/spawner/lootdrop/f13/medical/random_fev,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "rje" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20123,13 +20097,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"rjW" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "rjZ" = (
 /obj/structure/cable{
@@ -20182,6 +20149,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"rly" = (
+/obj/structure/table/reinforced,
+/obj/item/blueprint/research,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "rlJ" = (
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -20206,17 +20181,24 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
-"rnL" = (
+"rnV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
+/area/f13/building/hospital)
 "rog" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"roz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "roU" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -20246,12 +20228,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"rpM" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "rqS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -20438,14 +20414,10 @@
 	icon_state = "purplefull"
 	},
 /area/f13/caves)
-"rDU" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
+"rDO" = (
+/obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
+/area/f13/building/hospital)
 "rEX" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20944,20 +20916,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sgy" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"sgD" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
-	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "sgV" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -21055,13 +21013,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"snO" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "snS" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/blood/old{
@@ -21228,6 +21179,18 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"sxQ" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib6-old"
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "sxV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/f13{
@@ -21530,6 +21493,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"sMI" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "sNR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21562,6 +21532,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
+"sPf" = (
+/obj/structure/nest/supermutant,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "sPZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21613,17 +21590,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"sRq" = (
-/obj/machinery/door/airlock/medical{
-	name = null;
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"sRN" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "sSs" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -21743,12 +21709,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
-"sXc" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/bio_suit/hazmat,
-/obj/item/clothing/head/bio_hood/hazmat,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "sXf" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21832,11 +21792,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"tbG" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "tbP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/chem_pile,
@@ -21882,6 +21837,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/tunnel)
+"tcU" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tdi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -21901,13 +21863,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
-"teb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tep" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -21956,6 +21911,13 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/tunnel)
+"tgm" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tha" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -22082,6 +22044,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"tmn" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "tmV" = (
 /obj/structure/sign/poster/contraband/communist_state{
 	desc = "All hail the Chinese Communist Party!"
@@ -22272,6 +22245,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"txl" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "txt" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -22284,6 +22264,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
+"tzi" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tzw" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22510,13 +22497,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"tLu" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "tNM" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -22590,21 +22570,18 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"tSl" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "tSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
-/area/f13/caves)
-"tTa" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tTe" = (
 /obj/structure/closet/cabinet,
@@ -22763,12 +22740,6 @@
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"uch" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "ucB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -22789,13 +22760,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"ued" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "ufB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -22900,11 +22864,6 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"umN" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/rndboards,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "umW" = (
 /obj/structure/rack/shelf_metal,
@@ -23217,13 +23176,6 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/caves)
-"uDC" = (
-/obj/structure/closet,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "uDF" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /obj/effect/turf_decal/bot_red,
@@ -23280,9 +23232,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"uFM" = (
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "uHa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -23480,6 +23429,17 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"uRn" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "uRB" = (
 /obj/structure/barricade/bars,
 /obj/structure/disposalpipe/segment{
@@ -23499,6 +23459,20 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"uTv" = (
+/obj/item/clothing/head/hooded/human_head{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "uTw" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23605,6 +23579,17 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
+"uYP" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "uYT" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/f13{
@@ -23620,6 +23605,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"vaj" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "var" = (
 /obj/structure/nest/fireant{
 	max_mobs = 4;
@@ -23901,6 +23890,14 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"vlk" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vly" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building/massfusion)
@@ -24042,11 +24039,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"vsU" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/stockparts/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vsZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/neck/mantle/gecko,
@@ -24099,24 +24091,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"vyp" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vyr" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
-"vyD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "vyO" = (
@@ -24214,13 +24192,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"vCH" = (
-/obj/structure/nest/supermutant,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vCM" = (
 /obj/structure/bed/pod,
 /turf/open/floor/plating,
@@ -24267,24 +24238,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
+"vFq" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/organ/heart,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "vFL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vFY" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/structure/fermenting_barrel,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "vGl" = (
 /obj/item/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -24483,6 +24452,15 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/water,
 /area/f13/tunnel)
+"vSF" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vSH" = (
 /obj/structure/handrail/g_central{
 	dir = 4;
@@ -24543,13 +24521,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"vYs" = (
+"vYw" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -24679,6 +24654,14 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"wdy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "weh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25016,10 +24999,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"wyR" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wyS" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -25188,13 +25167,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"wGA" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wGI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/weather/dirt{
@@ -25236,17 +25208,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"wJH" = (
-/obj/structure/table,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"wKj" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/caves)
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "wKJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile{
@@ -25261,11 +25230,6 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
-"wKO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wKV" = (
 /obj/structure/rack,
@@ -25291,10 +25255,6 @@
 "wMj" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"wMN" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wNu" = (
 /obj/item/cigbutt{
 	pixel_y = 6
@@ -25359,6 +25319,10 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"wRM" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "wSA" = (
 /obj/structure/spider/stickyweb{
 	icon_state = "stickyweb2"
@@ -25490,6 +25454,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"xaI" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xaX" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25508,6 +25477,20 @@
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xbB" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
+"xcf" = (
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xcj" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -25526,10 +25509,24 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"xcF" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/building/hospital)
 "xcJ" = (
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"xcQ" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "xcS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/high_chance,
@@ -25559,16 +25556,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/caution,
-/area/f13/caves)
-"xeB" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "xeD" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -25669,11 +25656,6 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/caves)
-"xkg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "xkj" = (
 /obj/structure/cable{
@@ -25794,15 +25776,6 @@
 	dir = 1
 	},
 /area/f13/caves)
-"xrU" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "xsg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25913,6 +25886,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/museum)
+"xzi" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "xzj" = (
 /obj/machinery/door/airlock/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -25978,15 +25960,6 @@
 "xCN" = (
 /obj/structure/decoration/warning,
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/caves)
-"xDE" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "xDN" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -26097,6 +26070,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"xKA" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xKU" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/barricade/wooden/strong,
@@ -26175,6 +26157,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"xMA" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "xMJ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -26214,6 +26203,13 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
+"xPG" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/building/hospital)
 "xPT" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/meatsalted,
@@ -26273,12 +26269,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"xSm" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "xSw" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -26476,6 +26466,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ycb" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ycU" = (
 /obj/structure/handrail/g_end{
 	pixel_x = 12;
@@ -26506,6 +26503,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"yel" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "yen" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /obj/effect/decal/cleanable/dirt,
@@ -26549,6 +26550,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"ygf" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ygq" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -26617,14 +26622,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"yiA" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "yiX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
@@ -26646,6 +26643,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
+"yle" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "ylF" = (
 /obj/machinery/porta_turret/syndicate{
 	faction = list("china")
@@ -70183,7 +70185,7 @@ aak
 aak
 aae
 aaa
-jdA
+aaa
 aaa
 aaa
 aaa
@@ -70440,29 +70442,29 @@ aak
 aae
 aae
 aaa
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-sRq
-sRq
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
+eij
+eij
+eij
+eij
+eij
+eij
+ifn
+ifn
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
 aaa
 aae
 aae
@@ -70697,29 +70699,29 @@ aae
 aae
 aae
 aaa
-uFM
-itn
-dEX
-wMN
-dEX
-dEX
-kCu
-dEX
+eij
+rgw
+kDe
+ach
+kDe
+kDe
+ygf
+kDe
 gYI
 gYI
-wyR
-uFM
-vsU
-hHB
-umN
-uFM
-cgM
+vaj
+eij
+iYW
+lem
+fxZ
+eij
+lJH
 gYI
-dEX
-uFM
-dEX
-iyV
-uFM
+kDe
+eij
+kDe
+xcf
+eij
 aaa
 aae
 aae
@@ -70954,29 +70956,29 @@ aae
 aae
 aae
 aaa
-uFM
+eij
 gYI
 gYI
-wMN
+ach
 gYI
-xDE
-xDE
-xDE
-xDE
-xDE
-dEX
-uFM
+fDo
+fDo
+fDo
+fDo
+fDo
+kDe
+eij
 gYI
 gYI
-nXd
-uFM
-rnL
-xrU
-sgy
-uFM
-dEX
-iod
-uFM
+faE
+eij
+rnV
+vSF
+pkU
+eij
+kDe
+esd
+eij
 aaa
 aae
 aae
@@ -71211,29 +71213,29 @@ aae
 aae
 aae
 aaa
-uFM
-dEX
-wGA
-lnY
+eij
+kDe
+tcU
+iOY
 gYI
-gfC
-iMN
-gfC
-gfC
-gfC
-vyp
-uFM
-gYI
-gYI
-pDL
-uFM
-aTU
+tgm
+vYw
+tgm
+tgm
+tgm
+fGE
+eij
 gYI
 gYI
-uFM
-iyL
-uFM
-uFM
+ycb
+eij
+loz
+gYI
+gYI
+eij
+rDO
+eij
+eij
 aaa
 aae
 aae
@@ -71468,29 +71470,29 @@ aak
 aak
 aae
 aaa
-uFM
-dEX
+eij
+kDe
 gYI
-lnY
-gUQ
-gfC
-iMN
-gfC
-gfC
-gfC
+iOY
+gmF
+tgm
+vYw
+tgm
+tgm
+tgm
 gYI
-uFM
+eij
 gYI
-snO
-yiA
-uFM
-ojE
+tzi
+eZX
+eij
+bge
 gYI
-wGA
-uFM
-dEX
+tcU
+eij
+kDe
 gYI
-uFM
+eij
 aaa
 aae
 aae
@@ -71725,29 +71727,29 @@ aae
 aae
 aae
 aaa
-uFM
-dEX
+eij
+kDe
 gYI
-uFM
+eij
 gYI
-tTa
-brP
-tTa
-kzE
-tTa
+xKA
+mWD
+xKA
+alA
+xKA
 gYI
-uFM
+eij
 gYI
-sgy
-sRN
-uFM
-oqQ
-gYI
-gYI
-gyf
+pkU
+iUh
+eij
+xMA
 gYI
 gYI
-uFM
+pNJ
+gYI
+gYI
+eij
 aaa
 aak
 aak
@@ -71982,29 +71984,29 @@ aae
 aae
 aae
 aaa
-uFM
-rpM
+eij
+kwd
 gYI
-uFM
-dEX
-wyR
+eij
+kDe
+vaj
 gYI
-dEX
-dEX
+kDe
+kDe
 gYI
 gYI
-iyL
-dEX
+rDO
+kDe
 gYI
-iRM
-uFM
-kkb
+vlk
+eij
+gAt
 gYI
-dEX
-uFM
+kDe
+eij
 gYI
-rDU
-uFM
+wKj
+eij
 aaa
 aak
 aae
@@ -72239,29 +72241,29 @@ aae
 aae
 aae
 aaa
-uFM
+eij
 gYI
-dEX
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-dEX
+kDe
+eij
+eij
+eij
+eij
+eij
+eij
+kDe
 gYI
-uFM
-dEX
-dEX
-pCX
-uFM
-kkb
+eij
+kDe
+kDe
+rly
+eij
+gAt
 gYI
-cMw
-uFM
-dEX
-sgy
-uFM
+tSl
+eij
+kDe
+pkU
+eij
 aaa
 aae
 aak
@@ -72496,29 +72498,29 @@ xwF
 aak
 aak
 aaa
-uFM
-wGA
-dEX
-uFM
-jEg
-kdY
-tbG
-vYs
-uFM
-iyL
-iyL
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-dEX
+eij
+tcU
+kDe
+eij
+qhx
+qDm
+ezK
+xPG
+eij
+rDO
+rDO
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+kDe
 gYI
-uFM
+eij
 aaa
 aae
 aak
@@ -72753,29 +72755,29 @@ xwF
 aak
 aak
 aaa
-uFM
+eij
 gYI
-dEX
-uFM
-oyq
-kdY
-bvM
-vYs
-uFM
-gYI
-gYI
-uFM
-dEX
-kLG
-uFM
-xkg
-gxo
-nIz
-lmB
-uFM
+kDe
+eij
+dig
+qDm
+uTv
+xPG
+eij
 gYI
 gYI
-uFM
+eij
+kDe
+wdy
+eij
+yle
+bbX
+kxI
+fUd
+eij
+gYI
+gYI
+eij
 aaa
 aae
 aae
@@ -73010,29 +73012,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
+eij
 gYI
 gYI
-uFM
-qDE
-ord
-kdY
-dPo
-uFM
+eij
+dbl
+dYI
+qDm
+txl
+eij
 gYI
-teb
-uFM
-dEX
-hvS
-uFM
-kCu
+sMI
+eij
+kDe
+ncQ
+eij
+ygf
 gYI
 gYI
 gYI
-uFM
-wGA
+eij
+tcU
 gYI
-uFM
+eij
 aaa
 aae
 aae
@@ -73267,29 +73269,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
-rpM
+eij
+kwd
 gYI
-uFM
-arl
-kdY
-mIL
-ohQ
-uFM
+eij
+vFq
+qDm
+gtD
+cmk
+eij
 gYI
 gYI
-iyL
+rDO
 gYI
-hnk
-uFM
-itn
+iVD
+eij
+rgw
 gYI
-sgy
+pkU
 gYI
-gUR
+eAn
 gYI
-bmN
-uFM
+wRM
+eij
 aaa
 aae
 aae
@@ -73524,29 +73526,29 @@ xwF
 aaB
 aaB
 aaa
-uFM
-dEX
+eij
+kDe
 gYI
-uFM
+eij
 auG
-kdY
-uch
-vyD
-uFM
+qDm
+bAN
+eJE
+eij
 gYI
 gYI
-uFM
+eij
 gYI
-dLy
-uFM
+xaI
+eij
 gYI
 gYI
 gYI
-dEX
-uFM
+kDe
+eij
 gYI
-dEX
-uFM
+kDe
+eij
 aaa
 aae
 aae
@@ -73781,29 +73783,29 @@ aak
 aaB
 aaB
 aaa
-uFM
+eij
 gYI
 gYI
-uFM
-qyt
-tbG
-exk
-kdY
-iyL
-dEX
-vCH
-uFM
+eij
+uRn
+ezK
+uYP
+qDm
+rDO
+kDe
+sPf
+eij
 gYI
-gYQ
-uFM
-mth
-bSe
-wKO
-xSm
-uFM
+oSW
+eij
+eUu
+hpx
+oAa
+gwG
+eij
 gYI
-dEX
-uFM
+kDe
+eij
 aaa
 aae
 aae
@@ -74038,29 +74040,29 @@ xwF
 xwF
 aaB
 aaa
-uFM
+eij
 gYI
-wGA
-uFM
-qyt
-tbG
-kdY
-tbG
-uFM
-dEX
+tcU
+eij
+uRn
+ezK
+qDm
+ezK
+eij
+kDe
 gYI
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
 gYI
 gYI
-uFM
+eij
 aaa
 aae
 aae
@@ -74295,29 +74297,29 @@ xwF
 xwF
 aar
 aaa
-uFM
-dEX
+eij
+kDe
 gYI
-uFM
-qyt
-kdY
-kdY
-rjW
-uFM
+eij
+uRn
+qDm
+qDm
+xcQ
+eij
 gYI
 gYI
-uFM
-nbB
-elT
-owG
-elT
-nbB
-elT
-owG
-uFM
+eij
+fwz
+efp
+hqM
+efp
+fwz
+efp
+hqM
+eij
 gYI
-wGA
-uFM
+tcU
+eij
 aaa
 aak
 aae
@@ -74552,29 +74554,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
-itn
+eij
+rgw
 gYI
-uFM
-pGt
-mLd
-vFY
-ols
-uFM
+eij
+nZC
+dKt
+sxQ
+jiM
+eij
+kDe
+gYI
+eij
+cun
+xzi
 dEX
-gYI
-uFM
-xTs
-kIL
-enW
-enW
-enW
-kIL
-enW
-uFM
-sgy
-teb
-uFM
+dEX
+dEX
+xzi
+dEX
+eij
+pkU
+sMI
+eij
 aaa
 adz
 adz
@@ -74809,29 +74811,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
+eij
 gYI
-wyR
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-itn
+vaj
+eij
+eij
+eij
+eij
+eij
+eij
+rgw
 gYI
-uFM
-enW
-xTs
-enW
-fvL
-btU
-enW
-wJH
-uFM
+eij
+dEX
+cun
+dEX
+bUO
+ggM
+dEX
+tmn
+eij
 gYI
-kDe
-uFM
+gnh
+eij
 aaa
 adz
 adz
@@ -75066,29 +75068,29 @@ aak
 aak
 aak
 aaa
-uFM
+eij
 gYI
 gYI
-uFM
-lmM
-kOX
-riX
-tLu
-uFM
+eij
+cpY
+lQr
+oOc
+xcF
+eij
 gYI
 gYI
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-iyL
-uFM
-uFM
+eij
+eij
+eij
+eij
+eij
+eij
+rDO
+eij
+eij
 gYI
 gYI
-uFM
+eij
 aaa
 aae
 aae
@@ -75323,29 +75325,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
-dEX
+eij
+kDe
 gYI
-uFM
-aGe
-ayr
-xeB
-dwI
-iyL
-vCH
+eij
+qUo
+cYc
+mQI
+nDq
+rDO
+sPf
 gYI
-gyf
-dEX
-dEX
-dEX
-kVD
-dEX
-dEX
-dEX
-iyL
+pNJ
+kDe
+kDe
+kDe
+mvi
+kDe
+kDe
+kDe
+rDO
 gYI
-fBY
-uFM
+mga
+eij
 aaa
 aae
 aae
@@ -75580,29 +75582,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
+eij
 gYI
-dEX
-uFM
-lmM
-sgD
-tLu
-ued
-uFM
-dEX
+kDe
+eij
+cpY
+xbB
+xcF
+nGY
+eij
+kDe
 gYI
-uFM
-dEX
-sXc
-sXc
-uDC
-uDC
-qtH
-anC
-uFM
+eij
+kDe
+nAn
+nAn
+qXK
+qXK
+yel
+mDA
+eij
 gYI
-dEX
-uFM
+kDe
+eij
 aaa
 aae
 aae
@@ -75837,29 +75839,29 @@ xwF
 xwF
 xwF
 aaa
-uFM
-gUQ
+eij
+gmF
 gYI
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-wMN
-wMN
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
+eij
+eij
+eij
+eij
+eij
+eij
+ach
+ach
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
 gYI
-dFS
-uFM
+roz
+eij
 aaa
 aae
 aae
@@ -76094,29 +76096,29 @@ aaB
 aaB
 aaB
 aaa
-uFM
+eij
 gYI
 gYI
-wMN
+ach
 gYI
 gYI
-qtH
-dEX
-dEX
-dEX
+yel
+kDe
+kDe
+kDe
 gYI
 gYI
 gYI
 gYI
-wyR
+vaj
 gYI
 gYI
-wGA
+tcU
 gYI
-wMN
+ach
 gYI
 gYI
-uFM
+eij
 aaa
 aae
 aae
@@ -76351,29 +76353,29 @@ aaB
 ilg
 aaB
 aaa
-uFM
-wGA
-dEX
-nxf
+eij
+tcU
+kDe
+iQk
 gYI
 gYI
 gYI
 gYI
-hCE
+iok
 gYI
 gYI
-qtH
+yel
 gYI
-peT
+mkc
 gYI
 gYI
 gYI
-dEX
-hCE
-nxf
-dEX
-dEX
-uFM
+kDe
+iok
+iQk
+kDe
+kDe
+eij
 aaa
 aae
 aak
@@ -76608,29 +76610,29 @@ aaB
 aaB
 yeX
 aaa
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
-uFM
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
+eij
 aaa
 aae
 aak

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -452,10 +452,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "auG" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "auM" = (
 /obj/structure/chair/wood{
@@ -485,6 +484,15 @@
 /obj/item/pen/fountain,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
+	},
+/area/f13/caves)
+"awN" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "axw" = (
@@ -532,6 +540,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
+"aBx" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "aCD" = (
 /obj/structure/junk/small/tv{
 	pixel_y = 20
@@ -690,6 +703,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"aJS" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "aKH" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -810,6 +829,12 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating,
 /area/f13/building/museum)
+"aQl" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "aQy" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/waste{
@@ -940,6 +965,16 @@
 	dir = 10
 	},
 /area/f13/caves)
+"aZT" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "bao" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/mountain,
@@ -961,6 +996,11 @@
 "bbV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
+/area/f13/caves)
+"bbX" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1588,6 +1628,10 @@
 "bEJ" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/tunnel)
+"bFp" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "bFx" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
@@ -5196,6 +5240,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"cga" = (
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "cge" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/jackboots,
@@ -5261,6 +5313,17 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"cic" = (
+/obj/item/bodypart/l_arm,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "cid" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -5323,6 +5386,13 @@
 /obj/machinery/telecomms/server/presets/legion,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"cjf" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "cjg" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
@@ -5983,6 +6053,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"cuV" = (
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "cvq" = (
 /obj/machinery/button/door{
 	id = "salad";
@@ -6269,6 +6342,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"cDU" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "cEf" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -6950,6 +7030,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
+"duG" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "duJ" = (
 /obj/structure/nest/raider{
 	max_mobs = 3;
@@ -6995,6 +7082,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
+/area/f13/caves)
+"dxu" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "dya" = (
 /obj/structure/table/glass,
@@ -7124,10 +7216,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dEX" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "dFj" = (
 /obj/machinery/light{
@@ -7398,6 +7488,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"dTm" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/organ/heart,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "dTO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7681,6 +7781,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"eiJ" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ejG" = (
 /obj/machinery/light{
 	dir = 1
@@ -8288,6 +8392,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"eMt" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "eMJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -8404,6 +8514,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/caves)
+"eSb" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "eSw" = (
@@ -8553,6 +8671,12 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"fad" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "fae" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8603,11 +8727,23 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"feb" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "feC" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/caves)
+"feM" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "feP" = (
 /obj/structure/simple_door/metal,
@@ -9335,6 +9471,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"gcu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "gcv" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -9445,6 +9589,10 @@
 "giT" = (
 /obj/structure/nest/supermutant/melee,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"gjc" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "gjs" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary,
@@ -9740,6 +9888,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gAJ" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "gAQ" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -9883,6 +10035,11 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"gHY" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/breathing_masks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "gJb" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10096,9 +10253,7 @@
 /turf/open/water,
 /area/f13/caves)
 "gYI" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "gZn" = (
 /obj/structure/nest/deathclaw/mother,
@@ -10164,6 +10319,12 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"heI" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "hff" = (
 /obj/item/chair,
@@ -10296,6 +10457,10 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hmW" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hmZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -10315,6 +10480,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hnv" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "hod" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10473,6 +10645,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"hwf" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hwR" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/weather/dirt{
@@ -11181,6 +11358,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"ims" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "imJ" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
@@ -11703,6 +11886,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"iKe" = (
+/obj/item/clothing/head/hooded/human_head{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "iKs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11784,6 +11978,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"iNJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "iNR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -12086,6 +12285,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"jdC" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "jdR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
@@ -12126,6 +12332,12 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
+"jgX" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "jhn" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
@@ -12177,6 +12389,10 @@
 "jmO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"jne" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "jnp" = (
 /obj/effect/decal/waste{
@@ -12374,6 +12590,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"jzV" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "jAc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -12389,6 +12609,10 @@
 	throw_range = 9
 	},
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"jAs" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "jBq" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12558,6 +12782,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
+"jJN" = (
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "jKx" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13{
@@ -12700,6 +12931,13 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
+/area/f13/caves)
+"jQP" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "jRd" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -13303,11 +13541,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "kDe" = (
-/obj/structure/closet/crate/miningcar,
-/obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "kDw" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13928,6 +14163,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"lqe" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/breathing_tanks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "lqn" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -14253,6 +14494,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/caves)
+"lFy" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "lGc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -14312,6 +14560,11 @@
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"lHu" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lIr" = (
 /turf/open/floor/plasteel/f13{
@@ -14712,6 +14965,11 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"lZA" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lZN" = (
 /obj/structure/closet/crate/trashcart,
@@ -15259,6 +15517,12 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"mHA" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "mIM" = (
 /obj/machinery/workbench/mbench,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -15732,6 +15996,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"niJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "niW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/weather/dirt,
@@ -15969,6 +16239,11 @@
 	icon_state = "purplefull"
 	},
 /area/f13/caves)
+"nvZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
@@ -16165,6 +16440,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"nJO" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "nKt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -16712,6 +16993,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"onM" = (
+/obj/machinery/door/airlock/medical{
+	name = null;
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ooQ" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
@@ -17167,6 +17455,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"oOe" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "oOk" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -17356,6 +17648,13 @@
 /obj/structure/bed/pod,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
+"oXU" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "oYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -17475,6 +17774,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pcP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pde" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17491,6 +17795,17 @@
 /obj/effect/decal/cleanable/ash/large,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"peu" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/caves)
 "peA" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -17556,6 +17871,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/caves)
+"phJ" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "pia" = (
@@ -17709,6 +18032,15 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/flora/wasteplant/wild_yucca,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"pqw" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib6-old"
+	},
+/obj/structure/fermenting_barrel,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "pqy" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -18231,6 +18563,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"pRu" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pRy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18517,6 +18853,13 @@
 	},
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/caves)
+"qhk" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "qhp" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -18581,6 +18924,10 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"qjV" = (
+/obj/structure/simple_door/house,
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "qkf" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/gibs{
@@ -19448,6 +19795,13 @@
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"raM" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "raS" = (
 /obj/machinery/button/door{
 	id = "hell";
@@ -19728,6 +20082,11 @@
 	icon_state = "floordirty"
 	},
 /area/f13/tunnel)
+"rtp" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "rtz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -20227,6 +20586,10 @@
 "rZE" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"rZF" = (
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "rZP" = (
 /obj/structure/chair/wood{
@@ -20736,6 +21099,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
+"sCt" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "sCQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -20949,6 +21317,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
+/area/f13/caves)
+"sOF" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "sOQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21827,6 +22200,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
+"tHK" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "tHT" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/indestructible/ground/inside/subway,
@@ -22824,6 +23201,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"uSU" = (
+/obj/structure/table/reinforced,
+/obj/item/blueprint/research,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "uTw" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22945,6 +23327,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"uZK" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "var" = (
 /obj/structure/nest/fireant{
 	max_mobs = 4;
@@ -22981,6 +23369,10 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/caves)
+"vbN" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "vbO" = (
 /obj/structure/table/wood/settler,
@@ -23069,6 +23461,14 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
+"vfg" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "vfF" = (
@@ -23599,6 +23999,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"vJl" = (
+/obj/structure/closet,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vJq" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -23739,6 +24146,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"vPL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vQn" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23828,6 +24240,14 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/caves)
+"vWH" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "vYx" = (
@@ -23937,6 +24357,11 @@
 /obj/structure/cross,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"wbs" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "wbM" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23975,6 +24400,11 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/f13,
+/area/f13/caves)
+"wff" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wft" = (
 /obj/structure/decoration/rag{
@@ -24296,6 +24726,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"wyw" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wyS" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -24688,6 +25123,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"wXU" = (
+/obj/effect/spawner/lootdrop/f13/medical/random_fev,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "wYE" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -25068,6 +25507,16 @@
 "xuR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/caves)
+"xvM" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "xvT" = (
 /obj/structure/bed/mattress,
@@ -25512,6 +25961,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13,
+/area/f13/caves)
+"xTi" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "xTs" = (
 /turf/open/floor/f13{
@@ -68097,8 +68560,8 @@ bFx
 bFx
 bFx
 bFx
-aah
-aah
+bFx
+bFx
 bFx
 bFx
 bFx
@@ -68354,18 +68817,18 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bOn
 adz
 adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
+bOn
 aae
 aae
 aae
@@ -68611,18 +69074,18 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bOn
 adz
 adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
+bOn
 aae
 aae
 aae
@@ -68868,18 +69331,18 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bOn
 adz
 adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
+bOn
 aae
 aae
 aae
@@ -69114,28 +69577,9 @@ aae
 aae
 aae
 aae
+aak
+aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
 aae
 aae
 aae
@@ -69144,6 +69588,25 @@ aae
 aae
 aae
 aak
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bOn
+adz
+adz
+bOn
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -69370,36 +69833,6 @@ aak
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aak
 aae
@@ -69409,6 +69842,36 @@ aae
 aae
 aae
 aae
+aae
+aak
+aak
+aak
+aae
+aaa
+kDe
+aaa
+aaa
+aaa
+aaa
+bOn
+adz
+adz
+bOn
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aae
 aae
@@ -69638,34 +70101,34 @@ aae
 aae
 aae
 aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aak
-aak
-aak
-aae
 aak
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+onM
+onM
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+aaa
 aae
 aae
 aae
@@ -69896,33 +70359,33 @@ aae
 aae
 aae
 aae
-adz
-adz
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aak
-aak
-aak
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+gYI
+dEX
+gYI
+gYI
+pRu
+gYI
+gYI
+gYI
+gjc
+cuV
+sOF
+wyw
+pcP
+cuV
+rtp
+gYI
+gYI
+cuV
+gYI
+jJN
+cuV
+aaa
 aae
 aae
 aae
@@ -70153,33 +70616,33 @@ aae
 aae
 aae
 aae
-adz
-adz
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+gYI
+dEX
+gYI
+jgX
+jgX
+jgX
+jgX
+jgX
+gYI
+cuV
+gYI
+gYI
+jzV
+cuV
+vPL
+uZK
+vbN
+cuV
+gYI
+rZF
+cuV
+aaa
 aae
 aae
 aak
@@ -70410,33 +70873,33 @@ aae
 aae
 aae
 aae
-adz
-adz
 aae
 aae
-aae
-aae
-aae
-aae
-aak
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
-aak
-aae
-aak
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+jne
+cuV
+gYI
+eiJ
+eiJ
+eiJ
+eiJ
+eiJ
+gYI
+cuV
+gYI
+gYI
+jzV
+cuV
+dxu
+gYI
+gYI
+cuV
+hmW
+cuV
+cuV
+aaa
 aae
 aae
 aak
@@ -70667,33 +71130,33 @@ aae
 aae
 aae
 aak
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
 aae
-aae
-aak
-aak
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+gYI
+cuV
+gYI
+eiJ
+eiJ
+eiJ
+eiJ
+eiJ
+gYI
+cuV
+gYI
+bFp
+tHK
+cuV
+oOe
+gYI
+jne
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aak
@@ -70924,33 +71387,33 @@ aae
 aae
 aae
 aae
-adz
-adz
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-adz
-adz
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+gYI
+cuV
+gYI
+aJS
+feb
+aJS
+aJS
+aJS
+gYI
+cuV
+gYI
+vbN
+tHK
+cuV
+oOe
+gYI
+gYI
+qjV
+gYI
+gYI
+cuV
+aaa
 aak
 aak
 aae
@@ -71181,35 +71644,35 @@ aae
 aae
 aae
 aae
-adz
-adz
 aae
 aae
-aae
-aae
-aae
-aae
+aaa
+cuV
+gYI
+gYI
+cuV
+gYI
+gjc
+gYI
+gYI
+gYI
+gYI
+gYI
+hmW
+gYI
+gYI
+wff
+cuV
+oOe
+gYI
+gYI
+cuV
+gYI
+jne
+cuV
+aaa
 aak
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
+aae
 aae
 aae
 aae
@@ -71438,35 +71901,35 @@ aak
 aae
 aae
 aae
-adz
-adz
 aae
 aae
+aaa
+cuV
+gYI
+gYI
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+gYI
+gYI
+cuV
+gYI
+gYI
+uSU
+cuV
+oOe
+gYI
+ims
+cuV
+gYI
+vbN
+cuV
+aaa
 aae
-aae
-aae
-aae
-aae
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
-adz
+aak
 aae
 aae
 aak
@@ -71697,31 +72160,31 @@ aar
 xwF
 aak
 aak
-aak
-aak
-bWr
-bWr
-bWr
-xwF
-xwF
-adz
-xwF
-xwF
-xwF
-xwF
-xwF
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-xwF
-xwF
-aak
-aak
+aaa
+cuV
+jne
+gYI
+cuV
+awN
+auG
+auG
+oXU
+cuV
+hmW
+hmW
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aak
 aak
@@ -71954,31 +72417,31 @@ xwF
 xwF
 aak
 aak
-aak
-aak
-qcP
-aaB
-aaB
-aaB
-oSf
-aaB
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-ssl
-aaB
-xwF
-xwF
-aak
+aaa
+cuV
+gYI
+gYI
+cuV
+xTi
+auG
+iKe
+oXU
+cuV
+gYI
+gYI
+cuV
+gYI
+iNJ
+cuV
+hwf
+hwf
+aBx
+sCt
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -72211,31 +72674,31 @@ xwF
 xwF
 xwF
 xwF
-aaB
-aaB
-lxm
-uhX
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+xvM
+phJ
+auG
+lFy
+cuV
+gYI
+gYI
+cuV
+gYI
+feM
+cuV
+pRu
+gYI
+gYI
+gYI
+cuV
+jne
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -72468,31 +72931,31 @@ xwF
 xwF
 xwF
 xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-uhX
-aaB
-xwF
-aak
-aak
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+dTm
+auG
+cic
+duG
+cuV
+gYI
+gYI
+hmW
+gYI
+nvZ
+cuV
+gYI
+gYI
+vbN
+gYI
+gAJ
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -72725,31 +73188,31 @@ xwF
 xwF
 aaB
 aaB
-aaB
-aaB
-aaB
-aaB
-svj
+aaa
+cuV
+gYI
+gYI
+cuV
 auG
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-xwF
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-xwF
+auG
+nJO
+auG
+cuV
+gYI
+gYI
+cuV
+gYI
+bbX
+cuV
+gYI
+gYI
+gYI
+gYI
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -72982,31 +73445,31 @@ aak
 aak
 aaB
 aaB
-aaB
-aaB
-aaB
-aaB
-uhX
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-fSX
-aaB
-aak
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+vfg
+auG
+vWH
+auG
+hmW
+gYI
+gjc
+cuV
+gYI
+lZA
+cuV
+lqe
+gHY
+lHu
+niJ
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -73239,31 +73702,31 @@ xwF
 xwF
 xwF
 aaB
-aaB
-aaB
-gzX
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
+aaa
+cuV
+gYI
+jne
+cuV
+vfg
+auG
+auG
+auG
+cuV
+gYI
+gYI
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -73496,31 +73959,31 @@ xwF
 xwF
 xwF
 aar
-xwF
-xwF
-dEX
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+vfg
+auG
+auG
+raM
+cuV
+gYI
+gYI
+cuV
+aZT
+gcu
+aZT
+gcu
+aZT
+gcu
+aZT
+cuV
+gYI
+jne
+cuV
+aaa
 aak
 aae
 aae
@@ -73753,31 +74216,31 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-yeX
-aaB
-aaB
-xwF
-xwF
-aak
-aak
-aak
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aak
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+cjf
+eSb
+pqw
+eMt
+cuV
+gYI
+gYI
+cuV
+xTs
+fad
+xTs
+xTs
+xTs
+fad
+xTs
+cuV
+vbN
+gYI
+cuV
+aaa
 adz
 adz
 aae
@@ -74010,31 +74473,31 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aar
-aak
-aak
-aak
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-xGL
-xwF
-xwF
-xwF
-xwF
+aaa
+cuV
+gYI
+gjc
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+gYI
+gYI
+cuV
+xTs
+xTs
+xTs
+xTs
+mHA
+xTs
+peu
+cuV
+gYI
+gYI
+cuV
+aaa
 adz
 adz
 aae
@@ -74267,31 +74730,31 @@ aak
 aak
 aak
 aak
-aak
-xwF
-aak
-xwF
-xwF
-aak
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aar
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-aaB
-xwF
-aak
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+jAs
+jdC
+wXU
+jAs
+cuV
+gYI
+gYI
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+hmW
+cuV
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -74524,31 +74987,31 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aak
-xwF
-xwF
-xwF
-xwF
-qcP
-aaB
-aaB
-aaB
-aaB
-aaB
-kDe
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+aQl
+wbs
+jQP
+hnv
+hmW
+gjc
+gYI
+qjV
+gYI
+gYI
+gYI
+vbN
+gYI
+gYI
+gYI
+hmW
+gYI
+vbN
+cuV
+aaa
 aae
 aae
 aae
@@ -74781,31 +75244,31 @@ xwF
 xwF
 xwF
 xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aak
-xwF
-aak
+aaa
+cuV
+gYI
+gYI
+cuV
+jAs
+cDU
+jAs
+qhk
+cuV
+gYI
+gYI
+cuV
+gYI
+heI
+heI
+vJl
+vJl
+jne
+cga
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -75038,31 +75501,31 @@ xwF
 xwF
 xwF
 xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aar
-xwF
-xwF
-xwF
-xwF
-xwF
+aaa
+cuV
+gYI
+gYI
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+dEX
+dEX
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -75295,31 +75758,31 @@ aaB
 aaB
 aaB
 aaB
-aaB
-aaB
-aaB
+aaa
+cuV
 gYI
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+gYI
+dEX
+gYI
+gYI
+jne
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+gjc
+gYI
+gYI
+jne
+gYI
+dEX
+gYI
+gYI
+cuV
+aaa
 aae
 aae
 aae
@@ -75552,31 +76015,31 @@ aaB
 aaB
 ilg
 aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-ilg
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+aaa
+cuV
+jne
+gYI
+dEX
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+jne
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+gYI
+dEX
+gYI
+gYI
+cuV
+aaa
 aae
 aak
 aak
@@ -75809,31 +76272,31 @@ aaB
 aaB
 aaB
 yeX
-aaB
-aaB
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aak
-xwF
-xGL
-aaB
-aaB
-aaB
-aaB
-svj
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-aak
-xwF
-xwF
+aaa
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+cuV
+aaa
 aae
 aak
 aae
@@ -76066,31 +76529,31 @@ xwF
 xwF
 xwF
 aar
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-aak
-aak
-xwF
-xwF
-xwF
-aaB
-aaB
-aaB
-skM
-aaB
-aaB
-aaB
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
-xwF
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aak
 aak
@@ -76332,15 +76795,15 @@ xwF
 xwF
 xwF
 xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
+xwF
+xwF
+xwF
+xwF
+aak
+xwF
+xwF
+xwF
+xwF
 xwF
 xwF
 xwF
@@ -76589,15 +77052,15 @@ xwF
 aak
 xwF
 xwF
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
+xwF
+aak
+xwF
+xwF
+xwF
+xwF
+xwF
+xwF
+xwF
 xwF
 xwF
 xwF

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -248,14 +248,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"ajU" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ajX" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
@@ -335,6 +327,14 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
+"anC" = (
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "anY" = (
 /obj/structure/nest/assaultron{
 	infinite = 1;
@@ -410,6 +410,16 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"arl" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/organ/heart,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "arY" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -463,6 +473,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
@@ -473,13 +486,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"auX" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "avE" = (
 /obj/structure/wreck/trash/engine{
 	pixel_x = 9
@@ -527,6 +533,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/ash_rock,
 /area/f13/caves)
+"ayr" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "ayu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -542,13 +556,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
-"aAV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "aBg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/broken{
@@ -556,14 +563,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
-"aBu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "aCD" = (
 /obj/structure/junk/small/tv{
 	pixel_y = 20
@@ -649,6 +648,18 @@
 /area/f13/caves)
 "aGd" = (
 /turf/open/floor/f13/wood,
+/area/f13/caves)
+"aGe" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "aGf" = (
 /obj/machinery/workbench/forge,
@@ -880,6 +891,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"aTU" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "aTZ" = (
 /turf/open/floor/carpet/black,
 /area/f13/building)
@@ -1026,14 +1042,6 @@
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bhc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "bhe" = (
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -1146,6 +1154,10 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"bmN" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "bmR" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/inside/mountain,
@@ -1229,6 +1241,16 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"brP" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "brR" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_0"
@@ -1285,6 +1307,15 @@
 /obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"btU" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "btV" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/item/stack/f13Cash/caps/fivezerozero,
@@ -1327,6 +1358,20 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"bvM" = (
+/obj/item/clothing/head/hooded/human_head{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "bvU" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -1347,15 +1392,6 @@
 	layer = 3
 	},
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
-"bwr" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/breathing_tanks,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "bwu" = (
 /obj/structure/chair/wood{
@@ -4390,20 +4426,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"bQn" = (
-/obj/item/clothing/head/hooded/human_head{
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "bQp" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -4760,6 +4782,11 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"bSe" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/breathing_masks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "bSm" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
@@ -5288,6 +5315,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building)
+"cgM" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "chj" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -6302,15 +6337,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"cDv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "cDz" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6435,6 +6461,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"cMw" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "cML" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -6541,11 +6573,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"cSr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "cSO" = (
 /obj/structure/bed/mattress{
@@ -6777,17 +6804,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/caves)
-"dgT" = (
-/obj/structure/table,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/caves)
 "dhP" = (
 /obj/structure/window/fulltile/house{
@@ -7068,6 +7084,16 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
+"dwI" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "dwM" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -7214,13 +7240,6 @@
 "dEX" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
-"dFa" = (
-/obj/structure/nest/ghoul,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "dFj" = (
 /obj/machinery/light{
 	dir = 8
@@ -7266,6 +7285,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"dFS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "dFY" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -7332,12 +7358,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"dJQ" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "dKc" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -7383,6 +7403,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"dLy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "dLI" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -7422,6 +7447,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"dPo" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "dPK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/old,
@@ -7671,17 +7703,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
-"ebN" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "ebV" = (
 /obj/item/storage/box/lights/tubes,
 /mob/living/simple_animal/hostile/radroach,
@@ -7829,22 +7850,13 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"elt" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"elT" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/caves)
-"elW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "elZ" = (
 /obj/structure/table,
@@ -7870,6 +7882,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"enW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "eoj" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -7881,10 +7901,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
-"eov" = (
-/obj/effect/spawner/lootdrop/f13/medical/random_fev,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "eoB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7962,16 +7978,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"erm" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "erF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -8104,6 +8110,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/caves)
+"exk" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "exn" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/manual/ncr/jobguide,
@@ -8209,12 +8226,6 @@
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/caves)
-"eCh" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "eCp" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8465,12 +8476,6 @@
 "eNE" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"eNF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "eOb" = (
 /obj/machinery/light{
@@ -8765,11 +8770,6 @@
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"feY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ffg" = (
 /obj/machinery/door/airlock/grunge,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -8927,17 +8927,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"fpv" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "fpS" = (
 /obj/structure/simple_door/room{
 	name = "Barracks II"
@@ -8963,11 +8952,6 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
-"fqS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "fqT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel{
@@ -9002,14 +8986,6 @@
 	},
 /obj/structure/nest/supermutant,
 /turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
-"ftg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "ftM" = (
 /obj/structure/table/wood/poker,
@@ -9053,6 +9029,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tunnel,
 /area/f13/sewer)
+"fvL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "fwD" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9139,6 +9126,10 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/water,
 /area/f13/caves)
+"fBY" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "fCu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9166,11 +9157,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/tunnel)
-"fDa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "fDh" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -9186,11 +9172,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"fFs" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/plush,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "fFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9422,17 +9403,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fUe" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "fVh" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -9474,13 +9444,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"fYk" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "fYG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
@@ -9511,10 +9474,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"gaM" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "gaN" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9592,6 +9551,13 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gfC" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ggk" = (
 /obj/structure/table,
 /obj/item/ammo_box/shotgun/slug,
@@ -9752,12 +9718,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"goU" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "gph" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/wreck/trash/engine,
@@ -9896,6 +9856,14 @@
 /obj/structure/wreck/trash/engine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"gxo" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "gxz" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
@@ -9914,6 +9882,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"gyf" = (
+/obj/structure/simple_door/house,
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "gyt" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -10238,12 +10210,6 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gRO" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/bio_suit/hazmat,
-/obj/item/clothing/head/bio_hood/hazmat,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "gRP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10284,6 +10250,19 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
+/area/f13/caves)
+"gUQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"gUR" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
 "gUU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10326,6 +10305,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
+"gYQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "gZn" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10366,16 +10350,6 @@
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"hbW" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/item/stack/sheet/animalhide/human,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "hcf" = (
 /obj/structure/chair/wood,
@@ -10426,13 +10400,6 @@
 /obj/effect/decal/fakelattice,
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"hgm" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "hgv" = (
 /obj/effect/decal/fakelattice,
@@ -10545,6 +10512,15 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"hnk" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -10707,6 +10683,14 @@
 /obj/effect/landmark/start/f13/ncrranger,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"hvS" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hvT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -10761,11 +10745,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"hyx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/rndboards,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hzG" = (
 /mob/living/simple_animal/hostile/raider/firefighter{
 	name = "Tunnel Torturers Raider"
@@ -10813,6 +10792,15 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/caves)
+"hCE" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "hCT" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10908,6 +10896,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"hHB" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10988,13 +10981,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"hMY" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "hNr" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -11016,15 +11002,6 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"hON" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ultracite,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "hOV" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
@@ -11492,6 +11469,11 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
+"iod" = (
+/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "iof" = (
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/floor/f13{
@@ -11596,6 +11578,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"itn" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "itt" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -11697,11 +11688,22 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"iyL" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "iyM" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"iyV" = (
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "izf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -12015,6 +12017,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"iMN" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "iMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12098,6 +12104,14 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/caves)
+"iRM" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "iRN" = (
 /obj/structure/rack,
@@ -12350,6 +12364,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"jdA" = (
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "jdR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
@@ -12490,10 +12507,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"jpI" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "jqi" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	icon_state = "neutralrusty"
@@ -12608,16 +12621,6 @@
 "jvL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
-"jwa" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "jwj" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -12633,15 +12636,6 @@
 "jzc" = (
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"jzh" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "jzA" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -12756,12 +12750,17 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"jEV" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
+"jEg" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
 	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "jFh" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -13189,6 +13188,14 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/caves)
+"kdY" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "keb" = (
 /obj/structure/table/optable/abductor,
 /obj/item/restraints/handcuffs,
@@ -13284,6 +13291,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/tunnel)
+"kkb" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kkd" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -13468,16 +13479,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"kvB" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kwC" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -13552,6 +13553,12 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"kzE" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kzN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -13587,11 +13594,8 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/tunnel)
-"kBG" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
+"kCu" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "kCz" = (
@@ -13614,7 +13618,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "kDe" = (
-/turf/closed/wall/f13/store,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "kDw" = (
 /obj/structure/cargocrate,
@@ -13663,14 +13673,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"kHZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "kIe" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
@@ -13690,6 +13692,15 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/caves)
+"kIL" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/caves)
 "kJd" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -13734,10 +13745,11 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"kLz" = (
-/obj/structure/ladder/unbreakable{
-	id = "followersbasement";
-	height = 1
+"kLG" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
@@ -13755,10 +13767,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"kMN" = (
-/obj/structure/simple_door/house,
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -13785,6 +13793,16 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
+"kOX" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "kPE" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -13827,17 +13845,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"kRy" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "kRZ" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/closed/wall/f13/wood,
@@ -13873,20 +13880,6 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"kTV" = (
-/obj/item/bodypart/l_arm,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbear1"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "kTX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -13937,6 +13930,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"kVD" = (
+/obj/structure/nest/ghoul,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kVU" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
@@ -14151,10 +14151,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
-"lhy" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "lhO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -14220,6 +14216,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"lmB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"lmM" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "lmW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14234,6 +14239,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lnY" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "loD" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/generic,
@@ -14412,13 +14423,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lxK" = (
-/obj/machinery/door/airlock/medical{
-	name = null;
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "lxU" = (
 /obj/effect/decal/fakelattice,
 /obj/item/ammo_casing/shotgun/improvised,
@@ -14594,13 +14598,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"lEY" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "lFa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -14677,10 +14674,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/f13/caves)
-"lHg" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lHm" = (
 /obj/structure/wreck/trash/five_tires,
@@ -14791,10 +14784,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"lMY" = (
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
 "lNe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -14933,14 +14922,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"lTJ" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "lTS" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
@@ -15001,20 +14982,6 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
-"lUT" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "lUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -15456,6 +15423,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"mth" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/breathing_tanks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "mtF" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -15566,15 +15542,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"myX" = (
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
-"mzc" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/machinery/light/small/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "mzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
@@ -15645,13 +15612,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"mEl" = (
-/obj/effect/spawner/lootdrop/trash,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "mEQ" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -15674,6 +15634,20 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
+/area/f13/caves)
+"mIL" = (
+/obj/item/bodypart/l_arm,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "mIM" = (
 /obj/machinery/workbench/mbench,
@@ -15779,16 +15753,9 @@
 /obj/item/clothing/under/f13/vault/v13,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"mLm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/strong,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"mLo" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
+"mLd" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15796,6 +15763,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
+/area/f13/caves)
+"mLm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "mLS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16041,6 +16014,16 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"nbB" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "nbQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
@@ -16400,6 +16383,13 @@
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
+"nxf" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "nyY" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -16426,11 +16416,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"nAJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "nAQ" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -16486,11 +16471,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
-"nDO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/breathing_masks,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "nDR" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13{
@@ -16580,6 +16560,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"nIz" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "nIE" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -16705,14 +16693,6 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
-/area/f13/caves)
-"nOO" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "nOW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16867,17 +16847,9 @@
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"nWC" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/structure/fermenting_barrel,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
+"nXd" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "nXl" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -16974,18 +16946,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"obJ" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
-"obL" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "obM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17055,6 +17015,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"ohQ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "oib" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -17088,6 +17055,16 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/caves)
+"ojE" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "ojM" = (
 /obj/structure/nest/deathclaw{
@@ -17131,6 +17108,12 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/caves)
+"ols" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "olP" = (
 /obj/item/trash/f13/dog,
@@ -17240,6 +17223,24 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"oqQ" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"ord" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "ory" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -17329,6 +17330,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/caves)
+"owG" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "owV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17365,14 +17379,19 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"oyu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"oyq" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/obj/machinery/light/broken{
-	dir = 1
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "oyC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17996,6 +18015,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"peT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pfa" = (
 /obj/structure/sign/poster/contraband/smoke{
 	pixel_y = 32
@@ -18182,16 +18207,6 @@
 "ppq" = (
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
-"pqb" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "pqq" = (
 /obj/structure/flora/grass/jungle/b,
@@ -18399,10 +18414,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"pAR" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18468,11 +18479,26 @@
 	icon_state = "bluerustyfull"
 	},
 /area/f13/caves)
+"pCX" = (
+/obj/structure/table/reinforced,
+/obj/item/blueprint/research,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pDI" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"pDL" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pDW" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -18498,12 +18524,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"pFH" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"pGt" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "pGB" = (
 /obj/machinery/light/small{
@@ -18606,11 +18632,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"pJO" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/stockparts/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pLh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18662,14 +18683,6 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
-	},
-/area/f13/caves)
-"pNA" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
 	},
 /area/f13/caves)
 "pNE" = (
@@ -19322,13 +19335,6 @@
 "qsY" = (
 /turf/open/floor/wood_common,
 /area/f13/caves)
-"qtf" = (
-/obj/structure/table/reinforced,
-/obj/item/circular_saw,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "qtg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19349,6 +19355,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/tunnel)
+"qtH" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "qtU" = (
 /obj/machinery/conveyor/inverted,
 /obj/effect/turf_decal/stripes/line{
@@ -19440,6 +19450,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"qyt" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "qyC" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/timeddoor,
@@ -19486,15 +19507,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"qAi" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "qAw" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -19513,13 +19525,6 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"qAS" = (
-/obj/structure/closet,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "qBT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19553,6 +19558,16 @@
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
+/area/f13/caves)
+"qDE" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "qDL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19975,13 +19990,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
-"qZL" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "qZV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -20098,6 +20106,10 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/tunnel)
+"riX" = (
+/obj/effect/spawner/lootdrop/f13/medical/random_fev,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "rje" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -20111,6 +20123,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"rjW" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "rjZ" = (
 /obj/structure/cable{
@@ -20178,12 +20197,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"rnb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "rnh" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -20193,16 +20206,16 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
+"rnL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "rog" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
-/area/f13/caves)
-"roN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "roU" = (
 /obj/structure/closet/crate/bin,
@@ -20233,6 +20246,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"rpM" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "rqS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
@@ -20418,6 +20437,14 @@
 /turf/open/floor/f13{
 	icon_state = "purplefull"
 	},
+/area/f13/caves)
+"rDU" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "rEX" = (
 /obj/machinery/light{
@@ -20635,10 +20662,6 @@
 	color = "#363636"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
-"rOX" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "rPt" = (
 /obj/structure/table,
@@ -20921,6 +20944,20 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"sgy" = (
+/obj/structure/nest/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"sgD" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "sgV" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -20955,14 +20992,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/museum)
-"sig" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "sjg" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /obj/structure/flora/rock/pile/largejungle{
@@ -21026,16 +21055,19 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"snO" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "snS" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"soe" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "soz" = (
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -21083,13 +21115,6 @@
 "ssu" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"ssS" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "sta" = (
 /obj/effect/decal/remains/human,
@@ -21505,15 +21530,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"sNL" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "sNR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21597,6 +21613,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"sRq" = (
+/obj/machinery/door/airlock/medical{
+	name = null;
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"sRN" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "sSs" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -21716,6 +21743,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/clinic)
+"sXc" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "sXf" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21799,6 +21832,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
+"tbG" = (
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "tbP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/chem_pile,
@@ -21864,6 +21902,13 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"teb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "tep" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/waste{
@@ -21924,11 +21969,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"tio" = (
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "tit" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -22108,16 +22148,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"tpq" = (
-/obj/effect/decal/waste{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "tpI" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -22164,16 +22194,6 @@
 	name = "Door Control"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"trE" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/obj/item/organ/heart,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "ttk" = (
 /obj/structure/table,
@@ -22326,10 +22346,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"tCj" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "tCu" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22446,13 +22462,6 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"tIn" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "tIq" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/showcase/machinery/cloning_pod,
@@ -22501,6 +22510,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"tLu" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "tNM" = (
 /obj/structure/handrail/g_central{
 	dir = 1;
@@ -22516,15 +22532,6 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
-"tOI" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tOJ" = (
 /obj/structure/barricade/bars,
@@ -22590,6 +22597,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
+"tTa" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "tTe" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/light{
@@ -22640,13 +22656,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/radroach_meat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"tWh" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tWi" = (
 /obj/item/shield/riot,
@@ -22754,6 +22763,12 @@
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"uch" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "ucB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -22774,6 +22789,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"ued" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "ufB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -22878,6 +22900,11 @@
 /obj/effect/decal/fakelattice,
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/tunnel,
+/area/f13/caves)
+"umN" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "umW" = (
 /obj/structure/rack/shelf_metal,
@@ -23099,13 +23126,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
-"uzt" = (
-/obj/structure/nest/supermutant,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "uzY" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/machinery/light/small{
@@ -23197,6 +23217,13 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/caves)
+"uDC" = (
+/obj/structure/closet,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "uDF" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /obj/effect/turf_decal/bot_red,
@@ -23253,6 +23280,9 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"uFM" = (
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "uHa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -23449,14 +23479,6 @@
 /turf/open/indestructible/ground/inside/subway{
 	name = "stone floor"
 	},
-/area/f13/caves)
-"uRq" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "uRB" = (
 /obj/structure/barricade/bars,
@@ -23908,10 +23930,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"vnb" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vnu" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
@@ -24024,6 +24042,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"vsU" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vsZ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/neck/mantle/gecko,
@@ -24076,10 +24099,24 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vyp" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vyr" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
+"vyD" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "vyO" = (
@@ -24177,6 +24214,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
+"vCH" = (
+/obj/structure/nest/supermutant,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vCM" = (
 /obj/structure/bed/pod,
 /turf/open/floor/plating,
@@ -24229,6 +24273,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vFY" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib6-old"
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "vGl" = (
 /obj/item/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -24487,14 +24543,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"vYl" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
+"vYs" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -24719,12 +24773,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
-"wiD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wiW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24968,6 +25016,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"wyR" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wyS" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -25089,12 +25141,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"wEa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wEh" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -25132,11 +25178,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"wFd" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wFO" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -25147,6 +25188,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"wGA" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wGI" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/turf_decal/weather/dirt{
@@ -25188,11 +25236,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"wJu" = (
-/obj/machinery/light/broken{
-	dir = 1
+"wJH" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wKJ" = (
 /obj/structure/table/reinforced,
@@ -25208,6 +25261,11 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/caves)
+"wKO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wKV" = (
 /obj/structure/rack,
@@ -25230,17 +25288,13 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
-"wLL" = (
-/obj/structure/table/reinforced,
-/obj/item/blueprint/research,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wMj" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"wMN" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wNu" = (
 /obj/item/cigbutt{
 	pixel_y = 6
@@ -25289,19 +25343,6 @@
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
-	},
-/area/f13/caves)
-"wQi" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
 	},
 /area/f13/caves)
 "wQZ" = (
@@ -25370,15 +25411,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"wWA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wXa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25437,9 +25469,6 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
-"wZJ" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
 "wZK" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25530,6 +25559,16 @@
 /obj/structure/window/reinforced,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/caution,
+/area/f13/caves)
+"xeB" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "xeD" = (
 /obj/structure/wreck/trash/four_barrels,
@@ -25630,6 +25669,11 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
+/area/f13/caves)
+"xkg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "xkj" = (
 /obj/structure/cable{
@@ -25750,6 +25794,15 @@
 	dir = 1
 	},
 /area/f13/caves)
+"xrU" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "xsg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25790,10 +25843,6 @@
 "xuR" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/caves)
-"xvo" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "xvT" = (
 /obj/structure/bed/mattress,
@@ -25930,6 +25979,15 @@
 /obj/structure/decoration/warning,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
+"xDE" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "xDN" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/destructible/tribal_torch/lit,
@@ -26030,17 +26088,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"xKd" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "xKm" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -26050,15 +26097,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"xKG" = (
-/mob/living/simple_animal/hostile/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "xKU" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/barricade/wooden/strong,
@@ -26235,6 +26273,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"xSm" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "xSw" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -26371,16 +26415,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"xYL" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "xYM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -26435,13 +26469,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"ybl" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ybG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -26463,10 +26490,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
-"ydy" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ydH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -26549,13 +26572,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/caves)
-"yhr" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "yhG" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -26601,6 +26617,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"yiA" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "yiX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
@@ -70159,7 +70183,7 @@ aak
 aak
 aae
 aaa
-wZJ
+jdA
 aaa
 aaa
 aaa
@@ -70416,29 +70440,29 @@ aak
 aae
 aae
 aaa
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-lxK
-lxK
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+sRq
+sRq
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 aaa
 aae
 aae
@@ -70673,29 +70697,29 @@ aae
 aae
 aae
 aaa
-kDe
-oyu
+uFM
+itn
 dEX
-ydy
+wMN
 dEX
 dEX
-myX
+kCu
 dEX
 gYI
 gYI
-jpI
-kDe
-pJO
-wFd
-hyx
-kDe
-sig
+wyR
+uFM
+vsU
+hHB
+umN
+uFM
+cgM
 gYI
 dEX
-kDe
+uFM
 dEX
-kLz
-kDe
+iyV
+uFM
 aaa
 aae
 aae
@@ -70930,29 +70954,29 @@ aae
 aae
 aae
 aaa
-kDe
+uFM
 gYI
 gYI
-ydy
+wMN
 gYI
-sNL
-sNL
-sNL
-sNL
-sNL
+xDE
+xDE
+xDE
+xDE
+xDE
 dEX
-kDe
+uFM
 gYI
 gYI
-lHg
-kDe
-cSr
-tOI
-ybl
-kDe
+nXd
+uFM
+rnL
+xrU
+sgy
+uFM
 dEX
-mzc
-kDe
+iod
+uFM
 aaa
 aae
 aae
@@ -71187,29 +71211,29 @@ aae
 aae
 aae
 aaa
-kDe
+uFM
 dEX
-mEl
-rnb
+wGA
+lnY
 gYI
-lEY
-pAR
-lEY
-lEY
-lEY
-tCj
-kDe
-gYI
-gYI
-fYk
-kDe
-fFs
+gfC
+iMN
+gfC
+gfC
+gfC
+vyp
+uFM
 gYI
 gYI
-kDe
-lhy
-kDe
-kDe
+pDL
+uFM
+aTU
+gYI
+gYI
+uFM
+iyL
+uFM
+uFM
 aaa
 aae
 aae
@@ -71444,29 +71468,29 @@ aak
 aak
 aae
 aaa
-kDe
+uFM
 dEX
 gYI
-rnb
-cDv
-lEY
-pAR
-lEY
-lEY
-lEY
+lnY
+gUQ
+gfC
+iMN
+gfC
+gfC
+gfC
 gYI
-kDe
+uFM
 gYI
-kBG
-nOO
-kDe
-pqb
+snO
+yiA
+uFM
+ojE
 gYI
-mEl
-kDe
+wGA
+uFM
 dEX
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -71701,29 +71725,29 @@ aae
 aae
 aae
 aaa
-kDe
+uFM
 dEX
 gYI
-kDe
+uFM
 gYI
-vYl
-kvB
-vYl
-eCh
-vYl
+tTa
+brP
+tTa
+kzE
+tTa
 gYI
-kDe
+uFM
 gYI
-ybl
-soe
-kDe
-tWh
-gYI
-gYI
-kMN
+sgy
+sRN
+uFM
+oqQ
 gYI
 gYI
-kDe
+gyf
+gYI
+gYI
+uFM
 aaa
 aak
 aak
@@ -71958,29 +71982,29 @@ aae
 aae
 aae
 aaa
-kDe
-wJu
+uFM
+rpM
 gYI
-kDe
+uFM
 dEX
-jpI
-gYI
-dEX
-dEX
-gYI
-gYI
-lhy
-dEX
-gYI
-ajU
-kDe
-rOX
+wyR
 gYI
 dEX
-kDe
+dEX
 gYI
-lTJ
-kDe
+gYI
+iyL
+dEX
+gYI
+iRM
+uFM
+kkb
+gYI
+dEX
+uFM
+gYI
+rDU
+uFM
 aaa
 aak
 aae
@@ -72215,29 +72239,29 @@ aae
 aae
 aae
 aaa
-kDe
+uFM
 gYI
 dEX
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 dEX
 gYI
-kDe
+uFM
 dEX
 dEX
-wLL
-kDe
-rOX
+pCX
+uFM
+kkb
 gYI
-eNF
-kDe
+cMw
+uFM
 dEX
-ybl
-kDe
+sgy
+uFM
 aaa
 aae
 aak
@@ -72472,29 +72496,29 @@ xwF
 aak
 aak
 aaa
-kDe
-mEl
+uFM
+wGA
 dEX
-kDe
-mLo
-auG
-tio
-hgm
-kDe
-lhy
-lhy
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+jEg
+kdY
+tbG
+vYs
+uFM
+iyL
+iyL
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 dEX
 gYI
-kDe
+uFM
 aaa
 aae
 aak
@@ -72729,29 +72753,29 @@ xwF
 aak
 aak
 aaa
-kDe
+uFM
 gYI
 dEX
-kDe
-lUT
-auG
-bQn
-hgm
-kDe
+uFM
+oyq
+kdY
+bvM
+vYs
+uFM
 gYI
 gYI
-kDe
+uFM
 dEX
-ftg
-kDe
-nAJ
-uRq
-kHZ
-roN
-kDe
+kLG
+uFM
+xkg
+gxo
+nIz
+lmB
+uFM
 gYI
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -72986,29 +73010,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
+uFM
 gYI
 gYI
-kDe
-hbW
-xKd
-auG
-qtf
-kDe
+uFM
+qDE
+ord
+kdY
+dPo
+uFM
 gYI
-pFH
-kDe
+teb
+uFM
 dEX
-elW
-kDe
-myX
+hvS
+uFM
+kCu
 gYI
 gYI
 gYI
-kDe
-mEl
+uFM
+wGA
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -73243,29 +73267,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
-wJu
+uFM
+rpM
 gYI
-kDe
-trE
-auG
-kTV
-hMY
-kDe
+uFM
+arl
+kdY
+mIL
+ohQ
+uFM
 gYI
 gYI
-lhy
+iyL
 gYI
-jzh
-kDe
-oyu
+hnk
+uFM
+itn
 gYI
-ybl
+sgy
 gYI
-lMY
+gUR
 gYI
-vnb
-kDe
+bmN
+uFM
 aaa
 aae
 aae
@@ -73500,29 +73524,29 @@ xwF
 aaB
 aaB
 aaa
-kDe
+uFM
 dEX
 gYI
-kDe
+uFM
 auG
-auG
-dJQ
-auG
-kDe
+kdY
+uch
+vyD
+uFM
 gYI
 gYI
-kDe
+uFM
 gYI
-fqS
-kDe
+dLy
+uFM
 gYI
 gYI
 gYI
 dEX
-kDe
+uFM
 gYI
 dEX
-kDe
+uFM
 aaa
 aae
 aae
@@ -73757,29 +73781,29 @@ aak
 aaB
 aaB
 aaa
-kDe
+uFM
 gYI
 gYI
-kDe
-fpv
-tio
-fUe
-auG
-lhy
+uFM
+qyt
+tbG
+exk
+kdY
+iyL
 dEX
-uzt
-kDe
+vCH
+uFM
 gYI
-feY
-kDe
-bwr
-nDO
-fDa
-wEa
-kDe
+gYQ
+uFM
+mth
+bSe
+wKO
+xSm
+uFM
 gYI
 dEX
-kDe
+uFM
 aaa
 aae
 aae
@@ -74014,29 +74038,29 @@ xwF
 xwF
 aaB
 aaa
-kDe
+uFM
 gYI
-mEl
-kDe
-fpv
-tio
-auG
-tio
-kDe
+wGA
+uFM
+qyt
+tbG
+kdY
+tbG
+uFM
 dEX
 gYI
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 gYI
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -74271,29 +74295,29 @@ xwF
 xwF
 aar
 aaa
-kDe
+uFM
 dEX
 gYI
-kDe
-fpv
-auG
-auG
-auX
-kDe
+uFM
+qyt
+kdY
+kdY
+rjW
+uFM
 gYI
 gYI
-kDe
-jwa
-pNA
-wQi
-pNA
-jwa
-pNA
-wQi
-kDe
+uFM
+nbB
+elT
+owG
+elT
+nbB
+elT
+owG
+uFM
 gYI
-mEl
-kDe
+wGA
+uFM
 aaa
 aak
 aae
@@ -74528,29 +74552,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
-oyu
+uFM
+itn
 gYI
-kDe
-tIn
-ebN
-nWC
-goU
-kDe
+uFM
+pGt
+mLd
+vFY
+ols
+uFM
 dEX
 gYI
-kDe
+uFM
 xTs
-xKG
-bhc
-bhc
-bhc
-xKG
-bhc
-kDe
-ybl
-pFH
-kDe
+kIL
+enW
+enW
+enW
+kIL
+enW
+uFM
+sgy
+teb
+uFM
 aaa
 adz
 adz
@@ -74785,29 +74809,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
+uFM
 gYI
-jpI
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-oyu
+wyR
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+itn
 gYI
-kDe
-bhc
+uFM
+enW
 xTs
-bhc
-kRy
-elt
-bhc
-dgT
-kDe
+enW
+fvL
+btU
+enW
+wJH
+uFM
 gYI
-qAi
 kDe
+uFM
 aaa
 adz
 adz
@@ -75042,29 +75066,29 @@ aak
 aak
 aak
 aaa
-kDe
+uFM
 gYI
 gYI
-kDe
-gaM
-erm
-eov
-ssS
-kDe
+uFM
+lmM
+kOX
+riX
+tLu
+uFM
 gYI
 gYI
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-lhy
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+iyL
+uFM
+uFM
 gYI
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -75299,29 +75323,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
+uFM
 dEX
 gYI
-kDe
-hON
-obJ
-xYL
-tpq
-lhy
-uzt
+uFM
+aGe
+ayr
+xeB
+dwI
+iyL
+vCH
 gYI
-kMN
+gyf
 dEX
 dEX
 dEX
-dFa
+kVD
 dEX
 dEX
 dEX
-lhy
+iyL
 gYI
-obL
-kDe
+fBY
+uFM
 aaa
 aae
 aae
@@ -75556,29 +75580,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
+uFM
 gYI
 dEX
-kDe
-gaM
-jEV
-ssS
-qZL
-kDe
+uFM
+lmM
+sgD
+tLu
+ued
+uFM
 dEX
 gYI
-kDe
+uFM
 dEX
-gRO
-gRO
-qAS
-qAS
-xvo
-aBu
-kDe
+sXc
+sXc
+uDC
+uDC
+qtH
+anC
+uFM
 gYI
 dEX
-kDe
+uFM
 aaa
 aae
 aae
@@ -75813,29 +75837,29 @@ xwF
 xwF
 xwF
 aaa
-kDe
-cDv
+uFM
+gUQ
 gYI
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-ydy
-ydy
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+wMN
+wMN
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 gYI
-aAV
-kDe
+dFS
+uFM
 aaa
 aae
 aae
@@ -76070,13 +76094,13 @@ aaB
 aaB
 aaB
 aaa
-kDe
+uFM
 gYI
 gYI
-ydy
+wMN
 gYI
 gYI
-xvo
+qtH
 dEX
 dEX
 dEX
@@ -76084,15 +76108,15 @@ gYI
 gYI
 gYI
 gYI
-jpI
+wyR
 gYI
 gYI
-mEl
+wGA
 gYI
-ydy
+wMN
 gYI
 gYI
-kDe
+uFM
 aaa
 aae
 aae
@@ -76327,29 +76351,29 @@ aaB
 ilg
 aaB
 aaa
-kDe
-mEl
+uFM
+wGA
 dEX
-yhr
+nxf
 gYI
 gYI
 gYI
 gYI
-wWA
+hCE
 gYI
 gYI
-xvo
+qtH
 gYI
-wiD
+peT
 gYI
 gYI
 gYI
 dEX
-wWA
-yhr
+hCE
+nxf
 dEX
 dEX
-kDe
+uFM
 aaa
 aae
 aak
@@ -76584,29 +76608,29 @@ aaB
 aaB
 yeX
 aaa
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
-kDe
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
+uFM
 aaa
 aae
 aak

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -248,6 +248,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
+"ajU" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ajX" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
@@ -452,6 +460,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "auG" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
 	},
@@ -462,6 +473,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"auX" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "avE" = (
 /obj/structure/wreck/trash/engine{
 	pixel_x = 9
@@ -484,15 +502,6 @@
 /obj/item/pen/fountain,
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
-	},
-/area/f13/caves)
-"awN" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "axw" = (
@@ -533,6 +542,13 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
+"aAV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "aBg" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/machinery/light/broken{
@@ -540,9 +556,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/building/museum)
-"aBx" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+"aBu" = (
+/obj/structure/table,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "aCD" = (
@@ -703,12 +722,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"aJS" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "aKH" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -829,12 +842,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"aQl" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/ammo/ultracite,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "aQy" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/waste{
@@ -965,16 +972,6 @@
 	dir = 10
 	},
 /area/f13/caves)
-"aZT" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "bao" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/mountain,
@@ -996,11 +993,6 @@
 "bbV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/vaultdoor,
-/area/f13/caves)
-"bbX" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "bcB" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -1034,6 +1026,14 @@
 /obj/item/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bhc" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "bhe" = (
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -1348,6 +1348,15 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
+"bwr" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/breathing_tanks,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "bwu" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -1628,10 +1637,6 @@
 "bEJ" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/tunnel)
-"bFp" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "bFx" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
@@ -4385,6 +4390,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"bQn" = (
+/obj/item/clothing/head/hooded/human_head{
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "bQp" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -5240,14 +5259,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"cga" = (
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/obj/item/reagent_containers/rag/towel,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "cge" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/jackboots,
@@ -5313,17 +5324,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"cic" = (
-/obj/item/bodypart/l_arm,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbear1"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "cid" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -5386,13 +5386,6 @@
 /obj/machinery/telecomms/server/presets/legion,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"cjf" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "cjg" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
@@ -6053,9 +6046,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"cuV" = (
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "cvq" = (
 /obj/machinery/button/door{
 	id = "salad";
@@ -6312,6 +6302,15 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"cDv" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "cDz" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6342,13 +6341,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"cDU" = (
-/obj/effect/decal/waste{
-	icon_state = "goo8"
-	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "cEf" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -6549,6 +6541,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"cSr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "cSO" = (
 /obj/structure/bed/mattress{
@@ -6780,6 +6777,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/caves)
+"dgT" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/caves)
 "dhP" = (
 /obj/structure/window/fulltile/house{
@@ -7030,13 +7038,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/caves)
-"duG" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "duJ" = (
 /obj/structure/nest/raider{
 	max_mobs = 3;
@@ -7082,11 +7083,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/caves)
-"dxu" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/plush,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "dya" = (
 /obj/structure/table/glass,
@@ -7216,7 +7212,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dEX" = (
-/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"dFa" = (
+/obj/structure/nest/ghoul,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "dFj" = (
@@ -7329,6 +7331,12 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"dJQ" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "dKc" = (
 /obj/structure/rack,
@@ -7488,16 +7496,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"dTm" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
-	},
-/obj/item/organ/heart,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "dTO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -7673,6 +7671,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
+"ebN" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "ebV" = (
 /obj/item/storage/box/lights/tubes,
 /mob/living/simple_animal/hostile/radroach,
@@ -7781,10 +7790,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"eiJ" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ejG" = (
 /obj/machinery/light{
 	dir = 1
@@ -7824,6 +7829,23 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"elt" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
+"elW" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "elZ" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
@@ -7859,6 +7881,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/clinic)
+"eov" = (
+/obj/effect/spawner/lootdrop/f13/medical/random_fev,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "eoB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7936,6 +7962,16 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"erm" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "erF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -8174,6 +8210,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"eCh" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "eCp" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
@@ -8392,12 +8434,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"eMt" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "eMJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -8429,6 +8465,12 @@
 "eNE" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"eNF" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "eOb" = (
 /obj/machinery/light{
@@ -8514,14 +8556,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
-	},
-/area/f13/caves)
-"eSb" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "eSw" = (
@@ -8671,12 +8705,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"fad" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "fae" = (
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8727,28 +8755,21 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"feb" = (
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "feC" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"feM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "feP" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"feY" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ffg" = (
 /obj/machinery/door/airlock/grunge,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -8906,6 +8927,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"fpv" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "fpS" = (
 /obj/structure/simple_door/room{
 	name = "Barracks II"
@@ -8931,6 +8963,11 @@
 	},
 /turf/open/water,
 /area/f13/tunnel)
+"fqS" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "fqT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel{
@@ -8965,6 +9002,14 @@
 	},
 /obj/structure/nest/supermutant,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/caves)
+"ftg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "ftM" = (
 /obj/structure/table/wood/poker,
@@ -9121,6 +9166,11 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/tunnel)
+"fDa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "fDh" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -9136,6 +9186,11 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"fFs" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "fFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9367,6 +9422,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fUe" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "fVh" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -9408,6 +9474,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
+"fYk" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "fYG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
@@ -9438,6 +9511,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"gaM" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "gaN" = (
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9471,14 +9548,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"gcu" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/caves)
 "gcv" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/rust,
@@ -9590,10 +9659,6 @@
 /obj/structure/nest/supermutant/melee,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gjc" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "gjs" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary,
 /obj/effect/decal/cleanable/dirt,
@@ -9685,6 +9750,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
+	},
+/area/f13/caves)
+"goU" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "gph" = (
@@ -9888,10 +9959,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"gAJ" = (
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
 "gAQ" = (
 /obj/structure/decoration/vent{
 	layer = 2.8
@@ -10035,11 +10102,6 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
-"gHY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/breathing_masks,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "gJb" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10176,6 +10238,12 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowPartsWeighted,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"gRO" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "gRP" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10253,6 +10321,9 @@
 /turf/open/water,
 /area/f13/caves)
 "gYI" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "gZn" = (
@@ -10296,6 +10367,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"hbW" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "hcf" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/inside/subway,
@@ -10319,12 +10400,6 @@
 	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"heI" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/bio_suit/hazmat,
-/obj/item/clothing/head/bio_hood/hazmat,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "hff" = (
 /obj/item/chair,
@@ -10351,6 +10426,13 @@
 /obj/effect/decal/fakelattice,
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
+/area/f13/caves)
+"hgm" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "hgv" = (
 /obj/effect/decal/fakelattice,
@@ -10457,10 +10539,6 @@
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"hmW" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hmZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -10480,13 +10558,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hnv" = (
-/obj/effect/decal/waste{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "hod" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10645,11 +10716,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"hwf" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "hwR" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/weather/dirt{
@@ -10695,6 +10761,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"hyx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rndboards,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "hzG" = (
 /mob/living/simple_animal/hostile/raider/firefighter{
 	name = "Tunnel Torturers Raider"
@@ -10917,6 +10988,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
+"hMY" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "hNr" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -10938,6 +11016,15 @@
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"hON" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "hOV" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
 /turf/open/floor/plasteel/f13{
@@ -11357,12 +11444,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
-"ims" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
-/obj/effect/spawner/lootdrop/f13/cash_random_low,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "imJ" = (
 /obj/structure/table/wood/poker,
@@ -11886,17 +11967,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"iKe" = (
-/obj/item/clothing/head/hooded/human_head{
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "iKs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -11978,11 +12048,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
-"iNJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "iNR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -12285,13 +12350,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"jdC" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "jdR" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
@@ -12332,12 +12390,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/rust,
 /area/f13/tunnel)
-"jgX" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "jhn" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
@@ -12390,10 +12442,6 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jne" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "jnp" = (
 /obj/effect/decal/waste{
 	pixel_x = 20;
@@ -12441,6 +12489,10 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
+/area/f13/caves)
+"jpI" = (
+/obj/structure/nest/supermutant,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "jqi" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
@@ -12556,6 +12608,16 @@
 "jvL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building/museum)
+"jwa" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "jwj" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -12571,6 +12633,15 @@
 "jzc" = (
 /obj/item/trash/f13/rotten,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"jzh" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "jzA" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -12590,10 +12661,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"jzV" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "jAc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -12609,10 +12676,6 @@
 	throw_range = 9
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"jAs" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "jBq" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12692,6 +12755,13 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/caves)
+"jEV" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "jFh" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -12782,13 +12852,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
-"jJN" = (
-/obj/structure/ladder/unbreakable{
-	id = "followersbasement";
-	height = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "jKx" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13{
@@ -12931,13 +12994,6 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/area/f13/caves)
-"jQP" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
-	},
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "jRd" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -13412,6 +13468,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"kvB" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kwC" = (
 /obj/structure/simple_door/metal/barred,
 /obj/structure/lattice/catwalk,
@@ -13521,6 +13587,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/tunnel)
+"kBG" = (
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kCz" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -13541,8 +13614,8 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
 "kDe" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "kDw" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13589,6 +13662,14 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"kHZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "kIe" = (
 /turf/open/floor/plasteel/f13{
@@ -13653,6 +13734,13 @@
 	name = "cave"
 	},
 /area/f13/caves)
+"kLz" = (
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "kMc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
@@ -13667,6 +13755,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"kMN" = (
+/obj/structure/simple_door/house,
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/f13/raidertreads,
@@ -13735,6 +13827,17 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"kRy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "kRZ" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/closed/wall/f13/wood,
@@ -13770,6 +13873,20 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"kTV" = (
+/obj/item/bodypart/l_arm,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "kTX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -14034,6 +14151,10 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/building/museum)
+"lhy" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "lhO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -14163,12 +14284,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
-"lqe" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/breathing_tanks,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "lqn" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -14296,6 +14411,13 @@
 "lxm" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"lxK" = (
+/obj/machinery/door/airlock/medical{
+	name = null;
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lxU" = (
 /obj/effect/decal/fakelattice,
@@ -14472,6 +14594,13 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"lEY" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "lFa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -14492,13 +14621,6 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "greendirtyfull"
-	},
-/area/f13/caves)
-"lFy" = (
-/obj/structure/table/reinforced,
-/obj/item/circular_saw,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "lGc" = (
@@ -14556,15 +14678,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
+"lHg" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "lHm" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"lHu" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lIr" = (
 /turf/open/floor/plasteel/f13{
@@ -14670,6 +14791,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"lMY" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "lNe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder/reinforced,
@@ -14808,6 +14933,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"lTJ" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "lTS" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/structure/spider/stickyweb,
@@ -14868,6 +15001,20 @@
 	name = "stone floor"
 	},
 /area/f13/tunnel)
+"lUT" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "lUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
@@ -14965,11 +15112,6 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"lZA" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "lZN" = (
 /obj/structure/closet/crate/trashcart,
@@ -15424,6 +15566,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"myX" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
+"mzc" = (
+/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "mzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
@@ -15494,6 +15645,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"mEl" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "mEQ" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -15516,12 +15674,6 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"mHA" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/caves)
 "mIM" = (
 /obj/machinery/workbench/mbench,
@@ -15632,6 +15784,18 @@
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"mLo" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "mLS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15996,12 +16160,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"niJ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "niW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/weather/dirt,
@@ -16239,11 +16397,6 @@
 	icon_state = "purplefull"
 	},
 /area/f13/caves)
-"nvZ" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/vault/equipment,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "nws" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/building/massfusion)
@@ -16273,6 +16426,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"nAJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "nAQ" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -16328,6 +16486,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/tunnel)
+"nDO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/breathing_masks,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "nDR" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13{
@@ -16440,12 +16603,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"nJO" = (
-/obj/structure/nest/supermutant,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "nKt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -16548,6 +16705,14 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
+/area/f13/caves)
+"nOO" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "nOW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16702,6 +16867,18 @@
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"nWC" = (
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib6-old"
+	},
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "nXl" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -16797,6 +16974,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"obJ" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stack/sheet/mineral/uranium,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
+"obL" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "obM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16993,13 +17182,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"onM" = (
-/obj/machinery/door/airlock/medical{
-	name = null;
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "ooQ" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/meat/steak/plain/human{
@@ -17182,6 +17364,15 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
+/area/f13/caves)
+"oyu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "oyC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17455,10 +17646,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
-"oOe" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "oOk" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -17648,13 +17835,6 @@
 /obj/structure/bed/pod,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
-"oXU" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/f13/canned/ncr/igauna_bits,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "oYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -17774,11 +17954,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"pcP" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/rndboards,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pde" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17795,17 +17970,6 @@
 /obj/effect/decal/cleanable/ash/large,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"peu" = (
-/obj/structure/table,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/caves)
 "peA" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -17871,14 +18035,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
-	},
-/area/f13/caves)
-"phJ" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "pia" = (
@@ -18027,20 +18183,21 @@
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"pqb" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pqq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/flora/wasteplant/wild_yucca,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"pqw" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib6-old"
-	},
-/obj/structure/fermenting_barrel,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "pqy" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -18242,6 +18399,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
+"pAR" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18337,6 +18498,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pFH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pGB" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18438,6 +18606,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"pJO" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "pLh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18489,6 +18662,14 @@
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
+	},
+/area/f13/caves)
+"pNA" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/caves)
 "pNE" = (
@@ -18563,10 +18744,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"pRu" = (
-/mob/living/simple_animal/hostile/ghoul/glowing/strong,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "pRy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18853,13 +19030,6 @@
 	},
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/caves)
-"qhk" = (
-/obj/effect/decal/waste{
-	icon_state = "goo12"
-	},
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "qhp" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -18924,10 +19094,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"qjV" = (
-/obj/structure/simple_door/house,
-/turf/closed/wall/f13/store,
-/area/f13/caves)
 "qkf" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/gibs{
@@ -19156,6 +19322,13 @@
 "qsY" = (
 /turf/open/floor/wood_common,
 /area/f13/caves)
+"qtf" = (
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "qtg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19313,6 +19486,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
+"qAi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "qAw" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -19331,6 +19513,13 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"qAS" = (
+/obj/structure/closet,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "qBT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19786,6 +19975,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/caves)
+"qZL" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "qZV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightlifter,
@@ -19794,13 +19990,6 @@
 "raI" = (
 /obj/structure/ore_box,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"raM" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
 /area/f13/caves)
 "raS" = (
 /obj/machinery/button/door{
@@ -19989,6 +20178,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"rnb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/caves)
 "rnh" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -20003,6 +20198,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
+/area/f13/caves)
+"roN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "roU" = (
 /obj/structure/closet/crate/bin,
@@ -20082,11 +20282,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/tunnel)
-"rtp" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "rtz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -20441,6 +20636,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
+"rOX" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "rPt" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -20586,10 +20785,6 @@
 "rZE" = (
 /obj/structure/nest/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"rZF" = (
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "rZP" = (
 /obj/structure/chair/wood{
@@ -20760,6 +20955,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/museum)
+"sig" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "sjg" = (
 /obj/structure/flora/wasteplant/wild_xander,
 /obj/structure/flora/rock/pile/largejungle{
@@ -20830,6 +21033,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"soe" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "soz" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /obj/effect/turf_decal/bot,
@@ -20876,6 +21083,13 @@
 "ssu" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ssS" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "sta" = (
 /obj/effect/decal/remains/human,
@@ -21099,11 +21313,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker)
-"sCt" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "sCQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -21296,6 +21505,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"sNL" = (
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "sNR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -21317,11 +21535,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor{
 	icon_state = "floorrusty"
 	},
-/area/f13/caves)
-"sOF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/stockparts/deluxe,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "sOQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21711,6 +21924,11 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"tio" = (
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "tit" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -21890,6 +22108,16 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"tpq" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "tpI" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/clothing_high,
@@ -21936,6 +22164,16 @@
 	name = "Door Control"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"trE" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/obj/item/organ/heart,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "ttk" = (
 /obj/structure/table,
@@ -22088,6 +22326,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"tCj" = (
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "tCu" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -22200,13 +22442,16 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/museum)
-"tHK" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "tHT" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"tIn" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
 /area/f13/caves)
 "tIq" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -22271,6 +22516,15 @@
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/caves)
+"tOI" = (
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tOJ" = (
 /obj/structure/barricade/bars,
@@ -22386,6 +22640,13 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/radroach_meat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"tWh" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "tWi" = (
 /obj/item/shield/riot,
@@ -22838,6 +23099,13 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/tunnel)
+"uzt" = (
+/obj/structure/nest/supermutant,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "uzY" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /obj/machinery/light/small{
@@ -23182,6 +23450,14 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"uRq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "uRB" = (
 /obj/structure/barricade/bars,
 /obj/structure/disposalpipe/segment{
@@ -23200,11 +23476,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/red{
 	icon_state = "redrustyfull"
 	},
-/area/f13/caves)
-"uSU" = (
-/obj/structure/table/reinforced,
-/obj/item/blueprint/research,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "uTw" = (
 /obj/item/kirbyplants/random,
@@ -23327,12 +23598,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"uZK" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "var" = (
 /obj/structure/nest/fireant{
 	max_mobs = 4;
@@ -23369,10 +23634,6 @@
 	},
 /obj/effect/mob_spawn/human/corpse/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/caves)
-"vbN" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "vbO" = (
 /obj/structure/table/wood/settler,
@@ -23461,14 +23722,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
-"vfg" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/caves)
 "vfF" = (
@@ -23655,6 +23908,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"vnb" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "vnu" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
@@ -23999,13 +24256,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
-"vJl" = (
-/obj/structure/closet,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vJq" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -24146,11 +24396,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
-"vPL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "vQn" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24242,13 +24487,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/caves)
-"vWH" = (
-/obj/effect/decal/waste{
-	icon_state = "goo10"
+"vYl" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "vYx" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -24357,11 +24603,6 @@
 /obj/structure/cross,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
-"wbs" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/stack/sheet/mineral/uranium,
-/turf/open/floor/plasteel/dark,
-/area/f13/caves)
 "wbM" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24400,11 +24641,6 @@
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/f13,
-/area/f13/caves)
-"wff" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wft" = (
 /obj/structure/decoration/rag{
@@ -24483,6 +24719,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/caves)
+"wiD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "wiW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24726,11 +24968,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
-"wyw" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/caves)
 "wyS" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -24852,6 +25089,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"wEa" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wEh" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24889,6 +25132,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"wFd" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plastic/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wFO" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -24940,6 +25188,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"wJu" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wKJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile{
@@ -24976,6 +25230,14 @@
 	icon_state = "whiterustysolid"
 	},
 /area/f13/tunnel)
+"wLL" = (
+/obj/structure/table/reinforced,
+/obj/item/blueprint/research,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wMj" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
@@ -25027,6 +25289,19 @@
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
+	},
+/area/f13/caves)
+"wQi" = (
+/obj/structure/decoration/vent,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/caves)
 "wQZ" = (
@@ -25095,6 +25370,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/tunnel)
+"wWA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "wXa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25122,10 +25406,6 @@
 /obj/structure/spider/stickyweb,
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/caves)
-"wXU" = (
-/obj/effect/spawner/lootdrop/f13/medical/random_fev,
-/turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "wYE" = (
 /obj/effect/turf_decal/caution{
@@ -25157,6 +25437,9 @@
 	name = "stone floor"
 	},
 /area/f13/caves)
+"wZJ" = (
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "wZK" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25508,15 +25791,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
-"xvM" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1"
-	},
-/obj/item/stack/sheet/animalhide/human,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
+"xvo" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "xvT" = (
 /obj/structure/bed/mattress,
@@ -25753,6 +26030,17 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
+"xKd" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/caves)
 "xKm" = (
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25762,6 +26050,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"xKG" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/caves)
 "xKU" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/barricade/wooden/strong,
@@ -25962,20 +26259,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13,
 /area/f13/caves)
-"xTi" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibmid1";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/caves)
 "xTs" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -26088,6 +26371,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/plating,
 /area/f13/building/museum)
+"xYL" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "xYM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/destructible/tribal_torch/lit,
@@ -26142,6 +26435,13 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"ybl" = (
+/obj/structure/nest/ghoul,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ybG" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -26163,6 +26463,10 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"ydy" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/caves)
 "ydH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -26244,6 +26548,13 @@
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
 	},
+/area/f13/caves)
+"yhr" = (
+/obj/structure/simple_door/metal/store,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/caves)
 "yhG" = (
 /obj/structure/rack,
@@ -69848,7 +70159,7 @@ aak
 aak
 aae
 aaa
-kDe
+wZJ
 aaa
 aaa
 aaa
@@ -70105,29 +70416,29 @@ aak
 aae
 aae
 aaa
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-onM
-onM
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+lxK
+lxK
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
 aaa
 aae
 aae
@@ -70362,29 +70673,29 @@ aae
 aae
 aae
 aaa
-cuV
-gYI
-gYI
+kDe
+oyu
+dEX
+ydy
+dEX
+dEX
+myX
 dEX
 gYI
 gYI
-pRu
+jpI
+kDe
+pJO
+wFd
+hyx
+kDe
+sig
 gYI
-gYI
-gYI
-gjc
-cuV
-sOF
-wyw
-pcP
-cuV
-rtp
-gYI
-gYI
-cuV
-gYI
-jJN
-cuV
+dEX
+kDe
+dEX
+kLz
+kDe
 aaa
 aae
 aae
@@ -70619,29 +70930,29 @@ aae
 aae
 aae
 aaa
-cuV
+kDe
 gYI
 gYI
+ydy
+gYI
+sNL
+sNL
+sNL
+sNL
+sNL
 dEX
-gYI
-jgX
-jgX
-jgX
-jgX
-jgX
-gYI
-cuV
+kDe
 gYI
 gYI
-jzV
-cuV
-vPL
-uZK
-vbN
-cuV
-gYI
-rZF
-cuV
+lHg
+kDe
+cSr
+tOI
+ybl
+kDe
+dEX
+mzc
+kDe
 aaa
 aae
 aae
@@ -70876,29 +71187,29 @@ aae
 aae
 aae
 aaa
-cuV
+kDe
+dEX
+mEl
+rnb
 gYI
-jne
-cuV
-gYI
-eiJ
-eiJ
-eiJ
-eiJ
-eiJ
-gYI
-cuV
-gYI
-gYI
-jzV
-cuV
-dxu
+lEY
+pAR
+lEY
+lEY
+lEY
+tCj
+kDe
 gYI
 gYI
-cuV
-hmW
-cuV
-cuV
+fYk
+kDe
+fFs
+gYI
+gYI
+kDe
+lhy
+kDe
+kDe
 aaa
 aae
 aae
@@ -71133,29 +71444,29 @@ aak
 aak
 aae
 aaa
-cuV
+kDe
+dEX
 gYI
+rnb
+cDv
+lEY
+pAR
+lEY
+lEY
+lEY
 gYI
-cuV
+kDe
 gYI
-eiJ
-eiJ
-eiJ
-eiJ
-eiJ
+kBG
+nOO
+kDe
+pqb
 gYI
-cuV
+mEl
+kDe
+dEX
 gYI
-bFp
-tHK
-cuV
-oOe
-gYI
-jne
-cuV
-gYI
-gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -71390,29 +71701,29 @@ aae
 aae
 aae
 aaa
-cuV
+kDe
+dEX
+gYI
+kDe
+gYI
+vYl
+kvB
+vYl
+eCh
+vYl
+gYI
+kDe
+gYI
+ybl
+soe
+kDe
+tWh
 gYI
 gYI
-cuV
-gYI
-aJS
-feb
-aJS
-aJS
-aJS
-gYI
-cuV
-gYI
-vbN
-tHK
-cuV
-oOe
+kMN
 gYI
 gYI
-qjV
-gYI
-gYI
-cuV
+kDe
 aaa
 aak
 aak
@@ -71647,29 +71958,29 @@ aae
 aae
 aae
 aaa
-cuV
+kDe
+wJu
+gYI
+kDe
+dEX
+jpI
+gYI
+dEX
+dEX
 gYI
 gYI
-cuV
+lhy
+dEX
 gYI
-gjc
+ajU
+kDe
+rOX
 gYI
+dEX
+kDe
 gYI
-gYI
-gYI
-gYI
-hmW
-gYI
-gYI
-wff
-cuV
-oOe
-gYI
-gYI
-cuV
-gYI
-jne
-cuV
+lTJ
+kDe
 aaa
 aak
 aae
@@ -71904,29 +72215,29 @@ aae
 aae
 aae
 aaa
-cuV
+kDe
 gYI
+dEX
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+dEX
 gYI
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
+kDe
+dEX
+dEX
+wLL
+kDe
+rOX
 gYI
-gYI
-cuV
-gYI
-gYI
-uSU
-cuV
-oOe
-gYI
-ims
-cuV
-gYI
-vbN
-cuV
+eNF
+kDe
+dEX
+ybl
+kDe
 aaa
 aae
 aak
@@ -72161,29 +72472,29 @@ xwF
 aak
 aak
 aaa
-cuV
-jne
-gYI
-cuV
-awN
+kDe
+mEl
+dEX
+kDe
+mLo
 auG
-auG
-oXU
-cuV
-hmW
-hmW
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
+tio
+hgm
+kDe
+lhy
+lhy
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+dEX
 gYI
-gYI
-cuV
+kDe
 aaa
 aae
 aak
@@ -72418,29 +72729,29 @@ xwF
 aak
 aak
 aaa
-cuV
+kDe
 gYI
-gYI
-cuV
-xTi
+dEX
+kDe
+lUT
 auG
-iKe
-oXU
-cuV
+bQn
+hgm
+kDe
 gYI
 gYI
-cuV
+kDe
+dEX
+ftg
+kDe
+nAJ
+uRq
+kHZ
+roN
+kDe
 gYI
-iNJ
-cuV
-hwf
-hwf
-aBx
-sCt
-cuV
 gYI
-gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -72675,29 +72986,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
 gYI
 gYI
-cuV
-xvM
-phJ
+kDe
+hbW
+xKd
 auG
-lFy
-cuV
+qtf
+kDe
+gYI
+pFH
+kDe
+dEX
+elW
+kDe
+myX
 gYI
 gYI
-cuV
 gYI
-feM
-cuV
-pRu
+kDe
+mEl
 gYI
-gYI
-gYI
-cuV
-jne
-gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -72932,29 +73243,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
+wJu
 gYI
-gYI
-cuV
-dTm
+kDe
+trE
 auG
-cic
-duG
-cuV
+kTV
+hMY
+kDe
 gYI
 gYI
-hmW
+lhy
 gYI
-nvZ
-cuV
+jzh
+kDe
+oyu
 gYI
+ybl
 gYI
-vbN
+lMY
 gYI
-gAJ
-gYI
-gYI
-cuV
+vnb
+kDe
 aaa
 aae
 aae
@@ -73189,29 +73500,29 @@ xwF
 aaB
 aaB
 aaa
-cuV
+kDe
+dEX
 gYI
-gYI
-cuV
+kDe
 auG
 auG
-nJO
+dJQ
 auG
-cuV
+kDe
 gYI
 gYI
-cuV
+kDe
 gYI
-bbX
-cuV
-gYI
-gYI
+fqS
+kDe
 gYI
 gYI
-cuV
 gYI
+dEX
+kDe
 gYI
-cuV
+dEX
+kDe
 aaa
 aae
 aae
@@ -73446,29 +73757,29 @@ aak
 aaB
 aaB
 aaa
-cuV
+kDe
 gYI
 gYI
-cuV
-vfg
+kDe
+fpv
+tio
+fUe
 auG
-vWH
-auG
-hmW
+lhy
+dEX
+uzt
+kDe
 gYI
-gjc
-cuV
+feY
+kDe
+bwr
+nDO
+fDa
+wEa
+kDe
 gYI
-lZA
-cuV
-lqe
-gHY
-lHu
-niJ
-cuV
-gYI
-gYI
-cuV
+dEX
+kDe
 aaa
 aae
 aae
@@ -73703,29 +74014,29 @@ xwF
 xwF
 aaB
 aaa
-cuV
+kDe
 gYI
-jne
-cuV
-vfg
+mEl
+kDe
+fpv
+tio
 auG
-auG
-auG
-cuV
+tio
+kDe
+dEX
+gYI
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
 gYI
 gYI
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-gYI
-gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -73960,29 +74271,29 @@ xwF
 xwF
 aar
 aaa
-cuV
+kDe
+dEX
 gYI
-gYI
-cuV
-vfg
+kDe
+fpv
 auG
 auG
-raM
-cuV
+auX
+kDe
 gYI
 gYI
-cuV
-aZT
-gcu
-aZT
-gcu
-aZT
-gcu
-aZT
-cuV
+kDe
+jwa
+pNA
+wQi
+pNA
+jwa
+pNA
+wQi
+kDe
 gYI
-jne
-cuV
+mEl
+kDe
 aaa
 aak
 aae
@@ -74217,29 +74528,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
+oyu
 gYI
+kDe
+tIn
+ebN
+nWC
+goU
+kDe
+dEX
 gYI
-cuV
-cjf
-eSb
-pqw
-eMt
-cuV
-gYI
-gYI
-cuV
+kDe
 xTs
-fad
-xTs
-xTs
-xTs
-fad
-xTs
-cuV
-vbN
-gYI
-cuV
+xKG
+bhc
+bhc
+bhc
+xKG
+bhc
+kDe
+ybl
+pFH
+kDe
 aaa
 adz
 adz
@@ -74474,29 +74785,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
 gYI
-gjc
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
+jpI
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+oyu
 gYI
+kDe
+bhc
+xTs
+bhc
+kRy
+elt
+bhc
+dgT
+kDe
 gYI
-cuV
-xTs
-xTs
-xTs
-xTs
-mHA
-xTs
-peu
-cuV
-gYI
-gYI
-cuV
+qAi
+kDe
 aaa
 adz
 adz
@@ -74731,29 +75042,29 @@ aak
 aak
 aak
 aaa
-cuV
+kDe
 gYI
 gYI
-cuV
-jAs
-jdC
-wXU
-jAs
-cuV
+kDe
+gaM
+erm
+eov
+ssS
+kDe
 gYI
 gYI
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-hmW
-cuV
-cuV
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+lhy
+kDe
+kDe
 gYI
 gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -74988,29 +75299,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
+dEX
 gYI
+kDe
+hON
+obJ
+xYL
+tpq
+lhy
+uzt
 gYI
-cuV
-aQl
-wbs
-jQP
-hnv
-hmW
-gjc
+kMN
+dEX
+dEX
+dEX
+dFa
+dEX
+dEX
+dEX
+lhy
 gYI
-qjV
-gYI
-gYI
-gYI
-vbN
-gYI
-gYI
-gYI
-hmW
-gYI
-vbN
-cuV
+obL
+kDe
 aaa
 aae
 aae
@@ -75245,29 +75556,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
 gYI
+dEX
+kDe
+gaM
+jEV
+ssS
+qZL
+kDe
+dEX
 gYI
-cuV
-jAs
-cDU
-jAs
-qhk
-cuV
+kDe
+dEX
+gRO
+gRO
+qAS
+qAS
+xvo
+aBu
+kDe
 gYI
-gYI
-cuV
-gYI
-heI
-heI
-vJl
-vJl
-jne
-cga
-cuV
-gYI
-gYI
-cuV
+dEX
+kDe
 aaa
 aae
 aae
@@ -75502,29 +75813,29 @@ xwF
 xwF
 xwF
 aaa
-cuV
+kDe
+cDv
 gYI
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+ydy
+ydy
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
 gYI
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-dEX
-dEX
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-gYI
-gYI
-cuV
+aAV
+kDe
 aaa
 aae
 aae
@@ -75759,29 +76070,29 @@ aaB
 aaB
 aaB
 aaa
-cuV
+kDe
 gYI
 gYI
+ydy
+gYI
+gYI
+xvo
+dEX
+dEX
 dEX
 gYI
 gYI
-jne
 gYI
 gYI
+jpI
 gYI
 gYI
+mEl
+gYI
+ydy
 gYI
 gYI
-gYI
-gjc
-gYI
-gYI
-jne
-gYI
-dEX
-gYI
-gYI
-cuV
+kDe
 aaa
 aae
 aae
@@ -76016,29 +76327,29 @@ aaB
 ilg
 aaB
 aaa
-cuV
-jne
-gYI
+kDe
+mEl
 dEX
+yhr
 gYI
 gYI
 gYI
 gYI
+wWA
 gYI
 gYI
+xvo
 gYI
-jne
-gYI
-gYI
-gYI
-gYI
+wiD
 gYI
 gYI
 gYI
 dEX
-gYI
-gYI
-cuV
+wWA
+yhr
+dEX
+dEX
+kDe
 aaa
 aae
 aak
@@ -76273,29 +76584,29 @@ aaB
 aaB
 yeX
 aaa
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
-cuV
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
+kDe
 aaa
 aae
 aak

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -5,218 +5,28 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"aH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"bo" = (
-/turf/open/indestructible,
-/area/f13/wasteland)
-"bO" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"dd" = (
-/obj/machinery/workbench/advanced,
+"aK" = (
+/obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"dl" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"dF" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"ed" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
-"ep" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/wasteland)
-"eU" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	pixel_y = 6
-	},
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"fd" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
-"gV" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"hd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"hm" = (
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"hx" = (
-/obj/machinery/power/port_gen/pacman/super,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"hS" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/turf/open/floor/holofloor/carpet,
-/area/f13/wasteland)
-"iA" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"iF" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"jj" = (
-/obj/structure/railing/corner,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"ky" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"lh" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"lN" = (
-/obj/structure/cable,
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/solarpanel,
-/area/f13/wasteland)
-"mp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"nF" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"pt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"pJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"pW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"qj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"ql" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"qw" = (
-/obj/machinery/smoke_machine{
-	name = "HVAC Machine"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"qC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"qL" = (
-/obj/structure/lattice/catwalk,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"rn" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"rN" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
-"sn" = (
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"sG" = (
+"bc" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"th" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
+"bh" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"bo" = (
+/turf/open/indestructible,
+/area/f13/wasteland)
+"bY" = (
+/obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"tj" = (
+"cx" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -227,393 +37,29 @@
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"tM" = (
-/turf/closed/indestructible/riveted,
-/area/f13/wasteland)
-"vj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+"dk" = (
+/obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"vt" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"wa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"xg" = (
-/obj/effect/landmark/vertibird{
-	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
-	name = "Nash - Christus Saint Michaels Hospital - Rooftop"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"xh" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"xl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"xs" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/building/hospital)
-"xQ" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"yC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"yY" = (
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"zo" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"zx" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"zT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building/hospital)
-"zZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Al" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"AZ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"Be" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Bz" = (
-/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"BQ" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Co" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"CB" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/solarpanel,
-/area/f13/wasteland)
-"CG" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Ey" = (
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"EF" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Fj" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/indestructible,
-/area/f13/wasteland)
-"Fl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"FT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"GB" = (
-/obj/structure/nest/protectron,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Hb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"HT" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"IF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"JX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"JY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Lb" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Lv" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Lz" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"LH" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"LQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"LT" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/wasteland)
-"Mn" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"MO" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Nx" = (
-/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Ny" = (
+"dK" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"NT" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/transparent/openspace,
+"ed" = (
+/turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"QZ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Rq" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Rw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/floor,
+"ei" = (
+/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
-"RF" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
-"Sz" = (
-/obj/structure/ladder/unbreakable{
-	id = hospitalroof;
-	height = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"SK" = (
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"ST" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"TS" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Ut" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"UB" = (
-/obj/structure/railing/corner,
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"Va" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/ammo/military,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Vm" = (
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Vr" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Wv" = (
-/obj/structure/rack/shelf_metal,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"XO" = (
+"ek" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 6
@@ -629,22 +75,156 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"XU" = (
-/obj/structure/railing/corner{
-	dir = 4
+"fb" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"fd" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
+"fk" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"fo" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"gg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"gK" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"hm" = (
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"hS" = (
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
+"ih" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"iF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"XX" = (
-/obj/structure/railing{
+"jc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"jj" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"kF" = (
+/obj/structure/rack/shelf_metal,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"kU" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"lF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"lM" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"lV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"mK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"mP" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"nd" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"nF" = (
+/obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Zf" = (
+"oc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"ZA" = (
+/area/f13/building/hospital)
+"oi" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -657,7 +237,153 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"ZF" = (
+"oy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"ql" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"rF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"rN" = (
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
+"sn" = (
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"sz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"sE" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"te" = (
+/obj/machinery/smoke_machine{
+	name = "HVAC Machine"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"to" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"tp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"tJ" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"tM" = (
+/turf/closed/indestructible/riveted,
+/area/f13/wasteland)
+"uB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vc" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"wY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"xj" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"xs" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/hospital)
+"yB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"yV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"yY" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 4.1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zf" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"zx" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zK" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -666,6 +392,280 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"zT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building/hospital)
+"Am" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"AS" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"AZ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Bg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Bt" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"DL" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"En" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Ey" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"EV" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Fg" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Fj" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/indestructible,
+/area/f13/wasteland)
+"Ki" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"KV" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"KW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Lj" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Ll" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"LT" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/wasteland)
+"Mv" = (
+/obj/structure/cable,
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"MG" = (
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Nd" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Nh" = (
+/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Nt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"NT" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"OK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"OO" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"PU" = (
+/obj/structure/nest/protectron{
+	layer = 3;
+	max_mobs = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"RF" = (
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
+"Sz" = (
+/obj/structure/ladder/unbreakable{
+	id = hospitalroof;
+	height = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"SK" = (
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Tn" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
+	},
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"TD" = (
+/obj/effect/landmark/vertibird{
+	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
+	name = "Nash - Christus Saint Michaels Hospital - Rooftop"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Ul" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"UB" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"US" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Vg" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
+"Vr" = (
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"VU" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/ammo/military,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"WN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Xb" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Xv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"XU" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"XX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"YO" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"YT" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
 
 (1,1,1) = {"
 RF
@@ -44971,11 +44971,11 @@ SK
 SK
 SK
 LT
-dd
-Zf
-Zf
-Zf
-Va
+bY
+En
+En
+En
+VU
 LT
 SK
 SK
@@ -45218,21 +45218,21 @@ SK
 SK
 SK
 LT
-qL
-qL
-qL
-qL
+Vr
+Vr
+Vr
+Vr
 LT
 SK
 SK
 SK
 SK
 LT
-XO
-Zf
-Zf
-ST
-IF
+ek
+En
+En
+EV
+oy
 LT
 SK
 SK
@@ -45475,21 +45475,21 @@ SK
 SK
 SK
 LT
-qL
-qL
-qL
-qL
+Vr
+Vr
+Vr
+Vr
 LT
 SK
 SK
 SK
 SK
 LT
-vt
-dF
-Zf
-Zf
-CG
+nd
+AS
+En
+En
+Ul
 LT
 SK
 SK
@@ -45732,21 +45732,21 @@ SK
 SK
 SK
 LT
-qL
-qL
-qL
-qL
+Vr
+Vr
+Vr
+Vr
 LT
 SK
 SK
 SK
 SK
 LT
-th
-Zf
-Zf
-Zf
-GB
+lM
+En
+En
+En
+aK
 LT
 SK
 SK
@@ -45990,8 +45990,8 @@ SK
 SK
 LT
 LT
-ep
-ep
+Vg
+Vg
 LT
 LT
 SK
@@ -45999,11 +45999,11 @@ SK
 SK
 SK
 LT
-iA
-Zf
-Zf
-Zf
-Ut
+kU
+En
+En
+En
+US
 LT
 SK
 SK
@@ -46247,8 +46247,8 @@ SK
 SK
 SK
 SK
-Zf
-Zf
+En
+En
 SK
 SK
 SK
@@ -46256,11 +46256,11 @@ SK
 SK
 SK
 LT
-Wv
-hx
-Zf
-MO
-LH
+kF
+MG
+En
+YT
+fb
 LT
 SK
 SK
@@ -46501,21 +46501,21 @@ hm
 NT
 SK
 SK
-dl
+bh
 SK
 SK
-TS
-Zf
+dk
+En
 SK
-dl
+bh
 SK
 SK
-Bz
+Nh
 SK
 LT
 LT
 LT
-Rq
+Ki
 LT
 LT
 LT
@@ -46757,15 +46757,15 @@ hm
 hm
 NT
 SK
-Rw
-FT
-FT
-FT
-wa
-FT
-FT
-FT
-vj
+Ll
+Am
+Am
+Am
+KW
+Am
+Am
+Am
+rF
 SK
 SK
 SK
@@ -46774,7 +46774,7 @@ SK
 SK
 SK
 SK
-Vm
+xj
 SK
 SK
 SK
@@ -47013,17 +47013,17 @@ hm
 hm
 hm
 NT
-xQ
-zZ
-lh
-lh
-lh
-lh
-lh
-lh
-lh
-Lv
-HT
+DL
+yB
+zf
+zf
+zf
+zf
+zf
+zf
+zf
+vc
+ih
 SK
 SK
 SK
@@ -47271,25 +47271,25 @@ hm
 hm
 NT
 SK
-zZ
-lh
-lh
-Nx
-lh
-lh
-lh
-lh
-Lv
+yB
+zf
+zf
+ei
+zf
+zf
+zf
+zf
+vc
 SK
 SK
 SK
-qw
-sG
+dK
+bc
 SK
 SK
 SK
-Ny
-Ny
+te
+te
 SK
 SK
 SK
@@ -47528,25 +47528,25 @@ hm
 hm
 NT
 SK
-zZ
-lh
-lh
-lh
-lh
-lh
-lh
-lh
-Lv
+yB
+zf
+zf
+zf
+zf
+zf
+zf
+zf
+vc
 SK
 SK
 SK
-Vr
-Ny
+sE
+te
 SK
 SK
 SK
-Ny
-sG
+te
+bc
 SK
 SK
 SK
@@ -47784,26 +47784,26 @@ hm
 hm
 hm
 NT
-xQ
-Hb
-lh
-lh
-lh
-Lb
-lh
-xg
-lh
-ky
-HT
+DL
+WN
+zf
+zf
+zf
+Xb
+zf
+TD
+zf
+wY
+ih
 SK
 SK
-qw
-Ny
+dK
+te
 SK
 SK
 SK
-Ny
-Ny
+te
+te
 SK
 SK
 SK
@@ -48042,25 +48042,25 @@ hm
 hm
 NT
 SK
-zZ
-lh
-lh
-lh
-lh
-lh
-lh
-lh
-Lv
+yB
+zf
+zf
+zf
+zf
+zf
+zf
+zf
+vc
 SK
 SK
-Vm
-qw
-Ny
+xj
+dK
+te
 SK
 SK
 SK
-sG
-Ny
+bc
+te
 SK
 SK
 SK
@@ -48299,25 +48299,25 @@ hm
 hm
 NT
 SK
-zZ
-lh
-lh
-lh
-lh
-lh
-lh
-lh
-Lv
+yB
+zf
+zf
+zf
+zf
+zf
+zf
+zf
+vc
 SK
 SK
 SK
-Vr
-Ny
+sE
+te
 SK
 SK
 SK
-Ny
-Ny
+te
+te
 SK
 SK
 SK
@@ -48555,24 +48555,24 @@ hm
 hm
 hm
 NT
-xQ
-zZ
-lh
-lh
-lh
-lh
-lh
-lh
-lh
-Lv
-eU
+DL
+yB
+zf
+zf
+zf
+zf
+zf
+zf
+zf
+vc
+Tn
 SK
 SK
 SK
 SK
 SK
 SK
-Bz
+Nh
 SK
 SK
 SK
@@ -48813,15 +48813,15 @@ hm
 hm
 NT
 SK
-pW
-JY
-JY
-JY
-xl
-JY
-JY
-JY
-zo
+OK
+lV
+lV
+lV
+Xv
+lV
+lV
+lV
+yV
 SK
 SK
 SK
@@ -49070,26 +49070,26 @@ xs
 xs
 xs
 SK
-Bz
-Co
+Nh
+KV
 SK
-Vm
-Co
-SK
-SK
-Co
+xj
+KV
 SK
 SK
+KV
 SK
-CB
-yC
-lN
-CB
-yC
-lN
-CB
-yC
-lN
+SK
+SK
+fk
+gg
+Mv
+fk
+gg
+Mv
+fk
+gg
+Mv
 SK
 SK
 AZ
@@ -49321,10 +49321,10 @@ hm
 hm
 hm
 xs
-qj
-gV
-xh
-EF
+Nd
+Lj
+Fg
+to
 xs
 SK
 SK
@@ -49338,15 +49338,15 @@ SK
 SK
 SK
 SK
-CB
-qC
-lN
-CB
-qC
-lN
-CB
-qC
-lN
+fk
+fo
+Mv
+fk
+fo
+Mv
+fk
+fo
+Mv
 SK
 SK
 AZ
@@ -49578,10 +49578,10 @@ hm
 hm
 hm
 xs
-BQ
+OO
 Ey
-ZF
-tj
+zK
+cx
 xs
 SK
 SK
@@ -49591,19 +49591,19 @@ SK
 SK
 SK
 SK
-Vm
+xj
 SK
 SK
 SK
-CB
-qC
-lN
-CB
-qC
-lN
-CB
-qC
-lN
+fk
+fo
+Mv
+fk
+fo
+Mv
+fk
+fo
+Mv
 SK
 SK
 AZ
@@ -49835,10 +49835,10 @@ hm
 hm
 hm
 xs
-aH
+sz
 Ey
 Ey
-ZA
+oi
 xs
 SK
 SK
@@ -49852,15 +49852,15 @@ SK
 SK
 SK
 SK
-CB
-qC
-lN
-CB
-qC
-lN
-CB
-qC
-lN
+fk
+fo
+Mv
+fk
+fo
+Mv
+fk
+fo
+Mv
 SK
 SK
 AZ
@@ -50092,32 +50092,32 @@ hm
 hm
 hm
 xs
-Lz
+PU
 Ey
 Ey
-Al
+oc
 xs
 SK
 SK
-rn
-rn
-rn
-rn
-rn
-rn
+tJ
+tJ
+tJ
+tJ
+tJ
+tJ
 SK
 SK
 SK
 SK
-CB
-qC
-lN
-CB
-qC
-lN
-CB
-qC
-lN
+fk
+fo
+Mv
+fk
+fo
+Mv
+fk
+fo
+Mv
 SK
 SK
 AZ
@@ -50352,9 +50352,9 @@ xs
 Sz
 Ey
 Ey
-QZ
+gK
 zT
-bO
+mP
 SK
 SK
 SK
@@ -50367,13 +50367,13 @@ SK
 SK
 SK
 SK
-hd
+jc
 SK
 SK
-hd
+jc
 SK
 SK
-hd
+jc
 SK
 SK
 SK
@@ -50611,28 +50611,28 @@ xs
 xs
 xs
 xs
-JX
-mp
-Be
-Be
-Be
-Be
-Be
-Be
-pt
-pJ
-LQ
-LQ
-LQ
-Fl
-LQ
-LQ
-Fl
-LQ
-LQ
-Fl
-LQ
-Mn
+YO
+Nt
+Bg
+Bg
+Bg
+Bg
+Bg
+Bg
+mK
+lF
+tp
+tp
+tp
+uB
+tp
+tp
+uB
+tp
+tp
+uB
+tp
+Bt
 SK
 AZ
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -1,45 +1,42 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ac" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
 "aj" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"aO" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/solar_control{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "bo" = (
 /turf/open/indestructible,
 /area/f13/wasteland)
-"bx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"cE" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/smes,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"dC" = (
-/obj/structure/chair/wood{
-	dir = 4
+"cX" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ed" = (
 /turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
+"eo" = (
+/obj/structure/barricade/tentclothcorner{
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "fd" = (
 /obj/effect/decal/cleanable/dirt{
@@ -47,10 +44,16 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"fk" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 4
-	},
+"fr" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"gK" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "hm" = (
@@ -75,11 +78,16 @@
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"kn" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+"jP" = (
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"no" = (
+/obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "nF" = (
@@ -88,13 +96,29 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"pO" = (
-/obj/structure/chair/wood{
-	dir = 8
+"nK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"ql" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/transparent/openspace,
 /area/f13/wasteland)
-"qi" = (
+"rN" = (
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
+"sn" = (
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"tg" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -105,51 +129,42 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"ql" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"qm" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"rq" = (
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"rN" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
-"sh" = (
-/obj/structure/chair/wood,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"sn" = (
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"tq" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "tM" = (
 /turf/closed/indestructible/riveted,
 /area/f13/wasteland)
-"uD" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
+"ue" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"uY" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vq" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"wd" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	layer = 2.95;
+	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"wj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/solar,
+"wS" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"xf" = (
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"xi" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "xs" = (
@@ -162,6 +177,18 @@
 	smooth = 1
 	},
 /area/f13/building/hospital)
+"xt" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/tracker,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"yi" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "yY" = (
 /obj/structure/railing{
 	dir = 6;
@@ -172,14 +199,29 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"zm" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/pistol/m1911,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
+"zx" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zy" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/floor/carpet/red,
 /area/f13/wasteland)
-"zu" = (
+"zT" = (
+/obj/structure/simple_door/house,
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building/hospital)
+"AQ" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -191,36 +233,14 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
-"zx" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"zT" = (
-/obj/structure/simple_door/house,
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building/hospital)
 "AZ" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Cq" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"Dk" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
-	},
+"Ed" = (
+/mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Ey" = (
@@ -232,43 +252,7 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/wasteland)
-"Iv" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"IF" = (
-/obj/structure/barricade/tentclothcorner{
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Jz" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"KE" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	layer = 2.95;
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"LT" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/wasteland)
-"MM" = (
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"Nl" = (
+"KR" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/f13/mre,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -276,11 +260,27 @@
 /obj/item/reagent_containers/glass/beaker/waterbottle,
 /turf/open/floor/carpet/red,
 /area/f13/wasteland)
-"NH" = (
-/obj/structure/barricade/tentclothcorner{
+"Lf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
 	},
+/area/f13/building/hospital)
+"LT" = (
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/wasteland)
+"Mn" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/solar,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"MM" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/wasteland)
 "NT" = (
 /obj/structure/railing{
@@ -288,34 +288,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"OB" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"Qj" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4;
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Ql" = (
-/obj/effect/decal/remains/human,
+"NV" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
 /turf/open/floor/carpet/red,
 /area/f13/wasteland)
-"QC" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"Rt" = (
+"Op" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/power/terminal{
@@ -325,16 +304,47 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"Pl" = (
+/obj/structure/nest/protectron{
+	layer = 3;
+	max_mobs = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"QW" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Rf" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4;
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
-"RZ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
+"RG" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"RQ" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "Sz" = (
 /obj/structure/ladder/unbreakable{
-	id = Followers1;
+	id = hospitalroof;
 	height = 2
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -344,14 +354,8 @@
 "SK" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"TJ" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"TP" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
+"TG" = (
+/obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "UB" = (
@@ -361,9 +365,23 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"WT" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/tracker,
+"UV" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"VF" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"Xi" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "XU" = (
@@ -378,31 +396,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Ya" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar_control{
-	dir = 1
-	},
-/obj/machinery/light,
+"Zf" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/smes,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
 	},
 /area/f13/building/hospital)
-"YP" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"YU" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
 
 (1,1,1) = {"
 RF
@@ -44180,7 +44180,7 @@ hm
 hm
 hm
 NT
-WT
+xt
 SK
 SK
 SK
@@ -44437,13 +44437,13 @@ hm
 hm
 hm
 NT
-RZ
-wj
-wj
-wj
-wj
-wj
-wj
+uY
+Mn
+Mn
+Mn
+Mn
+Mn
+Mn
 SK
 SK
 SK
@@ -44694,7 +44694,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -44951,13 +44951,13 @@ hm
 hm
 hm
 NT
-RZ
-wj
-wj
-wj
-wj
-wj
-wj
+uY
+Mn
+Mn
+Mn
+Mn
+Mn
+Mn
 SK
 SK
 SK
@@ -45208,7 +45208,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -45465,13 +45465,13 @@ hm
 hm
 hm
 NT
-RZ
-wj
-wj
-wj
-wj
-wj
-wj
+uY
+Mn
+Mn
+Mn
+Mn
+Mn
+Mn
 SK
 SK
 SK
@@ -45722,7 +45722,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -45979,13 +45979,13 @@ hm
 hm
 hm
 NT
-RZ
-wj
-wj
-wj
-wj
-wj
-wj
+uY
+Mn
+Mn
+Mn
+Mn
+Mn
+Mn
 SK
 SK
 SK
@@ -46236,7 +46236,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -46493,13 +46493,13 @@ hm
 hm
 hm
 NT
-RZ
-wj
-wj
-wj
-wj
-wj
-wj
+uY
+Mn
+Mn
+Mn
+Mn
+Mn
+Mn
 SK
 SK
 SK
@@ -46750,7 +46750,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -47007,7 +47007,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -47264,11 +47264,11 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
-dC
+QW
 SK
 SK
 SK
@@ -47521,12 +47521,12 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
-rq
-sh
-tq
-Jz
+Ed
+TG
+ue
+gK
 SK
 SK
 SK
@@ -47778,12 +47778,12 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
-TJ
-pO
-TJ
+no
+RG
+no
 SK
 SK
 SK
@@ -48035,7 +48035,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -48292,7 +48292,7 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
 SK
 SK
@@ -48549,13 +48549,13 @@ hm
 hm
 hm
 NT
-RZ
+uY
 SK
-NH
-TP
-TP
-TP
-Qj
+xi
+cX
+cX
+cX
+Rf
 SK
 SK
 SK
@@ -48806,13 +48806,13 @@ xs
 xs
 xs
 xs
-RZ
+uY
 SK
-kn
-Cq
-Nl
-YP
-KE
+yi
+NV
+KR
+MM
+wd
 SK
 SK
 SK
@@ -49058,18 +49058,18 @@ hm
 hm
 hm
 xs
-Rt
-OB
-cE
-cE
+Op
+RQ
+Zf
+Zf
 xs
-RZ
+uY
 SK
-kn
-MM
-MM
-YU
-KE
+yi
+xf
+xf
+vq
+wd
 SK
 SK
 SK
@@ -49315,18 +49315,18 @@ hm
 hm
 hm
 xs
-QC
+Pl
 Ey
-qi
-zu
+tg
+AQ
 xs
-RZ
+uY
 SK
-kn
-MM
-MM
-MM
-KE
+yi
+xf
+xf
+xf
+wd
 SK
 SK
 SK
@@ -49572,18 +49572,18 @@ hm
 hm
 hm
 xs
-bx
+jP
 Ey
 Ey
-Ya
+aO
 xs
-RZ
+uY
 SK
-kn
-MM
-MM
-MM
-KE
+yi
+xf
+xf
+xf
+wd
 SK
 SK
 SK
@@ -49832,15 +49832,15 @@ xs
 Ey
 Ey
 Ey
-ac
+nK
 xs
-RZ
+uY
 SK
-Dk
-MM
-Ql
-MM
-KE
+UV
+xf
+fr
+xf
+wd
 SK
 SK
 SK
@@ -50089,15 +50089,15 @@ xs
 Sz
 Ey
 Ey
-Iv
+Lf
 zT
-RZ
+uY
 SK
-kn
-zm
-qm
-YP
-KE
+yi
+VF
+zy
+MM
+wd
 SK
 SK
 SK
@@ -50350,11 +50350,11 @@ xs
 xs
 SK
 SK
-uD
-fk
-fk
-fk
-IF
+Xi
+wS
+wS
+wS
+eo
 SK
 SK
 SK

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -5,37 +5,49 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"aO" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar_control{
+"aH" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "bo" = (
 /turf/open/indestructible,
 /area/f13/wasteland)
-"cX" = (
-/obj/structure/barricade/tentclothedge{
+"bO" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"dd" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"dl" = (
+/obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"dF" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
 "ed" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"eo" = (
-/obj/structure/barricade/tentclothcorner{
-	pixel_y = 3
+"ep" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
+"eU" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
 	},
+/mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "fd" = (
@@ -44,26 +56,36 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
-"fr" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"gK" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
+"gV" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"hd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "hm" = (
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"hx" = (
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
 "hS" = (
 /obj/structure/window/fulltile/wood{
 	max_integrity = 140
 	},
 /turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
+"iA" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
 "iF" = (
 /obj/structure/railing{
@@ -78,16 +100,28 @@
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"jP" = (
-/obj/machinery/light{
-	dir = 1
+"ky" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
+/area/f13/wasteland)
+"lh" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
 	},
-/area/f13/building/hospital)
-"no" = (
-/obj/effect/decal/remains/human,
+/area/f13/wasteland)
+"lN" = (
+/obj/structure/cable,
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"mp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "nF" = (
@@ -96,18 +130,70 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"nK" = (
+"pt" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"pJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"pW" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"qj" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"qw" = (
+/obj/machinery/smoke_machine{
+	name = "HVAC Machine"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"qC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"qL" = (
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"rn" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "rN" = (
 /turf/closed/wall/f13/wood,
@@ -118,54 +204,83 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"tg" = (
+"sG" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"th" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"tj" = (
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
+/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
+/obj/structure/nest/protectron,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "tM" = (
 /turf/closed/indestructible/riveted,
 /area/f13/wasteland)
-"ue" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"uY" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"vq" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"wd" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	layer = 2.95;
-	pixel_y = 3
+"vj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/roof,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
 /area/f13/wasteland)
-"wS" = (
-/obj/structure/barricade/tentclothedge{
+"vt" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"wa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"xg" = (
+/obj/effect/landmark/vertibird{
+	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
+	name = "Nash - Christus Saint Michaels Hospital - Rooftop"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"xh" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"xl" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"xf" = (
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"xi" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 1
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
 	},
-/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "xs" = (
 /turf/closed/indestructible/rock{
@@ -177,15 +292,18 @@
 	smooth = 1
 	},
 /area/f13/building/hospital)
-"xt" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/tracker,
+"xQ" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"yi" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
+"yC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
@@ -199,6 +317,16 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"zo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
 "zx" = (
 /obj/structure/railing{
 	dir = 4
@@ -208,30 +336,27 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"zy" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
 "zT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/simple_door/house,
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/hospital)
-"AQ" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+"zZ" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Al" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "AZ" = (
 /obj/structure/railing{
@@ -239,48 +364,171 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Ed" = (
-/mob/living/simple_animal/hostile/raider/tribal,
+"Be" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"Ey" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
+"Bz" = (
+/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"BQ" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Co" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"CB" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"CG" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Ey" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"EF" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "Fj" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/wasteland)
-"KR" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/turf/open/floor/carpet/red,
+"Fl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"Lf" = (
+"FT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"GB" = (
+/obj/structure/nest/protectron,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Hb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"HT" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"IF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"JX" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
-"LT" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/wasteland)
-"Mn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/solar,
+/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"MM" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+"JY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Lb" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Lv" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Lz" = (
+/obj/structure/nest/protectron{
+	layer = 3;
+	max_mobs = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"LH" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"LQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"LT" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/wasteland)
+"Mn" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"MO" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Nx" = (
+/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Ny" = (
+/obj/machinery/smoke_machine{
+	name = "HVAC Machine"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "NT" = (
 /obj/structure/railing{
@@ -288,75 +536,54 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"NV" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"Op" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/power/terminal{
-	dir = 1
+"QZ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"Pl" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+"Rq" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Rw" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/f13/building/hospital)
-"QW" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Rf" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4;
-	pixel_y = 3
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
 	},
-/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
-"RG" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"RQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
 "Sz" = (
 /obj/structure/ladder/unbreakable{
 	id = hospitalroof;
 	height = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "SK" = (
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"TG" = (
-/obj/structure/chair/wood,
-/turf/open/indestructible/ground/outside/roof,
+"ST" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"TS" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Ut" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
 "UB" = (
 /obj/structure/railing/corner,
@@ -365,24 +592,42 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
-"UV" = (
-/obj/structure/simple_door/tentflap_cloth{
-	pixel_y = -3
-	},
+"Va" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/ammo/military,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Vm" = (
+/mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"VF" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/pistol/m1911,
-/obj/item/ammo_box/magazine/m45,
-/obj/item/ammo_box/magazine/m45,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland)
-"Xi" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 8
-	},
+"Vr" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Wv" = (
+/obj/structure/rack/shelf_metal,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"XO" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 6
+	},
+/obj/item/crowbar{
+	pixel_y = 6
+	},
+/obj/item/wrench{
+	pixel_y = 6
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
 "XU" = (
 /obj/structure/railing/corner{
@@ -397,11 +642,29 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Zf" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/smes,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"ZA" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/solar_control{
 	dir = 1
 	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"ZF" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 
 (1,1,1) = {"
@@ -44180,7 +44443,7 @@ hm
 hm
 hm
 NT
-xt
+SK
 SK
 SK
 SK
@@ -44437,13 +44700,6 @@ hm
 hm
 hm
 NT
-uY
-Mn
-Mn
-Mn
-Mn
-Mn
-Mn
 SK
 SK
 SK
@@ -44457,6 +44713,13 @@ SK
 SK
 SK
 SK
+LT
+LT
+LT
+LT
+LT
+LT
+LT
 SK
 SK
 SK
@@ -44694,26 +44957,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+SK
+SK
+LT
+LT
+LT
+LT
+LT
+LT
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+dd
+Zf
+Zf
+Zf
+Va
+LT
 SK
 SK
 SK
@@ -44951,25 +45214,25 @@ hm
 hm
 hm
 NT
-uY
-Mn
-Mn
-Mn
-Mn
-Mn
-Mn
+SK
+SK
+SK
+LT
+qL
+qL
+qL
+qL
+LT
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+XO
+Zf
+Zf
+ST
+IF
 LT
 SK
 SK
@@ -45208,26 +45471,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+SK
+SK
+LT
+qL
+qL
+qL
+qL
+LT
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+vt
+dF
+Zf
+Zf
+CG
+LT
 SK
 SK
 SK
@@ -45465,26 +45728,26 @@ hm
 hm
 hm
 NT
-uY
-Mn
-Mn
-Mn
-Mn
-Mn
-Mn
+SK
+SK
+SK
+LT
+qL
+qL
+qL
+qL
+LT
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+th
+Zf
+Zf
+Zf
+GB
+LT
 SK
 SK
 SK
@@ -45722,26 +45985,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+SK
+SK
+LT
+LT
+ep
+ep
+LT
+LT
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+iA
+Zf
+Zf
+Zf
+Ut
+LT
 SK
 SK
 SK
@@ -45979,26 +46242,26 @@ hm
 hm
 hm
 NT
-uY
-Mn
-Mn
-Mn
-Mn
-Mn
-Mn
+SK
+SK
+SK
+SK
+SK
+Zf
+Zf
 SK
 SK
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+Wv
+hx
+Zf
+MO
+LH
+LT
 SK
 SK
 SK
@@ -46236,26 +46499,26 @@ hm
 hm
 hm
 NT
-uY
 SK
 SK
+dl
 SK
 SK
+TS
+Zf
+SK
+dl
 SK
 SK
+Bz
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+LT
+LT
+LT
+Rq
+LT
+LT
+LT
 SK
 SK
 SK
@@ -46493,13 +46756,16 @@ hm
 hm
 hm
 NT
-uY
-Mn
-Mn
-Mn
-Mn
-Mn
-Mn
+SK
+Rw
+FT
+FT
+FT
+wa
+FT
+FT
+FT
+vj
 SK
 SK
 SK
@@ -46508,10 +46774,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
+Vm
 SK
 SK
 SK
@@ -46750,17 +47013,17 @@ hm
 hm
 hm
 NT
-uY
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+xQ
+zZ
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+Lv
+HT
 SK
 SK
 SK
@@ -47007,26 +47270,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+zZ
+lh
+lh
+Nx
+lh
+lh
+lh
+lh
+Lv
 SK
 SK
 SK
+qw
+sG
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+Ny
+Ny
 SK
 SK
 SK
@@ -47264,26 +47527,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+zZ
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+Lv
 SK
 SK
 SK
-QW
+Vr
+Ny
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+Ny
+sG
 SK
 SK
 SK
@@ -47521,26 +47784,26 @@ hm
 hm
 hm
 NT
-uY
-SK
-Ed
-TG
-ue
-gK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+xQ
+Hb
+lh
+lh
+lh
+Lb
+lh
+xg
+lh
+ky
+HT
 SK
 SK
-SK
-SK
+qw
+Ny
 SK
 SK
 SK
+Ny
+Ny
 SK
 SK
 SK
@@ -47778,26 +48041,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+zZ
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+Lv
 SK
 SK
-no
-RG
-no
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+Vm
+qw
+Ny
 SK
 SK
 SK
+sG
+Ny
 SK
 SK
 SK
@@ -48035,26 +48298,26 @@ hm
 hm
 hm
 NT
-uY
+SK
+zZ
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+Lv
 SK
 SK
 SK
+Vr
+Ny
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+Ny
+Ny
 SK
 SK
 SK
@@ -48292,24 +48555,24 @@ hm
 hm
 hm
 NT
-uY
+xQ
+zZ
+lh
+lh
+lh
+lh
+lh
+lh
+lh
+Lv
+eU
 SK
 SK
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+Bz
 SK
 SK
 SK
@@ -48549,16 +48812,16 @@ hm
 hm
 hm
 NT
-uY
 SK
-xi
-cX
-cX
-cX
-Rf
-SK
-SK
-SK
+pW
+JY
+JY
+JY
+xl
+JY
+JY
+JY
+zo
 SK
 SK
 SK
@@ -48806,27 +49069,27 @@ xs
 xs
 xs
 xs
-uY
 SK
-yi
-NV
-KR
-MM
-wd
+Bz
+Co
 SK
+Vm
+Co
 SK
 SK
-SK
+Co
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+CB
+yC
+lN
+CB
+yC
+lN
+CB
+yC
+lN
 SK
 SK
 AZ
@@ -49058,18 +49321,11 @@ hm
 hm
 hm
 xs
-Op
-RQ
-Zf
-Zf
+qj
+gV
+xh
+EF
 xs
-uY
-SK
-yi
-xf
-xf
-vq
-wd
 SK
 SK
 SK
@@ -49082,8 +49338,15 @@ SK
 SK
 SK
 SK
-SK
-SK
+CB
+qC
+lN
+CB
+qC
+lN
+CB
+qC
+lN
 SK
 SK
 AZ
@@ -49315,18 +49578,11 @@ hm
 hm
 hm
 xs
-Pl
+BQ
 Ey
-tg
-AQ
+ZF
+tj
 xs
-uY
-SK
-yi
-xf
-xf
-xf
-wd
 SK
 SK
 SK
@@ -49335,12 +49591,19 @@ SK
 SK
 SK
 SK
+Vm
 SK
 SK
 SK
-SK
-SK
-SK
+CB
+qC
+lN
+CB
+qC
+lN
+CB
+qC
+lN
 SK
 SK
 AZ
@@ -49572,18 +49835,11 @@ hm
 hm
 hm
 xs
-jP
+aH
 Ey
 Ey
-aO
+ZA
 xs
-uY
-SK
-yi
-xf
-xf
-xf
-wd
 SK
 SK
 SK
@@ -49596,8 +49852,15 @@ SK
 SK
 SK
 SK
-SK
-SK
+CB
+qC
+lN
+CB
+qC
+lN
+CB
+qC
+lN
 SK
 SK
 AZ
@@ -49829,32 +50092,32 @@ hm
 hm
 hm
 xs
+Lz
 Ey
 Ey
-Ey
-nK
+Al
 xs
-uY
-SK
-UV
-xf
-fr
-xf
-wd
 SK
 SK
-SK
+rn
+rn
+rn
+rn
+rn
+rn
 SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+CB
+qC
+lN
+CB
+qC
+lN
+CB
+qC
+lN
 SK
 SK
 AZ
@@ -50089,15 +50352,9 @@ xs
 Sz
 Ey
 Ey
-Lf
+QZ
 zT
-uY
-SK
-yi
-VF
-zy
-MM
-wd
+bO
 SK
 SK
 SK
@@ -50110,7 +50367,13 @@ SK
 SK
 SK
 SK
+hd
 SK
+SK
+hd
+SK
+SK
+hd
 SK
 SK
 SK
@@ -50348,28 +50611,28 @@ xs
 xs
 xs
 xs
-SK
-SK
-Xi
-wS
-wS
-wS
-eo
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+JX
+mp
+Be
+Be
+Be
+Be
+Be
+Be
+pt
+pJ
+LQ
+LQ
+LQ
+Fl
+LQ
+LQ
+Fl
+LQ
+LQ
+Fl
+LQ
+Mn
 SK
 AZ
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -1,6 +1,42 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"aj" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "bo" = (
 /turf/open/indestructible,
+/area/f13/wasteland)
+"bx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"cE" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/smes,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"dC" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ed" = (
 /turf/closed/mineral/random/low_chance,
@@ -11,6 +47,12 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
+"fk" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "hm" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
@@ -20,12 +62,71 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/wasteland)
+"iF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"jj" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"kn" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"nF" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"pO" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"qi" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"qm" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"rq" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "rN" = (
 /turf/closed/wall/f13/wood,
+/area/f13/wasteland)
+"sh" = (
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "sn" = (
 /turf/open/transparent/openspace{
@@ -33,22 +134,274 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"tq" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "tM" = (
 /turf/closed/indestructible/riveted,
 /area/f13/wasteland)
+"uD" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"wj" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/solar,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"xs" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/hospital)
+"yY" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 4.1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zm" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"zu" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"zx" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zT" = (
+/obj/structure/simple_door/house,
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building/hospital)
+"AZ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Cq" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"Dk" = (
+/obj/structure/simple_door/tentflap_cloth{
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Ey" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "Fj" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/wasteland)
+"Iv" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"IF" = (
+/obj/structure/barricade/tentclothcorner{
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Jz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"KE" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 1;
+	layer = 2.95;
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "LT" = (
-/obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/wasteland)
+"MM" = (
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"Nl" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"NH" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"NT" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"OB" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"Qj" = (
+/obj/structure/barricade/tentclothcorner{
+	dir = 4;
+	pixel_y = 3
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Ql" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"QC" = (
+/obj/structure/nest/protectron{
+	layer = 3;
+	max_mobs = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"Rt" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
+"RZ" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Sz" = (
+/obj/structure/ladder/unbreakable{
+	id = Followers1;
+	height = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "SK" = (
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"TJ" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"TP" = (
+/obj/structure/barricade/tentclothedge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"UB" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"WT" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/tracker,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"XU" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"XX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Ya" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/solar_control{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
+"YP" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"YU" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/carpet/red,
 /area/f13/wasteland)
 
 (1,1,1) = {"
@@ -43063,23 +43416,23 @@ sn
 sn
 sn
 sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-hm
+UB
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+XU
 hm
 hm
 hm
@@ -43312,15 +43665,15 @@ hm
 hm
 hm
 hm
-hm
-sn
-sn
-sn
-sn
-sn
-sn
-sn
-sn
+jj
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+yY
 SK
 SK
 SK
@@ -43336,7 +43689,7 @@ SK
 SK
 SK
 SK
-hm
+AZ
 hm
 hm
 hm
@@ -43569,7 +43922,7 @@ hm
 hm
 hm
 hm
-hm
+NT
 SK
 SK
 SK
@@ -43593,7 +43946,7 @@ SK
 SK
 SK
 SK
-hm
+AZ
 hm
 hm
 hm
@@ -43826,7 +44179,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+WT
 SK
 SK
 SK
@@ -43849,8 +44203,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -44083,7 +44436,14 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+wj
+wj
+wj
+wj
+wj
+wj
 SK
 SK
 SK
@@ -44100,14 +44460,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -44340,7 +44693,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -44363,8 +44717,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -44597,14 +44950,14 @@ hm
 hm
 hm
 hm
-hm
-SK
-SK
-SK
-SK
-SK
-SK
-SK
+NT
+RZ
+wj
+wj
+wj
+wj
+wj
+wj
 SK
 SK
 SK
@@ -44621,7 +44974,7 @@ LT
 SK
 SK
 SK
-hm
+AZ
 hm
 hm
 hm
@@ -44854,7 +45207,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -44877,8 +45231,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -45111,7 +45464,14 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+wj
+wj
+wj
+wj
+wj
+wj
 SK
 SK
 SK
@@ -45128,14 +45488,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -45368,7 +45721,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -45391,8 +45745,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -45625,7 +45978,14 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+wj
+wj
+wj
+wj
+wj
+wj
 SK
 SK
 SK
@@ -45642,14 +46002,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -45882,7 +46235,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -45905,8 +46259,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -46139,7 +46492,14 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+wj
+wj
+wj
+wj
+wj
+wj
 SK
 SK
 SK
@@ -46156,14 +46516,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+iF
 hm
 hm
 hm
@@ -46396,7 +46749,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -46419,8 +46773,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -46653,7 +47006,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -46676,8 +47030,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -46910,7 +47263,12 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+SK
+SK
+SK
+dC
 SK
 SK
 SK
@@ -46929,12 +47287,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -47167,7 +47520,13 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+SK
+rq
+sh
+tq
+Jz
 SK
 SK
 SK
@@ -47185,13 +47544,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -47424,7 +47777,13 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+SK
+SK
+TJ
+pO
+TJ
 SK
 SK
 SK
@@ -47442,13 +47801,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -47681,7 +48034,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -47704,8 +48058,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -47938,7 +48291,8 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
 SK
 SK
 SK
@@ -47961,8 +48315,7 @@ SK
 SK
 SK
 SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -48195,7 +48548,14 @@ hm
 hm
 hm
 hm
-hm
+NT
+RZ
+SK
+NH
+TP
+TP
+TP
+Qj
 SK
 SK
 SK
@@ -48212,14 +48572,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -48447,12 +48800,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+xs
+xs
+xs
+xs
+xs
+RZ
+SK
+kn
+Cq
+Nl
+YP
+KE
 SK
 SK
 SK
@@ -48469,14 +48829,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -48704,12 +49057,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+Rt
+OB
+cE
+cE
+xs
+RZ
+SK
+kn
+MM
+MM
+YU
+KE
 SK
 SK
 SK
@@ -48726,14 +49086,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -48961,12 +49314,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+QC
+Ey
+qi
+zu
+xs
+RZ
+SK
+kn
+MM
+MM
+MM
+KE
 SK
 SK
 SK
@@ -48983,14 +49343,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -49218,12 +49571,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+bx
+Ey
+Ey
+Ya
+xs
+RZ
+SK
+kn
+MM
+MM
+MM
+KE
 SK
 SK
 SK
@@ -49240,14 +49600,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -49475,12 +49828,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+Ey
+Ey
+Ey
+ac
+xs
+RZ
+SK
+Dk
+MM
+Ql
+MM
+KE
 SK
 SK
 SK
@@ -49497,14 +49857,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -49732,12 +50085,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+Sz
+Ey
+Ey
+Iv
+zT
+RZ
+SK
+kn
+zm
+qm
+YP
+KE
 SK
 SK
 SK
@@ -49754,14 +50114,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -49989,12 +50342,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+xs
+xs
+xs
+xs
+xs
+xs
+SK
+SK
+uD
+fk
+fk
+fk
+IF
 SK
 SK
 SK
@@ -50011,14 +50371,7 @@ SK
 SK
 SK
 SK
-SK
-SK
-SK
-SK
-SK
-SK
-SK
-hm
+AZ
 hm
 hm
 hm
@@ -50251,31 +50604,31 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+nF
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+aj
 hm
 hm
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -46,7 +46,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "ed" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
@@ -150,7 +150,7 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/item/stock_parts/cell/ammo/mfc,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "jX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -160,7 +160,7 @@
 "kY" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "lk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -292,7 +292,7 @@
 "ve" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "vI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -300,10 +300,16 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"vT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "wA" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "wD" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -322,7 +328,7 @@
 "yd" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "yY" = (
 /obj/structure/railing{
 	dir = 6;
@@ -375,7 +381,7 @@
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Ef" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /turf/open/indestructible/ground/outside/roof,
@@ -383,7 +389,7 @@
 "Er" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Ey" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
@@ -485,20 +491,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "LT" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/wasteland)
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/building/hospital)
 "Nl" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/ammo/military,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Nw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -506,7 +506,7 @@
 	termtag = "Business"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "NT" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -516,20 +516,21 @@
 "Oi" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Pg" = (
 /obj/structure/reagent_dispensers/barrel/two,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "PZ" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Qx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
@@ -543,6 +544,13 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"Sl" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/building/hospital)
 "Sn" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	pixel_y = 6
@@ -568,8 +576,9 @@
 /area/f13/wasteland)
 "To" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/light,
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Tt" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -593,8 +602,11 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/item/stock_parts/cell/ammo/ec,
 /obj/item/stock_parts/cell/ammo/ec,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Vn" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -614,11 +626,11 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "Wa" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "WH" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -634,7 +646,7 @@
 "XC" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
+/area/f13/building/hospital)
 "XU" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -44713,13 +44725,13 @@ SK
 SK
 SK
 SK
-LT
-LT
-LT
-LT
-LT
-LT
-LT
+xs
+xs
+xs
+xs
+xs
+xs
+xs
 SK
 SK
 SK
@@ -44960,23 +44972,23 @@ NT
 SK
 SK
 SK
-LT
-LT
-LT
-LT
-LT
-LT
+xs
+xs
+xs
+xs
+xs
+xs
 SK
 SK
 SK
 SK
-LT
+xs
 kY
-eQ
-eQ
-eQ
+Ey
+vT
+Ey
 Nl
-LT
+xs
 SK
 SK
 SK
@@ -45217,23 +45229,23 @@ NT
 SK
 SK
 SK
+xs
 LT
-To
-To
-To
-To
 LT
-SK
-SK
-SK
-SK
 LT
+LT
+xs
+SK
+SK
+SK
+SK
+xs
 Vp
-eQ
-eQ
+Ey
+Ey
 Oi
 Nw
-LT
+xs
 SK
 SK
 SK
@@ -45474,23 +45486,23 @@ NT
 SK
 SK
 SK
+xs
+Sl
+LT
 LT
 To
-To
-To
-To
-LT
+xs
 SK
 SK
 SK
 SK
-LT
+xs
 dH
 Wa
-eQ
-eQ
+Ey
+Ey
 Qx
-LT
+xs
 SK
 SK
 SK
@@ -45731,23 +45743,23 @@ NT
 SK
 SK
 SK
+xs
 LT
-To
-To
-To
-To
 LT
-SK
-SK
-SK
-SK
 LT
+LT
+xs
+SK
+SK
+SK
+SK
+xs
 jL
-eQ
-eQ
-eQ
+Ey
+Ey
+Ey
 wA
-LT
+xs
 SK
 SK
 SK
@@ -45988,23 +46000,23 @@ NT
 SK
 SK
 SK
-LT
-LT
+xs
+xs
 PZ
 PZ
-LT
-LT
+xs
+xs
 SK
 SK
 SK
 SK
-LT
+xs
 Vb
-eQ
-eQ
-eQ
+Ey
+Ey
+Ey
 Pg
-LT
+xs
 SK
 SK
 SK
@@ -46255,13 +46267,13 @@ SK
 SK
 SK
 SK
-LT
+xs
 Do
 ve
-eQ
+Ey
 yd
 XC
-LT
+xs
 SK
 SK
 SK
@@ -46512,13 +46524,13 @@ SK
 SK
 Ef
 SK
-LT
-LT
-LT
+xs
+xs
+xs
 Er
-LT
-LT
-LT
+xs
+xs
+xs
 SK
 SK
 SK

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -5,28 +5,475 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"aK" = (
-/obj/structure/nest/protectron,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+"aN" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
 /area/f13/wasteland)
 "bc" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"bo" = (
+/turf/open/indestructible,
+/area/f13/wasteland)
+"ce" = (
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"ch" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"cr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"dH" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"ed" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
+"ej" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"eQ" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"fd" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
+"fQ" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"hm" = (
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"hH" = (
+/obj/machinery/smoke_machine{
+	name = "HVAC Machine"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"hS" = (
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/turf/open/floor/holofloor/carpet,
+/area/f13/wasteland)
+"ic" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"id" = (
+/obj/structure/cable,
+/obj/machinery/power/solar,
+/turf/open/floor/plasteel/solarpanel,
+/area/f13/wasteland)
+"ie" = (
+/obj/machinery/smoke_machine{
+	name = "HVAC Machine"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"ij" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"in" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"iF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"jj" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"jL" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"jX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"kY" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"lk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"mG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"mU" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"bh" = (
+"nF" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"oy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"oA" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"pm" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"pq" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"ql" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"ri" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"rN" = (
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
+"sn" = (
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"sv" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"tA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"tM" = (
+/turf/closed/indestructible/riveted,
+/area/f13/wasteland)
+"uu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"uw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"uI" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"uJ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"ve" = (
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"vI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"wA" = (
+/obj/structure/nest/protectron,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"wD" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"xs" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/hospital)
+"yd" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"yY" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 4.1
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zx" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"zT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/building/hospital)
+"AZ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"CQ" = (
+/obj/effect/landmark/vertibird{
+	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
+	name = "Nash - Christus Saint Michaels Hospital - Rooftop"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"CY" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Do" = (
+/obj/structure/rack/shelf_metal,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Ef" = (
+/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Er" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Ey" = (
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"ED" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"bo" = (
+"Fj" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/wasteland)
-"bY" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+"GG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
 /area/f13/wasteland)
-"cx" = (
+"GH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Hw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Ik" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Im" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Ir" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
+	},
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Jo" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Jr" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"JB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"KT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"KV" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -37,29 +484,122 @@
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"dk" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
+"LT" = (
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/wasteland)
+"Nl" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/ammo/military,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Nw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"dK" = (
-/obj/machinery/smoke_machine{
-	name = "HVAC Machine"
+"NT" = (
+/obj/structure/railing{
+	layer = 4.1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Oi" = (
+/obj/structure/chair/f13chair2,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Pg" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"PZ" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
+"Qx" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"RF" = (
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
+"RU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/wasteland)
+"Sn" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	pixel_y = 6
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"ed" = (
-/turf/closed/mineral/random/low_chance,
+"St" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"ei" = (
+"Sz" = (
+/obj/structure/ladder/unbreakable{
+	id = "hospitalroof";
+	height = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"SK" = (
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"To" = (
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Tt" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
-"ek" = (
+"Um" = (
+/mob/living/simple_animal/hostile/raider/tribal,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"UB" = (
+/obj/structure/railing/corner,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
+"Vb" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland)
+"Vn" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"Vp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 6
@@ -75,485 +615,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"fb" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"fd" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
-"fk" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/solarpanel,
-/area/f13/wasteland)
-"fo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"gg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"gK" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"hm" = (
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"hS" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/turf/open/floor/holofloor/carpet,
-/area/f13/wasteland)
-"ih" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"iF" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"jc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"jj" = (
-/obj/structure/railing/corner,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"kF" = (
-/obj/structure/rack/shelf_metal,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"kU" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"lF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"lM" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"lV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"mK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"mP" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"nd" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"nF" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"oc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"oi" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar_control{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"oy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"ql" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"rF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"rN" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
-"sn" = (
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"sz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"sE" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"te" = (
-/obj/machinery/smoke_machine{
-	name = "HVAC Machine"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"to" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"tp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"tJ" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"tM" = (
-/turf/closed/indestructible/riveted,
-/area/f13/wasteland)
-"uB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"vc" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"wY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"xj" = (
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"xs" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/building/hospital)
-"yB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"yV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"yY" = (
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"zf" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"zx" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"zK" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"zT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building/hospital)
-"Am" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"AS" = (
+"Wa" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
-"AZ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"Bg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Bt" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"DL" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"En" = (
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Ey" = (
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"EV" = (
-/obj/structure/chair/f13chair2,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Fg" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Fj" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/indestructible,
-/area/f13/wasteland)
-"Ki" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"KV" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"KW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Lj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Ll" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"LT" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/wasteland)
-"Mv" = (
-/obj/structure/cable,
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/solarpanel,
-/area/f13/wasteland)
-"MG" = (
-/obj/machinery/power/port_gen/pacman/super,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Nd" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/knot,
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"Nh" = (
-/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"Nt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"NT" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"OK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"OO" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"PU" = (
+"WH" = (
 /obj/structure/nest/protectron{
 	layer = 3;
 	max_mobs = 1;
@@ -561,87 +627,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"RF" = (
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
-"Sz" = (
-/obj/structure/ladder/unbreakable{
-	id = hospitalroof;
-	height = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"SK" = (
+"WL" = (
+/obj/machinery/hydroponics/constructable,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"Tn" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	pixel_y = 6
-	},
-/mob/living/simple_animal/hostile/raider/tribal,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"TD" = (
-/obj/effect/landmark/vertibird{
-	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
-	name = "Nash - Christus Saint Michaels Hospital - Rooftop"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Ul" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
+"XC" = (
+/obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"UB" = (
-/obj/structure/railing/corner,
-/turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
-	},
-/area/f13/wasteland)
-"US" = (
-/obj/structure/reagent_dispensers/barrel/two,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"Vg" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/wasteland)
-"Vr" = (
-/obj/structure/lattice/catwalk,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"VU" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/ammo/military,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland)
-"WN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Xb" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
-/area/f13/wasteland)
-"Xv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkdirty"
-	},
 /area/f13/wasteland)
 "XU" = (
 /obj/structure/railing/corner{
@@ -655,16 +647,24 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"YO" = (
+"Yb" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"YT" = (
-/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/solar_control{
+	dir = 1
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"ZO" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 
 (1,1,1) = {"
@@ -44971,11 +44971,11 @@ SK
 SK
 SK
 LT
-bY
-En
-En
-En
-VU
+kY
+eQ
+eQ
+eQ
+Nl
 LT
 SK
 SK
@@ -45218,21 +45218,21 @@ SK
 SK
 SK
 LT
-Vr
-Vr
-Vr
-Vr
+To
+To
+To
+To
 LT
 SK
 SK
 SK
 SK
 LT
-ek
-En
-En
-EV
-oy
+Vp
+eQ
+eQ
+Oi
+Nw
 LT
 SK
 SK
@@ -45475,21 +45475,21 @@ SK
 SK
 SK
 LT
-Vr
-Vr
-Vr
-Vr
+To
+To
+To
+To
 LT
 SK
 SK
 SK
 SK
 LT
-nd
-AS
-En
-En
-Ul
+dH
+Wa
+eQ
+eQ
+Qx
 LT
 SK
 SK
@@ -45732,21 +45732,21 @@ SK
 SK
 SK
 LT
-Vr
-Vr
-Vr
-Vr
+To
+To
+To
+To
 LT
 SK
 SK
 SK
 SK
 LT
-lM
-En
-En
-En
-aK
+jL
+eQ
+eQ
+eQ
+wA
 LT
 SK
 SK
@@ -45990,8 +45990,8 @@ SK
 SK
 LT
 LT
-Vg
-Vg
+PZ
+PZ
 LT
 LT
 SK
@@ -45999,11 +45999,11 @@ SK
 SK
 SK
 LT
-kU
-En
-En
-En
-US
+Vb
+eQ
+eQ
+eQ
+Pg
 LT
 SK
 SK
@@ -46247,8 +46247,8 @@ SK
 SK
 SK
 SK
-En
-En
+eQ
+eQ
 SK
 SK
 SK
@@ -46256,11 +46256,11 @@ SK
 SK
 SK
 LT
-kF
-MG
-En
-YT
-fb
+Do
+ve
+eQ
+yd
+XC
 LT
 SK
 SK
@@ -46501,21 +46501,21 @@ hm
 NT
 SK
 SK
-bh
+ED
 SK
 SK
-dk
-En
+ri
+eQ
 SK
-bh
+ED
 SK
 SK
-Nh
+Ef
 SK
 LT
 LT
 LT
-Ki
+Er
 LT
 LT
 LT
@@ -46757,15 +46757,15 @@ hm
 hm
 NT
 SK
-Ll
-Am
-Am
-Am
-KW
-Am
-Am
-Am
-rF
+uw
+GH
+GH
+GH
+oy
+GH
+GH
+GH
+tA
 SK
 SK
 SK
@@ -46774,7 +46774,7 @@ SK
 SK
 SK
 SK
-xj
+Um
 SK
 SK
 SK
@@ -47013,17 +47013,17 @@ hm
 hm
 hm
 NT
-DL
-yB
-zf
-zf
-zf
-zf
-zf
-zf
-zf
-vc
-ih
+ZO
+mG
+ce
+ce
+ce
+ce
+ce
+ce
+ce
+oA
+Sn
 SK
 SK
 SK
@@ -47271,25 +47271,25 @@ hm
 hm
 NT
 SK
-yB
-zf
-zf
-ei
-zf
-zf
-zf
-zf
-vc
+mG
+ce
+ce
+Tt
+ce
+ce
+ce
+ce
+oA
 SK
 SK
 SK
-dK
-bc
+ie
+pm
 SK
 SK
 SK
-te
-te
+hH
+hH
 SK
 SK
 SK
@@ -47528,25 +47528,25 @@ hm
 hm
 NT
 SK
-yB
-zf
-zf
-zf
-zf
-zf
-zf
-zf
-vc
+mG
+ce
+ce
+ce
+ce
+ce
+ce
+ce
+oA
 SK
 SK
 SK
-sE
-te
+mU
+hH
 SK
 SK
 SK
-te
-bc
+hH
+pm
 SK
 SK
 SK
@@ -47784,26 +47784,26 @@ hm
 hm
 hm
 NT
-DL
-WN
-zf
-zf
-zf
-Xb
-zf
-TD
-zf
-wY
-ih
+ZO
+Im
+ce
+ce
+ce
+aN
+ce
+CQ
+ce
+GG
+Sn
 SK
 SK
-dK
-te
+ie
+hH
 SK
 SK
 SK
-te
-te
+hH
+hH
 SK
 SK
 SK
@@ -48042,25 +48042,25 @@ hm
 hm
 NT
 SK
-yB
-zf
-zf
-zf
-zf
-zf
-zf
-zf
-vc
+mG
+ce
+ce
+ce
+ce
+ce
+ce
+ce
+oA
 SK
 SK
-xj
-dK
-te
+Um
+ie
+hH
 SK
 SK
 SK
-bc
-te
+pm
+hH
 SK
 SK
 SK
@@ -48299,25 +48299,25 @@ hm
 hm
 NT
 SK
-yB
-zf
-zf
-zf
-zf
-zf
-zf
-zf
-vc
+mG
+ce
+ce
+ce
+ce
+ce
+ce
+ce
+oA
 SK
 SK
 SK
-sE
-te
+mU
+hH
 SK
 SK
 SK
-te
-te
+hH
+hH
 SK
 SK
 SK
@@ -48555,24 +48555,24 @@ hm
 hm
 hm
 NT
-DL
-yB
-zf
-zf
-zf
-zf
-zf
-zf
-zf
-vc
-Tn
+ZO
+mG
+ce
+ce
+ce
+ce
+ce
+ce
+ce
+oA
+Ir
 SK
 SK
 SK
 SK
 SK
 SK
-Nh
+Ef
 SK
 SK
 SK
@@ -48813,15 +48813,15 @@ hm
 hm
 NT
 SK
-OK
-lV
-lV
-lV
-Xv
-lV
-lV
-lV
-yV
+in
+Hw
+Hw
+Hw
+JB
+Hw
+Hw
+Hw
+RU
 SK
 SK
 SK
@@ -49070,26 +49070,26 @@ xs
 xs
 xs
 SK
-Nh
-KV
+Ef
+pq
 SK
-xj
-KV
-SK
-SK
-KV
+Um
+pq
 SK
 SK
+pq
 SK
-fk
-gg
-Mv
-fk
-gg
-Mv
-fk
-gg
-Mv
+SK
+SK
+bc
+uI
+id
+bc
+uI
+id
+bc
+uI
+id
 SK
 SK
 AZ
@@ -49321,10 +49321,10 @@ hm
 hm
 hm
 xs
-Nd
-Lj
-Fg
-to
+Jr
+Vn
+ej
+CY
 xs
 SK
 SK
@@ -49338,15 +49338,15 @@ SK
 SK
 SK
 SK
-fk
-fo
-Mv
-fk
-fo
-Mv
-fk
-fo
-Mv
+bc
+uJ
+id
+bc
+uJ
+id
+bc
+uJ
+id
 SK
 SK
 AZ
@@ -49578,10 +49578,10 @@ hm
 hm
 hm
 xs
-OO
+sv
 Ey
-zK
-cx
+fQ
+KV
 xs
 SK
 SK
@@ -49591,19 +49591,19 @@ SK
 SK
 SK
 SK
-xj
+Um
 SK
 SK
 SK
-fk
-fo
-Mv
-fk
-fo
-Mv
-fk
-fo
-Mv
+bc
+uJ
+id
+bc
+uJ
+id
+bc
+uJ
+id
 SK
 SK
 AZ
@@ -49835,10 +49835,10 @@ hm
 hm
 hm
 xs
-sz
+KT
 Ey
 Ey
-oi
+Yb
 xs
 SK
 SK
@@ -49852,15 +49852,15 @@ SK
 SK
 SK
 SK
-fk
-fo
-Mv
-fk
-fo
-Mv
-fk
-fo
-Mv
+bc
+uJ
+id
+bc
+uJ
+id
+bc
+uJ
+id
 SK
 SK
 AZ
@@ -50092,32 +50092,32 @@ hm
 hm
 hm
 xs
-PU
+WH
 Ey
 Ey
-oc
+uu
 xs
 SK
 SK
-tJ
-tJ
-tJ
-tJ
-tJ
-tJ
+WL
+WL
+WL
+WL
+WL
+WL
 SK
 SK
 SK
 SK
-fk
-fo
-Mv
-fk
-fo
-Mv
-fk
-fo
-Mv
+bc
+uJ
+id
+bc
+uJ
+id
+bc
+uJ
+id
 SK
 SK
 AZ
@@ -50352,9 +50352,9 @@ xs
 Sz
 Ey
 Ey
-gK
+ij
 zT
-mP
+Jo
 SK
 SK
 SK
@@ -50367,13 +50367,13 @@ SK
 SK
 SK
 SK
-jc
+Ik
 SK
 SK
-jc
+Ik
 SK
 SK
-jc
+Ik
 SK
 SK
 SK
@@ -50611,28 +50611,28 @@ xs
 xs
 xs
 xs
-YO
-Nt
-Bg
-Bg
-Bg
-Bg
-Bg
-Bg
-mK
-lF
-tp
-tp
-tp
-uB
-tp
-tp
-uB
-tp
-tp
-uB
-tp
-Bt
+cr
+vI
+St
+St
+St
+St
+St
+St
+ch
+lk
+jX
+jX
+jX
+ic
+jX
+jX
+ic
+jX
+jX
+ic
+jX
+wD
 SK
 AZ
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -144,21 +144,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"alz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/mirror{
-	pixel_x = -1;
-	pixel_y = 29
-	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "anv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -247,14 +232,12 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
 "aCj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/comfy/plywood{
+	dir = 1
 	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 8
-	},
-/area/f13/building/hospital)
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "aGA" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt,
@@ -866,13 +849,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dnp" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 4
-	},
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "dof" = (
 /obj/structure/dresser,
@@ -939,9 +919,11 @@
 /turf/open/indestructible,
 /area/f13/wasteland)
 "dHP" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "dKF" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1013,7 +995,6 @@
 	},
 /area/f13/ncr)
 "eav" = (
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 9;
 	icon_state = "bluerusty"
@@ -1399,10 +1380,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
 "gde" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/healthanalyzer,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 29
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "geI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2021,10 +2011,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iDT" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/structure/table,
+/obj/item/bodybag/containment,
+/obj/item/bodybag/containment,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iFg" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -2127,16 +2121,6 @@
 /obj/item/bodypart/l_arm,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
-"jkQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "jof" = (
 /obj/structure/table,
 /obj/item/stack/medical/ointment,
@@ -2175,13 +2159,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "juL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/structure/table,
-/obj/item/bodybag/containment,
-/obj/item/bodybag/containment,
-/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jvX" = (
@@ -2382,13 +2364,6 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"ktt" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "kur" = (
 /turf/closed/wall,
 /area/f13/ncr)
@@ -2430,11 +2405,6 @@
 "kEe" = (
 /turf/open/floor/carpet/orange,
 /area/f13/ncr)
-"kFg" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "kFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -2465,6 +2435,18 @@
 /area/f13/wasteland)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
+/area/f13/building/hospital)
+"kLi" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "kMB" = (
 /obj/structure/railing/corner{
@@ -2603,7 +2585,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "loK" = (
-/obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 10;
 	icon_state = "bluedirty"
@@ -2791,6 +2772,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"lTX" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "lUm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3417,10 +3403,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"ogI" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "oiY" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/building)
@@ -3505,9 +3487,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "oDl" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "oDo" = (
@@ -3586,10 +3566,14 @@
 /turf/open/indestructible,
 /area/f13/wasteland/ncr)
 "oSq" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "oTC" = (
 /obj/machinery/light{
@@ -3643,13 +3627,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"pqc" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/syndi,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "psD" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -4004,6 +3981,13 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"rcU" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "rhv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/handrail{
@@ -4054,7 +4038,6 @@
 	light_color = "#c1caff"
 	},
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
-/obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
 	},
@@ -4304,14 +4287,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sfh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/comfy/plywood{
+	dir = 1
 	},
-/obj/structure/legion_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 8
-	},
-/area/f13/building/hospital)
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "sjx" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13{
@@ -4395,6 +4376,10 @@
 "sGc" = (
 /turf/open/transparent/openspace,
 /area/f13/ncr)
+"sHj" = (
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "sHx" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4581,18 +4566,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"tun" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "tvg" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -4629,14 +4602,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"tEn" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "tEW" = (
 /obj/structure/barricade/bars,
 /obj/item/shard,
@@ -4694,7 +4659,6 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/machinery/hydroponics/soil,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
 	},
@@ -4772,13 +4736,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
-"ubG" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/security,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "ucd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4911,10 +4868,8 @@
 	},
 /area/f13/building/massfusion)
 "uxf" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 8
-	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "uxm" = (
 /obj/structure/barricade/wooden,
@@ -5599,10 +5554,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"yha" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "yic" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/mop,
@@ -49168,14 +49119,14 @@ tnt
 bhm
 bhm
 eav
-sfh
-aCj
-aCj
-uxf
-uxf
-uxf
-uxf
-iDT
+mjv
+mjv
+mjv
+tYl
+tYl
+tYl
+tYl
+tYl
 loK
 lqO
 mZk
@@ -49684,11 +49635,11 @@ qOL
 sVJ
 enE
 tRs
-oSq
-oSq
-oSq
+xam
+xam
+xam
 rqa
-dnp
+hJV
 fhI
 ivA
 lqO
@@ -50974,7 +50925,7 @@ nRq
 tfy
 wXb
 lqO
-alz
+gde
 kWR
 vfp
 gLr
@@ -52238,7 +52189,7 @@ vqz
 vqz
 aaL
 aKa
-ubG
+aCj
 aKa
 aKa
 eCS
@@ -52752,7 +52703,7 @@ vqz
 vqz
 aaL
 aKa
-pqc
+sfh
 aKa
 aKa
 aKa
@@ -53526,7 +53477,7 @@ aKa
 ocx
 aKa
 aKa
-dHP
+sHj
 bhm
 gLr
 oab
@@ -54294,9 +54245,9 @@ vqz
 vqz
 vqz
 bhm
-ktt
-tun
-oDl
+rcU
+kLi
+dnp
 cym
 bhm
 cnB
@@ -54567,9 +54518,9 @@ gah
 kJl
 lqO
 tmP
-juL
-jkQ
-gde
+iDT
+oSq
+dHP
 lqO
 xpn
 pws
@@ -54808,10 +54759,10 @@ vqz
 vqz
 vqz
 bhm
-tEn
-kFg
-yha
-ogI
+juL
+lTX
+oDl
+uxf
 bhm
 gah
 kJl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -11,6 +11,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"aaL" = (
+/obj/structure/fluff/railing,
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "aaZ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -308,9 +315,6 @@
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
-	},
-/obj/effect/overlay/junk/toilet{
-	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -647,6 +651,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"cwS" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "cym" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
@@ -823,11 +833,8 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/effect/overlay/junk/sink{
-	pixel_y = 15
-	},
-/obj/effect/overlay/junk/mirror{
-	pixel_y = 32
+/obj/structure/toilet{
+	pixel_y = 7
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -917,11 +924,8 @@
 /turf/open/indestructible,
 /area/f13/wasteland)
 "dHP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "dKF" = (
 /obj/structure/railing{
@@ -1047,6 +1051,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/corner,
 /area/f13/building/hospital)
+"evf" = (
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "ext" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 10
@@ -1064,6 +1073,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"eCS" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette,
+/obj/item/storage/fancy/cigarettes,
+/obj/item/lighter/greyscale,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "eHs" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbrokenvertical"
@@ -1247,6 +1263,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/radiation)
+"flP" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "fmJ" = (
 /obj/structure/sign/poster/prewar/poster75{
 	pixel_y = 32
@@ -1368,12 +1388,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
 "gde" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 29
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
 "geI" = (
@@ -1999,8 +2025,11 @@
 	},
 /area/f13/building/hospital)
 "iFg" = (
-/obj/structure/simple_door/house,
 /obj/structure/barricade/wooden/planks/pregame,
+/obj/machinery/door/airlock/medical{
+	name = "Clinic Morgue";
+	req_one_access_txt = "124"
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -2134,10 +2163,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "juL" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jvX" = (
 /obj/item/kirbyplants{
@@ -2399,6 +2428,13 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"kIJ" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/engine,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
@@ -2634,6 +2670,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"lCy" = (
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "lDT" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
@@ -2700,6 +2741,14 @@
 /obj/item/shard,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"lQW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "lSK" = (
 /obj/machinery/light{
 	dir = 8
@@ -2728,11 +2777,14 @@
 	},
 /area/f13/ncr)
 "lUm" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "lYF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2957,6 +3009,13 @@
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"mMf" = (
+/obj/structure/ladder/unbreakable{
+	id = Followers1;
+	height = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
@@ -3311,9 +3370,9 @@
 	},
 /area/f13/building/hospital)
 "ocx" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "odJ" = (
 /obj/structure/railing{
@@ -3425,17 +3484,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "oDl" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/clothing/glasses/hud/health/night,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "oDo" = (
 /turf/closed/wall/mineral/concrete,
@@ -3543,7 +3596,11 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
+/obj/item/reagent_containers/rag/towel,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -3981,6 +4038,18 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
+"rqL" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "rsw" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
@@ -4127,6 +4196,10 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"rRc" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "rRp" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace,
@@ -4235,13 +4308,12 @@
 	},
 /area/f13/building/massfusion)
 "sjy" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/chair/comfy/plywood{
+	dir = 1
 	},
-/area/f13/building/hospital)
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "sjM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4305,6 +4377,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"sEl" = (
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "sFr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4341,12 +4417,11 @@
 /turf/closed/indestructible/riveted,
 /area/f13/wasteland/ncr)
 "sRn" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "sRu" = (
 /obj/structure/railing{
@@ -4518,6 +4593,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"twf" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "txr" = (
 /obj/structure/rack,
 /obj/item/storage/book/bible/booze,
@@ -4571,6 +4658,15 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plasteel/f13,
 /area/f13/building)
+"tPa" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace{
+	name = "air";
+	sunlight_state = 1
+	},
+/area/f13/wasteland)
 "tQg" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -4689,6 +4785,11 @@
 "uez" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital)
+"ueM" = (
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building/hospital)
 "uhv" = (
 /obj/structure/table/reinforced,
@@ -4944,6 +5045,16 @@
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vwx" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/item/bodybag/containment,
+/obj/item/bodybag/containment,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "vAd" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -4973,6 +5084,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
+"vEn" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "vFt" = (
 /obj/item/organ/liver,
 /obj/effect/decal/cleanable/dirt,
@@ -4988,6 +5106,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"vGi" = (
+/obj/structure/simple_door/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
+	},
+/area/f13/building/hospital)
 "vHu" = (
 /obj/structure/rack/shelf_metal,
 /obj/structure/bedsheetbin/towel,
@@ -5047,6 +5172,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"wdx" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "wex" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
@@ -5293,6 +5424,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"xqG" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/science,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "xsR" = (
 /obj/machinery/light{
 	dir = 1;
@@ -50836,7 +50974,7 @@ nRq
 tfy
 wXb
 lqO
-kWR
+gde
 kWR
 vfp
 gLr
@@ -51607,8 +51745,8 @@ xJA
 iRY
 xvZ
 lqO
-lqO
-lqO
+twf
+kWR
 lqO
 gah
 kJl
@@ -51842,11 +51980,11 @@ vqz
 vqz
 vqz
 vqz
-vqz
-vqz
-vqz
-lDT
-lDT
+tPa
+tPa
+tPa
+cwS
+cwS
 bhm
 gah
 kQF
@@ -52098,12 +52236,12 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
+aKa
+vEn
 aKa
 aKa
-aKa
-aKa
-aKa
+eCS
 bhm
 lLE
 gnV
@@ -52355,12 +52493,12 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
+aKa
+lCy
 aKa
 aKa
-aKa
-aKa
-aKa
+evf
 bhm
 gLr
 kJl
@@ -52612,9 +52750,9 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
 aKa
-aKa
+sjy
 aKa
 aKa
 aKa
@@ -52869,7 +53007,7 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
 aKa
 aKa
 aKa
@@ -53126,9 +53264,9 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
 aKa
-aKa
+xqG
 aKa
 aKa
 aKa
@@ -53383,12 +53521,12 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
+aKa
+lCy
 aKa
 aKa
-aKa
-aKa
-aKa
+sEl
 bhm
 gLr
 oab
@@ -53400,10 +53538,10 @@ lqO
 lLE
 kJl
 lqO
-sjy
+dHP
 sRn
 dHP
-lqO
+dHP
 lqO
 nnp
 ucd
@@ -53640,9 +53778,9 @@ vqz
 vqz
 vqz
 vqz
-vqz
+aaL
 aKa
-aKa
+kIJ
 aKa
 aKa
 aKa
@@ -53657,10 +53795,10 @@ lqO
 gah
 gnV
 lqO
-oDl
-ocx
-lUm
-lqO
+cym
+dfR
+cym
+cym
 lqO
 xJf
 mMd
@@ -53898,11 +54036,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+bhm
+bhm
+bhm
+ueM
 bhm
 gah
 gnV
@@ -53914,10 +54052,10 @@ lqO
 gLr
 kJl
 iFg
-ocx
-ocx
-ocx
-lqO
+cym
+dfR
+tmP
+dfR
 lqO
 dfR
 dfR
@@ -54155,11 +54293,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+oDl
+rqL
+wdx
+cym
 bhm
 cnB
 kJl
@@ -54171,10 +54309,10 @@ lqO
 gah
 kGi
 lqO
-juL
-ocx
-gde
-lqO
+cym
+cym
+dfR
+cym
 lqO
 oXx
 lCa
@@ -54412,11 +54550,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+cym
+cym
+cym
+cym
 bhm
 hjx
 oab
@@ -54428,10 +54566,10 @@ lqO
 gah
 kJl
 lqO
-lqO
-lqO
-lqO
-lqO
+tmP
+vwx
+lUm
+juL
 lqO
 xpn
 pws
@@ -54669,11 +54807,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+lQW
+ocx
+rRc
+flP
 bhm
 gah
 kJl
@@ -54926,11 +55064,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+cym
+cym
+cym
+cym
 bhm
 gLr
 qkB
@@ -55183,12 +55321,12 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
 bhm
+mMf
+cym
+cym
+cym
+vGi
 whs
 xam
 xam
@@ -55440,11 +55578,11 @@ vqz
 vqz
 vqz
 vqz
-aKa
-aKa
-aKa
-aKa
-aKa
+bhm
+bhm
+bhm
+bhm
+bhm
 bhm
 bhm
 bhm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -144,6 +144,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"alz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 29
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/hospital)
 "anv" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -924,9 +939,9 @@
 /turf/open/indestructible,
 /area/f13/wasteland)
 "dHP" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "dKF" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1263,10 +1278,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/radiation)
-"flP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "fmJ" = (
 /obj/structure/sign/poster/prewar/poster75{
 	pixel_y = 32
@@ -1388,19 +1399,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
 "gde" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/mirror{
-	pixel_x = -1;
-	pixel_y = 29
-	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "geI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2125,6 +2127,16 @@
 /obj/item/bodypart/l_arm,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
+"jkQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "jof" = (
 /obj/structure/table,
 /obj/item/stack/medical/ointment,
@@ -2163,9 +2175,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "juL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/healthanalyzer,
+/obj/item/bodybag/containment,
+/obj/item/bodybag/containment,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jvX" = (
@@ -2366,6 +2382,13 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
+"ktt" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "kur" = (
 /turf/closed/wall,
 /area/f13/ncr)
@@ -2407,6 +2430,11 @@
 "kEe" = (
 /turf/open/floor/carpet/orange,
 /area/f13/ncr)
+"kFg" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "kFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -2670,11 +2698,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"lCy" = (
-/obj/structure/table/wood,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "lDT" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
@@ -2741,14 +2764,6 @@
 /obj/item/shard,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"lQW" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "lSK" = (
 /obj/machinery/light{
 	dir = 8
@@ -2777,14 +2792,16 @@
 	},
 /area/f13/ncr)
 "lUm" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "lYF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3014,7 +3031,7 @@
 /area/f13/building/hospital)
 "mMf" = (
 /obj/structure/ladder/unbreakable{
-	id = Followers1;
+	id = hospitalroof;
 	height = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -3370,10 +3387,10 @@
 	},
 /area/f13/building/hospital)
 "ocx" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "odJ" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3400,6 +3417,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
+"ogI" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "oiY" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/building)
@@ -3484,10 +3505,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "oDl" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "oDo" = (
@@ -3623,6 +3643,13 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"pqc" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "psD" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -4038,18 +4065,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
-"rqL" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "rsw" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
@@ -4196,10 +4211,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"rRc" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "rRp" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace,
@@ -4308,12 +4319,9 @@
 	},
 /area/f13/building/massfusion)
 "sjy" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/syndi,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "sjM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4377,10 +4385,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"sEl" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "sFr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4577,6 +4581,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
+"tun" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "tvg" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt{
@@ -4593,18 +4609,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
-"twf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "txr" = (
 /obj/structure/rack,
 /obj/item/storage/book/bible/booze,
@@ -4625,6 +4629,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"tEn" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "tEW" = (
 /obj/structure/barricade/bars,
 /obj/item/shard,
@@ -4760,6 +4772,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"ubG" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "ucd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5045,16 +5064,6 @@
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vwx" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/table,
-/obj/item/bodybag/containment,
-/obj/item/bodybag/containment,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "vAd" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -5084,13 +5093,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/hospital)
-"vEn" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/security,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "vFt" = (
 /obj/item/organ/liver,
 /obj/effect/decal/cleanable/dirt,
@@ -5172,12 +5174,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"wdx" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "wex" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
@@ -5603,6 +5599,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"yha" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "yic" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/mop,
@@ -50974,7 +50974,7 @@ nRq
 tfy
 wXb
 lqO
-gde
+alz
 kWR
 vfp
 gLr
@@ -51745,7 +51745,7 @@ xJA
 iRY
 xvZ
 lqO
-twf
+lUm
 kWR
 lqO
 gah
@@ -52238,7 +52238,7 @@ vqz
 vqz
 aaL
 aKa
-vEn
+ubG
 aKa
 aKa
 eCS
@@ -52495,7 +52495,7 @@ vqz
 vqz
 aaL
 aKa
-lCy
+ocx
 aKa
 aKa
 evf
@@ -52752,7 +52752,7 @@ vqz
 vqz
 aaL
 aKa
-sjy
+pqc
 aKa
 aKa
 aKa
@@ -53523,10 +53523,10 @@ vqz
 vqz
 aaL
 aKa
-lCy
+ocx
 aKa
 aKa
-sEl
+dHP
 bhm
 gLr
 oab
@@ -53538,10 +53538,10 @@ lqO
 lLE
 kJl
 lqO
-dHP
+sjy
 sRn
-dHP
-dHP
+sjy
+sjy
 lqO
 nnp
 ucd
@@ -54294,9 +54294,9 @@ vqz
 vqz
 vqz
 bhm
+ktt
+tun
 oDl
-rqL
-wdx
 cym
 bhm
 cnB
@@ -54567,9 +54567,9 @@ gah
 kJl
 lqO
 tmP
-vwx
-lUm
 juL
+jkQ
+gde
 lqO
 xpn
 pws
@@ -54808,10 +54808,10 @@ vqz
 vqz
 vqz
 bhm
-lQW
-ocx
-rRc
-flP
+tEn
+kFg
+yha
+ogI
 bhm
 gah
 kJl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -232,8 +232,19 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
 "aCj" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 29
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "aGA" = (
 /obj/structure/bed/roller,
@@ -362,6 +373,13 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
+"bkV" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "blr" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -846,13 +864,9 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dnp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "dof" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt{
@@ -918,10 +932,7 @@
 /turf/open/indestructible,
 /area/f13/wasteland)
 "dHP" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "dKF" = (
@@ -1380,15 +1391,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
 "gde" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "geI" = (
@@ -1448,6 +1451,13 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"gqs" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "guf" = (
 /obj/machinery/light{
 	dir = 4
@@ -1676,6 +1686,16 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/f13/building)
+"hrs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/item/bodybag/containment,
+/obj/item/bodybag/containment,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "hsd" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
@@ -2008,9 +2028,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iDT" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/healthanalyzer,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iFg" = (
@@ -2152,19 +2172,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "juL" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/structure/mirror{
-	pixel_x = -1;
-	pixel_y = 29
-	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jvX" = (
 /obj/item/kirbyplants{
@@ -2263,10 +2278,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"jUZ" = (
-/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jVE" = (
@@ -2997,7 +3008,7 @@
 /area/f13/building/hospital)
 "mMf" = (
 /obj/structure/ladder/unbreakable{
-	id = hospitalroof;
+	id = "hospitalroof";
 	height = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -3083,6 +3094,11 @@
 	dir = 8
 	},
 /area/f13/building/hospital)
+"neQ" = (
+/obj/structure/table/wood,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "nfc" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
 /turf/open/floor/plasteel/f13{
@@ -3353,10 +3369,13 @@
 	},
 /area/f13/building/hospital)
 "ocx" = (
-/obj/structure/table/wood,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "odJ" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3467,9 +3486,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "oDl" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "oDo" = (
 /turf/closed/wall/mineral/concrete,
 /area/f13/building/massfusion)
@@ -3546,12 +3573,11 @@
 /turf/open/indestructible,
 /area/f13/wasteland/ncr)
 "oSq" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/security,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "oTC" = (
 /obj/machinery/light{
 	dir = 1;
@@ -3855,13 +3881,6 @@
 "qvL" = (
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
-"qDK" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/syndi,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "qEi" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -4264,10 +4283,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sfh" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "sjx" = (
 /obj/machinery/iv_drip,
@@ -4276,9 +4301,12 @@
 	},
 /area/f13/building/massfusion)
 "sjy" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "sjM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4840,16 +4868,8 @@
 	},
 /area/f13/building/massfusion)
 "uxf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "uxm" = (
 /obj/structure/barricade/wooden,
@@ -5381,16 +5401,6 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
-"xwZ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/table,
-/obj/item/bodybag/containment,
-/obj/item/bodybag/containment,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "xAT" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5487,16 +5497,6 @@
 	name = "concrete wall"
 	},
 /area/f13/wasteland/ncr)
-"xTt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "xTy" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -50925,7 +50925,7 @@ nRq
 tfy
 wXb
 lqO
-juL
+aCj
 kWR
 vfp
 gLr
@@ -51696,7 +51696,7 @@ xJA
 iRY
 xvZ
 lqO
-uxf
+sfh
 kWR
 lqO
 gah
@@ -52189,7 +52189,7 @@ vqz
 vqz
 aaL
 aKa
-oSq
+gqs
 aKa
 aKa
 eCS
@@ -52446,7 +52446,7 @@ vqz
 vqz
 aaL
 aKa
-ocx
+neQ
 aKa
 aKa
 evf
@@ -52703,7 +52703,7 @@ vqz
 vqz
 aaL
 aKa
-qDK
+sjy
 aKa
 aKa
 aKa
@@ -53474,10 +53474,10 @@ vqz
 vqz
 aaL
 aKa
-ocx
+neQ
 aKa
 aKa
-oDl
+dnp
 bhm
 gLr
 oab
@@ -53489,10 +53489,10 @@ lqO
 lLE
 kJl
 lqO
-sjy
+dHP
 sRn
-sjy
-sjy
+dHP
+dHP
 lqO
 nnp
 ucd
@@ -54245,9 +54245,9 @@ vqz
 vqz
 vqz
 bhm
-dHP
-gde
-sfh
+bkV
+oDl
+iDT
 cym
 bhm
 cnB
@@ -54518,9 +54518,9 @@ gah
 kJl
 lqO
 tmP
-xwZ
-xTt
-iDT
+hrs
+juL
+oSq
 lqO
 xpn
 pws
@@ -54759,10 +54759,10 @@ vqz
 vqz
 vqz
 bhm
-dnp
+ocx
 lUm
-aCj
-jUZ
+uxf
+gde
 bhm
 gah
 kJl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -232,12 +232,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/ncr)
 "aCj" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/security,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "aGA" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt,
@@ -849,9 +846,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "dnp" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "dof" = (
@@ -919,9 +918,10 @@
 /turf/open/indestructible,
 /area/f13/wasteland)
 "dHP" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/healthanalyzer,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "dKF" = (
@@ -1380,19 +1380,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/wasteland/ncr)
 "gde" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/mirror{
-	pixel_x = -1;
-	pixel_y = 29
-	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/closet/crate/trashcart,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "geI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2011,13 +2008,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iDT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/structure/table,
-/obj/item/bodybag/containment,
-/obj/item/bodybag/containment,
-/obj/item/storage/box/bodybags,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/healthanalyzer,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "iFg" = (
@@ -2159,12 +2152,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "juL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 29
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "jvX" = (
 /obj/item/kirbyplants{
@@ -2263,6 +2263,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
+"jUZ" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jVE" = (
@@ -2435,18 +2439,6 @@
 /area/f13/wasteland)
 "kJl" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
-/area/f13/building/hospital)
-"kLi" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "kMB" = (
 /obj/structure/railing/corner{
@@ -2772,22 +2764,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"lTX" = (
+"lUm" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
-"lUm" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/building/hospital)
 "lYF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3487,9 +3467,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "oDl" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "oDo" = (
 /turf/closed/wall/mineral/concrete,
 /area/f13/building/massfusion)
@@ -3566,15 +3546,12 @@
 /turf/open/indestructible,
 /area/f13/wasteland/ncr)
 "oSq" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/chair/comfy/plywood{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "oTC" = (
 /obj/machinery/light{
 	dir = 1;
@@ -3878,6 +3855,13 @@
 "qvL" = (
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
+"qDK" = (
+/obj/structure/chair/comfy/plywood{
+	dir = 1
+	},
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "qEi" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -3981,13 +3965,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/ncr)
-"rcU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "rhv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fence/handrail{
@@ -4287,12 +4264,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sfh" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 1
-	},
-/obj/structure/fluff/beach_umbrella/syndi,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "sjx" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13{
@@ -4376,10 +4352,6 @@
 "sGc" = (
 /turf/open/transparent/openspace,
 /area/f13/ncr)
-"sHj" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
 "sHx" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4868,8 +4840,16 @@
 	},
 /area/f13/building/massfusion)
 "uxf" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building/hospital)
 "uxm" = (
 /obj/structure/barricade/wooden,
@@ -5401,6 +5381,16 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/building/hospital)
+"xwZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table,
+/obj/item/bodybag/containment,
+/obj/item/bodybag/containment,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "xAT" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5497,6 +5487,16 @@
 	name = "concrete wall"
 	},
 /area/f13/wasteland/ncr)
+"xTt" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "xTy" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -50925,7 +50925,7 @@ nRq
 tfy
 wXb
 lqO
-gde
+juL
 kWR
 vfp
 gLr
@@ -51696,7 +51696,7 @@ xJA
 iRY
 xvZ
 lqO
-lUm
+uxf
 kWR
 lqO
 gah
@@ -52189,7 +52189,7 @@ vqz
 vqz
 aaL
 aKa
-aCj
+oSq
 aKa
 aKa
 eCS
@@ -52703,7 +52703,7 @@ vqz
 vqz
 aaL
 aKa
-sfh
+qDK
 aKa
 aKa
 aKa
@@ -53477,7 +53477,7 @@ aKa
 ocx
 aKa
 aKa
-sHj
+oDl
 bhm
 gLr
 oab
@@ -54245,9 +54245,9 @@ vqz
 vqz
 vqz
 bhm
-rcU
-kLi
-dnp
+dHP
+gde
+sfh
 cym
 bhm
 cnB
@@ -54518,9 +54518,9 @@ gah
 kJl
 lqO
 tmP
+xwZ
+xTt
 iDT
-oSq
-dHP
 lqO
 xpn
 pws
@@ -54759,10 +54759,10 @@ vqz
 vqz
 vqz
 bhm
-juL
-lTX
-oDl
-uxf
+dnp
+lUm
+aCj
+jUZ
 bhm
 gah
 kJl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -31802,14 +31802,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"hbh" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "hbv" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -32512,12 +32504,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
 "hyh" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/ladder/unbreakable{
+	id = "followersbasement";
+	height = 2
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "hyj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43144,15 +43135,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/f13/building)
-"mXB" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "mXD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -61648,11 +61630,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/massfusion)
-"xfT" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/hospital)
 "xgk" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -107264,7 +107241,7 @@ qEh
 qEh
 gLa
 ijr
-xfT
+tFm
 hyh
 aFP
 oqr
@@ -107521,8 +107498,8 @@ uZi
 uZi
 aKA
 ijr
-hbh
-mXB
+aFD
+aFD
 aFP
 aae
 vGC

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -32508,6 +32508,9 @@
 	id = "followersbasement";
 	height = 2
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "hyj" = (
@@ -107241,7 +107244,7 @@ qEh
 qEh
 gLa
 ijr
-tFm
+aFD
 hyh
 aFP
 oqr

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -53781,6 +53781,13 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sUd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/house{
+	req_one_access_txt = "124"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/f13/building/hospital)
 "sUl" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -109826,7 +109833,7 @@ kEo
 vlO
 vqp
 vlO
-ekB
+sUd
 aEs
 aGq
 aFP


### PR DESCRIPTION
Adds some solar panels to the roof of Texarkana General as well as adds a morgue to the hospital for Followers Use. Brings Texarkana General off of Fiat Power and actually makes the APC required to keep the building powered for long periods of time.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds a smoke break area to the hospital.
add: Adds a solar panel to the rooftop of the hospital.
add: Adds a vertibird landing spot to the rooftop of the hospital.
add: Adds a morgue to the second floor of the hospital.
add: Adds a basement level to the hospital.
tweak: Changed the location of the janitor's closet on the second floor of the hospital.
tweak: Makes the bathroom on the second floor of the hospital actually usable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
