### PR TITLE
Oli fixes the north bunker a tad, adds colormate to nash & redwater

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -27996,6 +27996,12 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"fce" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "fck" = (
 /obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
@@ -42767,10 +42773,11 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "mLx" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain3"
+	},
+/area/f13/wasteland)
 "mLF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50842,11 +50849,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "rcQ" = (
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain3"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "rcY" = (
 /obj/structure/spacevine,
 /turf/closed/indestructible/rock{
@@ -53448,12 +53454,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"sFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "sFD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -61778,6 +61778,10 @@
 	},
 /turf/open/water,
 /area/f13/wasteland)
+"xeF" = (
+/obj/machinery/gear_painter,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "xeL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -77970,8 +77974,8 @@ vGN
 axz
 bYq
 gTk
-aaT
 yiK
+xeF
 qwd
 kFF
 bqM
@@ -94645,7 +94649,7 @@ dNL
 xLC
 eeK
 tJp
-rcQ
+mLx
 qmG
 oBf
 tRk
@@ -103605,7 +103609,7 @@ aNB
 wxZ
 tdj
 oUj
-mLx
+rcQ
 fvm
 oJz
 tdj
@@ -104085,8 +104089,8 @@ pBa
 hEG
 aHy
 oJz
-mLx
-sFt
+rcQ
+fce
 aHA
 aBw
 azh

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -76,6 +76,11 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"acg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "ach" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -254,6 +259,12 @@
 	dir = 4
 	},
 /area/f13/city)
