### PR TITLE
Various Tribal Fixes, Paper No Longer Requires Hatchet

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -367,22 +367,6 @@
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 
-/datum/crafting_recipe/rollingpaper
-	name = "Rolling Paper"
-	time = 10
-	reqs = list(/obj/item/paper = 1)
-	result = /obj/item/rollingpaper
-	subcategory = CAT_MISCELLANEOUS
-	category = CAT_MISC
-
-/datum/crafting_recipe/rollingpaperbundle
-	name = "Rolling Paper (x10)"
-	time = 10
-	reqs = list(/obj/item/paper = 10)
-	result = /obj/item/storage/fancy/rollingpapers
-	subcategory = CAT_MISCELLANEOUS
-	category = CAT_MISC
-
 /*
 /datum/crafting_recipe/electrochromatic_kit
 	name = "Electrochromatic Kit"

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -362,9 +362,24 @@
 /datum/crafting_recipe/naturalpaper
 	name = "Hand-Pressed Paper"
 	time = 30
-	reqs = list(/datum/reagent/water = 50, /obj/item/stack/sheet/mineral/wood = 1)
-	tools = list(/obj/item/hatchet)
+	reqs = list(/datum/reagent/water = 50, /datum/reagent/ash = 20, /obj/item/stack/sheet/mineral/wood = 1)
 	result = /obj/item/paper_bin/bundlenatural
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+
+/datum/crafting_recipe/rollingpaper
+	name = "Rolling Paper"
+	time = 10
+	reqs = list(/obj/item/paper = 1)
+	result = /obj/item/rollingpaper
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+
+/datum/crafting_recipe/rollingpaperbundle
+	name = "Rolling Paper (x10)"
+	time = 10
+	reqs = list(/obj/item/paper = 10)
+	result = /obj/item/storage/fancy/rollingpapers
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -276,10 +276,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 
 GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
-	null, \
-	new/datum/stack_recipe_list("floor tiles", list( \
 	new/datum/stack_recipe("wooden floor tile", /obj/item/stack/tile/wood, 1, 4, 20), \
-		)), \
 	null, \
 	new/datum/stack_recipe_list("pews", list( \
 		new /datum/stack_recipe("pew (middle)", /obj/structure/chair/pew, 3, one_per_turf = TRUE, on_floor = TRUE),\

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -54,10 +54,7 @@
 /obj/item/smelling_salts/proc/can_revive(mob/living/carbon/T)
 	var/obj/item/organ/brain/BR = T.getorgan(/obj/item/organ/brain)
 	var/obj/item/organ/heart = T.getorgan(/obj/item/organ/heart)
-	var/tlimit = DEFIB_TIME_LIMIT * 10
 	if(T.suiciding || T.hellbound || HAS_TRAIT(src, TRAIT_HUSK) || AmBloodsucker(T))
-		return
-	if ((world.time - T.timeofdeath) < tlimit)
 		return
 	if((T.getBruteLoss() >= 160) || (T.getFireLoss() >= 160))
 		return

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -296,6 +296,8 @@
 	reagent_flags = OPENCONTAINER
 	custom_materials = list(/datum/material/glass = 500)
 	w_class = WEIGHT_CLASS_NORMAL
+	var/fill_icon = 'icons/obj/food/soupsalad.dmi'
+	var/fill_state = "fullbowl"
 
 /obj/item/reagent_containers/glass/bowl/attackby(obj/item/I,mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks))
@@ -327,7 +329,7 @@
 /obj/item/reagent_containers/glass/bowl/update_overlays()
 	. = ..()
 	if(reagents && reagents.total_volume)
-		var/mutable_appearance/filling = mutable_appearance('icons/obj/food/soupsalad.dmi', "fullbowl")
+		var/mutable_appearance/filling = mutable_appearance(fill_icon, fill_state)
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		. += filling
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -230,17 +230,14 @@
 	desc = "A hand-carved wooden bowl, for all your bowl-related needs."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "wooden_bowl"
+	fill_icon = 'icons/obj/lavaland/ash_flora.dmi'
+	fill_state =  "woodenfullbowl"
 
 /obj/item/reagent_containers/glass/bowl/wooden_bowl/update_icon_state()
 	if(!reagents || !reagents.total_volume)
 		icon_state = "wooden_bowl"
 
-/obj/item/reagent_containers/glass/bowl/update_overlays()
-	. = ..()
-	if(reagents && reagents.total_volume)
-		. += mutable_appearance('icons/obj/lavaland/ash_flora.dmi', "woodenfullbowl", color = mix_color_from_reagents(reagents.reagent_list))
-
-/obj/item/reagent_containers/glass/bowl/mushroom_bowl/attackby(obj/item/I,mob/user, params)
+/obj/item/reagent_containers/glass/bowl/wooden_bowl/attackby(obj/item/I,mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks))
 		var/obj/item/reagent_containers/food/snacks/S = I
 		if(I.w_class > WEIGHT_CLASS_SMALL)

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -237,7 +237,7 @@
 	if(!reagents || !reagents.total_volume)
 		icon_state = "wooden_bowl"
 
-/obj/item/reagent_containers/glass/bowl/wooden_bowl/attackby(obj/item/I,mob/user, params)
+/obj/item/reagent_containers/glass/bowl/wooden_bowl/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks))
 		var/obj/item/reagent_containers/food/snacks/S = I
 		if(I.w_class > WEIGHT_CLASS_SMALL)


### PR DESCRIPTION
## About The Pull Request
Smelling salts no longer fail to work depending on the time since death.
Crafting wooden floor tiles in sets of 20 no longer crafts a single wooden barricade at 5x cost.
Wooden bowls are now completely functional and the sprites work well.
Crafting paper no longer requires a hatchet as a tool. In exchange, ash is required.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Fel 
tweak: Paper no longer requires a hatchet to craft. Instead, it requires 20u of ash in addition to the water.
fix: Smelling salts now works more consistently.
fix: Bulk-crafting wooden floor tiles now actually works.
fix: Wooden bowl sprites update properly, and give the proper custom soup and salad.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

fixes: #428 