### PR TITLE
Gives some quirks their recipes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1,3 +1,35 @@
+GLOBAL_LIST_INIT(chemwhiz_recipes, list(
+    /datum/crafting_recipe/jet, 
+    /datum/crafting_recipe/turbo, 
+    /datum/crafting_recipe/psycho, 
+    /datum/crafting_recipe/medx, 
+    /datum/crafting_recipe/medx/chemistry, 
+    /datum/crafting_recipe/stimpak, 
+    /datum/crafting_recipe/stimpak/chemistry, 
+    /datum/crafting_recipe/stimpak5, 
+    /datum/crafting_recipe/stimpak5/chemistry, 
+    /datum/crafting_recipe/superstimpak, 
+    /datum/crafting_recipe/superstimpak5, 
+    /datum/crafting_recipe/buffout,
+    /datum/crafting_recipe/steady))
+
+GLOBAL_LIST_INIT(basic_explosive_recipes, list(
+	/datum/crafting_recipe/frag_shrapnel, 
+	/datum/crafting_recipe/stinger, 
+	/datum/crafting_recipe/flashbang,
+	/datum/crafting_recipe/smokebomb, 
+	/datum/crafting_recipe/rocket_base, 
+	/datum/crafting_recipe/weakrocket))
+
+GLOBAL_LIST_INIT(adv_explosive_recipes, list(
+	/datum/crafting_recipe/incendiary, 
+	/datum/crafting_recipe/concussion, 
+	/datum/crafting_recipe/radgrenade, 
+	/datum/crafting_recipe/empgrenade, 
+	/datum/crafting_recipe/incendiaryrocket, 
+	/datum/crafting_recipe/strongrocket))
+
+
 //predominantly positive traits
 //this file is named weirdly so that positive traits are listed above negative ones
 
@@ -330,38 +362,14 @@
 /datum/quirk/chemwhiz/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
-	H.mind.learned_recipes += list(
-		/datum/crafting_recipe/jet, 
-		/datum/crafting_recipe/turbo, 
-		/datum/crafting_recipe/psycho, 
-		/datum/crafting_recipe/medx, 
-		/datum/crafting_recipe/medx/chemistry, 
-		/datum/crafting_recipe/stimpak, 
-		/datum/crafting_recipe/stimpak/chemistry, 
-		/datum/crafting_recipe/stimpak5, 
-		/datum/crafting_recipe/stimpak5/chemistry, 
-		/datum/crafting_recipe/superstimpak, 
-		/datum/crafting_recipe/superstimpak5, 
-		/datum/crafting_recipe/buffout,
-		/datum/crafting_recipe/steady)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.chemwhiz_recipes
 
 /datum/quirk/chemwhiz/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
-		H.mind.learned_recipes -= list(
-			/datum/crafting_recipe/jet, 
-			/datum/crafting_recipe/turbo, 
-			/datum/crafting_recipe/psycho, 
-			/datum/crafting_recipe/medx, 
-			/datum/crafting_recipe/medx/chemistry, 
-			/datum/crafting_recipe/stimpak, 
-			/datum/crafting_recipe/stimpak/chemistry, 
-			/datum/crafting_recipe/stimpak5, 
-			/datum/crafting_recipe/stimpak5/chemistry, 
-			/datum/crafting_recipe/superstimpak, 
-			/datum/crafting_recipe/superstimpak5, 
-			/datum/crafting_recipe/buffout,
-			/datum/crafting_recipe/steady)
+		H.mind.learned_recipes -= GLOB.chemwhiz_recipes
 
 
 /datum/quirk/pa_wear
@@ -456,25 +464,15 @@
 
 /datum/quirk/explosive_crafting/add()
 	var/mob/living/carbon/human/H = quirk_holder
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
 	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
-	H.mind.learned_recipes += list(
-		/datum/crafting_recipe/frag_shrapnel, 
-		/datum/crafting_recipe/stinger, 
-		/datum/crafting_recipe/flashbang,
-		/datum/crafting_recipe/smokebomb, 
-		/datum/crafting_recipe/rocket_base, 
-		/datum/crafting_recipe/weakrocket)
+	H.mind.learned_recipes |= GLOB.basic_explosive_recipes
 
 /datum/quirk/explosive_crafting/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
