### PR TITLE
Redwater/Nash Loadout Updates + Minor Tweaks

### DIFF
--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -794,8 +794,8 @@
 	dynamic_fhair_suffix = ""
 
 /obj/item/clothing/head/f13/flatranger
-	name = "NCR gambler ranger hat"
-	desc = "A rustic, homely style gambler hat adorning an NCR Ranger patch. Yeehaw!"
+	name = "gambler ranger hat"
+	desc = "A rustic, homely style gambler hat adorning an Texas Ranger patch. Yeehaw!"
 	icon_state = "gamblerrang"
 	item_state = "gamblerrang"
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -69,7 +69,7 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.01
 	clothing_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+//	slowdown = SHOES_SLOWDOWN+1
 	strip_delay = 50
 	equip_delay_other = 50
 	resistance_flags = NONE

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -1262,10 +1262,11 @@
 
 /obj/item/clothing/suit/armor/light/leather/rig
 	name = "chest gear harness"
-	desc = "a handmade tactical rig. The actual rig is made of a black, fiberous cloth, being attached to a dusty desert-colored belt. A flask and two ammo pouches hang from the belt."
+	desc = "a handmade tactical rig. The actual rig is made of a black, fiberous cloth, being attached to a dusty desert-colored belt with enough room for four small items."
 	icon_state = "r_gear_rig"
 	item_state = "r_gear_rig"
 	body_parts_hidden = 0
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/four
 	
 ////////////////
 // ARMOR KITS // 
@@ -1759,7 +1760,7 @@
 	max_integrity = 200
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/huge
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T3 * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T1)
 
 /obj/item/clothing/suit/armor/medium/duster/navyblue
 	name = "head of security's jacket"

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -94,7 +94,7 @@ Mayor
 	backpack_contents = list(
 		/obj/item/clothing/suit/armor/medium/duster/town/mayor = 1,
 		/obj/item/clothing/head/f13/town/mayor = 1,
-		/obj/item/gun/ballistic/revolver/m29/snub = 1,
+		/obj/item/gun/ballistic/revolver/m29/peacekeeper = 1,
 		/obj/item/ammo_box/m44 = 2,
 		/obj/item/clothing/shoes/f13/cowboy = 1,
 		/obj/item/clothing/mask/cigarette/cigar = 1,
@@ -107,8 +107,8 @@ Mayor
 		/obj/item/clothing/shoes/jackboots = 1,
 		/obj/item/clothing/suit/armor/light/duster/battlecoat/vault/overseer = 1,
 		/obj/item/reagent_containers/food/drinks/flask/vault113,
-		/obj/item/gun/energy/laser/pistol= 1,
-		/obj/item/stock_parts/cell/ammo/ec = 1,
+		/obj/item/gun/ballistic/automatic/pistol/beretta/automatic = 1,
+		/obj/item/ammo_box/magazine/m9mm/doublestack = 1,
 		)
 
 /datum/outfit/loadout/highroller
@@ -119,8 +119,8 @@ Mayor
 		/obj/item/clothing/under/f13/sleazeball = 1,
 		/obj/item/clothing/shoes/laceup = 1,
 		/obj/item/toy/cards/deck/unum = 1,
-		/obj/item/gun/ballistic/automatic/pistol/type17 = 1,
-		/obj/item/ammo_box/magazine/m10mm/adv/simple = 2,
+		/obj/item/gun/ballistic/automatic/pistol/mk23 = 1,
+		/obj/item/ammo_box/magazine/m45/socom = 2,
 	)
 
 
@@ -167,7 +167,6 @@ Mayor
 	backpack = /obj/item/storage/backpack/satchel/leather
 	satchel = /obj/item/storage/backpack/satchel/leather
 	r_hand = /obj/item/storage/briefcase/secretary
-	l_hand = /obj/item/book/granter/trait/selection
 	l_pocket = /obj/item/storage/bag/money/small/settler
 	r_pocket = /obj/item/flashlight/seclite
 	shoes = 		/obj/item/clothing/shoes/f13/fancy
@@ -275,23 +274,27 @@ Mayor
 	name = "The Law Man"
 	suit = /obj/item/clothing/suit/armor/medium/duster/town/sheriff
 	head = /obj/item/clothing/head/f13/town/sheriff
-	l_pocket = /obj/item/storage/belt/holster
+	uniform = /obj/item/clothing/under/f13/police/formal
+	neck = /obj/item/storage/belt/holster/ranger45
 	r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
-	belt = /obj/item/gun/ballistic/revolver/m29/peacekeeper
+	shoes = /obj/item/clothing/shoes/f13/military/plated
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/c4570 = 3,
-		/obj/item/ammo_box/m44 = 2,
+		/obj/item/attachments/scope = 1,
 		)
 
 /datum/outfit/loadout/thechief
 	name = "The Chief"
-	uniform = /obj/item/clothing/under/f13/police/formal
+	uniform = /obj/item/clothing/under/f13/police/chief
 	suit = /obj/item/clothing/suit/armor/medium/duster/town/chief
 	head = /obj/item/clothing/head/f13/town/chief
-	belt = /obj/item/storage/belt/holster/legholster
-	shoes = /obj/item/clothing/shoes/jackboots
-	r_hand = /obj/item/gun/energy/laser/aer9
-
+	neck = /obj/item/storage/belt/holster/ranger45
+	shoes = /obj/item/clothing/shoes/combat
+	r_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller
+	backpack_contents = list(/obj/item/ammo_box/shotgun/slug = 1, 
+		/obj/item/ammo_box/shotgun/buck = 2,
+		)
+/*
 /datum/outfit/loadout/pew
 	name = "Tactical"
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller
@@ -301,7 +304,7 @@ Mayor
 		/obj/item/ammo_box/shotgun/buck = 1,
 		/obj/item/ammo_box/shotgun/trainshot = 1,
 		/obj/item/gun/energy/laser/auto/oasis = 1,
-		)
+		)*/
 
 /datum/outfit/job/den/f13sheriff/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -356,7 +359,6 @@ Mayor
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	belt = /obj/item/storage/belt/military/assault
-	suit = /obj/item/clothing/suit/armor/heavy/vest/bulletproof
 	suit_store = /obj/item/storage/belt/holster/legholster/police
 	l_pocket = /obj/item/storage/bag/money/small/settler
 	r_pocket = /obj/item/flashlight/flare
@@ -418,7 +420,7 @@ Mayor
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /*--------------------------------------------------------------*/
-
+/*
 /datum/job/oasis/f13farmer
 	title = "Farmer"
 	flag = F13FARMER
@@ -499,9 +501,9 @@ Mayor
 		/obj/item/seeds/cannabis = 1,
 		/obj/item/seeds/tea/catnip = 1,
 		)
-
+*/
 /*--------------------------------------------------------------*/
-
+/*
 /datum/job/oasis/f13prospector
 	title = "Prospector"
 	flag = F13PROSPECTOR
@@ -546,7 +548,7 @@ Mayor
 		/obj/item/melee/onehanded/knife/hunting,
 		/obj/item/gun/ballistic/automatic/pistol/n99,
 		/obj/item/ammo_box/magazine/m10mm/adv/simple = 2,
-		/obj/item/book/granter/crafting_recipe/ODF = 1,
+		w = 1,
 		)
 
 /datum/outfit/job/den/f13settler/pre_equip(mob/living/carbon/human/H)
@@ -589,6 +591,7 @@ Mayor
 		/obj/item/pickaxe/silver = 1,
 		/obj/item/shovel = 1,
 		)
+*/
 
 /*--------------------------------------------------------------*/
 
@@ -602,6 +605,12 @@ Mayor
 	description = "Handy with a scalpel and scanner, your expertise in the practice of medicine makes you an indispensible asset to the settlement of Nash. Just remember that you're no Follower - medicine doesn't come for free, and you aren't here out of the kindness of your heart. Make sure to turn a profit on your services, or the Mayor might reconsider your position!"
 	enforces = "Medicine is a public service, and you are under control of local governance - but remember public doesn't equate to free."
 	selection_color = "#dcba97"
