### PR TITLE
Escapes opening square brackets which were causing MDB to fail

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
@@ -1000,7 +1000,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/spawner/north,
 /obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished{
-	info = "Why's the [ILLEGIBLE] Here?? They're screaming something about [ILLEGIBLE]... No.. this can't be.."
+	info = "Why's the \[ILLEGIBLE] Here?? They're screaming something about \[ILLEGIBLE]... No.. this can't be.."
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
@@ -1000,7 +1000,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/spawner/north,
 /obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished{
-	info = "Why's the \[ILLEGIBLE] Here?? They're screaming something about \[ILLEGIBLE]... No.. this can't be.."
+	info = "Why\'s the \[ILLEGIBLE] Here?? They're screaming something about \[ILLEGIBLE]... No.. this can\'t be.."
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
@@ -1000,7 +1000,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/spawner/north,
 /obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished{
-	info = "Why\'s the \[ILLEGIBLE] Here?? They're screaming something about \[ILLEGIBLE]... No.. this can\'t be.."
+	info = "Why\'s the \[ILLEGIBLE] Here?? They\'re screaming something about \[ILLEGIBLE]... No.. this can\'t be.."
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Upper.dmm
@@ -1000,7 +1000,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/spawner/north,
 /obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished{
-	info = "Why\'s the \[ILLEGIBLE] Here?? They\'re screaming something about \[ILLEGIBLE]... No.. this can\'t be.."
+	info = "Why's the \[ILLEGIBLE] Here?? They're screaming something about \[ILLEGIBLE]... No.. this can't be.."
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)


### PR DESCRIPTION
## About The Pull Request
Byond considers [square brackets] in quotes to be replacement bits for a variable in the square bracket
ie: "There are [number_of_apples] in this pile.", where number_of_apples is a variable.

Which is why MDB is failing, because map files can't be changed during compile-time.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->