### PR TITLE
Even More FoA fixes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1872,8 +1872,8 @@
 	},
 /area/f13/tunnel/northwest)
 "ahh" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall/f13/store,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "ahi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11624,6 +11624,9 @@
 "aNs" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
@@ -28174,6 +28177,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/prewar/protectron{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
 	},
@@ -28661,13 +28667,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fut" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/stone,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 27
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
 /area/f13/building/hospital)
 "fuu" = (
 /obj/structure/chalkboard,
@@ -29780,6 +29791,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/hospital)
+"fWI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/building/hospital)
 "fWM" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -30286,8 +30306,8 @@
 	},
 /area/f13/wasteland)
 "gps" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/sign/departments/science,
+/turf/closed/wall/f13/store,
 /area/f13/building/hospital)
 "gpH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31943,6 +31963,7 @@
 	id = "followersdeskshutters";
 	name = "followers shutters"
 	},
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "heG" = (
@@ -34324,6 +34345,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"iwJ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/building/hospital)
 "iwQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -36180,15 +36210,6 @@
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"jtj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 8
-	},
-/area/f13/building/hospital)
 "jts" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -36932,6 +36953,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "jQm" = (
@@ -39455,6 +39477,7 @@
 	pixel_x = 1;
 	pixel_y = 4
 	},
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "lkG" = (
@@ -42012,6 +42035,10 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
+"mue" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "muJ" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt,
@@ -47616,9 +47643,6 @@
 /area/f13/building)
 "ppJ" = (
 /obj/item/chair,
-/obj/structure/sign/poster/prewar/protectron{
-	pixel_x = 32
-	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 4
 	},
@@ -49318,6 +49342,12 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"qnb" = (
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "qnk" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block,
@@ -52476,10 +52506,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"scg" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital)
 "scB" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -53165,12 +53191,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"syC" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "syG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -57036,20 +57056,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"uAu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 27
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/side{
-	dir = 1
-	},
-/area/f13/building/hospital)
 "uAJ" = (
 /obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/structure/flora/grass/coyote/one,
@@ -61437,6 +61443,7 @@
 	id = "followersdeskshutters";
 	name = "followers shutters"
 	},
+/obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "wVA" = (
@@ -108202,14 +108209,14 @@ ijr
 ijr
 ijr
 quc
-ijr
+wVw
 gmT
 lkE
 jQa
 ijr
 hey
 wVw
-wVw
+ijr
 ijr
 aEs
 aGq
@@ -108459,13 +108466,13 @@ aGr
 ijr
 uZi
 wxJ
-uZi
+lCD
 aMz
 uZi
 pCd
 cDe
-uZi
 lCD
+uZi
 eAT
 ijr
 oHk
@@ -108966,7 +108973,7 @@ aFP
 aEt
 aGq
 ijr
-fut
+iwJ
 waZ
 waZ
 dTv
@@ -109487,7 +109494,7 @@ gSw
 mns
 ijr
 kLx
-syC
+qnb
 lfs
 uRL
 ijr
@@ -109496,7 +109503,7 @@ kEo
 aJb
 uor
 ijr
-uAu
+fut
 aGq
 aFP
 aae
@@ -110255,7 +110262,7 @@ fFx
 tFm
 tZi
 tFm
-scg
+ahh
 ijr
 qGH
 rSW
@@ -111032,7 +111039,7 @@ cQC
 nBm
 aFY
 ehN
-jtj
+fWI
 aFY
 aFY
 aFY
@@ -111796,7 +111803,7 @@ ijr
 rbE
 tZi
 tFm
-gps
+mue
 ijr
 sFQ
 aFB
@@ -112820,7 +112827,7 @@ oHV
 aFP
 aEt
 jkY
-ahh
+gps
 pFw
 nAu
 rKl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1872,12 +1872,8 @@
 	},
 /area/f13/tunnel/northwest)
 "ahh" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/medical/surgical,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/structure/sign/departments/science,