+
+	loadout_options = list(
+	/datum/outfit/loadout/rescueranger,
+	/datum/outfit/loadout/stitcher,
+	/datum/outfit/loadout/mixer,
+	/datum/outfit/loadout/holidaydoc)
 
 	outfit = /datum/outfit/job/den/f13dendoc
 	access = list(ACCESS_BAR, ACCESS_CLINIC, ACCESS_CLONING)
@@ -656,6 +665,48 @@ Mayor
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_HIGH, src)
 
+/datum/outfit/loadout/rescueranger
+	name = "Search and Rescue"
+	backpack_contents = list(/obj/item/clothing/head/f13/police/sergeant = 1,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/auto5 = 1,
+		/obj/item/ammo_box/shotgun/buck = 1,
+		/obj/item/clothing/suit/toggle/labcoat/paramedic = 1,
+		/obj/item/folder/white = 1,
+		/obj/item/flashlight/pen/paramedic = 1,
+		)
+
+/datum/outfit/loadout/stitcher
+	name = "Stitcher"
+	backpack_contents = list(/obj/item/clothing/head/hardhat/white = 1,
+		/obj/item/grenade/flashbang = 1,
+		/obj/item/clothing/glasses/welding = 1,
+		/obj/item/storage/belt/medical/primitive = 1,
+		/obj/item/storage/medical/ancientfirstaid = 1,
+		/obj/item/circuitboard/machine/limbgrower = 1,
+		/obj/item/healthanalyzer/advanced = 1,
+		/obj/item/storage/belt/holster/legholster/police = 1,
+		)
+	
+/datum/outfit/loadout/mixer
+	name = "Mixer"
+	backpack_contents = list(/obj/item/clothing/head/beret/chem = 1,
+		/obj/item/melee/classic_baton/police = 1,
+		/obj/item/pen/sleepy = 1,
+		/obj/item/reagent_containers/glass/beaker/plastic = 1,
+		/obj/item/reagent_containers/glass/beaker/meta = 1, 
+		/obj/item/reagent_containers/hypospray = 1,
+		/obj/item/circuitboard/machine/bloodbankgen = 1,
+		)
+
+/datum/outfit/loadout/holidaydoc
+	name = "Holiday Doc"
+	backpack_contents = list(/obj/item/vending_refill/medical = 1, 
+		/obj/item/pda/medical = 1,
+		/obj/item/clothing/suit/hooded/surgical = 1,
+		/obj/item/storage/medical/ancientfirstaid = 1,
+		/obj/item/ammo_box/m44 = 1,
+		/obj/item/gun/ballistic/revolver/m29/snub = 1,
+		)
 /*--------------------------------------------------------------*/
 
 /datum/job/oasis/f13barkeep
@@ -762,6 +813,8 @@ Mayor
 		/datum/outfit/loadout/outdoorsman,
 		/datum/outfit/loadout/militia,
 		/datum/outfit/loadout/singer,
+		/datum/outfit/loadout/farmer,
+		/datum/outfit/loadout/prospector,
 	)
 	access = list(ACCESS_BAR)
 	minimal_access = list(ACCESS_BAR)
@@ -790,15 +843,49 @@ Mayor
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		)
 
+/datum/outfit/job/den/f13settler/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	head = pick(/obj/item/clothing/head/f13/ranger_hat/tan,\
+		/obj/item/clothing/head/soft/mime,\
+		/obj/item/clothing/head/soft/black,\
+		/obj/item/clothing/head/soft/grey,\
+		/obj/item/clothing/head/f13/gambler,\
+		/obj/item/clothing/head/f13/cowboy,\
+		/obj/item/clothing/head/f13/ranger_hat/banded,\
+		/obj/item/clothing/head/cowboyhat/white,\
+		/obj/item/clothing/head/beret/headband,\
+		/obj/item/clothing/head/cowboyhat/pink,\
+		/obj/item/clothing/head/f13/police/trooper,\
+		/obj/item/clothing/head/fedora/curator,\
+		/obj/item/clothing/head/fedora/det_hat,\
+		/obj/item/clothing/head/bowler)
+	uniform = pick(
+		/obj/item/clothing/under/f13/gentlesuit,\
+		/obj/item/clothing/under/f13/formal,\
+		/obj/item/clothing/under/f13/spring,\
+		/obj/item/clothing/under/f13/relaxedwear,\
+		/obj/item/clothing/under/f13/machinist,\
+		/obj/item/clothing/under/f13/brahminf,\
+		/obj/item/clothing/under/f13/cowboyb,\
+		/obj/item/clothing/under/f13/cowboyg,\
+		/obj/item/clothing/under/f13/cowboyt)
+
 /datum/outfit/loadout/provisioner
 	name = "Provisioner"
 	neck = /obj/item/clothing/neck/scarf/cptpatriot
 	suit = /obj/item/clothing/suit/jacket/miljacket
 	neck = /obj/item/clothing/ears/headphones
+	gloves = /obj/item/pda
+	shoes = /obj/item/clothing/shoes/f13/explorer
 	uniform = /obj/item/clothing/under/f13/merca
 	gloves = /obj/item/clothing/gloves/f13/leather
 	shoes = /obj/item/clothing/shoes/f13/explorer
 	backpack_contents = list(/obj/item/reagent_containers/food/drinks/flask = 1,
+	/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
+	/obj/item/ammo_box/magazine/m10mm/adv/simple = 1,
+	/obj/item/storage/medical/ancientfirstaid = 1,
+	/obj/item/reagent_containers/food/drinks/flask/survival = 1,
+	/obj/item/book/granter/trait/trekking = 1,
 	/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
 	/obj/item/ammo_box/magazine/m10mm/adv/simple = 1,
 	)
@@ -806,47 +893,68 @@ Mayor
 /datum/outfit/loadout/groundskeeper
 	name = "Groundskeeper"
 	head = /obj/item/clothing/head/soft/grey
-	belt = /obj/item/storage/belt/fannypack
+	belt = /obj/item/storage/belt/utility/waster
 	suit = /obj/item/clothing/under/f13/mechanic