-		H.mind.learned_recipes -= list(
-			/datum/crafting_recipe/frag_shrapnel, 
-			/datum/crafting_recipe/stinger, 
-			/datum/crafting_recipe/flashbang,
-			/datum/crafting_recipe/smokebomb, 
-			/datum/crafting_recipe/rocket_base, 
-			/datum/crafting_recipe/weakrocket)
+		H.mind.learned_recipes -= GLOB.basic_explosive_recipes
 
 /datum/quirk/advanced_explosive_crafting
 	name = "Advanced Explosive Crafting"
@@ -488,36 +486,16 @@
 /datum/quirk/advanced_explosive_crafting/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
-	H.mind.learned_recipes += list(
-		/datum/crafting_recipe/incendiary, 
-		/datum/crafting_recipe/concussion, 
-		/datum/crafting_recipe/radgrenade, 
-		/datum/crafting_recipe/empgrenade, 
-		/datum/crafting_recipe/incendiaryrocket, 
-		/datum/crafting_recipe/strongrocket, 
-		/datum/crafting_recipe/frag_shrapnel, 
-		/datum/crafting_recipe/stinger, 
-		/datum/crafting_recipe/flashbang,
-		/datum/crafting_recipe/smokebomb, 
-		/datum/crafting_recipe/rocket_base, 
-		/datum/crafting_recipe/weakrocket)
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.basic_explosive_recipes
+	H.mind.learned_recipes |= GLOB.adv_explosive_recipes
 
 /datum/quirk/advanced_explosive_crafting/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
-		H.mind.learned_recipes -= list(
-			/datum/crafting_recipe/incendiary, 
-			/datum/crafting_recipe/concussion, 
-			/datum/crafting_recipe/radgrenade, 
-			/datum/crafting_recipe/empgrenade, 
-			/datum/crafting_recipe/incendiaryrocket, 
-			/datum/crafting_recipe/strongrocket, 
-			/datum/crafting_recipe/frag_shrapnel, 
-			/datum/crafting_recipe/stinger, 
-			/datum/crafting_recipe/flashbang,
-			/datum/crafting_recipe/smokebomb, 
-			/datum/crafting_recipe/rocket_base, 
-			/datum/crafting_recipe/weakrocket)
+		H.mind.learned_recipes -= GLOB.basic_explosive_recipes
+		H.mind.learned_recipes -= GLOB.adv_explosive_recipes
 
 
 /datum/quirk/whitelegstraditions

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -327,6 +327,43 @@
 	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
 	locked =  FALSE
 
+/datum/quirk/chemwhiz/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
+	H.mind.learned_recipes += list(
+		/datum/crafting_recipe/jet, 
+		/datum/crafting_recipe/turbo, 
+		/datum/crafting_recipe/psycho, 
+		/datum/crafting_recipe/medx, 
+		/datum/crafting_recipe/medx/chemistry, 
+		/datum/crafting_recipe/stimpak, 
+		/datum/crafting_recipe/stimpak/chemistry, 
+		/datum/crafting_recipe/stimpak5, 
+		/datum/crafting_recipe/stimpak5/chemistry, 
+		/datum/crafting_recipe/superstimpak, 
+		/datum/crafting_recipe/superstimpak5, 
+		/datum/crafting_recipe/buffout,
+		/datum/crafting_recipe/steady)
+
+/datum/quirk/chemwhiz/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.mind.learned_recipes -= list(
+			/datum/crafting_recipe/jet, 
+			/datum/crafting_recipe/turbo, 
+			/datum/crafting_recipe/psycho, 
+			/datum/crafting_recipe/medx, 
+			/datum/crafting_recipe/medx/chemistry, 
+			/datum/crafting_recipe/stimpak, 
+			/datum/crafting_recipe/stimpak/chemistry, 
+			/datum/crafting_recipe/stimpak5, 
+			/datum/crafting_recipe/stimpak5/chemistry, 
+			/datum/crafting_recipe/superstimpak, 
+			/datum/crafting_recipe/superstimpak5, 
+			/datum/crafting_recipe/buffout,
+			/datum/crafting_recipe/steady)
+
+
 /datum/quirk/pa_wear
 	name = "PA Wear"
 	desc = "You've being around the wastes and have learned the importance of defense."
