### PR TITLE
Legion bandanas renamed and put into loadout

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -417,9 +417,9 @@
 /obj/item/clothing/mask/ncr_facewrap/attack_self(mob/user)
 	adjustmask(user)
 
-///////////////////
-//LEGION BANDANAS//
-///////////////////
+/////////////////////
+//"LEGION" BANDANAS//
+/////////////////////
 
 /obj/item/clothing/mask/bandana/legion
 	name = "legion mask template"
@@ -432,13 +432,13 @@
 	actions_types = list(/datum/action/item_action/adjust)
 
 /obj/item/clothing/mask/bandana/legion/camp
-	name = "camp duty bandana"
-	desc = "Simple black cloth intended for men on camp duty."
+	name = "desperado bandana"
+	desc = "Simple black cloth normally used by desperados"
 	icon_state = "legaux"
 
 /obj/item/clothing/mask/bandana/legion/legrecruit
-	name = "recruit bandana"
-	desc = "A coarse dark recruit bandana."
+	name = "thieves bandana"
+	desc = "A coarse dark thieves bandana."
 	icon_state = "legrecruit"
 
 /obj/item/clothing/mask/bandana/legion/legprime
@@ -447,20 +447,20 @@
 	icon_state = "legdecan"
 
 /obj/item/clothing/mask/bandana/legion/legvet
-	name = "veteran bandana"
-	desc = "A veterans bandana in red."
+	name = "bandito bandana"
+	desc = "A banditos bandana in red."
 	icon_state = "legvet"
 
 /obj/item/clothing/mask/bandana/legion/legdecan
-	name = "decanus bandana"
-	desc = "A fine decan bandana in dark red."
+	name = "outlaw bandana"
+	desc = "A fine bandana in dark red."
 	icon = 'icons/fallout/clothing/masks.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/mask.dmi'
 	icon_state = "legdecan"
 
 /obj/item/clothing/mask/bandana/legion/legcenturion
-	name = "centurion bandana"
-	desc = "A high quality bandana made for a centurion."
+	name = "overboss bandana"
+	desc = "A high quality bandana made for a overboss."
 	icon_state = "legcenturion"
 
 

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -110,6 +110,28 @@
 	path = /obj/item/clothing/mask/bandana/momentobandana
 	cost = 2
 
+/datum/gear/mask/bandana/outlaw
+	name = "outlaw bandana"
+	path = /obj/item/clothing/mask/bandana/legion/legdecan
+	cost = 2
+
+/datum/gear/mask/bandana/bandito 
+	name = "bandito bandana"
+	path = /obj/item/clothing/mask/bandana/legion/legvet
+	cost = 2
+
+/datum/gear/mask/bandana/thieves
+	name = "thieves bandana"
+	path = /obj/item/clothing/mask/bandana/legion/legrecruit
+	cost = 2
+
+/datum/gear/mask/bandana/desperado
+	name = "desperado bandana"
+	path = /obj/item/clothing/mask/bandana/legion/camp
+	cost = 2
+
+/// Misc
+
 /datum/gear/mask/moustache
 	name = "fake moustache"
 	path = /obj/item/clothing/mask/fakemoustache


### PR DESCRIPTION
## About The Pull Request
This PR renames the legion bandanas and puts it under the loadout menu so that way people can use them instead of them sitting in code.
![image](https://user-images.githubusercontent.com/29418371/182474618-8aedca50-b62b-4c41-b403-2bc31249b985.png)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: rename bandanas
add: adding them into loadout menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
