### PR TITLE
Fixes some improperly set stock part icons, some issues with bonfires.

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -236,8 +236,10 @@
 				//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 				W.pixel_x = clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
 				W.pixel_y = clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
-		else
-			return ..()
+		else //Standard attackby response, but also expose anything used on it to flame.
+			. = ..()
+			if(burning)
+				W.fire_act(1000, 500)
 
 
 /obj/structure/bonfire/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)
@@ -328,12 +330,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/structure/bonfire/proc/attempt_smoke_signal(obj/item/stack/sheet/cloth/sheet, mob/living/user, )
-	var/outdoors = FALSE
-	for(var/area_type in GLOB.outdoor_areas)
-		if(istype(get_area(src), area_type))
-			outdoors = TRUE
-			break
-	if(!outdoors)
+	if(!is_type_in_list(get_area(src), GLOB.outdoor_areas))
 		to_chat(user, span_warning("You must be outside to send a smoke signal."))
 		return
 	var/signalmessage = stripped_input(user, "What would you like to send via smoke signal?", "Smoke Signal")
@@ -358,8 +355,8 @@
 	
 
 /obj/structure/bonfire/proc/smoke_signal(mob/living/M, message, obj/structure/bonfire/B)
-	var/log_message = "(Smoke Signal) [message]"
-	log_say(log_message, M)
+	var/log_message = "[message]"
+	M.log_talk(log_message, LOG_CHAT)
 
 	for(var/mob/player in GLOB.player_list)
 		if(player == M)
@@ -371,12 +368,7 @@
 			to_chat(player, msg_dead)
 			continue
 		if(player.has_language(/datum/language/tribal) && !HAS_TRAIT(player, TRAIT_BLIND))
-			var/outdoors = FALSE
-			for(var/area_type in GLOB.outdoor_areas)
-				if(istype(get_area(src), area_type))
-					outdoors = TRUE
-					break
-			if(!outdoors)
+			if(!is_type_in_list(get_area(player), GLOB.outdoor_areas))
 				continue
 			var/dirmessage = "somewhere in the distance"
 			if(player.z == B.z)

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -199,14 +199,14 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 /obj/item/stock_parts/capacitor/adv
 	name = "capacitor"
 	desc = "A fairly modern design for a capacitor, it can take in and distribute power pretty quickly compared to a battery."
-	icon_state = "simple_capacitor"
+	icon_state = "basic_capacitor"
 	rating = 2
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 
 /obj/item/stock_parts/scanning_module/adv
 	name = "small antenna"
 	desc = "Useful for scanning and analyzing signals. Comes with a built in miniature light sensor, too!"
-	icon_state = "adv_scan_module"
+	icon_state = "small_antenna"
 	rating = 2
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=20)
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
T2 Capacitors and Analyzers had improperly set icons, resulting in a missing and improper sprite respectively. Bonfires used some pretty weird code to check for areas resulting in some errors with determining if potential "listeners" to smoke signals were outside, used the wrong logging, and failed to properly fire_act items afterattack. All of this is fixed!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:Fel
fix: Capacitor and Analyzer icons have been fixed!
fix: Tribals no longer have X-ray vision for specifically smoke. (They no longer see smoke signals while indoors.)
fix: Bonfires can light things used on them on fire again. Revolutionary, I know.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
