### PR TITLE
Voracious tweaks

### DIFF
--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -105,41 +105,87 @@ Behavior that's still missing from this component that original food items had t
 
 	. = COMPONENT_ITEM_NO_ATTACK //Point of no return I suppose
 
+	var/time_to_eat = eat_time
+	if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+		time_to_eat *= 0.5 // faster to eat, also faster to be fed
 	if(eater == feeder)//If you're eating it yourself.
-		if(!do_mob(feeder, eater, eat_time)) //Gotta pass the minimal eat time
+		if(!do_mob(feeder, eater, time_to_eat)) //Gotta pass the minimal eat time
 			return
 		var/eatverb = pick(eatverbs)
-		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50 && !HAS_TRAIT(eater, TRAIT_VORACIOUS))
-			to_chat(eater, "<span class='warning'>You don't feel like eating any more junk food at the moment!</span>")
-			return
-		else if(fullness <= 50)
-			eater.visible_message("<span class='notice'>[eater] hungrily [eatverb]s \the [parent], gobbling it down!</span>", "<span class='notice'>You hungrily [eatverb] \the [parent], gobbling it down!</span>")
-		else if(fullness > 50 && fullness < 150)
-			eater.visible_message("<span class='notice'>[eater] hungrily [eatverb]s \the [parent].</span>", "<span class='notice'>You hungrily [eatverb] \the [parent].</span>")
-		else if(fullness > 150 && fullness < 500)
-			eater.visible_message("<span class='notice'>[eater] [eatverb]s \the [parent].</span>", "<span class='notice'>You [eatverb] \the [parent].</span>")
-		else if(fullness > 500 && fullness < 600)
-			eater.visible_message("<span class='notice'>[eater] unwillingly [eatverb]s a bit of \the [parent].</span>", "<span class='notice'>You unwillingly [eatverb] a bit of \the [parent].</span>")
-		else if(fullness > (600 * (1 + eater.overeatduration / 2000)))	// The more you eat - the more you can eat
-			eater.visible_message("<span class='warning'>[eater] cannot force any more of \the [parent] to go down [eater.p_their()] throat!</span>", "<span class='warning'>You cannot force any more of \the [parent] to go down your throat!</span>")
-			return
+		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50)
+			if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+				to_chat(eater, span_notice("You happily choke down yet more junk food!"))
+				eater.adjust_disgust(-1)
+			else
+				to_chat(eater, span_danger("You feel sick as you choke down yet more junk food!"))
+				eater.adjust_disgust(1)
+		switch(fullness)
+			if(-INFINITY to 50)
+				if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+					eater.visible_message(
+						span_notice("[eater] ravenously [eatverb]s \the [parent], gobbling it down!"), 
+						span_notice("You ravenously [eatverb] \the [parent], gobbling it down!"))
+				else
+					eater.visible_message(
+						span_notice("[eater] hungrily [eatverb]s \the [parent], gobbling it down!"), 
+						span_notice("You hungrily [eatverb] \the [parent], gobbling it down!"))
+			if(50 to 200)
+				if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+					eater.visible_message(
+						span_notice("[eater] ravenously [eatverb]s \the [parent]!"), 
+						span_notice("You ravenously [eatverb] \the [parent]!"))
+				else
+					eater.visible_message(
+						span_notice("[eater] hungrily [eatverb]s \the [parent]."), 
+						span_notice("You hungrily [eatverb] \the [parent]."))
+			if(200 to 500)
+				if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+					eater.visible_message(
+						span_notice("[eater] vigorously [eatverb]s \the [parent]!"), 
+						span_notice("You vigorously [eatverb] \the [parent]!"))
+				else
+					eater.visible_message(
+						span_notice("[eater] [eatverb]s \the [parent]."), 
+						span_notice("You [eatverb] \the [parent]."))
+			if(500 to 650)
+				if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+					eater.visible_message(
+						span_notice("[eater] gluttonously [eatverb]s \the [parent]!"), 
+						span_notice("You gluttonously [eatverb] \the [parent]!"))
+				else
+					eater.visible_message(
+						span_notice("[eater] unwillingly [eatverb]s \the [parent]."), 
+						span_notice("You unwillingly [eatverb] \the [parent]."))
+			if((600 * (1 + eater.overeatduration / 1000)) to INFINITY)
+				if(HAS_TRAIT(eater, TRAIT_VORACIOUS))
+					eater.visible_message(
+						span_notice("[eater] gluttonously [eatverb]s \the [parent], cramming it down [eater.p_their()] throat!"), 
+						span_notice("You gluttonously [eatverb] \the [parent], cramming it down your throat!"))
+				else
+					eater.visible_message(
+						span_warning("[eater] cannot force any more of \the [parent] to go down [eater.p_their()] throat!"), 
+						span_warning("You cannot force any more of \the [parent] to go down your throat!"))
+					return
 	else //If you're feeding it to someone else.
 		if(isbrain(eater))
