### PR TITLE
Decreases loadout cost for peaked GWTB/RGBY caps

### DIFF
--- a/modular_sunset/code/modules/client/loadout/head.dm
+++ b/modular_sunset/code/modules/client/loadout/head.dm
@@ -21,19 +21,15 @@
 /datum/gear/head/goner_red/officer
 	name = "peaked cap, red"
 	path = /obj/item/clothing/head/helmet/f13/goner/officer/red
-	cost = 3
 
 /datum/gear/head/goner_green/officer
 	name = "peaked cap, green"
 	path = /obj/item/clothing/head/helmet/f13/goner/officer/green
-	cost = 3
 
 /datum/gear/head/goner_blue/officer
 	name = "peaked cap, blue"
 	path = /obj/item/clothing/head/helmet/f13/goner/officer/blue
-	cost = 3
 
 /datum/gear/head/goner_yellow/officer
 	name = "peaked cap, yellow"
 	path = /obj/item/clothing/head/helmet/f13/goner/officer/yellow
-	cost = 3


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
PR removes cost value for RGBY colored peaked caps, thus making them have the same cost as cheap helmets (since in loadout they're a downward path of helmets). Previously, it was `cost = 3` as it was copying idea of USA/PLA officer caps' "+1 point for style".
Please note that RGBY/GWTB peaked caps have same armor value as cheap helmets.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Anonymous
tweak: Makes GWTB/RGBY cost one point less in the char-setup loadout selection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
