### PR TITLE
Fixes a runtime in _box_magazine.dm

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -90,6 +90,8 @@
 	return FALSE
 
 /obj/item/ammo_box/proc/eject_round(obj/item/ammo_casing/casing_to_eject, index)
+	if(!istype(casing_to_eject, /obj/item/ammo_casing))
+		return
 	if(index)
 		stored_ammo[index] = null
 	casing_to_eject.forceMove(get_turf(src.loc))


### PR DESCRIPTION
## About The Pull Request

Fixes Runtime in _box_magazine.dm, line 95: Cannot execute null.forceMove().

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Runtime in _box_magazine.dm, line 95: Cannot execute null.forceMove(). NO MORE!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