-	gloves = /obj/item/clothing/gloves/color/yellow
-	backpack_contents = list(/obj/item/storage/bag/trash = 1, /obj/item/reagent_containers/spray/cleaner = 1,
-	/obj/item/gun/ballistic/revolver/hobo/piperifle = 1,
-	/obj/item/ammo_box/a556/stripper = 2,
-
+	gloves = /obj/item/clothing/gloves/color/black
+	shoes = /obj/item/clothing/shoes/sneakers/noslip
+	neck = /obj/item/storage/belt/holster/ranger44
+	backpack_contents = list(/obj/item/storage/bag/trash = 1, 
+	/obj/item/reagent_containers/spray/cleaner = 1,
+	/obj/item/mop = 1,
+	/obj/item/reagent_containers/glass/bucket/plastic = 1,
+	/obj/item/broom = 1,
+	/obj/item/stack/sheet/metal/fifty = 1,
+	/obj/item/lightreplacer = 1,
+	/obj/item/reagent_containers/spray/cleaner = 1,
 	)
 
 /datum/outfit/loadout/artisan
 	name = "Artisan"
-	glasses = /obj/item/clothing/glasses/welding
-	suit = /obj/item/clothing/under/f13/petrochico
-	belt = /obj/item/storage/belt/utility
+	uniform = /obj/item/clothing/under/f13/cowboyg
+	belt = /obj/item/storage/belt/mining/alt
 	gloves = /obj/item/clothing/gloves/f13/blacksmith
+	shoes = /obj/item/clothing/shoes/f13/military/leather
+	neck = /obj/item/storage/belt/holster/ranger357 
 	backpack_contents = list(/obj/item/twohanded/sledgehammer/simple = 1,
-	/obj/item/stack/sheet/metal/twenty = 1,
 	/obj/item/book/granter/crafting_recipe/ODF = 1,
+	/obj/item/clothing/glasses/welding = 1,
+	/obj/item/storage/belt/mining/alt = 1,
+	/obj/item/melee/smith/hammer/premade = 1,
+	/obj/item/stack/sheet/mineral/titanium = 15,
+	/obj/item/pickaxe/mini = 1,
+	/obj/item/mining_scanner = 1,
 	)
 
 /datum/outfit/loadout/outdoorsman
 	name = "Outdoorsman"
-	head = /obj/item/clothing/head/f13/beaver
-	suit = /obj/item/clothing/suit/armor/outfit/vest/cowboy
-	belt = /obj/item/storage/belt/bandolier
-	uniform = /obj/item/clothing/under/f13/bartenderalt
-	shoes = /obj/item/clothing/shoes/f13/fancy
-	backpack_contents = list(/obj/item/fishingrod = 1,
-	/obj/item/storage/fancy/cigarettes/cigars = 1,
-	/obj/item/gun/ballistic/revolver/widowmaker = 1,
-	/obj/item/ammo_box/shotgun/buck = 2,
+	head = /obj/item/clothing/head/helmet/f13/marlowhat
+	suit = /obj/item/clothing/suit/armor/light/leather/tanvest
+	belt = /obj/item/melee/onehanded/knife/bowie
+	uniform = /obj/item/clothing/under/f13/cowboyt
+	gloves = /obj/item/clothing/gloves/botanic_leather
+	shoes = /obj/item/clothing/shoes/f13/peltboots
+	backpack_contents = list(/obj/item/gun/ballistic/revolver/winchesterrebored = 1,
+	/obj/item/ammo_box/a762/doublestacked  = 2,
+	/obj/item/fishingrod = 1,
+	/obj/item/binoculars = 1,
+	/obj/item/crafting/campfirekit = 1,
+	/obj/item/storage/fancy/rollingpapers/makeshift =1,
 	)
 
 /datum/outfit/loadout/militia
 	name = "Militia"
 	head = /obj/item/clothing/head/helmet/armyhelmet
 	suit = /obj/item/clothing/suit/armor/medium/vest/breastplate
-	uniform = /obj/item/clothing/under/f13/mercc
+	uniform = /obj/item/clothing/under/f13/combat/militia
 	r_hand = /obj/item/gun/ballistic/rifle/hunting
 	gloves = /obj/item/clothing/gloves/f13/leather
+	shoes = /obj/item/clothing/shoes/f13/military
+	belt = /obj/item/storage/belt/bandolier
 	backpack_contents = list(/obj/item/ammo_box/a308 = 2,
+	/obj/item/shovel/trench =1,
+	/obj/item/binoculars = 1,
+	/obj/item/gun/ballistic/rifle/hunting = 1,
+	/obj/item/attachments/scope = 1,
 	)
 
 /datum/outfit/loadout/singer
@@ -856,10 +964,48 @@ Mayor
 	/obj/item/clothing/under/suit/black_really = 1,
 	/obj/item/clothing/gloves/evening = 1,
 	/obj/item/clothing/gloves/color/white = 1,
-	/obj/item/gun/ballistic/revolver/police = 1,
-	/obj/item/ammo_box/a357 = 2,
+	/obj/item/melee/classic_baton/militarypolice = 1,
+	/obj/item/grenade/smokebomb = 2,
+	/obj/item/clothing/accessory/pocketprotector/full = 1,
+	/obj/item/choice_beacon/music = 1,
+	/obj/item/gun/energy/laser/complianceregulator = 1,
+	/obj/item/stock_parts/cell/ammo/ec = 1,
 	)
 
+// if we ever add back the loadout display you'll have to put the items in places you want it to appear on the display model
+
+/datum/outfit/loadout/farmer
+	name = "Farmer"
+	backpack_contents = list(/obj/item/clothing/head/helmet/f13/brahmincowboyhat = 1,
+	/obj/item/clothing/under/f13/rustic = 1,
+	/obj/item/clothing/suit/armor/light/duster/battlecoat = 1,
+	/obj/item/clothing/gloves/botanic_leather = 1,
+	/obj/item/twohanded/fireaxe= 1,
+	/obj/item/storage/belt/utility/gardener = 1,
+	/obj/item/shovel/spade = 1,
+	/obj/item/cultivator = 1,
+	/obj/item/reagent_containers/glass/bucket/plastic = 1,
+	/obj/item/storage/bag/plants/portaseeder= 1,
+	/obj/item/seeds/bamboo = 1,
+	/obj/item/seeds/apple/gold = 1,
+	/obj/item/seeds/cannabis = 1,
+	)
+
+/datum/outfit/loadout/prospector
+	name = "Prospector"
+	backpack_contents = list(/obj/item/clothing/head/hardhat = 1,
+	/obj/item/clothing/under/overalls = 1,
+	/obj/item/clothing/suit/armor/light/leather/rig = 1,
+	/obj/item/clothing/gloves/patrol = 1,
+	/obj/item/clothing/shoes/workboots = 1,
+	/obj/item/storage/belt/utility/waster  = 1,
+	/obj/item/shovel/spade = 1,
+	/obj/item/pickaxe/silver = 1,
+	/obj/item/clothing/glasses/welding = 1,
+	/obj/item/t_scanner/adv_mining_scanner  = 1,
+	/obj/item/ammo_box/m44 = 2,
+	/obj/item/gun/ballistic/revolver/m29/snub 
+	)
 /*----------------------------------------------------------------
 --							Detective							--
 ----------------------------------------------------------------*/
@@ -955,13 +1101,13 @@ Mayor
 	suit = /obj/item/clothing/suit/armor/outfit/jacket/banker
 	gloves = /obj/item/clothing/gloves/color/white
 	shoes = /obj/item/clothing/shoes/laceup
-	backpack_contents = list(
-	/obj/item/cane=1,
-	/obj/item/gun/ballistic/automatic/hobo/zipgun=1,
-	/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
-	/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
-	/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass=1
-	)
+	backpack_contents = list(/obj/item/cane=1,
+		/obj/item/storage/belt/holster/ranger45 =1,
+		/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+		/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+		/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass=1,
+		/obj/item/lighter/gold = 1,
+		)
 
 /datum/outfit/loadout/loanshark
 	name = "Loanshark"
@@ -970,11 +1116,11 @@ Mayor
 	suit = /obj/item/clothing/suit/armor/outfit/vest
 	uniform = /obj/item/clothing/under/f13/sleazeball
 	shoes = /obj/item/clothing/shoes/sandal
-	backpack_contents = list(
-	/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
-	/obj/item/storage/box/matches=1,
-	/obj/item/gun/ballistic/automatic/smg/mini_uzi=1
-	)
+	backpack_contents = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+		/obj/item/storage/box/matches=1,
+		/obj/item/gun/ballistic/automatic/smg/mini_uzi=1,
+		/obj/item/instrument/violin/golden = 1,
+		)
 
 /datum/outfit/loadout/investor
 	name = "Investor"
@@ -983,10 +1129,10 @@ Mayor
 	uniform = /obj/item/clothing/under/f13/bennys
 	gloves = /obj/item/clothing/gloves/fingerless
 	shoes = /obj/item/clothing/shoes/laceup
