### PR TITLE
Sorts the Get Logs verb in desc numberical

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -8,6 +8,7 @@
 
 	for(var/i=0, i<max_iterations, i++)
 		var/list/choices = flist(path)
+		choices = sortList(choices, /proc/cmp_text_dsc)
 		if(path != root)
 			choices.Insert(1,"/")
 


### PR DESCRIPTION
## About The Pull Request
Sorts the `Get Server Log` verb menu by reverse alphabetical.
This makes it show the dates in descending order, so newer dates will show at the top.

It does have the side effect of causing the actual log bit to be reverse alphabetical, but that's a relatively minor thing.
![image](https://user-images.githubusercontent.com/44811257/181875609-0b8c52ae-dbaa-4b29-911d-3c9879762c61.png)

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
admin: The "Get Server Logs" verb is now sorted so newer dates are at the top.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
