### PR TITLE
Added support for armor to show genitals

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
@@ -2129,7 +2129,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/item/clothing/under/f13/legslavef,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -35348,7 +35348,7 @@
 /area/f13/building)
 "oSA" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -45354,7 +45354,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "toy" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
@@ -49465,7 +49465,7 @@
 	},
 /area/f13/village)
 "vej" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vey" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -21655,7 +21655,7 @@
 /area/f13/village)
 "cjY" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -42461,7 +42461,7 @@
 	},
 /area/f13/building/museum)
 "mGQ" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mGS" = (
@@ -50756,7 +50756,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -56819,7 +56819,7 @@
 	},
 /area/f13/building/massfusion)
 "uAJ" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/structure/flora/grass/coyote/one,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
@@ -2199,7 +2199,7 @@
 	icon_state = "mattress2";
 	pixel_y = 7
 	},
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/item/clothing/under/f13/legslavef,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -35865,7 +35865,7 @@
 /area/f13/building)
 "oSA" = (
 /obj/effect/decal/remains/human,
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/item/clothing/shoes/f13/rag,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -45983,7 +45983,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "toy" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
@@ -50171,7 +50171,7 @@
 	},
 /area/f13/village)
 "vej" = (
-/obj/item/clothing/suit/armor/slavelabor,
+/obj/item/clothing/suit/armor/outfit/slavelabor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vey" = (

--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		L = get_equipped_items()
 	for(var/A in L)
 		var/obj/item/I = A
-		if(I.body_parts_covered & GROIN)
+		if(I.body_parts_hidden & GROIN)
 			return FALSE
 	return TRUE
 
@@ -138,7 +138,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		L = get_equipped_items()
 	for(var/A in L)
 		var/obj/item/I = A
-		if(I.body_parts_covered & CHEST)
+		if(I.body_parts_hidden & CHEST)
 			return FALSE
 	return TRUE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -88,6 +88,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/mutantrace_variation = NONE //Are there special sprites for specific situations? Don't use this unless you need to.
 
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
+	/// The bodyparts *hidden* by the item, in case they should be different from what's covered. For things like open jackets and skimpy raider gear that should be a little bit revealing while still protective. Defaults to body_part_covered if not set
+	var/body_parts_hidden 
 	var/gas_transfer_coefficient = 1 // for leaking gas from turf to mask and vice-versa (for masks right now, but at some point, i'd like to include space helmets)
 	var/permeability_coefficient = 1 // for chemicals/diseases
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)
@@ -189,6 +191,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 	if(w_class <= WEIGHT_CLASS_NORMAL) //pulling small items doesn't slow you down much
 		drag_delay = 0.05 SECONDS
+	
+	if(isnull(body_parts_hidden))
+		body_parts_hidden = body_parts_covered
 
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL	//prevent reqdels

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -314,7 +314,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/leatherstrips
 
 GLOBAL_LIST_INIT(leatherstrips_recipes, list ( \
-	new/datum/stack_recipe("slave labor outfit", /obj/item/clothing/suit/armor/slavelabor, 2, time = 50),  \
+	new/datum/stack_recipe("slave labor outfit", /obj/item/clothing/suit/armor/outfit/slavelabor, 2, time = 50),  \
 	new/datum/stack_recipe("jabroni outfit", /obj/item/clothing/under/jabroni, 4, time = 80), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2, time = 40),  \
 	new/datum/stack_recipe("pet collar", /obj/item/clothing/neck/petcollar, 2, time = 40) \

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -171,6 +171,7 @@
 	icon_state = "tanleather"
 	item_state = "det_suit"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
+	body_parts_hidden = GROIN
 
 /obj/item/clothing/suit/armor/outfit/vest/cowboy //Originally cowboy stuff by Nienhaus
 	name = "brown vest"
@@ -295,6 +296,8 @@
 	species_exception = list(/datum/species/golem)
 	armor = ARMOR_VALUE_CLOTHES
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1)
+	body_parts_hidden = CHEST | ARMS
+	toggled_hidden_parts = ARMS
 
 /obj/item/clothing/suit/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"
@@ -340,6 +343,7 @@
 	icon_state = "sci_dep_jacket"
 	item_state = "sci_dep_jacket"
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T2)
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets
 
 /obj/item/clothing/suit/toggle/labcoat/depjacket/med
 	name = "medical jacket"