-	backpack_contents = list(
-		/obj/item/gun/ballistic/revolver/colt357=1,
-		/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
-		/obj/item/storage/box/matches=1
+	backpack_contents = list(/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+		/obj/item/storage/box/matches=1,
+		/obj/item/ingot/gold = 1,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
 		)
 /*--------------------------------------------------------------*/
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -14,8 +14,8 @@ Raider
 	social_faction = FACTION_RAIDERS
 	total_positions = 16
 	spawn_positions = 16
-	description = "You are an undesirable figure of some kind- the choice of why is up to you. You've decided to become a part of the town of Redwater for one reason or another, or at least feel you can semi-safely call it home. Be you a member of the Redwater Gangs that run the slave trade through the town or a weary exile looking for a way back home you've shacked up in the shanties, and your morals are your own.  Beware, life is cheap in Redwater."
-	supervisors = "The Overboss runs the town, and the Peacekeepers keep it tight... you might want to listen to them. Try to work with other outlaws rather than against them unless there is good reason not to"
+	description = "You are an Outlaw - the choice of why is up to you. You are responsible for making the wasteland unsafe and today is another day to antagonize it. You may be varied in your approaches, but you must have motives that are realistic for your job."
+	supervisors = "your conscious if you have one"
 	selection_color = "#df80af"
 	exp_requirements = 0
 	exp_type = EXP_TYPE_WASTELAND
@@ -60,7 +60,6 @@ Raider
 /datum/outfit/job/wasteland/f13raider
 	name = "Outlaw"
 	jobtype = /datum/job/wasteland/f13raider
-
 	id = null
 	ears = null
 	belt = null
@@ -74,9 +73,8 @@ Raider
 		/obj/item/melee/onehanded/club = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 		/obj/item/storage/bag/money/small/raider = 1,
-		/obj/item/radio/redwater = 1,
+		/obj/item/radio = 1,
 		)
-
 
 /datum/outfit/job/wasteland/f13raider/pre_equip(mob/living/carbon/human/H)
 	. = ..()
@@ -104,6 +102,15 @@ Raider
 			/obj/item/clothing/mask/bandana/gold,\
 			/obj/item/clothing/mask/bandana/black,\
 			/obj/item/clothing/mask/bandana/skull)
+	if(prob(50))
+		neck = pick(
+			/obj/item/clothing/neck/mantle/peltfur,\
+			/obj/item/clothing/neck/mantle/peltmountain,\
+			/obj/item/clothing/neck/mantle/poncho,\
+			/obj/item/clothing/neck/mantle/ragged,\
+			/obj/item/clothing/neck/mantle/brown,\
+			/obj/item/clothing/neck/mantle/gecko,\
+			/obj/item/clothing/neck/garlic_necklace)
 	head = pick(
 		/obj/item/clothing/head/sombrero,\
 		/obj/item/clothing/head/helmet/f13/raider,\
@@ -112,7 +119,31 @@ Raider
 		/obj/item/clothing/head/helmet/f13/raider/blastmaster,\
 		/obj/item/clothing/head/helmet/f13/raider/yankee,\
 		/obj/item/clothing/head/helmet/f13/raider/psychotic,\
-		/obj/item/clothing/head/helmet/f13/fiend)
+		/obj/item/clothing/head/helmet/f13/fiend,\
+		/obj/item/clothing/head/helmet/f13/hoodedmask,\
+			/obj/item/clothing/head/helmet/f13/motorcycle,\
+			/obj/item/clothing/head/helmet/f13/wastewarhat,\
+			/obj/item/clothing/head/helmet/f13/fiend,\
+			/obj/item/clothing/head/f13/bandit,\
+			/obj/item/clothing/head/f13/ranger_hat/banded,\
+			/obj/item/clothing/head/helmet/rus_ushanka,\
+			/obj/item/clothing/head/helmet/skull,\
+			/obj/item/clothing/head/collectable/petehat/gang,\
+			/obj/item/clothing/head/hunter,\
+			/obj/item/clothing/head/rice_hat,\
+			/obj/item/clothing/head/papersack/smiley,\
+			/obj/item/clothing/head/f13/pot,\
+			/obj/item/clothing/head/cone,\
+			/obj/item/clothing/head/kabuto,\
+			/obj/item/clothing/head/cowboyhat/sec,\
+			/obj/item/clothing/head/bomb_hood,\
+			/obj/item/clothing/head/cardborg,\
+			/obj/item/clothing/head/assu_helmet,\
+			/obj/item/clothing/head/chefhat,\
+			/obj/item/clothing/head/beret/headband,\
+			/obj/item/clothing/head/fedora,\
+			/obj/item/clothing/head/bowler,\
+		)
 	shoes = pick(
 			/obj/item/clothing/shoes/jackboots,\
 			/obj/item/clothing/shoes/f13/raidertreads)
@@ -135,7 +166,7 @@ Raider
 	add_verb(H, /mob/living/proc/creategang)
 
 /datum/outfit/loadout/raider_sadist
-	name = "Redwater Slaver"
+	name = "Sadist"
 	suit = /obj/item/clothing/suit/armor/light/raider/sadist
 	head = /obj/item/clothing/head/helmet/f13/raider/arclight
 	backpack_contents = list(
@@ -224,13 +255,13 @@ Raider
 		/obj/item/storage/pill_bottle/happy = 1,
 		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/stack/sheet/mineral/silver=2,
-		/obj/item/defibrillator/primitive=1,
+		/obj/item/clothing/accessory/pocketprotector/full = 1,
 		)
 
 /datum/outfit/loadout/raider_ncr
-	name = "NCR Deserter"
-	suit = /obj/item/clothing/suit/armor/exile/ncrexile
-	uniform = /obj/item/clothing/under/f13/exile
+	name = "Outlaw Ranger"
+	suit = /obj/item/clothing/suit/armor/medium/raider/combatduster 
+	uniform = /obj/item/clothing/under/f13/raider_leather
 	id = /obj/item/card/id/rusted
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/service = 1,
@@ -289,13 +320,14 @@ Raider
 	suit = /obj/item/clothing/suit/armor/medium/vest/bulletproof/big
 	uniform = /obj/item/clothing/under/f13/exile/vault
 	id = /obj/item/card/id/rusted/fadedvaultid
+	gloves = /obj/item/pda
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/smg/smg10mm = 1,
 		/obj/item/ammo_box/magazine/m10mm/adv/ext = 1,
 		)
 
 /datum/outfit/loadout/raider_tribal
-	name = "Sulphur Tribe Outcast"
+	name = "Tribal Outcast"
 	uniform = /obj/item/clothing/under/f13/exile/tribal
 	suit = /obj/item/clothing/suit/hooded/outcast/tribal
 	suit_store = /obj/item/twohanded/spear/bonespear
@@ -304,13 +336,14 @@ Raider
 	box = /obj/item/storage/survivalkit_tribal
 	back = /obj/item/storage/backpack/satchel/explorer
 	backpack_contents = list(
+		/obj/item/book/granter/trait/tribaltraditions =1,
 		/obj/item/clothing/mask/cigarette/pipe = 1,
 		/obj/item/melee/onehanded/knife/bone = 1,
 		/obj/item/book/granter/trait/bigleagues = 1,
 		)
 
-/datum/job/wasteland/f13raider/resident
-	title = "Redwater Resident"
+/datum/job/wasteland/f13raider/watcher
+	title = "Redwater Watcher"
 	flag = F13RAIDER
 	department_head = list("Captain")
 	head_announce = list("Security")
@@ -318,13 +351,13 @@ Raider
 	social_faction = FACTION_RAIDERS
 	total_positions = 10
 	spawn_positions = 10
-	description = "You are an undesirable resident of the bandit town Redwater- the choice of why is up to you. You have taken up the responsibility to protect and supervise the town to ensure that the slaves do not escape and are productive, as well as to protect the towns assets and make sure it has what it needs to thrive. You are only to leave town briefly to gather resources in order to expand and improve upon the current design. Assist the outbound outlaws who venture out for big gains, and protect them if they come home followed by angry victims. Beware, life is cheap in Redwater."
+	description = "You are an Redwater Watcher - the choice of why is up to you. You have taken up the responsibility to protect and supervise the town of Redwater to ensure that the slaves do not escape and are productive, as well as to protect the towns assets and make sure it has what it needs to thrive. You are only to leave town briefly to gather resources in order to expand and improve upon the current design. Assist the outbound outlaws who venture out for big gains, and protect them if they come home followed by angry victims. Beware, life is cheap in Redwater."
 	supervisors = "The Overboss runs the town, and you are responsible for making sure the town maintains a relative peace and order so that more nasty business can occur. Try to work with other outlaws rather than against them unless there is good reason not to"
 	selection_color = "#df80af"
 	exp_requirements = 0
 	exp_type = EXP_TYPE_WASTELAND
 
