### PR TITLE
removes stimulant to xlarge syringe

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -3256,8 +3256,8 @@
 /area/f13/raiders)
 "cGD" = (
 /obj/structure/table,
-/obj/item/reagent_containers/syringe/stimulants,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/syringe/xlarge,
 /turf/open/floor/f13{
 	icon_state = "tealwhrustychess"
 	},


### PR DESCRIPTION
## About The Pull Request
Remove stimulants syringe for extra large syringe 
![image](https://user-images.githubusercontent.com/29418371/180903337-053ecd24-fdd4-4d65-abc7-eab4645775c0.png)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: stimulants go bye, for extra large syringe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
