### PR TITLE
Fixes holsters and embiggens specialized belts

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -532,6 +532,9 @@ GLOBAL_LIST_INIT(gunbelt_allowed, typecacheof(list(
 	/obj/item/stock_parts/cell/ammo,
 	/obj/item/ammo_casing,
 	/obj/item/reagent_containers/spray/pepper,
+	/obj/item/reagent_containers/glass/beaker,
+	/obj/item/reagent_containers/glass/bottle,
+	/obj/item/reagent_containers/spray,
 	/obj/item/melee/onehanded/knife/hunting,
 	/obj/item/melee/baton,
 	/obj/item/melee/classic_baton/telescopic,
@@ -576,39 +579,6 @@ GLOBAL_LIST_INIT(storage_shoes_can_hold, typecacheof(list(
 	/obj/item/scalpel,
 	)))
 
-GLOBAL_LIST_INIT(storage_holster_can_hold, typecacheof(list(
-	/obj/item/gun/ballistic/automatic/pistol,
-	/obj/item/gun/ballistic/revolver,
-	/obj/item/ammo_box/magazine,
-	/obj/item/ammo_box/tube,
-	/obj/item/ammo_box/a357,
-	/obj/item/ammo_box/c38,
-	/obj/item/ammo_box/l10mm,
-	/obj/item/ammo_box/a762,
-	/obj/item/ammo_box/shotgun,
-	/obj/item/ammo_box/m44,
-	/obj/item/ammo_box/a762,
-	/obj/item/ammo_box/a556/stripper,
-	/obj/item/ammo_box/needle,
-	/obj/item/ammo_box/a308,
-	/obj/item/ammo_box/c4570,
-	/obj/item/ammo_box/a50MG,
-	/obj/item/ammo_box/c45rev,
-	/obj/item/gun/energy/laser/solar,
-	/obj/item/gun/energy/laser/pistol,
-	/obj/item/gun/energy/laser/plasma/pistol,
-	/obj/item/gun/energy/laser/plasma/glock,
-	/obj/item/gun/energy/laser/plasma/glock/extended,
-	/obj/item/gun/energy/laser/wattz,
-	/obj/item/gun/energy/laser/wattz/magneto,
-	/obj/item/gun/energy/laser/plasma/pistol/alien,
-	/obj/item/stock_parts/cell/ammo/ec,
-	)))
-
-GLOBAL_LIST_INIT(storage_magpouch_cant_hold, typecacheof(list(
-	/obj/item/gun
-	)))
-
 GLOBAL_LIST_INIT(storage_hat_can_hold, typecacheof(list(
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/toy/cards/deck,
@@ -644,52 +614,25 @@ GLOBAL_LIST_INIT(storage_holdout_can_hold, typecacheof(list(
 	/obj/item/gun/energy/laser/wattz,
 )))
 
-GLOBAL_LIST_INIT(storage_bulletbelt_can_hold, typecacheof(list(
-	/obj/item/ammo_box/magazine,
-	/obj/item/ammo_box/tube,
-	/obj/item/ammo_box/a357,
-	/obj/item/ammo_box/c38,
-	/obj/item/ammo_box/l10mm,
-	/obj/item/ammo_box/a762,
-	/obj/item/ammo_box/shotgun,
-	/obj/item/ammo_box/m44,
-	/obj/item/ammo_box/a762,
-	/obj/item/ammo_box/a556/stripper,
-	/obj/item/ammo_box/needle,
-	/obj/item/ammo_box/a308,
-	/obj/item/ammo_box/c4570,
-	/obj/item/ammo_box/a50MG,
-	/obj/item/gun/energy/laser/solar,
-	/obj/item/gun/energy/laser/pistol,
-	/obj/item/gun/energy/laser/plasma/pistol,
-	/obj/item/gun/energy/laser/plasma/glock,
-	/obj/item/gun/energy/laser/plasma/glock/extended,
-	/obj/item/gun/energy/laser/wattz,
-	/obj/item/gun/energy/laser/wattz/magneto,
-	/obj/item/gun/energy/laser/plasma/pistol/alien,
-	/obj/item/stock_parts/cell/ammo/ec,
-)))
-
-
 /// How many items total fit in a holster
 #define STORAGE_HOLSTER_MAX_ITEMS 7
 /// How much volume fits in a holster
-#define STORAGE_HOLSTER_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_HOLSTER_MAX_ITEMS
+#define STORAGE_HOLSTER_MAX_VOLUME WEIGHT_CLASS_SMALL * STORAGE_HOLSTER_MAX_ITEMS
 
 /// How many items total fit in a shoulder holster
 #define STORAGE_SHOULDER_HOLSTER_MAX_ITEMS 4
 /// How much volume fits in a holster
-#define STORAGE_SHOULDER_HOLSTER_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_SHOULDER_HOLSTER_MAX_ITEMS
+#define STORAGE_SHOULDER_HOLSTER_MAX_VOLUME WEIGHT_CLASS_SMALL * STORAGE_SHOULDER_HOLSTER_MAX_ITEMS
 
 /// How many items total fit in a belt
 #define STORAGE_BELT_MAX_ITEMS 14
 /// How much volume fits in a belt
-#define STORAGE_BELT_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_BELT_MAX_ITEMS
+#define STORAGE_BELT_MAX_VOLUME WEIGHT_CLASS_SMALL * STORAGE_BELT_MAX_ITEMS
 
 /// How many items total fit in a belt
 #define STORAGE_FANNYPACK_MAX_ITEMS 7
 /// How much volume fits in a belt
-#define STORAGE_FANNYPACK_MAX_VOLUME WEIGHT_CLASS_TINY * STORAGE_FANNYPACK_MAX_ITEMS
+#define STORAGE_FANNYPACK_MAX_VOLUME WEIGHT_CLASS_SMALL * STORAGE_FANNYPACK_MAX_ITEMS
 
 /// How many items total fit in a large survival kit
 #define STORAGE_TRIPLEKIT_MAX_ITEMS 21

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -114,14 +114,6 @@
 	max_w_class = WEIGHT_CLASS_TINY
 	//attack_hand_interact = FALSE
 
-/datum/component/storage/concrete/pockets/tiny/magpouch
-	max_items = 4
-
-/datum/component/storage/concrete/pockets/tiny/magpouch/Initialize()
-	. = ..()
-	max_w_class = WEIGHT_CLASS_SMALL
-	can_hold = GLOB.gunbelt_allowed
-
 /datum/component/storage/concrete/pockets/small/detective
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
 
@@ -189,3 +181,12 @@
 	. = ..()
 	can_hold = GLOB.ammobelt_allowed
 
+/// Combat armor bandolier / holster
+/datum/component/storage/concrete/pockets/magpouch
+	max_w_class = WEIGHT_CLASS_SMALL
+	max_items = STORAGE_SHOULDER_HOLSTER_MAX_ITEMS
+	max_combined_w_class = STORAGE_SHOULDER_HOLSTER_MAX_VOLUME
+
+/datum/component/storage/concrete/pockets/magpouch/Initialize()
+	. = ..()
+	can_hold = GLOB.gunbelt_allowed

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -600,6 +600,14 @@
 	item_state = "holster_leg"
 	slot_flags = ITEM_SLOT_BELT
 
+/obj/item/storage/belt/holster/legholster/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_items = STORAGE_HOLSTER_MAX_ITEMS
+	STR.max_combined_w_class = STORAGE_HOLSTER_MAX_VOLUME
+	STR.can_hold = GLOB.gunbelt_allowed
+
 /obj/item/storage/belt/holster/legholster/police/PopulateContents()
 	new /obj/item/gun/ballistic/revolver/police(src)
 	new /obj/item/ammo_box/a357(src)

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -1883,7 +1883,7 @@
 	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 5)
 	equip_delay_other = 50
 	max_integrity = 200
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny/magpouch // 4 slots for ammo!
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/magpouch // 4 slots for ammo!
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T1)
 
@@ -2177,7 +2177,7 @@
 	desc = "A leather top with a bandolier over it and a straps that cover the arms."
 	icon_state = "badlands"
 	item_state = "badlands"
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny/magpouch
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/magpouch
 	body_parts_hidden = ARMS | LEGS | GROIN
 
 /obj/item/clothing/suit/armor/medium/raider/combatduster
@@ -2297,7 +2297,7 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny/magpouch // 4 slots for ammo!
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/magpouch // 4 slots for ammo!
 	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T3, ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_DOWN_ENV_T2)
 
@@ -2504,7 +2504,7 @@
 	desc = "A suit of semi-flexible polycarbonate body armor with heavy padding to protect against melee attacks. Helps the wearer resist shoving in close quarters."
 	icon_state = "riot"
 	item_state = "swat_suit"
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/tiny/magpouch // 4 slots for ammo!
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/magpouch // 4 slots for ammo!
 	blocks_shove_knockdown = TRUE
 	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_DOWN_LASER_T2, ARMOR_MODIFIER_DOWN_FIRE_T3)


### PR DESCRIPTION
## About The Pull Request

Had an oversight with holsters, made them all shoulder holster sized when the belt one should be bigger.

Made holsters and belts hold about twice as much volume. Open for suggestions here!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Storage belts hold more volume.
fix: Fixed holsters being too smol.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