-	outfit = /datum/outfit/job/wasteland/f13raider/resident
+	outfit = /datum/outfit/job/wasteland/f13raider/watcher
 
 	access = list()
 	minimal_access = list()
@@ -353,11 +386,9 @@ Raider
 	/datum/outfit/loadout/demonness
 	)
 
-
-/datum/outfit/job/wasteland/f13raider/resident
-	name = "Redwater Resident"
-	jobtype = /datum/job/wasteland/f13raider/resident
-
+/datum/outfit/job/wasteland/f13raider/watcher
+	name = "Redwater Watcher"
+	jobtype = /datum/job/wasteland/f13raider/watcher
 	id = null
 	ears = null
 	belt = null
@@ -368,24 +399,34 @@ Raider
 	r_pocket = /obj/item/flashlight/flare
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 2,
-		/obj/item/melee/onehanded/club = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 		/obj/item/storage/bag/money/small/raider = 1,
 		/obj/item/radio/redwater = 1,
 		)
 
-
-/datum/outfit/job/wasteland/f13raider/resident/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/wasteland/f13raider/watcher/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	uniform = pick(
-		/obj/item/clothing/under/f13/merca, \
-		/obj/item/clothing/under/f13/mercc, \
-		/obj/item/clothing/under/f13/cowboyb, \
-		/obj/item/clothing/under/f13/cowboyg, \
-		/obj/item/clothing/under/f13/raider_leather, \
-		/obj/item/clothing/under/f13/raiderrags, \
-		/obj/item/clothing/under/pants/f13/ghoul, \
-		/obj/item/clothing/under/jabroni)
+		/obj/item/clothing/under/f13/bennys,\
+		/obj/item/clothing/under/f13/villain,\
+		/obj/item/clothing/under/f13/shiny,\
+		/obj/item/clothing/under/f13/raiderrags,\
+		/obj/item/clothing/under/f13/worn,\
+		/obj/item/clothing/under/jabroni,\
+		/obj/item/clothing/under/f13/raiderharness,\
+		/obj/item/clothing/under/pants/jeanripped,\
+		/obj/item/clothing/under/f13/rag,\
+		/obj/item/clothing/under/costume/pirate,\
+		/obj/item/clothing/under/costume/mummy,\
+		/obj/item/clothing/under/costume/scarecrow,\
+		/obj/item/clothing/under/f13/sleazeball)
+	suit = pick(
+		/obj/item/clothing/suit/armor/light/raider/supafly,\
+		/obj/item/clothing/suit/armor/medium/raider/yankee, \
+		/obj/item/clothing/suit/armor/light/raider/sadist, \
+		/obj/item/clothing/suit/armor/medium/raider/blastmaster, \
+		/obj/item/clothing/suit/armor/medium/raider/badlands, \
+		/obj/item/clothing/suit/armor/light/raider/painspike)
 	if(prob(10))
 		mask = pick(
 			/obj/item/clothing/mask/bandana/red,\
@@ -396,17 +437,58 @@ Raider
 			/obj/item/clothing/mask/bandana/skull)
 	shoes = pick(
 			/obj/item/clothing/shoes/jackboots,\
+			/obj/item/clothing/shoes/f13/rag,\
+			/obj/item/clothing/shoes/sandal,\
 			/obj/item/clothing/shoes/f13/raidertreads)
-
 	suit_store = pick(
 		/obj/item/gun/ballistic/revolver/detective, \
 		/obj/item/gun/ballistic/automatic/pistol/ninemil,\
 		/obj/item/gun/ballistic/automatic/pistol/m1911, \
 		/obj/item/gun/ballistic/automatic/pistol/type17, \
 		)
+	if(prob(75))
+		head = pick(/obj/item/clothing/head/helmet/f13/hoodedmask,\
+			/obj/item/clothing/head/helmet/f13/motorcycle,\
+			/obj/item/clothing/head/helmet/f13/wastewarhat,\
+			/obj/item/clothing/head/helmet/f13/fiend,\
+			/obj/item/clothing/head/f13/bandit,\
+			/obj/item/clothing/head/f13/ranger_hat/banded,\
+			/obj/item/clothing/head/helmet/rus_ushanka,\
+			/obj/item/clothing/head/helmet/skull,\
+			/obj/item/clothing/head/collectable/petehat/gang,\
+			/obj/item/clothing/head/hunter,\
+			/obj/item/clothing/head/rice_hat,\
+			/obj/item/clothing/head/papersack/smiley,\
+			/obj/item/clothing/head/f13/pot,\
+			/obj/item/clothing/head/cone,\
+			/obj/item/clothing/head/kabuto,\
+			/obj/item/clothing/head/cowboyhat/sec,\
+			/obj/item/clothing/head/bomb_hood,\
+			/obj/item/clothing/head/cardborg,\
+			/obj/item/clothing/head/assu_helmet,\
+			/obj/item/clothing/head/chefhat,\
+			/obj/item/clothing/head/beret/headband,\
+			/obj/item/clothing/head/fedora,\
+			/obj/item/clothing/head/bowler,\
+			/obj/item/clothing/head/sombrero,\
+			/obj/item/clothing/head/helmet/f13/raider,\
+			/obj/item/clothing/head/helmet/f13/raider/eyebot,\
+			/obj/item/clothing/head/helmet/f13/raider/arclight,\
+			/obj/item/clothing/head/helmet/f13/raider/blastmaster,\
+			/obj/item/clothing/head/helmet/f13/raider/yankee,\
+			/obj/item/clothing/head/helmet/f13/raider/psychotic,\
+			/obj/item/clothing/head/helmet/f13/fiend)
+	if(prob(50))
+		neck = pick(
+			/obj/item/clothing/neck/mantle/peltfur,\
+			/obj/item/clothing/neck/mantle/peltmountain,\
+			/obj/item/clothing/neck/mantle/poncho,\
+			/obj/item/clothing/neck/mantle/ragged,\
+			/obj/item/clothing/neck/mantle/brown,\
+			/obj/item/clothing/neck/mantle/gecko,\
+			/obj/item/clothing/neck/garlic_necklace)
 
-
-/datum/outfit/job/wasteland/f13raider/resident/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/wasteland/f13raider/watcher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
@@ -417,7 +499,7 @@ Raider
 
 
 /datum/outfit/loadout/raider_sheriff
-	name = "Redwater Peacekeeper"
+	name = "Peacekeeper"
 	suit = /obj/item/clothing/suit/armor/light/duster/desperado
 	uniform = /obj/item/clothing/under/syndicate/tacticool
 	head = /obj/item/clothing/head/f13/town/big
@@ -434,7 +516,7 @@ Raider
 		/obj/item/card/id/dogtag/sheriff = 1)
 
 /datum/outfit/loadout/raider_mobster
-	name = "Redwater Strongarm"
+	name = "Strongarm"
 	belt = /obj/item/storage/belt/military/assault
 	shoes = /obj/item/clothing/shoes/laceup
 	uniform = /obj/item/clothing/under/f13/densuit
@@ -450,7 +532,7 @@ Raider
 		)
 
 /datum/outfit/loadout/raider_slavekeeper
-	name = "Redwater Slavekeeper"
+	name = "Slavekeeper"
 	belt = /obj/item/storage/belt/bandolier
 	shoes = /obj/item/clothing/shoes/jackboots
 	uniform = /obj/item/clothing/under/costume/pirate
@@ -470,7 +552,7 @@ Raider
 		)
 
 /datum/outfit/loadout/raider_sawbones
-	name = "Redwater Sawbones"
+	name = "Sawbones"
 	belt = /obj/item/storage/belt/military/alt
 	shoes = /obj/item/clothing/shoes/sneakers/noslip
 	uniform = /obj/item/clothing/under/f13/lumberjack
@@ -500,23 +582,23 @@ Raider
 		/obj/item/storage/pill_bottle/happy = 1,
 		/obj/item/book/granter/trait/chemistry = 1,
 		/obj/item/stack/sheet/mineral/silver=2,
-		/obj/item/defibrillator/primitive=1,
+		/obj/item/clothing/accessory/pocketprotector/full = 1,
 		)
 		
 /datum/outfit/loadout/redwater_maintainer