@@ -392,12 +396,15 @@
 	desc = "A red leather jacket, with the word \"Warriors\" sewn above the white wings on the back."
 	icon_state = "warriors"
 	item_state = "owl"
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets
 
 /obj/item/clothing/suit/toggle/labcoat/wanderer
 	name = "wanderer jacket"
 	desc = "A zipped-up hoodie made of tanned leather."
 	icon_state = "wanderer"
 	item_state = "owl"
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets
+
 /obj/item/clothing/suit/toggle/labcoat/followers
 	name = "followers lab coat"
 	desc = "A worn-down white labcoat with some wiring hanging from the right side.<br>Upon closer inspection, you can see an ancient bloodstains that could tell an entire story about thrilling adventures of a previous owner."
@@ -410,6 +417,7 @@
 	icon_state = "armormedical"
 	desc = "A staunch, practical parka made out of a wind-breaking jacket, reinforced with metal plates."
 	hoodtype = /obj/item/clothing/head/hooded/parkahood/medical
+	body_parts_hidden = CHEST | ARMS
 
 /obj/item/clothing/head/hooded/parkahood/medical
 	name = "armored medical parka hood"
@@ -443,6 +451,15 @@
 	throw_range = 2
 	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEGLOVES|HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+
+/obj/item/clothing/suit/armor/outfit/slavelabor
+	name = "old leather strips"
+	desc = "Worn leather strips, used as makeshift protection from chafing and sharp stones by labor slaves."
+	icon = 'icons/fallout/clothing/suits_utility.dmi'
+	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_utility.dmi'
+	icon_state = "legion_slaveleather"
+	item_state = "legion_slaveleather"
+	body_parts_hidden = 0
 
 ///////////
 // LIGHT //
@@ -519,19 +536,22 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_light.dmi'
 	icon_state = "tribal"
 	item_state = "tribal"
-	flags_inv = HIDEJUMPSUIT
+	body_parts_hidden = GROIN|ARMS|LEGS
 
 /obj/item/clothing/suit/armor/light/tribal/cloak
 	name = "light tribal cloak"
 	desc = "A light cloak made from gecko skins and small metal plates at vital areas to give some protection, a favorite amongst scouts of the tribe."
 	icon_state = "lightcloak"
 	item_state = "lightcloak"
+	body_parts_hidden = CHEST|ARMS|LEGS
+
 
 /obj/item/clothing/suit/armor/light/tribal/simple
 	name = "simple tribal armor"
 	desc = "Armor made of leather strips and a large, flat piece of turquoise. The wearer is displaying the Wayfinders traditional garb."
 	icon_state = "tribal_armor"
 	item_state = "tribal_armor"
+	body_parts_hidden = CHEST|ARMS|LEGS
 
 /obj/item/clothing/suit/armor/light/tribal/sorrows
 	name = "Sorrows armour"
@@ -566,36 +586,42 @@
 	desc = "A chestplate, pauldron and vambrace that bear a distinct resemblance to a coolant tank, engine valves and an exhaust. Commonly worn by members of the Rustwalkers tribe"
 	icon_state = "rustwalkers_armour_light"
 	item_state = "rustwalkers_armour_light"
+	body_parts_hidden = ARMS
 	
 /obj/item/clothing/suit/armor/light/tribal/whitelegs
 	name = "White Legs light armour"
 	desc = "A series of tan and khaki armour plates, held in place with a considerable amount of strapping. Commonly worn by members of the White Legs tribe."
 	icon_state = "white_legs_armour_light"
 	item_state = "white_legs_armour_light"
+	body_parts_hidden = ARMS
 
 /obj/item/clothing/suit/armor/light/tribal/eighties
 	name = "80s light armour"
 	desc = "A plain, slightly cropped leather jacket with a black lining and neck brace, paired with a set of metal vambraces and a black belt of pouches. Commonly worn by the members of the 80s tribe."
 	icon_state = "80s_armour_light"
 	item_state = "80s_armour_light"
+	body_parts_hidden = ARMS
 
 /obj/item/clothing/suit/armor/light/tribal/deadhorses
 	name = "Dead Horses light armour"
 	desc = "A simple leather bandolier and gecko hide chest covering, with an engraved metal pauldron and a pair of black leather straps. Commonly worn by the members of the Dead Horses tribe."
 	icon_state = "dead_horses_armour_light"
 	item_state = "dead_horses_armour_light"
+	body_parts_hidden = 0
 
 /obj/item/clothing/suit/armor/light/tribal/geckocloak
 	name = "light tribal cloak"
 	desc = "Light cloak armor, made of gecko skins and minor metal plating to protect against light weaponry, a favorite amongst scouts of the tribe."
 	icon_state = "lightcloak"
 	item_state = "lightcloak"
