### PR TITLE
Gunner / Locust flag gets renamed and put into flag menu.

### DIFF
--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -195,7 +195,7 @@
 	item_state = "followersflag"
 	faction = FACTION_FOLLOWERS
 
-/// Locust flag but renamed
+/// Locust flag but renamed to bandit.
 
 /obj/item/flag/locust
 	name = "Bandit flag"
@@ -203,6 +203,8 @@
 	icon_state = "locustflag"
 	item_state = "locustflag"
 	faction = "Locust"
+
+/// Gunner flag but renamed to Outlaw.
 
 /obj/item/flag/outlaw
 	name = "Outlaw flag"

--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -297,6 +297,37 @@
 
 /obj/item/flag/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first)
 	dropped(thrower)
+
+
+/*   OLDER things that isnt the flags in a way, and how to use them in the upper things.
+				var/list/choices = list("NCR", "Legion", "Yuma", "BOS", "Followers", "Great Khans")
+					if(FACTION_NCR)
+						name = "NCR flag"
+						desc = "A flag with a two headed bear, the symbol of the New California Republic."
+						icon_state = "ncrflag"
+						item_state = "ncrflag"
+						faction = "NCR"
+					if(FACTION_LEGION)
+						name = "Legion flag"
+						desc = "A flag with a golden bull, the symbol of Caesar's Legion."
+						icon_state = "legionflag"
+						item_state = "legionflag"
+						faction = FACTION_LEGION
+					if("Yuma")
+						name = "Yuma flag"
+						desc = "A banner depicting three rivers meeting at its center, overlaid with an ear of corn."
+						icon_state = "cornflag"
+						item_state = "cornflag"
+						faction = FACTION_OASIS
+
+					if("Great Khans")
+						name = "Great Khans flag"
+						desc = "A flag worn and weathered from a long cherished history. A decorated smiling skull smiles mockingly upon those who challenge it."
+						icon_state = "khanflag"
+						item_state = "khanflag"
+						faction = "Great Khans"
+*/
+
 ////////Viper stuff////// subject to change, but this way was simple
 /obj/item/viper_venom
 	name = "Viper venom"

--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -195,12 +195,21 @@
 	item_state = "followersflag"
 	faction = FACTION_FOLLOWERS
 
+/// Locust flag but renamed
+
 /obj/item/flag/locust
-	name = "Locust flag"
-	desc = "A flag with a skull, the symbol of Locusts."
+	name = "Bandit flag"
+	desc = "A flag with a skull, maybe it marking where the cemetary is."
 	icon_state = "locustflag"
 	item_state = "locustflag"
 	faction = "Locust"
+
+/obj/item/flag/outlaw
+	name = "Outlaw flag"
+	desc = "A ragged flag with a skull emblazoned on it, commonly used by the local raider gangs."
+	icon_state = "gunnerflag"
+	item_state = "gunnerflag"
+	faction = "Gunner"
 
 /obj/item/flag/yuma
 	name = "Yuma banner"
@@ -233,27 +242,21 @@
 		if(do_after(user, 60, target = src))
 			var/obj/item/stack/sheet/leather/H = I
 			if(H.use(1))
-				var/list/choices = list("NCR", "Legion", "Yuma", "BOS", "Followers", "Great Khans")
+				var/list/choices = list("Bandit", "Outlaw", "BOS", "Followers")
 				var/flag = input("Please choose which faction flag you wish to create.") in choices
 				switch(flag)
-					if(FACTION_NCR)
-						name = "NCR flag"
-						desc = "A flag with a two headed bear, the symbol of the New California Republic."
-						icon_state = "ncrflag"
-						item_state = "ncrflag"
-						faction = "NCR"
-					if(FACTION_LEGION)
-						name = "Legion flag"
-						desc = "A flag with a golden bull, the symbol of Caesar's Legion."
-						icon_state = "legionflag"
-						item_state = "legionflag"
-						faction = FACTION_LEGION
-					if("Yuma")
-						name = "Yuma flag"
-						desc = "A banner depicting three rivers meeting at its center, overlaid with an ear of corn."
-						icon_state = "cornflag"
-						item_state = "cornflag"
-						faction = FACTION_OASIS
+					if("Bandit")
+						name = "Bandit flag"
+						desc = "A flag with a skull, maybe it marking where the cemetary is."
+						icon_state = "locustflag"
+						item_state = "locustflag"
+						faction = "Locust"
+					if("Outlaw")
+						name = "Outlaw flag"
+						desc = "A ragged flag with a skull emblazoned on it, commonly used by the local raider gangs."
+						icon_state = "gunnerflag"
+						item_state = "gunnerflag"
+						faction = "Gunner"
 					if(FACTION_BROTHERHOOD)
 						name = "BOS flag"
 						desc = "A red and black flag with a sword surrounded in gears and wings, in a dazzling gold."
@@ -266,12 +269,6 @@
 						icon_state = "followersflag"
 						item_state = "followersflag"
 						faction = FACTION_FOLLOWERS
-					if("Great Khans")
-						name = "Great Khans flag"
-						desc = "A flag worn and weathered from a long cherished history. A decorated smiling skull smiles mockingly upon those who challenge it."
-						icon_state = "khanflag"
-						item_state = "khanflag"
-						faction = "Great Khans"
 				update_icon()
 	else
 		attack_hand(user)


### PR DESCRIPTION
## About The Pull Request
Removes the Khans, NCR, Legion and Oasis flag from the menu and replaces the names for Locust and gunner flag, so that way they can be made. Gunners flag is named Outlaw flag with a new description and Locust flag was renamed to Bandit flag.
The image below is example on what is now.
![image](https://user-images.githubusercontent.com/29418371/182705461-a975f37f-b3dd-4694-a291-4f21dc87e8a5.png)
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: renames locust flag to bandit flag with same old description.
add: outlaw flag aka renamed Gunner to outlaw flag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
