### PR TITLE
FAL no longer spawns with an imaginary mag of null references

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -2026,8 +2026,7 @@
 	icon_state = "fnfal"
 	item_state = "fnfal"
 	mag_type = /obj/item/ammo_box/magazine/m762
-	init_mag_type = /obj/item/ammo_box/magazine/
-	extra_mag_types = list(/obj/item/ammo_box/magazine/w308)
+	init_mag_type = /obj/item/ammo_box/magazine/m762
 
 	slowdown = GUN_SLOWDOWN_RIFLE_MEDIUM_AUTO
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY


### PR DESCRIPTION
## About The Pull Request

So apparently the FAL spawned with a magazine that doesnt actually exist. Normally this is okay, but it had the wrong amount of ammo in it, so it made the gun invisible. welp. Now its visible and has the right mag

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: FAL comes with ammo and is now visible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