+/turf/closed/wall/f13/store,
 /area/f13/building/hospital)
 "ahi" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7999,6 +7995,7 @@
 	pixel_y = -27
 	},
 /obj/structure/table/optable,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "whitedirtysolid"
 	},
@@ -9869,9 +9866,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aHS" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
@@ -20364,6 +20360,7 @@
 /obj/item/weldingtool,
 /obj/item/weldingtool,
 /obj/item/weldingtool,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "bFO" = (
@@ -28665,9 +28662,12 @@
 /area/f13/wasteland)
 "fut" = (
 /obj/structure/table,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/building/hospital)
 "fuu" = (
 /obj/structure/chalkboard,
@@ -29089,11 +29089,12 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "fFx" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light/small{
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/surgical,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "fFF" = (
 /turf/open/indestructible/ground/outside/dirt{
@@ -29777,7 +29778,6 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/lamp/green,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/hospital)
 "fWM" = (
@@ -30286,10 +30286,8 @@
 	},
 /area/f13/wasteland)
 "gps" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "gpH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35969,7 +35967,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "jkY" = (
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "jlm" = (
@@ -36182,6 +36180,15 @@
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"jtj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/building/hospital)
 "jts" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -36543,7 +36550,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "jFG" = (
@@ -37106,7 +37113,6 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jVJ" = (
-/obj/machinery/light,
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -38035,7 +38041,7 @@
 	},
 /area/f13/wasteland)
 "kzy" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -38408,6 +38414,7 @@
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -27
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "kKh" = (
@@ -38474,6 +38481,9 @@
 /area/f13/wasteland)
 "kLx" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "kLE" = (
@@ -38546,11 +38556,11 @@
 	},
 /area/f13/building/mall)
 "kNl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
@@ -39670,10 +39680,10 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "lqP" = (
@@ -41333,7 +41343,7 @@
 /area/f13/building/mall)
 "mcH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "mcO" = (
@@ -44316,7 +44326,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -44460,7 +44470,6 @@
 /obj/item/reagent_containers/blood/radaway,
 /obj/item/book/granter/trait/lowsurgery,
 /obj/item/crafting/abraxo,
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "nGs" = (
@@ -46371,7 +46380,7 @@
 /area/f13/caves)
 "oHk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -47976,6 +47985,9 @@
 	},
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "pyD" = (
@@ -49243,7 +49255,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/building/mall)
 "qmp" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -49478,7 +49490,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -50016,6 +50028,9 @@
 /obj/item/organ/tongue,
 /obj/item/organ/tongue,
 /obj/item/organ/tongue,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "qHa" = (
@@ -50426,6 +50441,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "qST" = (
@@ -50721,6 +50737,7 @@
 /area/f13/village)
 "rbE" = (
 /obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "rbI" = (
@@ -52459,6 +52476,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"scg" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital)
 "scB" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -53144,6 +53165,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"syC" = (
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "syG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -53408,6 +53435,7 @@
 "sFQ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital)
 "sFS" = (
@@ -57008,6 +57036,20 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"uAu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 27
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/building/hospital)
 "uAJ" = (
 /obj/item/clothing/suit/armor/outfit/slavelabor,
 /obj/structure/flora/grass/coyote/one,
@@ -57608,6 +57650,7 @@
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "uRP" = (
@@ -61812,7 +61855,7 @@
 	},
 /area/f13/building/massfusion)
 "xgM" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -108151,7 +108194,7 @@ hmz
 aFP
 aEt
 bfz
-wcN
+ijr
 pwG
 aGp
 aGp
@@ -108424,8 +108467,8 @@ cDe
 uZi
 lCD
 eAT
-vmG
-aJp
+ijr
+oHk
 aGq
 aFP
 aae
@@ -108680,12 +108723,12 @@ wxJ
 wxJ
 kzy
 eAT
-gps
-ijr
-oHk
+uZi
+vmG
+aJp
 bfz
 aFP
-aRP
+aae
 dSM
 oVo
 tKP
@@ -108923,7 +108966,7 @@ aFP
 aEt
 aGq
 ijr
-dTv
+fut
 waZ
 waZ
 dTv
@@ -108942,7 +108985,7 @@ ijr
 aJp
 aGq
 aFP
-aRP
+aae
 dSM
 dCD
 fRG
@@ -109199,7 +109242,7 @@ ijr
 aJp
 aGq
 aFP
-aRP
+aae
 dSM
 dmq
 ucH
@@ -109444,7 +109487,7 @@ gSw
 mns
 ijr
 kLx
-rSW
+syC
 lfs
 uRL
 ijr
@@ -109453,10 +109496,10 @@ kEo
 aJb
 uor
 ijr
-jDy
+uAu
 aGq
 aFP
-aRP
+aae
 dSM
 aOB
 aMo
@@ -109700,7 +109743,7 @@ tFm
 aHT
 aCh
 ijr
-fFx
+aKZ
 lfs
 rSW
 nGn
@@ -109951,7 +109994,7 @@ mMF
 aEt
 bfz
 ijr
-ahh
+dIV
 tZi
 tFm
 reF
@@ -110208,11 +110251,11 @@ mMF
 aEs
 aKA
 ijr
-dIV
+fFx
 tFm
 tZi
 tFm
-tFm
+scg
 ijr
 qGH
 rSW
@@ -110721,11 +110764,11 @@ tJV
 aFP
 aEs
 aKA
+ijr
 wcN
-ijr
 aJo
 aJo
-ijr
+wcN
 ijr
 ijr
 ijr
@@ -110982,14 +111025,14 @@ cQC
 xgM
 aFY
 aFY
-aFY
-aFY
-ehN
-xgM
-aFY
+nBm
 aFY
 ehN
+cQC
+nBm
+aFY
 ehN
+jtj
 aFY
 aFY
 aFY
@@ -111753,7 +111796,7 @@ ijr
 rbE
 tZi
 tFm
-bCz
+gps
 ijr
 sFQ
 aFB
@@ -112010,7 +112053,7 @@ ijr
 kXK
 siM
 tZi
-fut
+bCz
 ijr
 cZv
 otp
@@ -112777,11 +112820,11 @@ oHV
 aFP
 aEt
 jkY
-aFP
+ahh
 pFw
 nAu
 rKl
-aFP
+ijr
 aCf
 fNV
 ofD
@@ -113548,11 +113591,11 @@ uUU
 aMy
 aJp
 bfz
-aFP
+ijr
 aDb
 jaC
 tEH
-aFP
+ijr
 sxK
 qle
 ofD
@@ -114070,18 +114113,18 @@ aae
 aae
 aae
 aae
+aRP
+aRP
+aRP
+aRP
 aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aRP
+aRP
+aRP
+aRP
 aae
 aMq
 wle


### PR DESCRIPTION
## About The Pull Request
Fixed more mapping issues with the FoA hospital, Should be brighter and internal walls near the workshop should be properly deconstruct-able. The mystery of the FoA Admins missing lamp has also been solved.

![image](https://user-images.githubusercontent.com/10771387/182743905-7dd32367-5ad6-4e17-8edb-fc4b23cc1c6f.png)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: FoA Hospital - More lighting.
add: FoA Hospital - Chemistry trashcan.
fix: FoA Hospital - Workshop now uses correct, deconstructable internal walls.
fix: FoA Hospital -  matrix turfs are now properly bordered by concrete wall turfs.
fix: FoA Hospital - Swapped errant concrete turfs for rock turfs near the south external wall.
fix: FoA Hospital - Fixed a LoS issue where people in the supply room doorway couldn't see the north end of the lobby.
fix: FoA Hospital - Front lobby desk now has metal bars like it used to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