+"ahE" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain3"
+	},
+/area/f13/wasteland)
 "ahZ" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -631,6 +642,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"azp" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "azO" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/road{
@@ -759,6 +776,10 @@
 	icon_state = "goo10"
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
+"aCH" = (
+/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "aCQ" = (
@@ -1641,8 +1662,8 @@
 /area/f13/wasteland)
 "boF" = (
 /mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "boM" = (
 /obj/structure/fence{
 	dir = 4
@@ -2495,6 +2516,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bTm" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "bUh" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -2653,7 +2681,7 @@
 	amount = 3
 	},
 /obj/structure/closet/crate/radiation,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/rust,
 /area/f13/caves)
 "bZJ" = (
 /obj/structure/fence{
@@ -3604,7 +3632,7 @@
 "cIv" = (
 /obj/structure/sign/warning/radiation,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "cIR" = (
 /obj/structure/window/fulltile/house{
@@ -3841,9 +3869,11 @@
 /area/f13/wasteland)
 "cPR" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "cQl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -4813,7 +4843,7 @@
 /obj/item/advanced_crafting_components/alloys,
 /obj/item/stack/crafting/armor_plate,
 /obj/item/stack/crafting/armor_plate,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/rust,
 /area/f13/caves)
 "dxK" = (
 /obj/machinery/light/small{
@@ -5801,7 +5831,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "egX" = (
 /obj/item/geiger_counter,
@@ -7023,11 +7053,22 @@
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/city)
 "ffE" = (
-/obj/item/flag/outlaw,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/shoes/workboots,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/hardhat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
+/obj/structure/closet/secure_closet/goodies{
+	anchorable = 0;
+	anchored = 1;
+	name = "loot locker";
+	req_access_txt = "150";
+	req_one_access_txt = "150"
 	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "ffL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -8059,7 +8100,7 @@
 	},
 /area/f13/city)
 "fSr" = (
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "fSx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9033,6 +9074,12 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"gGf" = (
+/obj/item/flag/outlaw,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "gGn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9247,7 +9294,7 @@
 "gPz" = (
 /obj/item/stack/sheet/lead/twenty,
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/rust,
 /area/f13/caves)
 "gPB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9414,7 +9461,7 @@
 /area/f13/wasteland)
 "gUX" = (
 /obj/structure/closet/crate/radiation,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/rust,
 /area/f13/caves)
 "gUZ" = (
 /obj/structure/window/fulltile/wood,
@@ -9763,9 +9810,9 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "hnr" = (
-/obj/item/flag/outlaw,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner"
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
 "hnu" = (
@@ -9873,6 +9920,11 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"hsk" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "hsB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -10134,6 +10186,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/city)
+"hFC" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "hFE" = (
 /obj/structure/wreck/car,
 /obj/effect/decal/waste{
@@ -10247,10 +10303,8 @@
 /area/f13/city)
 "hJG" = (
 /mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hJZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/topcenter,
@@ -10536,6 +10590,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"hTK" = (
+/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "hTU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
@@ -11679,10 +11737,10 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "iHp" = (
-/mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "iHL" = (
@@ -11919,7 +11977,7 @@
 /area/f13/city)
 "iQG" = (
 /obj/structure/spacevine,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "iQS" = (
 /obj/structure/car/rubbish2,
@@ -12889,9 +12947,10 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "jzE" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/caves)
 "jzT" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -14148,6 +14207,12 @@
 	icon_state = "horizontaltopbordertop1"
 	},
 /area/f13/wasteland)
+"kvB" = (
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/city)
 "kvK" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/spacevine,
@@ -17036,6 +17101,11 @@
 /obj/structure/flora/tallgrass4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"mFS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "mGh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -18169,6 +18239,12 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
+"nyA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "nyJ" = (
 /obj/item/shard,
 /turf/open/floor/f13{
@@ -18368,6 +18444,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"nIQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "nIS" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/dark,
@@ -18545,6 +18628,13 @@
 	icon_state = "outerturn"
 	},
 /area/f13/wasteland)
+"nSl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "nTl" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19823,10 +19913,9 @@
 /turf/open/water,
 /area/f13/wasteland)
 "oNk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/mob/living/simple_animal/hostile/supermutant/nightkin,
+/turf/open/floor/plasteel/dark,
+/area/f13/caves)
 "oNE" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -21351,7 +21440,7 @@
 /obj/item/stack/sheet/mineral/gold{
 	amount = 5
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/rust,
 /area/f13/caves)
 "pQv" = (
 /obj/effect/decal/cleanable/glass,
@@ -24036,7 +24125,7 @@
 /area/f13/city)
 "rXX" = (
 /obj/structure/sign/warning/radiation,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "rYb" = (
 /turf/closed/indestructible/rock,
@@ -24904,12 +24993,6 @@
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
 	icon_state = "horizontalinnermain2left"
-	},
-/area/f13/wasteland)
-"sFq" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
 "sFs" = (
@@ -26720,13 +26803,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"tUH" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
-	},
-/area/f13/wasteland)
 "tUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28603,9 +28679,11 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "vpy" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/item/flag/outlaw,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "vpP" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/barricade/wooden/planks{
@@ -28730,7 +28808,7 @@
 /area/f13/city)
 "vvR" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "vvX" = (
 /turf/open/floor/plating/rust,
@@ -29844,12 +29922,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/city)
-"wxu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "wxH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30126,13 +30198,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "wGW" = (
-/obj/structure/spider/cocoon,
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/remains/human,
-/obj/item/clothing/shoes/workboots,
 /obj/effect/decal/remains/human,
-/obj/item/twohanded/sledgehammer/rockethammer,
-/obj/item/clothing/head/hardhat,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
@@ -31920,12 +31988,6 @@
 	icon_state = "dark"
 	},
 /area/f13/city)
-"xYO" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain3"
-	},
-/area/f13/wasteland)
 "xYP" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -32023,7 +32085,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
 "ydE" = (
 /obj/effect/decal/cleanable/oil,
@@ -32927,7 +32989,7 @@ euo
 euo
 qqi
 uhE
-hJG
+kvB
 pjA
 osK
 sGV
@@ -33185,7 +33247,7 @@ euo
 qqi
 fAO
 tiQ
-jzE
+boF
 tiQ
 tiQ
 xdt
@@ -33441,7 +33503,7 @@ euo
 euo
 qqi
 hBk
-jzE
+boF
 hZn
 tCU
 hZn
@@ -34469,7 +34531,7 @@ euo
 eWO
 qqi
 uhE
-cPR
+hsk
 gGs
 pXw
 gZM
@@ -38018,7 +38080,7 @@ pzg
 fVZ
 mIh
 aBv
-sFq
+hnr
 oWN
 cQC
 ipV
@@ -38753,11 +38815,11 @@ oph
 tiN
 oph
 oph
+wEK
 oph
 oph
 oph
-oph
-jWM
+fSr
 vvR
 fSr
 fSr
@@ -39012,8 +39074,8 @@ oph
 tfn
 oph
 oph
-smZ
 oph
+rYb
 fSr
 fSr
 fSr
@@ -39270,7 +39332,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fwa
@@ -39527,7 +39589,7 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 xUu
@@ -39784,7 +39846,7 @@ oph
 oph
 wEK
 oph
-oph
+rYb
 fSr
 fSr
 gPz
@@ -40041,16 +40103,16 @@ tiN
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fSr
 xUu
 fSr
 vvR
-bjd
+jzE
 gIM
-bjd
+jzE
 jYC
 fSr
 dDr
@@ -40298,7 +40360,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 gMW
 gMW
@@ -40306,8 +40368,8 @@ lpm
 gMW
 ccr
 vvR
-uPr
-bjd
+nIQ
+jzE
 sfo
 fSr
 woA
@@ -40555,7 +40617,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fSr
@@ -40564,7 +40626,7 @@ fSr
 fSr
 fSr
 xYC
-bjd
+jzE
 vvR
 fSr
 woA
@@ -40812,7 +40874,7 @@ tfn
 oph
 tfn
 oph
-oph
+rYb
 fSr
 fSr
 iJF
@@ -40820,7 +40882,7 @@ iSn
 qZX
 dER
 fSr
-gIM
+cPR
 vvR
 gMW
 gMW
@@ -40840,7 +40902,7 @@ xme
 oia
 pXw
 geV
-oNk
+mFS
 ifF
 gGs
 dty
@@ -41069,7 +41131,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 xUu
@@ -41326,12 +41388,12 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 hXa
 gIM
-gIM
+bft
 rCE
 rBk
 gIM
@@ -41583,7 +41645,7 @@ oph
 oph
 tfn
 oph
-oph
+rYb
 fSr
 fSr
 fpf
@@ -41840,16 +41902,16 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 hXa
 tHX
 tHX
 htS
-bjd
+jzE
 uPr
-bjd
+jzE
 fSr
 gMW
 dDr
@@ -42097,7 +42159,7 @@ oph
 oph
 tfn
 oph
-oph
+rYb
 fSr
 fSr
 fSr
@@ -42354,13 +42416,13 @@ oph
 tfn
 tfn
 oph
-oph
+rYb
 fSr
-gMW
-gMW
-gMW
-gMW
-gMW
+fSr
+fSr
+fSr
+fSr
+fSr
 vvR
 bjd
 jOD
@@ -42611,17 +42673,17 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
-gMW
-gMW
-gMW
-ccr
-gMW
+fSr
+gIM
+ozb
+ffE
+fSr
 ccr
 vvR
 uPr
-bjd
+jzE
 lmJ
 gMW
 gMW
@@ -42653,7 +42715,7 @@ oFm
 oMa
 oMa
 gUg
-tUH
+bTm
 oMa
 oWN
 oge
@@ -42868,13 +42930,13 @@ tfn
 oph
 oph
 oph
-oph
+rYb
 fSr
-gMW
-gMW
-gMW
-gMW
-ccr
+fSr
+gIM
+azp
+ozb
+vvR
 ccr
 vvR
 tHX
@@ -42895,7 +42957,7 @@ art
 xme
 hOh
 wYK
-vpy
+hFC
 wQK
 gGs
 kcr
@@ -42909,7 +42971,7 @@ scQ
 pUW
 fbj
 jfi
-xYO
+ahE
 aGc
 ezc
 qaR
@@ -43125,15 +43187,15 @@ tfn
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
-fSr
-bjd
+gIM
+nSl
+acg
 vvR
-ccr
 gMW
-bjd
+jzE
 jhh
 gKi
 nVM
@@ -43382,7 +43444,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 xYC
@@ -43391,9 +43453,9 @@ azT
 fSr
 gMW
 fSr
-gIM
-bjd
-bjd
+cPR
+jzE
+jzE
 fSr
 fSr
 cQU
@@ -43411,7 +43473,7 @@ cVO
 wYK
 qys
 gGs
-wxu
+nyA
 wYK
 iEQ
 roR
@@ -43639,7 +43701,7 @@ tfn
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 gIM
@@ -43896,7 +43958,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 tHX
@@ -44153,13 +44215,13 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 tHX
 ozb
 vvR
-bjd
+jzE
 vvR
 gKi
 sKU
@@ -44410,13 +44472,13 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 tHX
 ozb
 cIv
-bjd
+jzE
 fSr
 tHX
 fSr
@@ -44667,7 +44729,7 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 tHX
@@ -44924,7 +44986,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 msP
@@ -45181,7 +45243,7 @@ oph
 nTJ
 oph
 oph
-oph
+rYb
 fSr
 fSr
 tHX
@@ -45438,15 +45500,15 @@ tiN
 oph
 oph
 oph
-oph
+rYb
 fSr
-bDj
+hTK
 tHX
 ozb
-ozb
+oNk
 mrM
 gIM
-bjd
+jzE
 fSr
 xUu
 fSr
@@ -45695,7 +45757,7 @@ tiN
 oph
 oph
 oph
-oph
+rYb
 fSr
 bVg
 rXX
@@ -45703,7 +45765,7 @@ fSr
 fSr
 fSr
 xYC
-bjd
+jzE
 egS
 nLo
 fSr
@@ -45952,14 +46014,14 @@ oph
 nTJ
 oph
 oph
-oph
+rYb
 fSr
 tHX
 fSr
 fSr
 fSr
 fSr
-tHX
+gBE
 vvR
 vvR
 gIM
@@ -46209,7 +46271,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 bVg
 dBV
@@ -46217,10 +46279,10 @@ ozb
 tHX
 fSr
 tHX
-bjd
+jzE
 vvR
 xsk
-bjd
+jzE
 nwB
 qkX
 jVo
@@ -46466,15 +46528,15 @@ oph
 oph
 oph
 oph
-oph
+rYb
 fSr
 xUu
 nLo
 xUu
 iHj
 fSr
-iHp
-bjd
+uPr
+jzE
 ydy
 tHX
 vvR
@@ -46723,18 +46785,18 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 xUu
 bGI
 xUu
 hQk
-bjd
-uPr
-bjd
-bjd
+jzE
+iHp
+jzE
+jzE
 gIM
-bjd
+jzE
 gau
 gau
 vlp
@@ -46980,13 +47042,13 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 tHX
 xUu
 meA
 lcI
-bjd
+jzE
 uPr
 fSr
 fSr
@@ -47237,7 +47299,7 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fSr
@@ -47494,7 +47556,7 @@ oph
 tfn
 oph
 oph
-oph
+rYb
 fSr
 xUu
 xUu
@@ -47504,7 +47566,7 @@ xUu
 tHX
 fSr
 fSr
-sKU
+tHX
 fSr
 rYb
 rYb
@@ -47751,7 +47813,7 @@ tiN
 oph
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fSr
@@ -48008,15 +48070,15 @@ tfn
 tiN
 oph
 oph
-oph
+rYb
 fSr
 bDj
 tHX
 tHX
 tHX
 bVg
-tHX
-tHX
+bVg
+aCH
 nIS
 tHX
 fSr
@@ -48265,7 +48327,7 @@ oph
 nTJ
 oph
 oph
-oph
+rYb
 fSr
 fSr
 fSr
@@ -48522,8 +48584,8 @@ oph
 tfn
 oph
 oph
-oph
-oph
+rYb
+rYb
 rYb
 rYb
 rYb
@@ -48779,8 +48841,8 @@ oph
 tfn
 oph
 oph
-oph
-oph
+rYb
+rYb
 rYb
 rYb
 rYb
@@ -49037,7 +49099,7 @@ oph
 oph
 oph
 oph
-oph
+rYb
 rYb
 rYb
 gMW
@@ -53245,7 +53307,7 @@ euo
 euo
 vrN
 pnb
-ffE
+vpy
 pnb
 pnb
 pnb
@@ -54998,7 +55060,7 @@ bxV
 oMa
 ojX
 cQC
-hnr
+gGf
 kgF
 kgF
 kgF
@@ -84695,7 +84757,7 @@ oph
 oph
 gEj
 tfn
-boF
+hJG
 oph
 oph
 oph
@@ -85979,12 +86041,12 @@ oph
 oph
 oph
 oph
-boF
+hJG
 oph
 oph
 oph
 oph
-boF
+hJG
 oph
 oph
 oph
@@ -86496,7 +86558,7 @@ oph
 oph
 oph
 oph
-boF
+hJG
 oph
 oph
 oph
@@ -87011,7 +87073,7 @@ oph
 oph
 oph
 oph
-boF
+hJG
 oph
 oph
 oph

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -19026,6 +19026,7 @@
 	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/gear_painter,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "lxy" = (


### PR DESCRIPTION
## About The Pull Request
Oli fixes the cheese in one of the north bunker and puts a tier5 melee instead of random free supersledge in a way, and also adds colormate to nash and redwater.
![image](https://user-images.githubusercontent.com/29418371/182963919-073a7951-f52a-47bb-bad3-460d86d7b0d8.png)
![image](https://user-images.githubusercontent.com/29418371/182963958-e59737d0-e462-4d78-b07f-90567192bf1a.png)
![image](https://user-images.githubusercontent.com/29418371/182964004-cf223144-b431-4ce1-a268-7c28bf24b041.png)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Northern bunker into an actual bunker worth it and not so cheeseable
add: colormate to redwater and nash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
