### PR TITLE
Brings Wasteland Drink machine change to here.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -500,6 +500,7 @@
 		/datum/reagent/consumable/coffee,
 		/datum/reagent/consumable/cream,
 		/datum/reagent/consumable/tea,
+		/datum/reagent/consumable/icetea,
 		/datum/reagent/consumable/space_cola,
 		/datum/reagent/consumable/spacemountainwind,
 		/datum/reagent/consumable/dr_gibb,
@@ -508,41 +509,57 @@
 		/datum/reagent/consumable/sodawater,
 		/datum/reagent/consumable/lemon_lime,
 		/datum/reagent/consumable/pwr_game,
+		/datum/reagent/consumable/shamblers,
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/consumable/pineapplejuice,
 		/datum/reagent/consumable/orangejuice,
+		/datum/reagent/consumable/grenadine,
 		/datum/reagent/consumable/limejuice,
 		/datum/reagent/consumable/tomatojuice,
 		/datum/reagent/consumable/lemonjuice,
-		/datum/reagent/consumable/sunset,
-		/datum/reagent/consumable/nuka_cola,
-		/datum/reagent/consumable/grenadine,
 		/datum/reagent/consumable/menthol,
+		/datum/reagent/consumable/sunset,
+		/datum/reagent/consumable/bawls,
+		/datum/reagent/consumable/vim,
+		/datum/reagent/consumable/nuka_cola,
+		/datum/reagent/consumable/grapejuice,
+		/datum/reagent/consumable/tea/forest,
+		/datum/reagent/consumable/tea/red,
+		/datum/reagent/consumable/tea/green,
+		/datum/reagent/consumable/grey_bull,
+		/datum/reagent/consumable/sol_dry,
+		/datum/reagent/consumable/cream_soda
 	)
 	upgrade_reagents = list(
 		/datum/reagent/consumable/banana,
 		/datum/reagent/consumable/berryjuice,
 		/datum/reagent/consumable/strawberryjuice,
-		/datum/reagent/consumable/vanilla,
-	)
-	upgrade_reagents2 = list(
 		/datum/reagent/consumable/applejuice,
 		/datum/reagent/consumable/carrotjuice,
 		/datum/reagent/consumable/pumpkinjuice,
 		/datum/reagent/consumable/watermelonjuice,
-		/datum/reagent/consumable/cherryjelly,
+		/datum/reagent/consumable/parsnipjuice,
+		/datum/reagent/consumable/bungojuice,
+		/datum/reagent/consumable/aloejuice,
+		/datum/reagent/consumable/peachjuice,
+		/datum/reagent/consumable/blumpkinjuice
+	)
+	upgrade_reagents2 = list(
+		/datum/reagent/consumable/vanilla,
+		/datum/reagent/consumable/coco,
+		/datum/reagent/consumable/lemonade,
+		/datum/reagent/consumable/buzz_fuzz,
+		/datum/reagent/consumable/menthol
 	)
 	upgrade_reagents3 = list(
 		/datum/reagent/drug/mushroomhallucinogen,
-		/datum/reagent/consumable/peachjuice,
-		/datum/reagent/consumable/bluecherryjelly,
+		/datum/reagent/consumable/laughter,
+		/datum/reagent/consumable/monkey_energy
 	)
 	emagged_reagents = list(
-		/datum/reagent/toxin/mindbreaker,
-		/datum/reagent/toxin/staminatoxin,
 		/datum/reagent/medicine/cryoxadone,
 		/datum/reagent/iron,
-		/datum/reagent/consumable/shamblers,
+		/datum/reagent/consumable/superlaughter
 	)
 
 /obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged
@@ -570,8 +587,9 @@
 	icon_state = "booze_dispenser"
 	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks/beer
 	dispensable_reagents = list(
-		/datum/reagent/consumable/ethanol/beer,
 		/datum/reagent/consumable/ethanol/kahlua,
+		/datum/reagent/consumable/ethanol/beer,
+		/datum/reagent/consumable/ethanol/beer/light,
 		/datum/reagent/consumable/ethanol/whiskey,
 		/datum/reagent/consumable/ethanol/wine,
 		/datum/reagent/consumable/ethanol/vodka,
@@ -589,25 +607,29 @@
 		/datum/reagent/consumable/ethanol/triple_sec,
 		/datum/reagent/consumable/ethanol/sake,
 		/datum/reagent/consumable/ethanol/applejack,
+		/datum/reagent/consumable/ethanol/champagne,
+		/datum/reagent/consumable/ethanol/fernet
 	)
 	upgrade_reagents = list(
 		/datum/reagent/consumable/ethanol,
-		/datum/reagent/consumable/ethanol/fernet,
+		/datum/reagent/consumable/ethanol/atomicbomb,
+		/datum/reagent/consumable/ethanol/thirteenloko,
+		/datum/reagent/consumable/ethanol/changelingsting,
+		/datum/reagent/consumable/ethanol/alexander,
+		/datum/reagent/consumable/ethanol/beer/green,
+		/datum/reagent/consumable/ethanol/trappist
 	)
 	upgrade_reagents2 = list(
 		/datum/reagent/consumable/ethanol/hooch,
 		/datum/reagent/consumable/ethanol/mead
-		)
-	upgrade_reagents3 = list(
-		/datum/reagent/consumable/ethanol/atomicbomb,
-		/datum/reagent/consumable/ethanol/thirteenloko,
-		)
-
-	emagged_reagents = list(
-		/datum/reagent/consumable/ethanol/alexander,
-		/datum/reagent/toxin/minttoxin,
-		/datum/reagent/consumable/ethanol/changelingsting,
 	)
+	upgrade_reagents3 = list(
+		/datum/reagent/medicine/antihol
+	)
+	emagged_reagents = list(
+	/datum/reagent/consumable/ethanol/rotgut
+	)
+
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Contains a large reservoir of the good stuff. This model has had its safeties shorted out."
 	obj_flags = CAN_BE_HIT | EMAGGED


### PR DESCRIPTION
## About The Pull Request
This PR brings the wasteland drink machines changes to here, so less mechanical farming and more rping. Which is good, so the process goes as followed.
tier 1 = Juices
tier 2 = a tad bit more juices / rare drinks / premade drinks.
tier 3 = premade drugs / Monkey Energy / Antihol
emagged/hacked = Rotgut / cryoxadone / Iron / Superlaughter

Dont like them, please leave comments + feedback on how to make it better or worse, either way. More bar rp incoming to a bar near you.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: drink machine fitting more drinks, so that way more roleplay less mechanical farming for the bartender to get you a fancy drink. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