-			to_chat(feeder, "<span class='warning'>[eater] doesn't seem to have a mouth!</span>")
+			to_chat(feeder, span_warning("[eater] doesn't seem to have a mouth!"))
 			return
-		if(fullness <= (600 * (1 + eater.overeatduration / 1000)))
-			eater.visible_message("<span class='danger'>[feeder] attempts to feed [eater] [parent].</span>", \
-									"<span class='userdanger'>[feeder] attempts to feed you [parent].</span>")
+		if(fullness <= (600 * (1 + eater.overeatduration / 1000)) || HAS_TRAIT(eater, TRAIT_VORACIOUS))
+			eater.visible_message(
+				span_danger("[feeder] attempts to feed [eater] [parent]."),
+				span_userdanger("[feeder] attempts to feed you [parent]."))
 		else
-			eater.visible_message("<span class='warning'>[feeder] cannot force any more of [parent] down [eater]'s throat!</span>", \
-									"<span class='warning'>[feeder] cannot force any more of [parent] down your throat!</span>")
+			eater.visible_message(
+				span_warning("[feeder] cannot force any more of [parent] down [eater]'s throat!"),
+				span_warning("[feeder] cannot force any more of [parent] down your throat!"))
 			return
-		if(!do_mob(feeder, eater)) //Wait 3 seconds before you can feed
+		if(!do_mob(feeder, eater, time_to_eat)) //Wait 3 / 1.5 seconds before you can feed
 			return
 
 		log_combat(feeder, eater, "fed", owner.reagents.log_list())
-		eater.visible_message("<span class='danger'>[feeder] forces [eater] to eat [parent]!</span>", \
-									"<span class='userdanger'>[feeder] forces you to eat [parent]!</span>")
+		eater.visible_message(
+			span_danger("[feeder] forces [eater] to eat [parent]!</span>"),
+			span_userdanger("[feeder] forces you to eat [parent]!</span>"))
 
 	TakeBite(eater, feeder)
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -185,7 +185,7 @@ All foods are distributed among various categories. Use common sense.
 					span_warning("[user] cannot force any more of [src] down [M]'s throat!"),
 					span_warning("[user] cannot force any more of [src] down your throat!"))
 				return