@@ -417,6 +454,28 @@
 	lose_text = "<span class='danger'You feel okay with the advancement of technology.</span>"
 	locked = FALSE
 
+/datum/quirk/explosive_crafting/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
+	H.mind.learned_recipes += list(
+		/datum/crafting_recipe/frag_shrapnel, 
+		/datum/crafting_recipe/stinger, 
+		/datum/crafting_recipe/flashbang,
+		/datum/crafting_recipe/smokebomb, 
+		/datum/crafting_recipe/rocket_base, 
+		/datum/crafting_recipe/weakrocket)
+
+/datum/quirk/explosive_crafting/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.mind.learned_recipes -= list(
+			/datum/crafting_recipe/frag_shrapnel, 
+			/datum/crafting_recipe/stinger, 
+			/datum/crafting_recipe/flashbang,
+			/datum/crafting_recipe/smokebomb, 
+			/datum/crafting_recipe/rocket_base, 
+			/datum/crafting_recipe/weakrocket)
+
 /datum/quirk/advanced_explosive_crafting
 	name = "Advanced Explosive Crafting"
 	desc = "Decades of engineering knowledge have taught you to make all kinds of horrible explosives."
@@ -425,6 +484,41 @@
 	gain_text = "<span class='notice'>You're on the no-fly list.'</span>"
 	lose_text = "<span class='danger'You feel like you're allowed to fly on planes again.</span>"
 	locked = TRUE
