### PR TITLE
Re-adds the changelog button

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -141,6 +141,15 @@ window "infowindow"
 		saved-params = "is-checked"
 		text = "TG Wiki"
 		command = "tgwiki"
+	elem "changelog"
+		type = BUTTON
+		pos = 320,5
+		size = 100x20
+		anchor1 = 50,0
+		anchor2 = 66,0
+		saved-params = "is-checked"
+		text = "Changelog"
+		command = "Changelog"
 	elem "github"
 		type = BUTTON
 		pos = 420,5


### PR DESCRIPTION
## About The Pull Request
Re-adds the handy changelog button to the menu, between the tg wiki button and the github button.
![image](https://user-images.githubusercontent.com/44811257/182302720-90d5c4df-29e8-4e07-a91e-a9643e2f05ba.png)


## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Re-added the changelog button to the upper right, next to the github button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