+	body_parts_hidden = ARMS
 
 /obj/item/clothing/suit/armor/light/tribal/strips
 	name = "light tribal armor"
 	desc = "Light armor made of leather stips and a large, flat piece of turquoise. Armor commonplace among the Wayfinders."
 	icon_state = "tribal_armor"
 	item_state = "tribal_armor"
+	body_parts_hidden = CHEST
 
 /// to be refactored to work with the New Tier System (tm)
 /obj/item/clothing/suit/hooded/cloak
@@ -612,6 +638,7 @@
 	equip_delay_other = 10
 	max_integrity = 100
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small
+	body_parts_hidden = 0
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1)
@@ -697,6 +724,7 @@
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_DOWN_LASER_T2)
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/hhunter
 	name = "Razorclaw helm"
@@ -719,6 +747,7 @@
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_DOWN_LASER_T2)
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/shunter
 	name = "quickclaw hood"
@@ -739,6 +768,7 @@
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_BULLET_T2)
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/deathclaw
 	name = "deathclaw cloak hood"
@@ -760,6 +790,7 @@
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_BULLET_T2)
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/razorclaw
 	name = "razorclaw helm"
@@ -776,7 +807,6 @@
 	icon_state = "desertcloak"
 	desc = "A practical cloak made out of animal hide."
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/desert
-	// body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 /obj/item/clothing/head/hooded/cloakhood/desert
 	name = "desert cloak hood"
@@ -809,7 +839,7 @@
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_MELEE_T1)
-
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/outcast
 	name = "patched leather hood"
@@ -836,6 +866,7 @@
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_MELEE_T1)
+	body_parts_hidden = 0
 
 /obj/item/clothing/head/hooded/cloakhood/tribaloutcast
 	name = "patched leather hood"
@@ -876,6 +907,7 @@
 	desc = "A leather top with a bandolier over it and a straps that cover the arms. Suited for warm climates, comes with storage space."
 	icon_state = "badlands"
 	item_state = "badlands"
+	body_parts_hidden = ARMS
 
 /obj/item/clothing/suit/armor/light/raider/tribalraider
 	name = "tribal raider wear"
@@ -884,6 +916,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_light.dmi'
 	icon_state = "tribal_outcast"
 	item_state = "tribal_outcast"
+	body_parts_hidden = ARMS | GROIN
 
 /obj/item/clothing/suit/armor/light/raider/supafly
 	name = "supa-fly raider armor"
@@ -1151,6 +1184,7 @@
 	max_integrity = 150
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets
 	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_DOWN_LASER_T2)
+	body_parts_hidden = ARMS | CHEST
 
 /obj/item/clothing/suit/armor/light/leather/Initialize()
 	/// make sure the parents work first for this, child lists take priority
@@ -1176,19 +1210,22 @@
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS| ARMS | HEAD
 	siemens_coefficient = 0.9
+	body_parts_hidden = ARMS | CHEST | GROIN | LEGS
 
 /obj/item/clothing/suit/armor/light/leather/leather_jacket
 	name = "bouncer jacket"
 	icon_state = "leather_jacket_fighter"
 	item_state = "leather_jacket_fighter"
 	desc = "A very stylish pre-War black, heavy leather jacket. Not always a good choice to wear this the scorching sun of the desert, and one of the arms has been torn off"
+	body_parts_hidden = ARMS | CHEST
+
 /obj/item/clothing/suit/armor/light/leather/leather_jacketmk2
 	name = "thick leather jacket"
 	desc = "This heavily padded leather jacket is unusual in that it has two sleeves. You'll definitely make a fashion statement whenever, and wherever, you rumble."
 	icon_state = "leather_jacket_thick"
 	item_state = "leather_jacket_thick"
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_DOWN_LASER_T2, ARMOR_MODIFIER_DOWN_FIRE_T2)
-
+	body_parts_hidden = ARMS | CHEST | LEGS
 
 // Recipe : one of the above + a suit_fashion leather coat
 /obj/item/clothing/suit/armor/light/leather/leathercoat
@@ -1198,12 +1235,14 @@
 	item_state = "leather_coat_fighter"
 	siemens_coefficient = 0.8
 	armor_tokens = list(ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_DOWN_LASER_T2)
+	body_parts_hidden = ARMS | CHEST
 
 /obj/item/clothing/suit/armor/light/leather/tanvest
 	name = "tanned vest"
 	icon_state = "tanleather"
 	item_state = "tanleather"
 	desc = "Layers of leather glued together to make a stiff vest, crude but gives some protection against wild beasts and knife stabs to the liver."
+	body_parts_hidden = 0
 
 /obj/item/clothing/suit/armor/light/leather/cowboyvest
 	name = "cowboy vest"