-	name = "Redwater Maintainer"
+	name = "Maintainer"
 	suit = /obj/item/clothing/suit/armor/medium/vest/kevlar
 	head = /obj/item/clothing/head/welding/weldingfire 
 	uniform = /obj/item/clothing/under/syndicate/coldres
-	neck = /obj/item/storage/belt/holster/ranger44
 	belt = /obj/item/storage/belt/utility/full/engi
 	shoes = /obj/item/clothing/shoes/plate
 	backpack_contents = list(
 		/obj/item/stack/sheet/metal/fifty = 1,
 		/obj/item/stack/sheet/glass/fifty = 1,
-		/obj/item/stack/sheet/mineral/titanium = 10,
-		/obj/item/reagent_containers/glass/bottle/blackpowder = 1,
-		/obj/item/ammo_box/m44 = 3,
+		/obj/item/stack/sheet/mineral/titanium = 15,
+		/obj/item/stack/ore/blackpowder/twenty = 1,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1,
+		/obj/item/ammo_box/shotgun/slug = 2
 		)
 
 /datum/outfit/loadout/nefarious_conman
@@ -555,6 +637,281 @@ Raider
 		/obj/item/seeds/cannabis = 1,
 		/obj/item/storage/fancy/rollingpapers = 1,
 		)
