### PR TITLE
Free T45b is gone & Replaced medium blueprint with mid-low blueprint

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -7831,11 +7831,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"giu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider/boss,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/raiders)
 "gjf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -8531,12 +8526,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"gMj" = (
-/obj/structure/nest/raider/ranged,
-/turf/open/indestructible/ground/outside/graveldirt{
-	dir = 8
-	},
-/area/f13/raiders)
 "gMW" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -19579,11 +19568,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"pKC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider/ranged,
-/turf/open/floor/f13/wood,
-/area/f13/raiders)
 "pKS" = (
 /turf/open/indestructible,
 /area/f13/caves)
@@ -22297,6 +22281,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/city)
+"sha" = (
+/obj/structure/nest/raider/ranged,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 1
+	},
+/area/f13/raiders)
 "shp" = (
 /obj/structure/fence{
 	dir = 4
@@ -22523,6 +22513,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"snb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/boss,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/raiders)
 "snv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -26824,6 +26819,11 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland)
+"vVE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/ranged,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "vVH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -28032,12 +28032,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"wZI" = (
-/obj/structure/nest/raider/ranged,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull"
-	},
-/area/f13/raiders)
 "wZW" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -57899,7 +57893,7 @@ oph
 eaC
 eHO
 nSg
-giu
+snb
 nSg
 rQO
 lcM
@@ -58682,7 +58676,7 @@ sgM
 kEx
 xbT
 nJf
-wZI
+ecD
 wOZ
 tgN
 kzG
@@ -59962,7 +59956,7 @@ qES
 iUs
 ukf
 ukf
-ukf
+sha
 ukf
 wGZ
 jBU
@@ -60481,7 +60475,7 @@ ukf
 ukf
 fyC
 ecD
-wZI
+ecD
 ecD
 wXv
 kzG
@@ -61762,7 +61756,7 @@ cqc
 cqc
 oou
 jgM
-gMj
+iUs
 wGZ
 uJU
 wOZ
@@ -64843,7 +64837,7 @@ ndq
 ndq
 pQV
 rtl
-pKC
+vVE
 tBA
 tBA
 hkX

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -7831,6 +7831,11 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"giu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/boss,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/raiders)
 "gjf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -8526,6 +8531,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gMj" = (
+/obj/structure/nest/raider/ranged,
+/turf/open/indestructible/ground/outside/graveldirt{
+	dir = 8
+	},
+/area/f13/raiders)
 "gMW" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -19568,6 +19579,11 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"pKC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider/ranged,
+/turf/open/floor/f13/wood,
+/area/f13/raiders)
 "pKS" = (
 /turf/open/indestructible,
 /area/f13/caves)
@@ -26284,7 +26300,7 @@
 /area/f13/wasteland)
 "vse" = (
 /obj/machinery/workbench,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/effect/spawner/lootdrop/f13/blueprintLowMid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/raiders)
 "vsk" = (
@@ -27661,7 +27677,7 @@
 "wHP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/water,
 /area/f13/city)
 "wIi" = (
@@ -28016,6 +28032,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"wZI" = (
+/obj/structure/nest/raider/ranged,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull"
+	},
+/area/f13/raiders)
 "wZW" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -57877,7 +57899,7 @@ oph
 eaC
 eHO
 nSg
-rQO
+giu
 nSg
 rQO
 lcM
@@ -58660,7 +58682,7 @@ sgM
 kEx
 xbT
 nJf
-ecD
+wZI
 wOZ
 tgN
 kzG
@@ -60459,7 +60481,7 @@ ukf
 ukf
 fyC
 ecD
-ecD
+wZI
 ecD
 wXv
 kzG
@@ -61740,7 +61762,7 @@ cqc
 cqc
 oou
 jgM
-iUs
+gMj
 wGZ
 uJU
 wOZ
@@ -64821,7 +64843,7 @@ ndq
 ndq
 pQV
 rtl
-oaw
+pKC
 tBA
 tBA
 hkX


### PR DESCRIPTION
## About The Pull Request
Bascially makes the free blueprint into a lower tier blueprint, and makes the tier 3 armor into
![image](https://user-images.githubusercontent.com/29418371/180598057-5f84241b-28b5-4408-9c0f-2f901b9e70be.png)
![image](https://user-images.githubusercontent.com/29418371/180597956-745f339e-bc8b-4a93-92b8-95cae96877aa.png)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: free raider camp has mobs instead of free as it had a blueprint and lower tier. 
tweak: Free possible t45b is gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