@@ -1225,7 +1264,7 @@
 	desc = "a handmade tactical rig. The actual rig is made of a black, fiberous cloth, being attached to a dusty desert-colored belt. A flask and two ammo pouches hang from the belt."
 	icon_state = "r_gear_rig"
 	item_state = "r_gear_rig"
-
+	body_parts_hidden = 0
 	
 ////////////////
 // ARMOR KITS // 
@@ -1240,6 +1279,7 @@
 	item_state = "armorkit"
 	heat_protection = CHEST | GROIN | LEGS| ARMS | HEAD
 	siemens_coefficient = 1.1
+	body_parts_hidden = 0
 
 /obj/item/clothing/suit/armor/light/kit/Initialize()
 	/// make sure the parents work first for this, child lists take priority
@@ -1268,6 +1308,7 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_light.dmi'
 	desc = "Well-made metal plates covering your vital organs."
 	icon_state = "light_plates"
+	body_parts_hidden = CHEST
 
 /* /obj/item/clothing/suit/armor/light/kit/Initialize()
 	. = ..()
@@ -1370,18 +1411,21 @@
 	desc = "A car seat leather duster, a timing belt bandolier, and armour plating made from various parts of a car, it surely would weigh the wearer down. Commonly worn by members of the Rustwalkers tribe."
 	icon_state = "rustwalkers_armour"
 	item_state = "rustwalkers_armour"
+	body_parts_hidden = CHEST
 
 /obj/item/clothing/suit/armor/medium/tribal/whitelegs
 	name = "White Legs armour"
 	desc = "A series of tan and khaki armour plates, held in place with a considerable amount of strapping and possibly duct tape. Commonly worn by members of the White Legs tribe."
 	icon_state = "white_legs_armour"
 	item_state = "white_legs_armour"
+	body_parts_hidden = ARMS | LEGS
 
 /obj/item/clothing/suit/armor/medium/tribal/eighties
 	name = "80s armour"
 	desc = "A ballistic duster with the number 80 stitched onto the back worn over a breastplate made from a motorcycle's engine housing, with kneepads made from stirrups. Worn by the members of the 80s tribe."
 	icon_state = "80s_armour"
 	item_state = "80s_armour"
+	body_parts_hidden = ARMS | CHEST
 
 /obj/item/clothing/suit/armor/medium/tribal/deadhorses
 	name = "Dead Horses armour"
@@ -1389,6 +1433,7 @@
 	icon_state = "dead_horses_armour"
 	item_state = "dead_horses_armour"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/bulletbelt
+	body_parts_hidden = 0
 
 /obj/item/clothing/suit/armor/medium/tribal/bone
 	name = "Reinforced Bone armor"
@@ -1431,7 +1476,7 @@
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_DOWN_MELEE_T1, ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_DOWN_ENV_T1)
-
+	body_parts_hidden = CHEST
 
 /obj/item/clothing/suit/armor/medium/vest/flak
 	name = "ancient flak vest"
@@ -1627,7 +1672,6 @@
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_MORE_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_UP_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_DOWN_ENV_T1)
 
-
 /obj/item/clothing/suit/armor/medium/vest/breastplate/light
 	name = "light armor plates"
 	desc = "Well-made metal plates covering your vital organs."
@@ -1637,7 +1681,6 @@
 	item_state = "armorkit"
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T2, ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_DOWN_ENV_T1)
-
 
 /obj/item/clothing/suit/armor/medium/vest/breastplate/oasis
 	name = "Nash steel breastplate"
@@ -1661,7 +1704,6 @@
 	icon_state = "steel_bib"
 	item_state = "steel_bib"
 	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_DOWN_ENV_T1)
-
 
 /obj/item/clothing/suit/armor/medium/vest/breastplate/scrap
 	name = "scrap metal chestplate"
@@ -2111,6 +2153,7 @@
 	strip_delay = 40
 	icon = 'icons/fallout/clothing/armored_medium.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/armor_medium.dmi'
+	body_parts_hidden = ARMS | LEGS | GROIN
 
 /obj/item/clothing/suit/armor/medium/raider/rebel
 	name = "rebel raider armor"
@@ -2132,6 +2175,7 @@
 	icon_state = "badlands"
 	item_state = "badlands"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny/magpouch
+	body_parts_hidden = ARMS | LEGS | GROIN
 
 /obj/item/clothing/suit/armor/medium/raider/combatduster
 	name = "combat duster"
@@ -2172,6 +2216,7 @@
 	item_state = "wastewar"
 	resistance_flags = FLAMMABLE
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/massive/swords
+	body_parts_hidden = CHEST | GROIN
 
 /obj/item/clothing/suit/armor/medium/raider/blastmaster
 	name = "blastmaster raider armor"
@@ -2186,6 +2231,7 @@
 	desc = "A set of armor made from bulky plastic and rubber. A faded sports team logo is printed in various places. Go Desert Rats!"
 	icon_state = "yankee"
 	item_state = "yankee"
+	body_parts_hidden = ARMS | CHEST
 
 /// Environmental raider armor
 /obj/item/clothing/suit/armor/medium/raider/iconoclast

--- a/code/modules/clothing/suits/arfsuits_unused.dm
+++ b/code/modules/clothing/suits/arfsuits_unused.dm
@@ -218,16 +218,6 @@ Suits. 0-10 in its primary value, slowdown 0, various utility
 	icon_state = "legion_combat2"
 	item_state = "legion_combat2"
 
-/obj/item/clothing/suit/armor/slavelabor
-	name = "old leather strips"
-	desc = "Worn leather strips, used as makeshift protection from chafing and sharp stones by labor slaves."
-	icon = 'icons/fallout/clothing/suits_utility.dmi'
-	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_utility.dmi'
-	icon_state = "legion_slaveleather"
-	item_state = "legion_slaveleather"
-	icon = 'icons/fallout/clothing/suits_utility.dmi'
-	mob_overlay_icon = 'icons/fallout/onmob/clothes/suit_utility.dmi'
-
 /obj/item/clothing/suit/armor/legion/vet/explorercanada
 	name = "custom explorer armor"
 	desc = "Armor based on layered strips of laminated linen and leather, the technique giving it surprising resilience for low weight. This one has been custom made."

--- a/code/modules/clothing/suits/f13factionarmor.dm
+++ b/code/modules/clothing/suits/f13factionarmor.dm
@@ -348,7 +348,7 @@
 	icon_state = "legion_combat2"
 	item_state = "legion_combat2"
 
-/obj/item/clothing/suit/armor/slavelabor
+/obj/item/clothing/suit/armor/outfit/slavelabor
 	name = "old leather strips"
 	desc = "Worn leather strips, used as makeshift protection from chafing and sharp stones by labor slaves."
 	icon = 'icons/fallout/clothing/suits_utility.dmi'

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -102,6 +102,9 @@
 			qdel(src)
 
 //Toggle exosuits for different aesthetic styles (hoodies, suit jacket buttons, etc)
+/obj/item/clothing/suit/toggle
+	/// If the suit has different hidden parts when toggled, use these for what it hides
+	var/toggled_hidden_parts
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	. = ..()
@@ -122,11 +125,17 @@
 	to_chat(usr, "<span class='notice'>You toggle [src]'s [togglename].</span>")
 	if(src.suittoggled)
 		src.icon_state = "[initial(icon_state)]"
+		src.body_parts_hidden = initial(src.body_parts_hidden)
 		src.suittoggled = FALSE
 	else if(!src.suittoggled)
 		src.icon_state = "[initial(icon_state)]_t"
+		if(!isnull(toggled_hidden_parts))
+			src.body_parts_hidden = src.toggled_hidden_parts
 		src.suittoggled = TRUE
 	usr.update_inv_wear_suit()
+	if(ismob(src.loc))
+		var/mob/mob_carrying_this = src.loc
+		mob_carrying_this.update_body(TRUE) // update skimpiness
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -200,6 +200,7 @@
 	desc = "We've saved money by giving you half a shirt!"
 	icon_state = "croptop"
 	body_parts_covered = CHEST|GROIN|ARMS
+	body_parts_hidden = CHEST
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = FALSE
 
@@ -268,6 +269,7 @@
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
 	body_parts_covered = CHEST|GROIN
+	body_parts_hidden = 0 // nudie~
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/durathread

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -1242,7 +1242,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 //Laborers farm and mine.
 /datum/outfit/loadout/slaveworker
 	name = "Worker"
-	suit = /obj/item/clothing/suit/armor/slavelabor
+	suit = /obj/item/clothing/suit/armor/outfit/slavelabor
 	uniform = /obj/item/clothing/under/f13/legslave
 	shoes =	/obj/item/clothing/shoes/f13/rag
 	r_hand = /obj/item/flashlight/flare/torch


### PR DESCRIPTION
## About The Pull Request

Added in a var to separate genital coverage from defensive coverage. So, we can have armor kits that dont hide genitals, labcoats that show off everything while open, jackets and vests that have your danglies peek out the bottom. Course if you're wearing anything underneath, or underwear, its all hidden.

Also gear harnesses no longer hide genitals.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Armor that should reasonably not hide your unmentionables will no longer hide your unmentionables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