+
+/datum/job/wasteland/f13raider/resident
+	title = "Redwater Resident"
+	flag = F13RAIDER
+	department_head = list("Captain")
+	head_announce = list("Security")
+	faction = FACTION_WASTELAND
+	social_faction = FACTION_RAIDERS
+	total_positions = 10
+	spawn_positions = 10
+	description = "You are a Redwater Resident - the choice of why is up to you. You are a squatter who has taken it upon themselves to call Redwater home and be a part of their ecosystem without responsibility. You are not a slave as you have built a good reputation for yourself, however you are not immune from consequences."
+	supervisors = "The Overboss and the Watchers"
+	selection_color = "#df80af"
+	exp_requirements = 0
+	exp_type = EXP_TYPE_WASTELAND
+
+	outfit = /datum/outfit/job/wasteland/f13raider/resident
+
+	access = list()
+	minimal_access = list()
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/patron = list(
+			/datum/job/wasteland/f13raider,
+		),
+		/datum/matchmaking_pref/protegee = list(
+			/datum/job/wasteland/f13raider,
+		),
+		/datum/matchmaking_pref/outlaw = list(
+			/datum/job/wasteland/f13raider,
+		),
+		/datum/matchmaking_pref/bounty_hunter = list(
+			/datum/job/wasteland/f13raider,
+		),
+	)
+	loadout_options = list(
+		/datum/outfit/loadout/tribal_drifter,
+		/datum/outfit/loadout/fish_wrangler,
+		/datum/outfit/loadout/tapster,
+		/datum/outfit/loadout/hospitalier,
+		/datum/outfit/loadout/shepherd,
+		/datum/outfit/loadout/fieldhand,
+		/datum/outfit/loadout/mole,
+		/datum/outfit/loadout/seductress,
+		/datum/outfit/loadout/pilferer,
+		/datum/outfit/loadout/trafficker
+	)
+
+/datum/outfit/job/wasteland/f13raider/resident
+	name = "Redwater Resident"
+	jobtype = /datum/job/wasteland/f13raider/resident
+
+	id = null
+	ears = null
+	belt = null
+	backpack = /obj/item/storage/backpack/satchel/explorer
+	satchel = /obj/item/storage/backpack/satchel/explorer
+	gloves = /obj/item/clothing/gloves/f13/handwraps
+	belt = /obj/item/melee/onehanded/knife/hunting
+	r_pocket = /obj/item/flashlight/flare
+	backpack_contents = list(
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+		/obj/item/storage/bag/money/small/raider = 1,
+		/obj/item/radio/redwater = 1,
+		)
+
+/datum/outfit/job/wasteland/f13raider/resident/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	uniform = pick(
+			/obj/item/clothing/under/f13/bennys,\
+			/obj/item/clothing/under/f13/villain,\
+			/obj/item/clothing/under/f13/shiny,\
+			/obj/item/clothing/under/rank/prisoner,\
+			/obj/item/clothing/under/f13/raiderrags,\
+			/obj/item/clothing/under/f13/worn,\
+			/obj/item/clothing/under/jabroni,\
+			/obj/item/clothing/under/f13/raiderharness,\
+			/obj/item/clothing/under/pants/jeanripped,\
+			/obj/item/clothing/under/f13/rag,\
+			/obj/item/clothing/under/costume/mummy,\
+			/obj/item/clothing/under/costume/scarecrow,\
+			/obj/item/clothing/under/misc/gear_harness,\
+			/obj/item/clothing/under/f13/sleazeball,\
+			/obj/item/clothing/under/costume/pirate)
+	if(prob(75))
+		head = pick(/obj/item/clothing/head/helmet/f13/hoodedmask,\
+			/obj/item/clothing/head/helmet/f13/motorcycle,\
+			/obj/item/clothing/head/helmet/f13/wastewarhat,\
+			/obj/item/clothing/head/helmet/f13/fiend,\
+			/obj/item/clothing/head/f13/bandit,\
+			/obj/item/clothing/head/f13/ranger_hat/banded,\
+			/obj/item/clothing/head/helmet/rus_ushanka,\
+			/obj/item/clothing/head/helmet/skull,\
+			/obj/item/clothing/head/collectable/petehat/gang,\
+			/obj/item/clothing/head/hunter,\
+			/obj/item/clothing/head/rice_hat,\
+			/obj/item/clothing/head/papersack/smiley,\
+			/obj/item/clothing/head/f13/pot,\
+			/obj/item/clothing/head/cone,\
+			/obj/item/clothing/head/kabuto,\
+			/obj/item/clothing/head/cowboyhat/sec,\
+			/obj/item/clothing/head/bomb_hood,\
+			/obj/item/clothing/head/cardborg,\
+			/obj/item/clothing/head/assu_helmet,\
+			/obj/item/clothing/head/chefhat,\
+			/obj/item/clothing/head/beret/headband,\
+			/obj/item/clothing/head/fedora,\
+			/obj/item/clothing/head/bowler)
+	shoes = pick(
+			/obj/item/clothing/shoes/sneakers/brown,\
+			/obj/item/clothing/shoes/f13/rag,\
+			/obj/item/clothing/shoes/sandal,\
+			/obj/item/clothing/shoes/f13/raidertreads)
+	if(prob(50))
+		neck = pick(
+			/obj/item/clothing/neck/mantle/peltfur,\
+			/obj/item/clothing/neck/mantle/peltmountain,\
+			/obj/item/clothing/neck/mantle/poncho,\
+			/obj/item/clothing/neck/mantle/ragged,\
+			/obj/item/clothing/neck/mantle/brown,\
+			/obj/item/clothing/neck/mantle/gecko,\
+			/obj/item/clothing/neck/garlic_necklace)
+	suit = pick(
+			/obj/item/clothing/suit/armor/light/kit/punk, \
+			/obj/item/clothing/suit/armor/light/kit/shoulder, \
+			/obj/item/clothing/suit/armor/light/kit)	
+
+/datum/outfit/job/wasteland/f13raider/resident/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	ADD_TRAIT(H, TRAIT_LONGPORKLOVER, src)
+
+	H.social_faction = FACTION_RAIDERS
+	add_verb(H, /mob/living/proc/creategang)
+
+
+/datum/outfit/loadout/tribal_drifter
+	name = "Tribal Drifter"
+	uniform = /obj/item/clothing/under/pants/f13/ghoul 
+	head = /obj/item/clothing/head/f13/headscarf
+	shoes = /obj/item/clothing/shoes/f13/rag
+	belt = /obj/item/melee/onehanded/machete/forgedmachete
+	gloves = /obj/item/clothing/gloves/bracer
+	l_hand = /obj/item/twohanded/spear/bonespear
+	neck = /obj/item/clothing/neck/mantle/ragged
+	backpack_contents = list(
+	/obj/item/book/granter/trait/tribaltraditions = 1,
+	/obj/item/book/granter/trait/selection/tribal = 1,
+	/obj/item/shovel/serrated = 1,)
+
+/datum/outfit/loadout/fish_wrangler
+	name = "Fish Wrangler"
+	backpack_contents = list(
+		/obj/item/binoculars = 1,
+		/obj/item/fishingrod = 1,
+		/obj/item/crowbar/smithedunitool = 1,
+		/obj/item/gun/ballistic/revolver/winchesterrebored = 1,
+		/obj/item/ammo_box/a762/doublestacked = 2,
+		/obj/item/clothing/under/f13/worn = 1,
+		/obj/item/clothing/head/f13/gambler = 1,
+		/obj/item/clothing/shoes/galoshes  = 1,
+		/obj/item/clothing/gloves/f13/leather = 1,)
+
+/datum/outfit/loadout/tapster
+	name = "Tapster"
+	backpack_contents = list(
+		/obj/item/choice_beacon/ingredients = 1,
+		/obj/item/reagent_containers/food/drinks/shaker = 1,
+		/obj/item/book/granter/action/drink_fling = 1,
+		/obj/item/reagent_containers/spray/cleaner = 1,
+		/obj/item/storage/belt/holster/legholster/police = 1,
+		/obj/item/clothing/under/f13/sleazeball = 1, 
+		/obj/item/clothing/head/bowler = 1,
+		/obj/item/clothing/shoes/laceup = 1,
+		/obj/item/clothing/gloves/rifleman = 1,
+		/obj/item/lighter/gold = 1,
+		)
+
+/datum/outfit/loadout/hospitalier
+	name = "Hospitalier"
+	backpack_contents = list(
+		/obj/item/book/granter/trait/medical = 1,
+		/obj/item/storage/medical/ancientfirstaid = 1,
+		/obj/item/storage/briefcase/medical  = 1,
+		/obj/item/storage/belt/holster/full = 1,
+		/obj/item/clothing/under/pants/tan = 1,
+		/obj/item/clothing/head/fedora/curator = 1,
+		/obj/item/clothing/shoes/cowboyboots/black = 1,
+		/obj/item/clothing/gloves/f13/crudemedical = 1,
+		)
+
+/datum/outfit/loadout/shepherd
+	name = "Shepherd"
+	backpack_contents = list(
+		/obj/item/storage/fancy/candle_box = 1,
+		/obj/item/reagent_containers/food/drinks/bottle/holywater = 1,
+		/obj/item/storage/bag/tribe_quiver = 1,
+		/obj/item/gun/ballistic/bow/crossbow = 1,
+		/obj/item/clothing/suit/bio_suit/plaguedoctorsuit = 1,
+		/obj/item/clothing/head/fluff/bandit = 1,
+		/obj/item/clothing/shoes/f13/fancy = 1,
+		/obj/item/clothing/gloves/evening/black = 1,
+		)
+		
+/datum/outfit/loadout/fieldhand
+	name = "Fieldhand"
+	backpack_contents = list(
+		/obj/item/reagent_containers/glass/bottle/nutrient/l4z = 1,
+		/obj/item/seeds/cannabis = 1,
+		/obj/item/shovel/trench = 1,
+		/obj/item/cultivator/rake = 1,
+		/obj/item/gun/ballistic/revolver/single_shotgun = 1,
+		/obj/item/ammo_box/shotgun/buck = 1,
+		/obj/item/clothing/under/f13/jamrock = 1,
+		/obj/item/clothing/head/scarecrow_hat = 1,
+		/obj/item/clothing/shoes/winterboots  = 1,
+		/obj/item/clothing/gloves/botanic_leather = 1,
+		)
+
+/datum/outfit/loadout/mole
+	name = "Mole"
+	backpack_contents = list(
+		/obj/item/book/granter/crafting_recipe/scav_one = 1,
+		/obj/item/pickaxe/mini = 1,
+		/obj/item/weldingtool/largetank = 1,
+		/obj/item/storage/belt/utility = 1, 
+		/obj/item/gun/ballistic/automatic/pistol/type17 = 1, 
+		/obj/item/ammo_box/magazine/m10mm/adv/simple = 2,
+		/obj/item/clothing/under/rank/civilian/curator/treasure_hunter = 1, 
+		/obj/item/clothing/head/radiation = 1,
+		/obj/item/clothing/glasses/welding = 1,
+		/obj/item/clothing/shoes/workboots/mining = 1,
+		/obj/item/clothing/gloves/legion/forgemaster = 1,
+		)
+
+/datum/outfit/loadout/seductress
+	name = "Seductress"
+	backpack_contents = list(
+		/obj/item/grenade/homemade/firebomb = 1,
+		/obj/item/bong/coconut = 1,
+		/obj/item/reagent_containers/glass/bottle/chloralhydrate = 1,
+		/obj/item/melee/classic_baton/telescopic = 1,
+		/obj/item/clothing/under/shorts/jeanbshorts = 1,
+		/obj/item/clothing/head/f13/trilby = 1,
+		/obj/item/clothing/shoes/f13/diesel/alt = 1,
+		/obj/item/clothing/gloves/combat = 1,
+		)
+
+/datum/outfit/loadout/pilferer
+	name = "Pilferer"
+	backpack_contents = list(
+		/obj/item/grenade/smokebomb = 2,
+		/obj/item/melee/onehanded/knife/throwing = 2,
+		/obj/item/storage/backpack/satchel/flat = 1,
+		/obj/item/melee/onehanded/knife/trench = 1,
+		/obj/item/clothing/under/syndicate/tacticool = 1,
+		/obj/item/clothing/mask/balaclava = 1,
+		/obj/item/clothing/shoes/f13/diesel = 1,
+		/obj/item/clothing/gloves/thief = 1,
+		)
+/datum/outfit/loadout/trafficker // https://youtu.be/9jROV2H9Sw0
+	name = "Trafficker"
+	backpack_contents = list(
+		/obj/item/reagent_containers/pill/patch/jet = 1, 
+		/obj/item/reagent_containers/hypospray/medipen/medx = 1,
+		/obj/item/reagent_containers/hypospray/medipen/psycho = 1, 
+		/obj/item/storage/fancy/cigarettes/cigpack_cannabis = 2, 
+		/obj/item/storage/belt/holster/ranger357 = 1, 
+		/obj/item/clothing/under/pants/f13/warboy = 1, 
+		/obj/item/clothing/suit/hooded/parka/grey = 1, 
+		/obj/item/clothing/shoes/f13/peltboots = 1, 
+		/obj/item/melee/unarmed/sappers = 1, 
+		)
+
+
 
 /datum/job/wasteland/f13wastelander
 	title = "Wastelander"
@@ -1875,7 +2232,7 @@ datum/job/wasteland/f13dendoctor
 	description = "Either you were captured by the Redwater slavers, or born into servitude.  Either way your life has been one of being treated as property to another human since the explosive collar was fitted to your neck.  Freedom feels like a dream long gone, hidden behind the fear of the signaler that would cause your head to sail off in an arc.  Despite that you've found a place in their society, and are a protected commodity.  Be you a field worker, sex slave, or pack mule.  The good news is, as long as you serve a purpose then you'll probably get to live, and being alive means a chance to escape."
 	selection_color = "#dcba97"
 
-	outfit = /datum/outfit/loadout/redwatersalve
+	outfit = /datum/outfit/loadout/redwaterslave
 
 	loadout_options = list(
 	/datum/outfit/loadout/worker,	//Fields or the bar, this is just a generic workman/woman.
@@ -1907,7 +2264,7 @@ datum/job/wasteland/f13dendoctor
 		),
 	)
 
-/datum/outfit/loadout/redwatersalve
+/datum/outfit/loadout/redwaterslave
 	name = "Redwater Slave"
 	uniform = /obj/item/clothing/under/f13/rag
 	back = /obj/item/storage/backpack/satchel/explorer
