### PR TITLE
Fixes socom mags

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -239,7 +239,7 @@
 	name = "bag with reloaded .44 bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 
 
 // .45 ACP
@@ -269,7 +269,7 @@
 	name = "bag with reloaded .45 ACP bullets"
 	desc = "The casings are worn, the gunpowder some homebrew mix of dubious quality. At least it goes bang."
 	icon_state = "improvshotbag"
-	multiple_sprites = 1
+	multiple_sprites = 3
 
 
 //.45-70 Gov't

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -130,6 +130,10 @@
 /obj/item/ammo_box/magazine/m45/socom/empty
 	start_empty = 1
 
+/obj/item/ammo_box/magazine/m45/socom/update_icon()
+	..()
+	icon_state = "[initial(icon_state)]-[stored_ammo.len ? "[max_ammo]" : "0"]" // I hate this system
+
 //.44 Magnum
 /obj/item/ammo_box/magazine/m44
 	name = "handgun magazine (.44 magnum)"


### PR DESCRIPTION
## About The Pull Request

Socom mags: Now visible when half empty.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Socom mags: now visible when half empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
