### PR TITLE
moves outlaw back under 'redwater'

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
 	"Den Mob Boss",
 	"Den Mob Enforcer",
 	"Den Doctor",
-	"Outlaw",
+//	"Outlaw",
 	"Faithful",
 	"Vigilante",
 	"Preacher",
@@ -242,7 +242,7 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
 
 GLOBAL_LIST_INIT(redwater_positions, list(
 	"Redwater Slave",
-//	"Outlaw",
+	"Outlaw",
 	"Redwater Resident",
 	"Redwater Watcher",
 	"Redwater Overboss",


### PR DESCRIPTION
## About The Pull Request
Moves outlaw back under 'redwater' in spawn menu to reflect their alleigances.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: moves outlaw back to redwater under spawn menu for clarity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
