### PR TITLE
khan stuff into loadouts

### DIFF
--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -901,8 +901,8 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
 ////////////////////////
 
 /obj/item/clothing/head/helmet/f13/khan
-	name = "Great Khan helmet"
-	desc = "A piece of headwear commonly worn by the Great Khans that appears to resemble stereotypical traditional Mongolian helmets - likely adapted from a pre-War motorcycle helmet.<br>It is black with two horns on either side and a small spike jutting from the top, much like a pickelhaube.<br>A leather covering protects the wearer's neck and ears from sunburn."
+	name = "horned helmet"
+	desc = "A piece of headwear commonly worn by the horned tribals that appears to resemble stereotypical traditional Mongolian helmets - likely adapted from a pre-War motorcycle helmet.<br>It is black with two horns on either side and a small spike jutting from the top, much like a pickelhaube.<br>A leather covering protects the wearer's neck and ears from sunburn."
 	icon = 'icons/fallout/clothing/khans.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/khaans.dmi'
 	icon_state = "khan_helmet"
@@ -920,7 +920,7 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
 
 
 /obj/item/clothing/head/helmet/f13/khan/pelt
-	desc = "A helmet with traditional horns, but wasteland-chique fur trimming instead of the classic leather cover. For the Khan who wants to show off their hair."
+	desc = "A helmet with traditional horns, but wasteland-chique fur trimming instead of the classic leather cover. For the horned tribals who wants to show off their hair."
 	icon_state = "khan_helmetpelt"
 	item_state = "khan_helmetpelt"
 
@@ -930,7 +930,7 @@ obj/item/clothing/head/helmet/f13/enclave/usmcriot
 
 
 /obj/item/clothing/head/helmet/f13/khan/bandana
-	name = "Great Khan bandana"
+	name = "outlaw bandana"
 	desc = "A bandana. Tougher than it looks. One side of the cloth is dark, the other red, so it can be reversed."
 	icon_state = "khan_bandana"
 	item_state = "khan_bandana"

--- a/modular_citadel/code/modules/client/loadout/hands.dm
+++ b/modular_citadel/code/modules/client/loadout/hands.dm
@@ -42,6 +42,11 @@
 	path = /obj/item/storage/backpack/cultpack
 	cost = 3
 
+/datum/gear/hands/backpack/old
+	name = "old satchel"
+	path = /obj/item/storage/backpack/satchel/old
+	cost = 3 
+
 /datum/gear/hands/briefcase/crafted
 	name = "briefcase"
 	path = /obj/item/storage/briefcase/crafted

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -262,6 +262,21 @@
 	path = /obj/item/clothing/head/f13/chinese/officer
 	cost = 3
 
+/datum/gear/head/khan_horned
+	name = "horned helmet"
+	path = /obj/item/clothing/head/helmet/f13/khan
+	cost = 3
+
+/datum/gear/head/khan_furtrimmed
+	name = "horned fur-trimmed helmet"
+	path = /obj/item/clothing/head/helmet/f13/khan/pelt
+	cost = 3
+
+/datum/gear/head/khan_bandana
+	name = "outlaw bandana"
+	path = /obj/item/clothing/head/helmet/f13/khan/bandana
+	cost = 3
+
 //NCR
 
 /datum/gear/head/ncr_sapper
@@ -404,22 +419,6 @@ datum/gear/head/steelpot_bandolier
 	restricted_roles = list("NCR Sergeant",
 							"NCR Heavy Trooper"
 						)
-
-/datum/gear/head/khan_bandana
-	name = "Great Khan bandana"
-	path = /obj/item/clothing/head/helmet/f13/khan/bandana
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
-	cost = 2
-	restricted_desc = "KHAN"
-	restricted_roles = list("Great Khan")
-
-/datum/gear/head/khan_furtrimmed
-	name = "Great Khan fur-trimmed helmet"
-	path = /obj/item/clothing/head/helmet/f13/khan/pelt
-	subcategory = LOADOUT_SUBCATEGORY_HEAD_FACTIONS
-	cost = 2
-	restricted_desc = "KHAN"
-	restricted_roles = list("Great Khan")
 
 /datum/gear/head/oasishelmet
 	name = "light security helmet"

--- a/modular_citadel/code/modules/client/loadout/shoes.dm
+++ b/modular_citadel/code/modules/client/loadout/shoes.dm
@@ -109,6 +109,16 @@
 	path = /obj/item/clothing/shoes/f13/military/plated
 	cost = 2
 
+/datum/gear/shoes/steeltipped
+	name = "steel tipped boots"
+	path = /obj/item/clothing/shoes/f13/military/khan
+	cost = 2
+
+/datum/gear/shoes/steelpelts
+	name = "steel tipped pelt boots"
+	path = /obj/item/clothing/shoes/f13/military/khan_pelt
+	cost = 2
+
 /datum/gear/shoes/patrol_boots
 	name = "NCR patrol boots"
 	path = /obj/item/clothing/shoes/f13/military/ncr
@@ -131,11 +141,3 @@
 							"NCR Rear Echelon",
 							"NCR Off-Duty"
 						)
-
-/datum/gear/shoes/khan_peltboots
-	name = "Great Khan pelt boots"
-	path = /obj/item/clothing/shoes/f13/military/khan_pelt
-	cost = 2
-	subcategory = LOADOUT_SUBCATEGORY_SHOES_FACTIONS
-	restricted_desc = "KHAN"
-	restricted_roles = list("Great Khan")


### PR DESCRIPTION
## About The Pull Request
Great khan stuff repurposed, the khan helmets renamed and put into loadouts, boots are put into loadout wise. That way they aren't sitting in code. These will most likely end up into modkits down the road, but this gives more love in a way.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Great Khan Helmets are renamed and removed of khans
add: great khan helmets are put into loadout and boots are too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
