### PR TITLE
Lagfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,5 +196,5 @@ Temporary Items
 
 #Linux custom
 start_server.sh
-tgui/public/tgui.bundle.css
-tgui/public/tgui.bundle.js
+/tgui/public/tgui.bundle.css
+/tgui/public/tgui.bundle.js

--- a/code/modules/jobs/loadout_ingame.dm
+++ b/code/modules/jobs/loadout_ingame.dm
@@ -138,7 +138,7 @@
 		data["items"] = selected_items
 		// if(!(selected_datum.name in preview_images) || !(dir2text(selected_direction) in preview_images[selected_datum.name]))
 		// 	generate_previews()
-		// data["preview"] = preview_images[selected_datum.name]
+		data["preview"] = preview_images[selected_datum.name]
 	return data
 
 /datum/component/loadout_selector/ui_act(action, params)

--- a/code/modules/jobs/loadout_ingame.dm
+++ b/code/modules/jobs/loadout_ingame.dm
@@ -136,9 +136,9 @@
 	data["selected"] = selected_name
 	if (selected_name)
 		data["items"] = selected_items
-		if(!(selected_datum.name in preview_images) || !(dir2text(selected_direction) in preview_images[selected_datum.name]))
-			generate_previews()
-		data["preview"] = preview_images[selected_datum.name]
+		// if(!(selected_datum.name in preview_images) || !(dir2text(selected_direction) in preview_images[selected_datum.name]))
+		// 	generate_previews()
+		// data["preview"] = preview_images[selected_datum.name]
 	return data
 
 /datum/component/loadout_selector/ui_act(action, params)
@@ -161,8 +161,8 @@
 
 	if (selected_datum)
 		//If random is used, get rid of the generated previews so we'll regenerate them if we re-select this outfit
-		if (selected_datum.contains_randomisation)
-			preview_images[selected_datum.name] = null
+//		if (selected_datum.contains_randomisation)
+//			preview_images[selected_datum.name] = null
 
 		//Clean up old dummy/outfit
 		QDEL_NULL(selected_datum)
@@ -178,7 +178,7 @@
 	selected_datum = new newtype
 	selected_items = selected_datum.ui_data()
 
-	generate_previews()
+//	generate_previews()
 	spawn()
 		if (usr)
 			ui_interact(usr)

--- a/tgui/packages/tgui/interfaces/LoadoutSelect.js
+++ b/tgui/packages/tgui/interfaces/LoadoutSelect.js
@@ -34,10 +34,10 @@ export const LoadoutSelect = (props, context) => {
           </Flex.Item>
           <Flex.Item height="100%" width="50%" style={{ "vertical-align": "top" }}>
             <Section title="Preview" fill>
-              {!data.preview && "No outfit selected.\n(Preview has been disabled due to lag, sorry!)"
+              {!data.items?.length && "No outfit selected."
               || (
                 <div style={{ "text-align": "center" }}>
-                  <img src={`data:image/jpeg;base64,${data.preview}`} style={{ "image-rendering": "pixelated", "-ms-interpolation-mode": "nearest-neighbor" }} width={220} height={220} /><br />
+                  <p>(Preview has been disabled due to lag, sorry!)</p>
                   <br />
                   <Button style={{ "margin": "auto", "display": "block", "text-align": "center" }} content={"Finished"} onClick={() => act('loadout_confirm')} />
                 </div>)}

--- a/tgui/packages/tgui/interfaces/LoadoutSelect.js
+++ b/tgui/packages/tgui/interfaces/LoadoutSelect.js
@@ -32,17 +32,6 @@ export const LoadoutSelect = (props, context) => {
                 </div>))}
             </Section>
           </Flex.Item>
-          <Flex.Item height="100%" width="50%" style={{ "vertical-align": "top" }}>
-            <Section title="Preview" fill>
-              {!data.preview && "No outfit selected."
-              || (
-                <div style={{ "text-align": "center" }}>
-                  <img src={`data:image/jpeg;base64,${data.preview}`} style={{ "image-rendering": "pixelated", "-ms-interpolation-mode": "nearest-neighbor" }} width={220} height={220} /><br />
-                  <br />
-                  <Button style={{ "margin": "auto", "display": "block", "text-align": "center" }} content={"Finished"} onClick={() => act('loadout_confirm')} />
-                </div>)}
-            </Section>
-          </Flex.Item>
         </Flex>
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/LoadoutSelect.js
+++ b/tgui/packages/tgui/interfaces/LoadoutSelect.js
@@ -32,6 +32,17 @@ export const LoadoutSelect = (props, context) => {
                 </div>))}
             </Section>
           </Flex.Item>
+          <Flex.Item height="100%" width="50%" style={{ "vertical-align": "top" }}>
+            <Section title="Preview" fill>
+              {!data.preview && "No outfit selected.\n(Preview has been disabled due to lag, sorry!)"
+              || (
+                <div style={{ "text-align": "center" }}>
+                  <img src={`data:image/jpeg;base64,${data.preview}`} style={{ "image-rendering": "pixelated", "-ms-interpolation-mode": "nearest-neighbor" }} width={220} height={220} /><br />
+                  <br />
+                  <Button style={{ "margin": "auto", "display": "block", "text-align": "center" }} content={"Finished"} onClick={() => act('loadout_confirm')} />
+                </div>)}
+            </Section>
+          </Flex.Item>
         </Flex>
       </Window.Content>
     </Window>


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Removes the preview from loadout selection, some reason TGUI does not like pulling icons and will take forever to cache them unlike the vanilla non-TGUI game prefs you normally see.

Idk, I'm disabling it for now and hopefully we can think of a way to generate a bunch of mannequins when the round starts so we don't have to worry about it.


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

