### PR TITLE
Re-enabled manually toggled biological turgidity

### DIFF
--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -228,3 +228,10 @@
 		return
 
 	mb_cd_timer = world.time + mb_cd_length
+
+/* /mob/living/carbon/human/verb/climax_verb()
+	set category = "IC"
+	set name = "Climax"
+	set desc = "Lets you choose a couple ways to ejaculate."
+	mob_climax()
+ */ // Just until the darn verb actually works =3

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -112,7 +112,7 @@
 			picked_organ.toggle_visibility(picked_visibility)
 	return
 
-/*/mob/living/carbon/verb/toggle_arousal_state()
+/mob/living/carbon/verb/toggle_arousal_state()
 	set category = "IC"
 	set name = "Toggle genital arousal"
 	set desc = "Allows you to toggle which genitals are showing signs of arousal."
@@ -132,7 +132,8 @@
 		else
 			to_chat(src,"<span class='userlove'>You can't make that genital [picked_organ.aroused_state ? "unaroused" : "aroused"]!</span>")
 		picked_organ.update_appearance()
-	return*/
+		update_body(TRUE)
+	return
 
 
 /obj/item/organ/genital/proc/modify_size(modifier, min = -INFINITY, max = INFINITY)

--- a/modular_citadel/code/datums/status_effects/chems.dm
+++ b/modular_citadel/code/datums/status_effects/chems.dm
@@ -72,6 +72,13 @@
 
 //Preamble
 
+/mob/living/verb/toggle_hypno()
+	set category = "IC"
+	set name = "Toggle Lewd Hypno"
+	set desc = "Allows you to toggle if you'd like lewd flavour messages for hypno features, such as MKUltra."
+	client.prefs.cit_toggles ^= HYPNO
+	to_chat(usr, "You [((client.prefs.cit_toggles & HYPNO) ?"will":"no longer")] receive lewd flavour messages for hypno.")
+
 /datum/status_effect/chem/enthrall
 	id = "enthrall"
 	alert_type = null


### PR DESCRIPTION
## About The Pull Request

You can get boners now. Just click "Toggle genital arousal" and turn whichever part you want on or off.

Still cant ejerkulate, working on that. 

Also reimplements a verb to toggle lewd hypnosis. Doesnt really do much, but for those who like to play with MK Ultra, it'll probably make it work a bit better. Its a work in progress!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Readded a verb that toggles genital arousal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
