### PR TITLE
Adds backpack to the backpack section

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -159,10 +159,14 @@ GLOBAL_LIST_INIT(security_depts_prefs, list(SEC_DEPT_RANDOM, SEC_DEPT_NONE, SEC_
 #define DDUFFELBAG "Department Duffel Bag"
 GLOBAL_LIST_INIT(backbaglist, list(DBACKPACK, DSATCHEL, DDUFFELBAG, //everything after this point is a non-department backpack
 	"Hiking Backpack" = /obj/item/storage/backpack,
-	"Grey Satchel" = /obj/item/storage/backpack/satchel,
+	"Service Backpack" = /obj/item/storage/backpack/enclave,
 	"Grey Duffel Bag" = /obj/item/storage/backpack/duffelbag,
+	"Grey Satchel" = /obj/item/storage/backpack/satchel,
 	"Leather Satchel" = /obj/item/storage/backpack/satchel/leather,
-	"Bone Satchel" = /obj/item/storage/backpack/satchel/bone,))
+	"Bone Satchel" = /obj/item/storage/backpack/satchel/bone,
+	"Old Satchel" = /obj/item/storage/backpack/satchel/old,
+	"Service Satchel" = /obj/item/storage/backpack/satchel/enclave
+	))
 
 //Suit/Skirt
 #define PREF_SUIT "Jumpsuit"

--- a/modular_citadel/code/modules/client/loadout/hands.dm
+++ b/modular_citadel/code/modules/client/loadout/hands.dm
@@ -57,34 +57,6 @@
 	path = /obj/item/storage/toolbox/mechanical/old
 	cost = 2
 
-/datum/gear/hands/backpack/legionr
-	name = "legion red cape backpack"
-	path = /obj/item/storage/backpack/legionr
-	cost = 2
-	restricted_desc = "Legion Veteran+"
-	restricted_roles = list("Legion Orator",
-							"Legion Centurion",
-							"Legion Veteran Decanus",
-							"Legion Prime Decanus",
-							"Legion Recruit Decanus",
-							"Legion Vexillarius",
-							"Veteran Legionnaire"
-						)
-
-/datum/gear/hands/backpack/legionb
-	name = "legion black cape backpack"
-	path = /obj/item/storage/backpack/legionb
-	cost = 2
-	restricted_desc = "Legion Veteran+"
-	restricted_roles = list("Legion Orator",
-							"Legion Centurion",
-							"Legion Veteran Decanus",
-							"Legion Prime Decanus",
-							"Legion Recruit Decanus",
-							"Legion Vexillarius",
-							"Veteran Legionnaire"
-						)
-
 /datum/gear/hands/cane
 	name = "cane"
 	path = /obj/item/cane


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/29418371/182493256-1a1b875b-5de8-4e65-b9f3-e2685a27bb48.png)
So that way I dont use three points on a backpack and I can spawn with it as my backpack instead of having a backpack within a backpack.
Remove the legion backpack from the loadout menu.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: backpack to backpain menu in a way.
remove: legion backpack from the lloadout menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
