### PR TITLE
Actually fixes synths not being able to heal burn damage.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -556,7 +556,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 	if(affecting && affecting.status == BODYPART_ROBOTIC)
 		//only heal to 25 if limb is damaged to or past 25 burn, otherwise heal normally
-		var/difference = affecting.burn_dam - 25
+		var/difference = affecting.burn_dam - 0
 		var/heal_amount = 15
 		if(difference >= 0)
 			heal_amount = difference
@@ -873,4 +873,3 @@ By design, d1 is the smallest direction and d2 is the highest
 	. = ..()
 	var/list/cable_colors = GLOB.cable_colors
 	color = pick(cable_colors)
-


### PR DESCRIPTION
## About The Pull Request
GDI I forgot to update the cable coils burn affect to let it heal past 25 the last time.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Lets Synthetics use cable coils to heal burn damage past 25, like I should have done the first go-around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
