### PR TITLE
*me gets multiline support that doesnt ruin everything

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,14 +1,14 @@
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
-	act = lowertext(act)
+	var/input_text = lowertext(act)
 	var/param = message
-	var/custom_param = findchar(act, " ")
+	var/custom_param = findchar(input_text, " ")
 	if(custom_param)
 		param = copytext(act, custom_param + length(act[custom_param]))
-		act = copytext(act, 1, custom_param)
+		input_text = copytext(input_text, 1, custom_param)
 
 	var/datum/emote/E
-	E = E.emote_list[act]
+	E = E.emote_list[input_text]
 	if(!E)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 		return

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -436,6 +436,7 @@
 	key = "me"
 	key_third_person = "custom"
 	message = null
+	emote_type = EMOTE_VISIBLE
 
 /datum/emote/living/custom/proc/check_invalid(mob/user, input)
 	if(stop_bad_mime.Find(input, 1, 1))
@@ -454,16 +455,11 @@
 		return FALSE
 	else if(!params)
 		var/custom_emote = stripped_multiline_input_or_reflect(user, "Choose an emote to display.", "Custom Emote", null, MAX_MESSAGE_LEN)
-		if(custom_emote && !check_invalid(user, custom_emote))
-			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
-			switch(type)
-				if("Visible")
-					emote_type = EMOTE_VISIBLE
-				if("Hearable")
-					emote_type = EMOTE_AUDIBLE
-				else
-					return
-			message = custom_emote
+		if(!custom_emote)
+			return FALSE
+		if(check_invalid(user, custom_emote))
+			return FALSE
+		message = custom_emote
 	else
 		message = params
 		if(type_override)
@@ -471,7 +467,6 @@
 	message = user.say_emphasis(message)
 	. = ..()
 	message = null
-	emote_type = EMOTE_VISIBLE
 
 /datum/emote/living/custom/replace_pronoun(mob/user, message)
 	return message
@@ -1149,7 +1144,7 @@ GLOBAL_LIST_INIT(special_phrases, list(
 		return FALSE
 
 	var/special_noun = null
-	var/special_phrase_input = special_override ? special_override : params
+	var/special_phrase_input = special_override ? special_override : lowertext(params)
 
 	for(var/which_special in GLOB.special_skill_list)
 		/// if the thing we said after the emote is in one of these lists, pick the corresponding key

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -7,7 +7,7 @@
 	display_typing_indicator()
 	var/message = input(usr, "", "say") as text|null
 	// If they don't type anything just drop the message.
-	clear_typing_indicator()		// clear it immediately!
+	clear_typing_indicator()
 	if(!length(message))
 		return
 	return say_verb(message)
@@ -17,10 +17,10 @@
 	set category = "IC"
 	if(!length(message))
 		return
-	if(GLOB.say_disabled)	//This is here to try to identify lag problems
+	if(GLOB.say_disabled)
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
-	clear_typing_indicator()		// clear it immediately!
+	clear_typing_indicator()
 	say(message)
 
 /mob/verb/me_typing_indicator()
@@ -28,19 +28,22 @@
 	set hidden = TRUE
 	set category = "IC"
 	display_typing_indicator()
-	var/message = input(usr, "", "me") as message|null
+	var/message = stripped_multiline_input_or_reflect(usr, "", "me")
 	// If they don't type anything just drop the message.
-	clear_typing_indicator()		// clear it immediately!
+	clear_typing_indicator()
+	if(GLOB.say_disabled)
+		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
+		return
 	if(!length(message))
 		return
-	return me_verb(message)
+	usr.emote("me",1,message,TRUE)
 
 /mob/verb/me_verb(message as message)
 	set name = "me"
 	set category = "IC"
 	if(!length(message))
 		return
-	if(GLOB.say_disabled)	//This is here to try to identify lag problems
+	if(GLOB.say_disabled)
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	


### PR DESCRIPTION
## About The Pull Request
You can put line breaks in standard custom emotes, so you can have paragraphs in your *me posts.

Also allows capitalization in inline *me emotes. So you can do '*me waves to YOU FUCKASSS' and have it show up correctly.

No longer breaks everything! Message input verbs suuuuuuuck!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added linebreaks to *me.
fix: Inline *me emotes now get their capitalization.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
