### PR TITLE
Molerat stew fix

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -51,7 +51,7 @@
 /datum/crafting_recipe/food/moleratstew
 	name = "Molerat Stew"
 	reqs = list(
-		/obj/item/reagent_containers/food/drinks/beer = 1,
+		/datum/reagent/consumable/ethanol/beer = 10,
 		/obj/item/reagent_containers/food/snacks/meat/slab/molerat = 1,
 		/obj/item/reagent_containers/food/snacks/grown/corn = 1,
 		/obj/item/reagent_containers/food/snacks/grown/soybeans = 1,


### PR DESCRIPTION
## About The Pull Request
changes the recipe for molerat stew from needing the beer bottle snack item, to needing the beer reagent.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
Change: swapped the beer in molerat stew from object to datum reagent
/:cl:
