### PR TITLE
Hospital udate 2 electric boogaloo

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -16359,6 +16359,13 @@
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"nzr" = (
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "nzz" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -24188,13 +24195,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/caves)
-"vCF" = (
-/obj/structure/simple_door/house,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "vCG" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -71232,7 +71232,7 @@ wYL
 gYI
 gYI
 dEX
-vCF
+nzr
 dEX
 dEX
 aaa
@@ -71745,7 +71745,7 @@ dEX
 rbm
 gYI
 gYI
-vCF
+nzr
 gYI
 gYI
 dEX
@@ -71994,7 +71994,7 @@ kDe
 kDe
 gYI
 gYI
-vCF
+nzr
 kDe
 gYI
 sqD
@@ -73279,7 +73279,7 @@ pmJ
 dEX
 gYI
 gYI
-vCF
+nzr
 gYI
 kMM
 dEX
@@ -73287,7 +73287,7 @@ nkA
 gYI
 vuF
 gYI
-vCF
+nzr
 gYI
 maa
 dEX

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -16359,10 +16359,6 @@
 /obj/structure/spider/cocoon,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nzr" = (
-/obj/structure/simple_door/house,
-/turf/closed/wall/f13/store,
-/area/f13/building/hospital)
 "nzz" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess"
@@ -24194,7 +24190,10 @@
 /area/f13/caves)
 "vCF" = (
 /obj/structure/simple_door/house,
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "vCG" = (
 /obj/effect/decal/cleanable/glass,
@@ -25992,11 +25991,11 @@
 	},
 /area/f13/caves)
 "xFT" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 3
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
+	},
+/obj/structure/bodycontainer/morgue{
+	dir = 0
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
 	icon_state = "whitedirtysolid"
@@ -71233,7 +71232,7 @@ wYL
 gYI
 gYI
 dEX
-xHk
+vCF
 dEX
 dEX
 aaa
@@ -71746,7 +71745,7 @@ dEX
 rbm
 gYI
 gYI
-nzr
+vCF
 gYI
 gYI
 dEX
@@ -71995,7 +71994,7 @@ kDe
 kDe
 gYI
 gYI
-xHk
+vCF
 kDe
 gYI
 sqD
@@ -73280,7 +73279,7 @@ pmJ
 dEX
 gYI
 gYI
-xHk
+vCF
 gYI
 kMM
 dEX
@@ -75336,7 +75335,7 @@ dQf
 xHk
 aoa
 gYI
-nzr
+xHk
 kDe
 kDe
 kDe

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -153,7 +153,7 @@
 	icon_state = "massfusionin"
 
 /area/f13/building/hospital
-	name = "Yuma General"
+	name = "Christus Saint Michaels Hospital"
 	icon_state = "hospital"
 
 /area/f13/building/mall


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Fixes the basement having walls in places it shouldn't be having walls as well as renames the hospital area to Christus Saint Michaels Hospital to fall in line with landmarks and the location of the area. 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: changed the basement a bit because i left walls where i shouldn't have.
tweak: renames hospital area from Yuma General to Christus Saint Michaels to better fit with our lore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