@@ -1916,6 +2273,11 @@ datum/job/wasteland/f13dendoctor
 	backpack_contents =  list(
 		/obj/item/reagent_containers/pill/healingpowder =1)
 
+/datum/outfit/job/wastelander/f13redwaterslave/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	if(prob(10))
+		head = pick(/obj/item/clothing/head/f13/servant,\
+			/obj/item/clothing/head/f13/hairband)
 
 //Worker
 /datum/outfit/loadout/worker
@@ -1961,6 +2323,13 @@ datum/job/wasteland/f13dendoctor
 //Redwater Resident Spawn Point code
 /obj/effect/landmark/start/redwaterResident
 	name = "Redwater Resident"
+	icon_state = "Wastelander"
+	jobspawn_override = TRUE
+	delete_after_roundstart = FALSE
+
+//Redwater Watcher Spawn Point code
+/obj/effect/landmark/start/redwaterwatcher
+	name = "Redwater Watcher"
 	icon_state = "Wastelander"
 	jobspawn_override = TRUE
 	delete_after_roundstart = FALSE

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -156,8 +156,8 @@ GLOBAL_LIST_INIT(oasis_positions, list(
 	"Secretary",
 	"Sheriff",
 	"Deputy",
-	"Farmer",
-	"Prospector",
+//	"Farmer",
+//	"Prospector",
 	"Doctor",
 	"Detective",
 	"Banker",
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
 	"Den Mob Boss",
 	"Den Mob Enforcer",
 	"Den Doctor",
-//	"Outlaw",
+	"Outlaw",
 	"Faithful",
 	"Vigilante",
 	"Preacher",
@@ -242,8 +242,9 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
 
 GLOBAL_LIST_INIT(redwater_positions, list(
 	"Redwater Slave",
-	"Outlaw",
+//	"Outlaw",
 	"Redwater Resident",
+	"Redwater Watcher",
 	"Redwater Overboss",
 ))
 


### PR DESCRIPTION
MINOR TWEAKS

/obj/item/clothing/suit/armor/light/leather/rig
- Added 4 small pockets
- Fixed the description

/obj/item/clothing/suit/armor/medium/duster
- The bullet armor wasnt good, so I changed it to be better for PVP combat.

/obj/item/clothing/shoes/galoshes

Removed slowdown

/obj/item/clothing/head/f13/flatranger
- Changed name and description, one of many NCR items that need to be reworked

OASIS LOADOUT CHANGES

MAYOR

no longer has shit guns that make no sense between loadouts and other jobs. It is a command position, and as such they have access to higher tier side arm weapons.

Frontier Leader = from Snub to Peacekeeper
First Citizen = From AEP7 to Auto Beretta
High Roller = From Type 17 (???????????????) to MK23
Mayor for Life keeps their custom M1911, its a really good gun

SECRETARY

- Removed trait selection book. Sorry, it just doesnt make sense and need the handspace for loadout icon and suitcase. Good news is now Secretaries have access to loadout choices.

SHERIFF

The Law Man
- Changed uniform to formal police uniform
- Removed peacekeeper, replaced with a holstered 45 APC revolver
- Gave military plated boots
- Gave scope

The Chief
- Gave them the Chief under instead of police formal
- They now have a 45 APC revolver holstered with ammo
- They now have combat boots with actual armor values, why they gave jackboots previously idk
- AEP9 has been replaced with a city killer shotgun.

- Unused loadout commented out

https://i.imgur.com/HDMg6WG.png

DEPUTY

- I didnt really wanna touch this too much beause I will ultimately nerf it. I'm looking at you Nash SWAT loadout, mk12 and a fully automatic assault rifle. But yeah I'll have to get to this another time.

- Removed the extra bulletproof vest, they dont need 2

PROSPECTOR AND FARMER

- Commented out entirely and integrated with better loadouts into the Citizen role.

TOWN DOCTOR

Town Doctors now have actual loadouts that are robust and bring value to the hospital. Check them out in this pic below:

https://i.imgur.com/7Ie0VR3.png

They have been given more ways to defend themselves, but limited ammo so they dont uhh you know become combat town doctor.

CITIZENS

All loadouts have been updated and given a LOT more value. Unfortunately I do not have an updated picture to show everything cohesively, you'll have to see through code what I did.

They have been entirely reworked so that they have balance and provide value to the town and players experience no matter your playstyle.

- I also added a bunch of randomizers for what they start out with in terms of uniform and hat.

BANKER

- They had unbalanced weapons between loadouts and lacked flavor, so I didnt want to do too much. I upgraded the guns and added a flavor item to each.

Classy = 45 revolver holster and a golden lighter
Loanshark = Golden violin, they get to keep their Uzi
Investor = Gold ignot and lever action shotgun

LOADOUT CHANGES FOR REDWATER

- Outlaws have been removed from Redwater not on the map but in the join selection screen (I dont want any map merge errors, it can be done on another PR)

- Outlaws description changed from
"You are an undesirable figure of some kind- the choice of why is up to you. You've decided to become a part of the town of Redwater for one reason or another, or at least feel you can semi-safely call it home. Be you a member of the Redwater Gangs that run the slave trade through the town or a weary exile looking for a way back home you've shacked up in the shanties, and your morals are your own.  Beware, life is cheap in Redwater."

to

"You are an Outlaw - the choice of why is up to you. You are responsible for making the wasteland unsafe and today is another day to antagonize it. You may be varied in your approaches, but you must have motives that are realistic for your job."

- Changed their radio to a normal one, not a redwater one for now

- Made it so 50% chance to get a neck item like a cape or poncho

- Updated random helmets you can get so that there is a higher variaton

- Updated all Outlaw loadouts names so they are more consistent and not so Redwater based

- Added pocketprotector to Quack Doctor loadout

- Changed NCR deserter to Outlaw Ranger and changed their clothes/armor

- Gave vault renegade a pipboy

- Changed Sulphur Tribe Outcast to 'Tribal Outcast' and gave them a Tribal Traditions skillgranter book

REDWATER WATCHERS

New-ish job that replaces the CURRENT Redwater Residents mean to be the people who maintain the town, whether that means guarding it, making sure slaves are productive, keeping up with the hospital, etc

- Fixed desc to make it fit
- Gave them randomizing uniform/suit/shoes/neck/hats that are redwater flavored

- Shrunk down the loadout names to keep them simple

- Fixed up some loadout stuff for Maintainer, gave them a lever action shotgun bumped their titanium up to 15 and gave them actual blackpowder instead of a scrawny bottle.

REDWATER RESIDENT

NEWWWWW JOB

	description = "You are a Redwater Resident - the choice of why is up to you. You are a squatter who has taken it upon themselves to call Redwater home and be a part of their ecosystem without responsibility. You are not a slave as you have built a good reputation for yourself, however you are not immune from consequences."

		/datum/outfit/loadout/tribal_drifter,
		/datum/outfit/loadout/fish_wrangler,
		/datum/outfit/loadout/tapster,
		/datum/outfit/loadout/hospitalier,
		/datum/outfit/loadout/shepherd,
		/datum/outfit/loadout/fieldhand,
		/datum/outfit/loadout/mole,
		/datum/outfit/loadout/seductress,
		/datum/outfit/loadout/pilferer,
		/datum/outfit/loadout/trafficker

Had a lot of fun putting this together, this job gets a full suite of attention which should encourage players to give it a spin, despite it being at a lower power level than Nash citizen. The chance for better helmet armor is present, pretty much if you wanted to be a squatter over in Redwater, take a break from the other redwater roles and have a low stress round, want to help do the farm without being a slave, etc, this job has a lot of options for players to explore.

Unfortunately do not have an updated picture of the loadouts, you'll have to look in the code.

REDWATER SLAVE

- Very subtle, 10 percent probability to get a hairband or servant hat. Seemed like the right thing to do.

- Fixed coding typo

JOBS.DM

Commented out farmer and prospector, moved Outlaw out of Redwater slot, and added Redwater Watchers

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
