### PR TITLE
Changes Shutters and Blast Door Crafting Recipes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -258,7 +258,7 @@
 
 /datum/crafting_recipe/blast_doors
 	name = "Blast Door"
-	reqs = list(/obj/item/stack/sheet/plasteel = 20, // 10x as expensive as a reinforced wall, but will block anything save for top-tier melee weapons or explosives
+	reqs = list(/obj/item/stack/sheet/prewar = 20, //Again, changed to use more readily available materials. 
 				/obj/item/stack/cable_coil = 15,
 				/obj/item/electronics/airlock = 1
 				)

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -246,7 +246,7 @@
 
 /datum/crafting_recipe/shutters/old
 	name = "Shutters"
-	reqs = list(/obj/item/stack/sheet/plasteel = 10, //5x as expensive as a reinforced wall, can be destroyed by mid-tier guns or high-tier melee. More useful to townies/comfy roles then for NCR/Legion.
+	reqs = list(/obj/item/stack/sheet/prewar = 10, //Changed to use more readily available Pre-War Alloys for CB. Maybe we'll see more use out of them this way.
 				/obj/item/stack/cable_coil = 10,
 				/obj/item/electronics/airlock = 1
 				)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Changes Shutters and Blast Door Crafting Recipes to use Pre-War Alloys instead of Plasteel to A: Give PWA a bit more use and B: Make it a bit easier to make shutters and blast doors for our weird engineering nerds. 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changes Shutter recipe to use 10 Pre-War Alloy instead of 10 Plasteel
tweak: Changes Blast Door recipe to use 20 Pre-War Alloy instead of 20 Plasteel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