+
+/datum/quirk/advanced_explosive_crafting/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
+	H.mind.learned_recipes += list(
+		/datum/crafting_recipe/incendiary, 
+		/datum/crafting_recipe/concussion, 
+		/datum/crafting_recipe/radgrenade, 
+		/datum/crafting_recipe/empgrenade, 
+		/datum/crafting_recipe/incendiaryrocket, 
+		/datum/crafting_recipe/strongrocket, 
+		/datum/crafting_recipe/frag_shrapnel, 
+		/datum/crafting_recipe/stinger, 
+		/datum/crafting_recipe/flashbang,
+		/datum/crafting_recipe/smokebomb, 
+		/datum/crafting_recipe/rocket_base, 
+		/datum/crafting_recipe/weakrocket)
+
+/datum/quirk/advanced_explosive_crafting/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.mind.learned_recipes -= list(
+			/datum/crafting_recipe/incendiary, 
+			/datum/crafting_recipe/concussion, 
+			/datum/crafting_recipe/radgrenade, 
+			/datum/crafting_recipe/empgrenade, 
+			/datum/crafting_recipe/incendiaryrocket, 
+			/datum/crafting_recipe/strongrocket, 
+			/datum/crafting_recipe/frag_shrapnel, 
+			/datum/crafting_recipe/stinger, 
+			/datum/crafting_recipe/flashbang,
+			/datum/crafting_recipe/smokebomb, 
+			/datum/crafting_recipe/rocket_base, 
+			/datum/crafting_recipe/weakrocket)
+
 
 /datum/quirk/whitelegstraditions
 	name = "White Legs traditions"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1,17 +1,17 @@
 GLOBAL_LIST_INIT(chemwhiz_recipes, list(
-    /datum/crafting_recipe/jet,
-    /datum/crafting_recipe/turbo,
-    /datum/crafting_recipe/psycho,
-    /datum/crafting_recipe/medx,
-    /datum/crafting_recipe/medx/chemistry,
-    /datum/crafting_recipe/stimpak,
-    /datum/crafting_recipe/stimpak/chemistry,
-    /datum/crafting_recipe/stimpak5,
-    /datum/crafting_recipe/stimpak5/chemistry,
-    /datum/crafting_recipe/superstimpak,
-    /datum/crafting_recipe/superstimpak5,
-    /datum/crafting_recipe/buffout,
-    /datum/crafting_recipe/steady))
+	/datum/crafting_recipe/jet,
+	/datum/crafting_recipe/turbo,
+	/datum/crafting_recipe/psycho,
+	/datum/crafting_recipe/medx,
+	/datum/crafting_recipe/medx/chemistry,
+	/datum/crafting_recipe/stimpak,
+	/datum/crafting_recipe/stimpak/chemistry,
+	/datum/crafting_recipe/stimpak5,
+	/datum/crafting_recipe/stimpak5/chemistry,
+	/datum/crafting_recipe/superstimpak,
+	/datum/crafting_recipe/superstimpak5,
+	/datum/crafting_recipe/buffout,
+	/datum/crafting_recipe/steady))
 
 GLOBAL_LIST_INIT(basic_explosive_recipes, list(
 	/datum/crafting_recipe/frag_shrapnel,

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1,32 +1,32 @@
 GLOBAL_LIST_INIT(chemwhiz_recipes, list(
-    /datum/crafting_recipe/jet, 
-    /datum/crafting_recipe/turbo, 
-    /datum/crafting_recipe/psycho, 
-    /datum/crafting_recipe/medx, 
-    /datum/crafting_recipe/medx/chemistry, 
-    /datum/crafting_recipe/stimpak, 
-    /datum/crafting_recipe/stimpak/chemistry, 
-    /datum/crafting_recipe/stimpak5, 
-    /datum/crafting_recipe/stimpak5/chemistry, 
-    /datum/crafting_recipe/superstimpak, 
-    /datum/crafting_recipe/superstimpak5, 
+    /datum/crafting_recipe/jet,
+    /datum/crafting_recipe/turbo,
+    /datum/crafting_recipe/psycho,
+    /datum/crafting_recipe/medx,
+    /datum/crafting_recipe/medx/chemistry,
+    /datum/crafting_recipe/stimpak,
+    /datum/crafting_recipe/stimpak/chemistry,
+    /datum/crafting_recipe/stimpak5,
+    /datum/crafting_recipe/stimpak5/chemistry,
+    /datum/crafting_recipe/superstimpak,
+    /datum/crafting_recipe/superstimpak5,
     /datum/crafting_recipe/buffout,
     /datum/crafting_recipe/steady))
 
 GLOBAL_LIST_INIT(basic_explosive_recipes, list(
-	/datum/crafting_recipe/frag_shrapnel, 
-	/datum/crafting_recipe/stinger, 
+	/datum/crafting_recipe/frag_shrapnel,
+	/datum/crafting_recipe/stinger,
 	/datum/crafting_recipe/flashbang,
-	/datum/crafting_recipe/smokebomb, 
-	/datum/crafting_recipe/rocket_base, 
+	/datum/crafting_recipe/smokebomb,
+	/datum/crafting_recipe/rocket_base,
 	/datum/crafting_recipe/weakrocket))
 
 GLOBAL_LIST_INIT(adv_explosive_recipes, list(
-	/datum/crafting_recipe/incendiary, 
-	/datum/crafting_recipe/concussion, 
-	/datum/crafting_recipe/radgrenade, 
-	/datum/crafting_recipe/empgrenade, 
-	/datum/crafting_recipe/incendiaryrocket, 
+	/datum/crafting_recipe/incendiary,
+	/datum/crafting_recipe/concussion,
+	/datum/crafting_recipe/radgrenade,
+	/datum/crafting_recipe/empgrenade,
+	/datum/crafting_recipe/incendiaryrocket,
 	/datum/crafting_recipe/strongrocket))
 
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
I've seen some complaints that the chem-whiz quirk doesn't give the recipes you'd get if you read the book. This fixes that, as well as the explosive crafting quirks

I don't think any other quirks should have recipes, but if they do, complain at me

Should fix issues #484 and #425

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Gave recipes to the chem-whiz and explosives crafting quirks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
