### PR TITLE
Sleeping while buckled to a bed heals more

### DIFF
--- a/modular_coyote/code/modules/regeneration/sleepingpart/regenerate_sleeping.dm
+++ b/modular_coyote/code/modules/regeneration/sleepingpart/regenerate_sleeping.dm
@@ -1,3 +1,4 @@
+#define BED_HEAL_BONUS 0.02
 
 // To trigger the sleeping tickies when the player is sleeping
 /datum/status_effect/incapacitating/sleeping/tick()
@@ -14,7 +15,7 @@
 
 // Definition!
 /datum/component/sleeping_regeneration
-	var/maxHealAmount = 0.03 // idfk
+	var/maxHealAmount = 0.02 // idfk
 
 // We want to check to make sure the component is a /mob/living, if it isnt, this component is incompatible.
 /datum/component/sleeping_regeneration/Initialize(...)
@@ -62,6 +63,11 @@
 	// get a heal amount from 0 to the maxHealAmount.
 	var/healAmount = rand(0,maxHealAmount)
 
+	var/obj/buckled_obj = L.buckled
+	if(buckled_obj && istype(buckled_obj, /obj/structure/bed))
+		if(!is_type_in_list(get_area(L), GLOB.outdoor_areas))
+			healAmount += BED_HEAL_BONUS
+
 	// Now pick a random element from the list, if it is BRUTE, OXY, TOX or BURN, apply the heal amount to one of them.
 	switch(pick(damagedParts))
 		if(BRUTE)
@@ -74,3 +80,5 @@
 			L.adjustFireLoss(-healAmount)
 	
 	// And that's it! We dont really need to add anything else, it will continue to call this function every tick.
+
+#undef BED_HEAL_BONUS


### PR DESCRIPTION
## About The Pull Request
As the title says. Slightly lowers the base maxHealAmount, but you can roughly double it by sleeping while buckled to a bed.
Without a bed, you heal on average about 0.2 damage per second. With a bed, this becomes 0.5 or so, give or take.

requires #436 for the global list outdoor_areas.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:Fel
add: Sleeping in a bed heals you faster! Just make sure you have a roof over your head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
