### PR TITLE
Update game_options.txt & more

### DIFF
--- a/code/modules/arousal/genitals_sprite_accessories.dm
+++ b/code/modules/arousal/genitals_sprite_accessories.dm
@@ -62,7 +62,11 @@
 
 /datum/sprite_accessory/testicles/single
 	icon_state = "single"
-	name = "Single" //Single as "single pair", for clarity.
+	name = "Pair of testicles" //Clarifies it for something else
+
+/datum/sprite_accessory/testicles/sheath
+	icon_state = "single"
+	name = "Sheath"
 
 //Vaginas
 /datum/sprite_accessory/vagina

--- a/code/modules/arousal/organs/testicles.dm
+++ b/code/modules/arousal/organs/testicles.dm
@@ -40,10 +40,11 @@
 
 /obj/item/organ/genital/testicles/update_appearance()
 	. = ..()
-	desc = "You see an [size_name] pair of testicles."
 	var/datum/sprite_accessory/S = GLOB.balls_shapes_list[shape]
 	var/icon_shape = S ? S.icon_state : "single"
 	icon_state = "testicles_[icon_shape]_[size]"
+	var/lowershape = lowertext(shape)
+	desc = "You see an [size_name] [lowershape]."
 	if(owner)
 		if(owner.dna.species.use_skintones)
 			if(ishuman(owner)) // Check before recasting type, although someone fucked up if you're not human AND have use_skintones somehow...

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -706,6 +706,7 @@ Records disabled until a use for them is found
 					dat += "<b>Has Testicles:</b><a style='display:block;width:50px' href='?_src_=prefs;preference=has_balls'>[features["has_balls"] == TRUE ? "Yes" : "No"]</a>"
 					if(features["has_balls"])
 						if(!pref_species.use_skintones)
+							dat += "<b>Testicles Type:</b> <a style='display:block;width:100px' href='?_src_=prefs;preference=balls_shape;task=input'>[features["balls_shape"]]</a>"
 							dat += "<b>Testicles Color:</b></a><BR>"
 							dat += "<span style='border: 1px solid #161616; background-color: #[features["balls_color"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=balls_color;task=input'>Change</a><br>"
 						dat += "<b>Testicles Visibility:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=balls_visibility;task=input'>[features["balls_visibility"]]</a>"
@@ -713,7 +714,7 @@ Records disabled until a use for them is found
 				dat += "<h3>Vagina</h3>"
 				dat += "<a style='display:block;width:50px' href='?_src_=prefs;preference=has_vag'>[features["has_vag"] == TRUE ? "Yes": "No" ]</a>"
 				if(features["has_vag"])
-					dat += "<b>Vagina Type:</b> <a style='display:block;width:100px' href='?_ssrc_=prefs;preference=vag_shape;task=input'>[features["vag_shape"]]</a>"
+					dat += "<b>Vagina Type:</b> <a style='display:block;width:100px' href='?_src_=prefs;preference=vag_shape;task=input'>[features["vag_shape"]]</a>"
 					if(!pref_species.use_skintones)
 						dat += "<b>Vagina Color:</b></a><BR>"
 						dat += "<span style='border: 1px solid #161616; background-color: #[features["vag_color"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=vag_color;task=input'>Change</a><br>"
@@ -2233,6 +2234,12 @@ Records disabled until a use for them is found
 							features["balls_color"] = sanitize_hexcolor(new_ballscolor, 6)
 						else
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
+
+				if("balls_shape")
+					var/new_shape
+					new_shape = input(user, "Balls Shape", "Character Preference") as null|anything in GLOB.balls_shapes_list
+					if(new_shape)
+						features["balls_shape"] = new_shape
 
 				if("balls_visibility")
 					var/n_vis = input(user, "Testicles Visibility", "Character Preference") as null|anything in CONFIG_GET(keyed_list/safe_visibility_toggles)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -887,6 +887,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["feature_cock_visibility"], features["cock_visibility"])
 
 	WRITE_FILE(S["feature_has_balls"], features["has_balls"])
+	WRITE_FILE(S["feature_balls_shape"], features["balls_shape"])
 	WRITE_FILE(S["feature_balls_color"], features["balls_color"])
 	WRITE_FILE(S["feature_balls_size"], features["balls_size"])
 	WRITE_FILE(S["feature_balls_visibility"], features["balls_visibility"])

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -663,7 +663,7 @@ BREASTS_CUPS_PREFS e
 
 ## Minimum and maximum limits for penis length from the character creation menu.
 PENIS_MIN_INCHES_PREFS 1
-PENIS_MAX_INCHES_PREFS 10
+PENIS_MAX_INCHES_PREFS 24
 
 ## Body size configs, the feature will be disabled if both min and max have the same value.
 BODY_SIZE_MIN 0.8


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Changes the upper limits for Dongs to 24 inches. Don't have to merge this but I figured it'd be nice for any taur players to have dongs to match.
Fixes not being able to select vaginas. #507 
Adds sheaths.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds sheaths as a ball options.
config: Changes PENIS_MAX_INCHES_PREFS from 10 to 24
fix: Fixes #507 and allows vagina types to be selected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