-			if(!do_mob(user, M, ((HAS_TRAIT(M, TRAIT_VORACIOUS)) ? 1 SECOND : 3 SECONDS))) //Wait 3 / 1 second(s) before you can feed
+			if(!do_mob(user, M, ((HAS_TRAIT(M, TRAIT_VORACIOUS)) ? 1 SECONDS : 3 SECONDS))) //Wait 3 / 1 second(s) before you can feed
 				return
 
 			M.visible_message(

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -118,41 +118,82 @@ All foods are distributed among various categories. Use common sense.
 			fullness += C.nutriment_factor * C.volume / C.metabolization_rate
 
 		if(M == user)								//If you're eating it yourself.
-			if(junkiness && M.satiety < -150 && M.nutrition > NUTRITION_LEVEL_STARVING + 50 )
-				to_chat(M, "<span class='notice'>You don't feel like eating any more junk food at the moment.</span>")
-				return 0
-			else if(fullness <= 50)
-				user.visible_message("<span class='notice'>[user] hungrily takes a [eatverb] from \the [src], gobbling it down!</span>", "<span class='notice'>You hungrily take a [eatverb] from \the [src], gobbling it down!</span>")
-			else if(fullness > 50 && fullness < 150)
-				user.visible_message("<span class='notice'>[user] hungrily takes a [eatverb] from \the [src].</span>", "<span class='notice'>You hungrily take a [eatverb] from \the [src].</span>")
-			else if(fullness > 150 && fullness < 500)
-				user.visible_message("<span class='notice'>[user] takes a [eatverb] from \the [src].</span>", "<span class='notice'>You take a [eatverb] from \the [src].</span>")
-			else if(fullness > 500 && fullness < 600)
-				user.visible_message("<span class='notice'>[user] unwillingly takes a [eatverb] of a bit of \the [src].</span>", "<span class='warning'>You unwillingly take a [eatverb] of a bit of \the [src].</span>")
-			else if(fullness > (600 * (1 + M.overeatduration / 2000)))	// The more you eat - the more you can eat
-				user.visible_message("<span class='warning'>[user] cannot force any more of \the [src] to go down [user.p_their()] throat!</span>", "<span class='danger'>You cannot force any more of \the [src] to go down your throat!</span>")
-				return 0
-		else
-			if(!isbrain(M))		//If you're feeding it to someone else.
-				if(fullness <= (600 * (1 + M.overeatduration / 1000)))
-					M.visible_message("<span class='danger'>[user] attempts to feed [M] [src].</span>", \
-										"<span class='userdanger'>[user] attempts to feed [M] [src].</span>")
+			if(junkiness && M.satiety < -150 && M.nutrition > NUTRITION_LEVEL_STARVING + 50)
+				if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+					to_chat(M, span_notice("You happily choke down yet more junk food!"))
+					M.adjust_disgust(-1)
 				else
-					M.visible_message("<span class='warning'>[user] cannot force any more of [src] down [M]'s throat!</span>", \
-										"<span class='warning'>[user] cannot force any more of [src] down [M]'s throat!</span>")
-					return 0
-
-				if(!do_mob(user, M))
-					return
-				log_combat(user, M, "fed", reagents.log_list())
-				M.visible_message("<span class='danger'>[user] forces [M] to eat [src].</span>", \
-									"<span class='userdanger'>[user] forces [M] to eat [src].</span>")
-
+					to_chat(M, span_danger("You feel sick as you choke down yet more junk food!"))
+					M.adjust_disgust(1)
+			switch(fullness)
+				if(-INFINITY to 50)
+					if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+						M.visible_message(
+							span_notice("[M] ravenously [eatverb]s \the [src], gobbling it down!"), 
+							span_notice("You ravenously [eatverb] \the [src], gobbling it down!"))
+					else
+						M.visible_message(
+							span_notice("[M] hungrily [eatverb]s \the [src], gobbling it down!"), 
+							span_notice("You hungrily [eatverb] \the [src], gobbling it down!"))
+				if(50 to 200)
+					if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+						M.visible_message(
+							span_notice("[M] ravenously [eatverb]s \the [src]!"), 
+							span_notice("You ravenously [eatverb] \the [src]!"))
+					else
+						M.visible_message(
+							span_notice("[M] hungrily [eatverb]s \the [src]."), 
+							span_notice("You hungrily [eatverb] \the [src]."))
+				if(200 to 500)
+					if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+						M.visible_message(
+							span_notice("[M] vigorously [eatverb]s \the [src]!"), 
+							span_notice("You vigorously [eatverb] \the [src]!"))
+					else
+						M.visible_message(
+							span_notice("[M] [eatverb]s \the [src]."), 
+							span_notice("You [eatverb] \the [src]."))
+				if(500 to 650)
+					if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+						M.visible_message(
+							span_notice("[M] gluttonously [eatverb]s \the [src]!"), 
+							span_notice("You gluttonously [eatverb] \the [src]!"))
+					else
+						M.visible_message(
+							span_notice("[M] unwillingly [eatverb]s \the [src]."), 
+							span_notice("You unwillingly [eatverb] \the [src]."))
+				if((600 * (1 + M.overeatduration / 1000)) to INFINITY)
+					if(HAS_TRAIT(M, TRAIT_VORACIOUS))
+						M.visible_message(
+							span_notice("[M] gluttonously [eatverb]s \the [src], cramming it down [M.p_their()] throat!"), 
+							span_notice("You gluttonously [eatverb] \the [src], cramming it down your throat!"))
+					else
+						M.visible_message(
+							span_warning("[M] cannot force any more of \the [src] to go down [M.p_their()] throat!"), 
+							span_warning("You cannot force any more of \the [src] to go down your throat!"))
+						return
+		else
+			if(isbrain(M))
+				to_chat(user, span_warning("[M] doesn't seem to have a mouth!"))
+				return
+			if(fullness <= (600 * (1 + M.overeatduration / 1000)) || HAS_TRAIT(M, TRAIT_VORACIOUS))
+				M.visible_message(
+					span_danger("[user] attempts to feed [M] [src]."),
+					span_userdanger("[user] attempts to feed you [src]."))
 			else
-				to_chat(user, "<span class='warning'>[M] doesn't seem to have a mouth!</span>")
+				M.visible_message(
+					span_warning("[user] cannot force any more of [src] down [M]'s throat!"),
+					span_warning("[user] cannot force any more of [src] down your throat!"))
+				return
+			if(!do_mob(user, M, ((HAS_TRAIT(M, TRAIT_VORACIOUS)) ? 1 SECOND : 3 SECONDS))) //Wait 3 / 1 second(s) before you can feed
 				return
 
+			M.visible_message(
+				span_danger("[user] forces [M] to eat [src]!</span>"),
+				span_userdanger("[user] forces you to eat [src]!</span>"))
+
 		if(reagents)								//Handle ingestion of the reagent.
+			log_combat(user, M, "fed", src.reagents.log_list())
 			if(M.satiety > -200)
 				M.satiety -= junkiness
 			playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), 1)


### PR DESCRIPTION
## About The Pull Request

Voracious folk can continue eating even after they're full. However, they're much faster to be forcefed, and still can be forcefed while full.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Voracious lets you keep eating even while you're full, but makes it easier for people to forcefeed you things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
