### PR TITLE
Gun changes, again

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -311,6 +311,41 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define BULLET_DAMAGE_SHOTGUN_PELLET 11
 #define BULLET_DAMAGE_SHOTGUN_SLUG 50
 
+/// Bullet damage falloff per tile defines
+#define BULLET_FALLOFF "bullet falloff per tile"
+#define BULLET_FALLOFF_PISTOL_LIGHT 3
+#define BULLET_FALLOFF_PISTOL_MEDIUM 5
+#define BULLET_FALLOFF_PISTOL_HEAVY 6
+#define BULLET_FALLOFF_RIFLE_LIGHT 5
+#define BULLET_FALLOFF_RIFLE_MEDIUM 10
+#define BULLET_FALLOFF_RIFLE_HEAVY 10
+#define BULLET_FALLOFF_SHOTGUN_PELLET 4
+#define BULLET_FALLOFF_SHOTGUN_SLUG 2
+
+/// Bullet damage falloff starting distance defines
+#define BULLET_FALLOFF_START "bullet falloff start distance"
+#define BULLET_FALLOFF_START_PISTOL_LIGHT 2
+#define BULLET_FALLOFF_START_PISTOL_MEDIUM 4
+#define BULLET_FALLOFF_START_PISTOL_HEAVY 5
+#define BULLET_FALLOFF_START_RIFLE_LIGHT 3
+#define BULLET_FALLOFF_START_RIFLE_MEDIUM 10
+#define BULLET_FALLOFF_START_RIFLE_HEAVY 20
+#define BULLET_FALLOFF_START_SHOTGUN_PELLET 0
+#define BULLET_FALLOFF_START_SHOTGUN_SLUG 5
+
+/// Bullet damage falloff default defines
+#define BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT list(BULLET_FALLOFF = BULLET_FALLOFF_PISTOL_LIGHT, BULLET_FALLOFF_START = BULLET_FALLOFF_START_PISTOL_LIGHT)
+#define BULLET_FALLOFF_DEFAULT_PISTOL_MEDIUM list(BULLET_FALLOFF = BULLET_FALLOFF_PISTOL_MEDIUM, BULLET_FALLOFF_START = BULLET_FALLOFF_START_PISTOL_MEDIUM)
+#define BULLET_FALLOFF_DEFAULT_PISTOL_HEAVY list(BULLET_FALLOFF = BULLET_FALLOFF_PISTOL_HEAVY, BULLET_FALLOFF_START = BULLET_FALLOFF_START_PISTOL_HEAVY)
+#define BULLET_FALLOFF_DEFAULT_RIFLE_LIGHT list(BULLET_FALLOFF = BULLET_FALLOFF_RIFLE_LIGHT, BULLET_FALLOFF_START = BULLET_FALLOFF_START_RIFLE_LIGHT)
+#define BULLET_FALLOFF_DEFAULT_RIFLE_MEDIUM list(BULLET_FALLOFF = BULLET_FALLOFF_RIFLE_MEDIUM, BULLET_FALLOFF_START = BULLET_FALLOFF_START_RIFLE_MEDIUM)
+#define BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY list(BULLET_FALLOFF = BULLET_FALLOFF_RIFLE_HEAVY, BULLET_FALLOFF_START = BULLET_FALLOFF_START_RIFLE_HEAVY)
+#define BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET list(BULLET_FALLOFF = BULLET_FALLOFF_START_PISTOL_LIGHT, BULLET_FALLOFF_START = BULLET_FALLOFF_START_SHOTGUN_PELLET)
+#define BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG list(BULLET_FALLOFF = BULLET_FALLOFF_SHOTGUN_PELLET, BULLET_FALLOFF_START = BULLET_FALLOFF_START_SHOTGUN_SLUG)
+
+/// Minimum bullet damage that falloff can take it to
+#define BULLET_FALLOFF_MIN_DAMAGE 3
+
 /// Bullet recoil defines
 #define BULLET_RECOIL_PISTOL_LIGHT 3
 #define BULLET_RECOIL_PISTOL_MEDIUM 3.5
@@ -625,6 +660,9 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define GUN_COCK_RIFLE_FAST (GUN_COCK_BASE * 0.75)
 #define GUN_COCK_RIFLE_LIGHTNING (GUN_COCK_BASE * 0.5)
 
+/// Refire speed multiplier for manual action guns, cus we no longer care about your cock length
+#define GUN_RIFLEMAN_REFIRE_DELAY_MULT 0.5
+
 #define MAX_ACCURACY_OFFSET  45 //It's both how big gun recoil can build up, and how hard you can miss
 #define RECOIL_REDUCTION_TIME 1 SECOND
 
@@ -658,3 +696,59 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define BURST_10_ROUND		list(mode_name="10-round bursts", mode_desc = "Short, uncontrolled bursts", automatic = 0, burst_size=10, fire_delay=null, icon="burst")
 
 #define WEAPON_NORMAL		list(mode_name="standard", burst_size=1, icon="semi")
+
+/// Bullet zone favoring defines
+/// High accuracy, generally goes where you mean to put it, for precision rifles and such
+#define ZONE_WEIGHT_PRECISION "precision_aim"
+/// Typical accuracy, based a bit on range
+#define ZONE_WEIGHT_SEMI_AUTO "semiauto_aim"
+/// Heavily weights limbs after its effective distance
+#define ZONE_WEIGHT_AUTOMATIC "automatic_aim"
+/// Always weights limbs heavily
+#define ZONE_WEIGHT_SHOTGUN "shotgun_aim"
+/// Always defers to the gun's setting, defaults to semi-auto if not defined
+#define ZONE_WEIGHT_GUNS_CHOICE "gun's_choice"
+
+/// Typical accuracy falloff
+#define ZONE_WEIGHT_FALLOFF_SEMI_AUTO 7
+/// Zone accuracy falls off quickly
+#define ZONE_WEIGHT_FALLOFF_AUTOMATIC 20
+/// You're hitting limbs most of the time
+#define ZONE_WEIGHT_FALLOFF_SHOTGUN 100
+
+/// Default zone weight list
+#define ZONE_WEIGHT_LIST_DEFAULT list(\
+	BODY_ZONE_HEAD = 6,\
+	BODY_ZONE_CHEST = 6,\
+	BODY_ZONE_L_ARM = 22,\
+	BODY_ZONE_R_ARM = 22,\
+	BODY_ZONE_L_LEG = 22,\
+	BODY_ZONE_R_LEG = 22)
+/// Precision zone weight list
+#define ZONE_WEIGHT_LIST_PRECISION list(\
+	BODY_ZONE_HEAD = 20,\
+	BODY_ZONE_CHEST = 40,\
+	BODY_ZONE_L_ARM = 5,\
+	BODY_ZONE_R_ARM = 5,\
+	BODY_ZONE_L_LEG = 5,\
+	BODY_ZONE_R_LEG = 5)
+/// Autofire zone weight list
+#define ZONE_WEIGHT_LIST_AUTOMATIC list(\
+	BODY_ZONE_HEAD = 1,\
+	BODY_ZONE_CHEST = 3,\
+	BODY_ZONE_L_ARM = 22,\
+	BODY_ZONE_R_ARM = 22,\
+	BODY_ZONE_L_LEG = 22,\
+	BODY_ZONE_R_LEG = 22)
+/// Pellet zone weight list
+#define ZONE_WEIGHT_LIST_SHOTGUN list(\
+	BODY_ZONE_HEAD = 1,\
+	BODY_ZONE_CHEST = 1,\
+	BODY_ZONE_L_ARM = 22,\
+	BODY_ZONE_R_ARM = 22,\
+	BODY_ZONE_L_LEG = 22,\
+	BODY_ZONE_R_LEG = 22)
+
+/// Gun skill flags
+/// Gun is affected by rifleman skill
+#define AFFECTED_BY_FAST_PUMP (1<<0)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -661,7 +661,7 @@ GLOBAL_LIST_INIT(main_body_parts, list(
 #define GUN_COCK_RIFLE_LIGHTNING (GUN_COCK_BASE * 0.5)
 
 /// Refire speed multiplier for manual action guns, cus we no longer care about your cock length
-#define GUN_RIFLEMAN_REFIRE_DELAY_MULT 0.5
+#define GUN_RIFLEMAN_REFIRE_DELAY_MULT 0.8
 
 #define MAX_ACCURACY_OFFSET  45 //It's both how big gun recoil can build up, and how hard you can miss
 #define RECOIL_REDUCTION_TIME 1 SECOND

--- a/code/modules/mob/clickdelay.dm
+++ b/code/modules/mob/clickdelay.dm
@@ -77,7 +77,7 @@
 	var/attack_speed = unarmed_attack_speed * GetActionCooldownMod() + GetActionCooldownAdjust()
 	var/obj/item/I = get_active_held_item()
 	if(I)
-		attack_speed = I.GetEstimatedAttackSpeed()
+		attack_speed = I.GetEstimatedAttackSpeed(src)
 		if(!I.clickdelay_mod_bypass)
 			attack_speed = attack_speed * GetActionCooldownMod() + GetActionCooldownAdjust()
 	return max(next_action, next_action_immediate, max(last_action, last_action_immediate) + attack_speed)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -28,11 +28,14 @@
 	return zone
 
 
-/proc/ran_zone(zone, probability = 80)
+/proc/ran_zone(zone, probability = 80, list/list_type = ZONE_WEIGHT_LIST_DEFAULT)
 	if(prob(probability))
 		zone = check_zone(zone)
 	else
-		zone = pickweight(list(BODY_ZONE_HEAD = 6, BODY_ZONE_CHEST = 6, BODY_ZONE_L_ARM = 22, BODY_ZONE_R_ARM = 22, BODY_ZONE_L_LEG = 22, BODY_ZONE_R_LEG = 22))
+		if(islist(list_type))
+			zone = pickweight(list_type)
+		else
+			zone = pickweight(ZONE_WEIGHT_LIST_DEFAULT)
 	return zone
 
 /proc/above_neck(zone)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -40,6 +40,8 @@
 		BB.damage *= G.damage_multiplier
 		BB.armour_penetration *= G.penetration_multiplier
 		BB.pixels_per_second *= G.projectile_speed_multiplier
+		if(BB.zone_accuracy_type == ZONE_WEIGHT_GUNS_CHOICE)
+			BB.zone_accuracy_type = G.get_zone_accuracy_type()
 		if(HAS_TRAIT(user, TRAIT_INSANE_AIM))
 			BB.ricochets_max = max(BB.ricochets_max, 10) //bouncy!
 			BB.ricochet_chance = max(BB.ricochet_chance, 100) //it wont decay so we can leave it at 100 for always bouncing

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -156,6 +156,10 @@ ATTACHMENTS
 	var/rigged = FALSE
 	var/vision_flags = 0
 	var/projectile_speed_multiplier = 1
+	/// How should this gun prefer to weight what limbs they hit
+	var/gun_accuracy_zone_type = ZONE_WEIGHT_SEMI_AUTO
+	/// What kind of traits should this gun be affected by
+	var/gun_skill_check
 
 /obj/item/gun/Initialize()
 	if(!recoil_dat && islist(init_recoil))
@@ -385,7 +389,7 @@ ATTACHMENTS
 		return
 
 	if (automatic == 0)
-		user.DelayNextAction(fire_delay)
+		user.DelayNextAction(1)
 	if (automatic == 1)
 		user.DelayNextAction(autofire_shot_delay)
 
@@ -417,17 +421,18 @@ ATTACHMENTS
 		return FALSE
 
 /obj/item/gun/CheckAttackCooldown(mob/user, atom/target)
-	if((user.a_intent == INTENT_HARM || INTENT_HELP) && user.Adjacent(target))		//melee
+	if(user.Adjacent(target)) //melee
 		return user.CheckActionCooldown(CLICK_CD_MELEE)
 	return user.CheckActionCooldown(get_clickcd())
 
 /obj/item/gun/proc/get_clickcd()
 	if (automatic == 0)
-		return isnull(chambered?.click_cooldown_override)? fire_delay : chambered.click_cooldown_override
+		return 1
+		//return isnull(chambered?.click_cooldown_override)? get_fire_delay(user) : chambered.click_cooldown_override
 	if (automatic == 1)
 		return isnull(chambered?.click_cooldown_override)? autofire_shot_delay : chambered.click_cooldown_override
 
-/obj/item/gun/GetEstimatedAttackSpeed()
+/obj/item/gun/GetEstimatedAttackSpeed(mob/user)
 	return get_clickcd()
 
 /obj/item/gun/proc/handle_pins(mob/living/user)
@@ -446,16 +451,16 @@ ATTACHMENTS
 /obj/item/gun/proc/recharge_newshot()
 	return
 
-/obj/item/gun/proc/on_cooldown()
+/obj/item/gun/proc/on_cooldown(mob/user)
 	if (automatic == 0)
-		return busy_action || firing || ((last_fire + fire_delay) > world.time)
+		return busy_action || firing || ((last_fire + get_fire_delay(user)) > world.time)
 	if (automatic == 1)
 		return busy_action || firing
 
 /obj/item/gun/proc/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", stam_cost = 0)
 	add_fingerprint(user)
 
-	if(on_cooldown())
+	if(on_cooldown(user))
 		return
 	if(safety)
 		to_chat(user, span_danger("The gun's safety is on!"))
@@ -679,7 +684,7 @@ ATTACHMENTS
 	if(!ishuman(user) || !ishuman(target))
 		return
 
-	if(on_cooldown())
+	if(on_cooldown(user))
 		return
 
 	if(user == target)
@@ -1201,6 +1206,21 @@ ATTACHMENTS
 
 	update_icon()
 	//then update any UIs with the new stats
+
+/obj/item/gun/proc/get_zone_accuracy_type()
+	if(automatic == TRUE)
+		return ZONE_WEIGHT_AUTOMATIC
+	if(burst_size > 1)
+		return ZONE_WEIGHT_AUTOMATIC
+	if(gun_accuracy_zone_type)
+		return gun_accuracy_zone_type
+	return ZONE_WEIGHT_SEMI_AUTO
+
+/obj/item/gun/proc/get_fire_delay(mob/user)
+	. = fire_delay
+	if(gun_skill_check & AFFECTED_BY_FAST_PUMP)
+		if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+			. *= GUN_RIFLEMAN_REFIRE_DELAY_MULT
 
 ///////////////////
 //GUNCODE ARCHIVE//

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -277,6 +277,7 @@
 		cock_delay = GUN_COCK_SHOTGUN_FAST
 		damage_multiplier *= GUN_LESS_DAMAGE_T2 // -15% damage
 		sawn_off = TRUE
+		gun_accuracy_zone_type = ZONE_WEIGHT_SHOTGUN
 		init_firemodes = list(
 			list(mode_name="Single-fire", mode_desc="Send Vagabonds flying back several paces", burst_size=1, icon="semi"),
 		)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -626,6 +626,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	cock_delay = GUN_COCK_RIFLE_BASE
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // Accurate semiauto fire
 	init_firemodes = list(
 		FULL_AUTO_600,
 		SEMI_AUTO_NODELAY
@@ -716,6 +717,7 @@
 		SEMI_AUTO_NODELAY
 	)
 	gun_tags = list(GUN_FA_MODDABLE)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	automatic_burst_overlay = FALSE
 	can_bayonet = TRUE
@@ -839,6 +841,7 @@
 		SEMI_AUTO_NODELAY
 	)
 	gun_tags = list(GUN_FA_MODDABLE)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // tacticool
 
 	can_scope = TRUE
 	silenced = TRUE
@@ -959,6 +962,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_bayonet = FALSE
 	semi_auto = TRUE
@@ -1168,6 +1172,7 @@
 		SEMI_AUTO_NODELAY
 	)
 	gun_tags = list(GUN_FA_MODDABLE)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	semi_auto = TRUE
 	automatic_burst_overlay = FALSE
@@ -1249,6 +1254,7 @@
 		SEMI_AUTO_NODELAY
 	)
 	gun_tags = list(GUN_FA_MODDABLE)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
@@ -1296,6 +1302,7 @@
 		SEMI_AUTO_NODELAY
 	)
 	gun_tags = list(GUN_FA_MODDABLE)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	automatic_burst_overlay = FALSE
 	semi_auto = TRUE
@@ -1341,6 +1348,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	en_bloc = 1
 	auto_eject = 1
@@ -1495,6 +1503,7 @@
 	damage_multiplier = GUN_EXTRA_DAMAGE_T4
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(1)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	semi_auto = TRUE
 	can_bayonet = FALSE
@@ -2046,6 +2055,7 @@ obj/item/gun/ballistic/automatic/bar
 		FULL_AUTO_300,
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	automatic = 1
 	fire_sound = 'sound/f13weapons/automaticrifle_BAR.ogg'
@@ -2080,6 +2090,7 @@ obj/item/gun/ballistic/automatic/bar
 		BURST_5_ROUND,
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	is_automatic = TRUE
 	automatic = 1
@@ -2338,6 +2349,7 @@ obj/item/gun/ballistic/automatic/bar
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // obviously
 
 	can_scope = FALSE
 	zoom_factor = 1.2
@@ -2374,6 +2386,7 @@ obj/item/gun/ballistic/automatic/bar
 		BURST_3_ROUND,
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	is_automatic = TRUE
 	spawnwithmagazine = TRUE

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -15,6 +15,7 @@
 	no_pin_required = TRUE
 	trigger_guard = TRIGGER_GUARD_NONE //so ashwalkers can use it
 	spawnwithmagazine = TRUE
+	casing_ejector = FALSE
 	var/recentdraw
 	var/draw_sound = 'sound/weapons/bowdraw.wav'
 	dryfire_text = "*no arrows*"
@@ -24,6 +25,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 /obj/item/gun/ballistic/bow/process_chamber(mob/living/user, empty_chamber = 0)
 	var/obj/item/ammo_casing/AC = chambered //Find chambered round

--- a/code/modules/projectiles/guns/ballistic/crafting.dm
+++ b/code/modules/projectiles/guns/ballistic/crafting.dm
@@ -54,7 +54,7 @@
 	fire_delay = 2
 	burst_shot_delay = 2
 	penetration_multiplier = 1.1
-	damage_multiplier = 5
+	damage_multiplier = 1
 
 /*
 /obj/item/gun/ballistic/automatic/smg/greasegun/high/attackby(obj/item/W, mob/user, params)
@@ -105,7 +105,7 @@
 /obj/item/gun/ballistic/automatic/smg/smg10mm/mid
 	name = "enhanced 10mm submachine gun"
 	penetration_multiplier = 1
-	damage_multiplier = 0
+	damage_multiplier = 1
 
 /*
 /obj/item/gun/ballistic/automatic/smg/smg10mm/mid/attackby(obj/item/W, mob/user, params)
@@ -135,7 +135,7 @@
 	burst_size = 3
 	fire_delay = 2
 	burst_shot_delay = 2
-	damage_multiplier = 6
+	damage_multiplier = 1
 	penetration_multiplier = 1.12
 
 /*
@@ -188,7 +188,7 @@
 	name = "enhanced ppsh-41"
 	burst_shot_delay = 1.5
 	fire_delay = 5
-	damage_multiplier = -9
+	damage_multiplier = 1
 	penetration_multiplier = 1
 
 /*
@@ -216,8 +216,8 @@
 */
 /obj/item/gun/ballistic/automatic/smg/ppsh/high
 	name = "advanced ppsh41"
-	damage_multiplier = 0
-	penetration_multiplier = 1.1
+	damage_multiplier = 1
+	penetration_multiplier = 1
 	burst_shot_delay = 1.5
 
 /*
@@ -272,7 +272,7 @@
 	name = "enhanced uzi"
 	fire_delay = 4
 	penetration_multiplier = 1
-	damage_multiplier = 0
+	damage_multiplier = 1
 
 /*
 /obj/item/gun/ballistic/automatic/smg/mini_uzi/mid/attackby(obj/item/W, mob/user, params)
@@ -300,7 +300,7 @@
 /obj/item/gun/ballistic/automatic/smg/mini_uzi/high
 	name = "advanced uzi"
 	fire_delay = 3
-	damage_multiplier = 5
+	damage_multiplier = 1
 	penetration_multiplier = 1.1
 
 /*
@@ -357,7 +357,7 @@
 	name = "enhanced r91 assault rifle"
 	fire_delay = 3
 	penetration_multiplier = 1
-	damage_multiplier = 0
+	damage_multiplier = 1
 	burst_shot_delay = 2
 
 /*
@@ -388,7 +388,7 @@
 /obj/item/gun/ballistic/automatic/assault_rifle/high
 	name = "advanced r91 assault rifle"
 	fire_delay = 3
-	damage_multiplier = 6
+	damage_multiplier = 1
 	penetration_multiplier = 1.12
 	burst_shot_delay = 2
 	burst_size = 3
@@ -421,7 +421,7 @@
 /obj/item/gun/ballistic/automatic/service/mid
 	name = "service rifle (improved)"
 	fire_delay = 4
-	damage_multiplier = 0
+	damage_multiplier = 1
 	penetration_multiplier = 1
 /*
 /obj/item/gun/ballistic/automatic/service/mid/attackby(obj/item/W, mob/user, params)
@@ -447,7 +447,7 @@
 /obj/item/gun/ballistic/automatic/service/high
 	name = "service rifle (masterwork)"
 	fire_delay = 3
-	damage_multiplier = 10
+	damage_multiplier = 1
 	penetration_multiplier = 1.2
 	weapon_weight = GUN_ONE_HAND_AKIMBO
 /*
@@ -529,7 +529,7 @@
 	name = "advanced colt rangemaster"
 	fire_delay = 4
 	penetration_multiplier = 1.14
-	damage_multiplier = 7
+	damage_multiplier = 1
 /*
 /obj/item/gun/ballistic/automatic/rangemaster/scoped/high/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/screwdriver))

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -75,6 +75,7 @@
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	init_recoil = HANDGUN_RECOIL(0.6)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // plug em in the skull!
 
 	can_suppress = FALSE
 	silenced = TRUE
@@ -431,7 +432,7 @@
 	suppressor_x_offset = 28
 	suppressor_y_offset = 20
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
-
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // Tacticool
 
 
 /* * * * * * * * * * * * * *
@@ -528,7 +529,7 @@
 	can_suppress = FALSE
 	automatic_burst_overlay = FALSE
 	fire_sound = 'sound/f13weapons/44mag.ogg'
-
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION 
 
 /* * * * * * * * * * *
  * 14mm Semi-Auto
@@ -569,6 +570,7 @@
  * Less melee damage
  * Uncommon
  * * * * * * * * * * */
+
 /obj/item/gun/ballistic/automatic/pistol/pistol14/compact
 	name = "compact 14mm pistol"
 	desc = "A Swiss SIG-Sauer 14mm handgun, this one is a compact model for concealed carry."

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -312,8 +312,7 @@
 	init_recoil = HANDGUN_RECOIL(1)
 
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
-
-
+	gun_accuracy_zone_type = ZONE_WEIGHT_AUTOMATIC // limbfucker2000
 
 /* * * * * * * * * * *
  * .44 magnum revolver
@@ -433,6 +432,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_LESS_DAMAGE_T1
 	init_recoil = HANDGUN_RECOIL(1.2)
+	gun_accuracy_zone_type = ZONE_WEIGHT_AUTOMATIC
 
 /* * * * * * * * * * *
  * .44 single-action revolver
@@ -462,6 +462,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	init_recoil = HANDGUN_RECOIL(0.8)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 
@@ -491,6 +492,7 @@
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 
@@ -517,6 +519,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = HANDGUN_RECOIL(1.2)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 	scope_state = "revolver_scope"
@@ -574,6 +577,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	init_recoil = HANDGUN_RECOIL(1.2)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	fire_sound = 'sound/f13weapons/sequoia.ogg'
 
@@ -634,6 +638,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = HANDGUN_RECOIL(0.8)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	fire_sound = 'sound/f13weapons/45revolver.ogg'
 
@@ -664,10 +669,9 @@
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	gun_accuracy_zone_type = ZONE_WEIGHT_AUTOMATIC
 
 	fire_sound = 'sound/f13weapons/magnum_fire.ogg'
-
-
 
 /* * * * * * * * * * *
  * Needler 'revolver'
@@ -692,6 +696,7 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = HANDGUN_RECOIL(0.8)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
 

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -35,6 +35,7 @@
 		SEMI_AUTO_NODELAY
 	)
 
+	gun_skill_check = AFFECTED_BY_FAST_PUMP
 	flags_1 =  CONDUCT_1
 	casing_ejector = FALSE
 	var/recentpump = 0 // to prevent spammage
@@ -50,18 +51,18 @@
 	return !!chambered?.BB
 
 /obj/item/gun/ballistic/rifle/attack_self(mob/living/user)
-	if(recentpump > world.time)
-		return
+	//if(recentpump > world.time)
+	//	return
 	if(IS_STAMCRIT(user))//CIT CHANGE - makes pumping shotguns impossible in stamina softcrit
 		to_chat(user, span_warning("You're too exhausted for that."))//CIT CHANGE - ditto
 		return//CIT CHANGE - ditto
 	pump(user, TRUE)
-	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
-		recentpump = world.time + GUN_COCK_RIFLE_LIGHTNING
-	else
-		recentpump = world.time + cock_delay
-		if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
-			user.adjustStaminaLossBuffered(pump_stam_cost) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
+	//if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+	//	recentpump = world.time + GUN_COCK_RIFLE_LIGHTNING
+	//else
+	//	recentpump = world.time + cock_delay
+	if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
+		user.adjustStaminaLossBuffered(pump_stam_cost) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
 	return
 
 /obj/item/gun/ballistic/rifle/blow_up(mob/user)
@@ -77,6 +78,7 @@
 	pump_unload(M)
 	pump_reload(M)
 	update_icon()	//I.E. fix the desc
+	update_firemode()
 	return 1
 
 /obj/item/gun/ballistic/rifle/proc/pump_unload(mob/M)
@@ -96,7 +98,12 @@
 	if (chambered)
 		. += "A [chambered.BB ? "live" : "spent"] one is in the chamber."
 
-
+/// Pump if click with empty thing
+/obj/item/gun/ballistic/rifle/shoot_with_empty_chamber(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
+	if(chambered)
+		attack_self(user)
+	else
+		..()
 
 /* * * * * * *
  * Repeaters *
@@ -126,14 +133,11 @@
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	cock_delay = GUN_COCK_RIFLE_BASE
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	scope_x_offset = 5
 	scope_y_offset = 13
 	pump_sound = 'sound/f13weapons/cowboyrepeaterreload.ogg'
-
-/obj/item/gun/ballistic/rifle/repeater/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
-	..()
-	src.pump(user)
 
 /* * * * * * * * * * *
  * Cowboy Repeater
@@ -181,7 +185,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_LIGHT
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -209,13 +213,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(3.6)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
 
@@ -253,13 +258,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(3)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 	scope_state = "scope_long"
@@ -293,7 +299,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -330,7 +336,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -372,13 +378,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(2.5)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 	scope_state = "scope_mosin"
@@ -412,13 +419,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	cock_delay = GUN_COCK_RIFLE_FAST
 	init_recoil = RIFLE_RECOIL(2.8)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	can_scope = TRUE
 	scope_state = "scope_mosin"
@@ -518,6 +526,7 @@
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = HMG_RECOIL(3)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 
 	zoomable = TRUE
 	zoom_amt = 10

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -25,13 +25,14 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	cock_delay = GUN_COCK_SHOTGUN_BASE
 
+	gun_skill_check = AFFECTED_BY_FAST_PUMP
 	can_scope = FALSE
 	flags_1 =  CONDUCT_1
 	casing_ejector = FALSE
@@ -52,18 +53,18 @@
 	return !!chambered?.BB
 
 /obj/item/gun/ballistic/shotgun/attack_self(mob/living/user)
-	if(recentpump > world.time)
-		return
+	//if(recentpump > world.time)
+	//	return
 	if(IS_STAMCRIT(user))//CIT CHANGE - makes pumping shotguns impossible in stamina softcrit
 		to_chat(user, span_warning("You're too exhausted for that."))//CIT CHANGE - ditto
 		return//CIT CHANGE - ditto
 	pump(user, TRUE)
-	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
-		recentpump = world.time + GUN_COCK_SHOTGUN_LIGHTNING
-	else
-		recentpump = world.time + cock_delay
-		if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
-			user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
+	//if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+	//	recentpump = world.time + GUN_COCK_SHOTGUN_LIGHTNING
+	//else
+	//	recentpump = world.time + cock_delay
+	if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
+		user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
 	return
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
@@ -79,6 +80,7 @@
 	pump_unload(M)
 	pump_reload(M)
 	update_icon()	//I.E. fix the desc
+	update_firemode()
 	return 1
 
 /obj/item/gun/ballistic/shotgun/proc/pump_unload(mob/M)
@@ -101,7 +103,12 @@
 /obj/item/gun/ballistic/shotgun/lethal
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/lethal
 
-
+/// Pump if click with empty thing
+/obj/item/gun/ballistic/shotgun/shoot_with_empty_chamber(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
+	if(chambered)
+		attack_self(user)
+	else
+		..()
 
 /* * * * * * * * * * * * * *
  * Double barrel shotguns  *
@@ -189,6 +196,7 @@
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_FASTEST
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 	init_firemodes = list(
 		list(mode_name="Single-fire", mode_desc="Send Vagabonds flying back several paces", burst_size=1, icon="semi"),
 		list(mode_name="Both Barrels", mode_desc="Give them the side-by-side", burst_size=2, icon="burst"),
@@ -237,7 +245,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -275,7 +283,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -323,7 +331,7 @@
 
 /obj/item/gun/ballistic/shotgun/trench
 	name = "trench shotgun"
-	desc = "A military shotgun designed for close-quarters fighting, equipped with a bayonet lug."
+	desc = "A quick military shotgun designed for close-quarters fighting, equipped with a bayonet lug."
 	icon_state = "trench"
 	item_state = "shotguntrench"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
@@ -340,7 +348,6 @@
 	cock_delay = GUN_COCK_SHOTGUN_FAST
 
 	can_bayonet = TRUE
-	fire_delay = 2
 	bayonet_state = "bayonet"
 	knife_x_offset = 24
 	knife_y_offset = 22
@@ -395,7 +402,7 @@
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_SLOW
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
@@ -417,7 +424,7 @@
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
 	name = "lever action shotgun"
-	desc = "A pistol grip lever action shotgun with a five-shell capacity underneath plus one in chamber."
+	desc = "A speedy pistol grip lever action shotgun with a five-shell capacity underneath plus one in chamber."
 	icon_state = "shotgunlever"
 	item_state = "shotgunlever"
 	icon_prefix = "shotgunlever"
@@ -522,7 +529,7 @@
 	weapon_weight = GUN_TWO_HAND_ONLY
 	draw_time = GUN_DRAW_LONG
 	fire_delay = GUN_FIRE_DELAY_NORMAL
-	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	autofire_shot_delay = GUN_FIRE_DELAY_SLOW
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -128,9 +128,6 @@
 	var/reflect_range_decrease = 5			//amount of original range that falls off when reflecting, so it doesn't go forever
 	var/is_reflectable = FALSE // Can it be reflected or not?
 
-	/// factor to multiply by for zone accuracy percent.
-	var/zone_accuracy_factor = 1
-
 		//Effects
 	var/stun = 0
 	var/knockdown = 0
@@ -163,6 +160,10 @@
 	var/embed_falloff_tile
 	/// For telling whether we want to roll for bone breaking or lacerations if we're bothering with wounds
 	sharpness = SHARP_NONE
+	/// Defines how much damage to lose per tile, and at what distance to start losing damage - currently unused
+	var/list/damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
+	/// bullet's general zone hit accuracy
+	var/zone_accuracy_type = ZONE_WEIGHT_GUNS_CHOICE
 
 /obj/item/projectile/Initialize()
 	. = ..()
@@ -187,6 +188,9 @@
 		bare_wound_bonus = max(0, bare_wound_bonus + wound_falloff_tile)
 	if(LAZYLEN(embedding))
 		embedding["embed_chance"] += embed_falloff_tile
+	//if(LAZYLEN(damage_falloff))
+	//	if(initial(range) - range >= damage_falloff[BULLET_FALLOFF_START])
+	//		damage = max(BULLET_FALLOFF_MIN_DAMAGE, damage - damage_falloff[BULLET_FALLOFF])
 	if(range <= 0 && loc)
 		on_range()
 
@@ -350,8 +354,19 @@
 			return TRUE
 
 	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	if(def_zone && check_zone(def_zone) != BODY_ZONE_CHEST)
-		def_zone = ran_zone(def_zone, max(100-(7*distance), 5) * zone_accuracy_factor) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+	if(distance > 1) // Point blank, you'll hit what you're aiming at
+		if(zone_accuracy_type == ZONE_WEIGHT_GUNS_CHOICE) // Someone didnt set our accuracy! Naughty!
+			zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
+		switch(zone_accuracy_type)
+			if(ZONE_WEIGHT_PRECISION) // guaranteed to hit the zone you aim for, unless its the head and they're more than 2 tiles away
+				if(def_zone && check_zone(def_zone) == BODY_ZONE_HEAD && distance > 2) // Aiming for the head more than 2 tiles away means a 20ish% chance to hit the head
+					def_zone = ran_zone(def_zone, 0, ZONE_WEIGHT_LIST_PRECISION) // Keeps good accuracy
+			if(ZONE_WEIGHT_SEMI_AUTO)
+				def_zone = ran_zone(def_zone, 100-(7*distance), ZONE_WEIGHT_LIST_DEFAULT) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+			if(ZONE_WEIGHT_AUTOMATIC)
+				def_zone = ran_zone(def_zone, 100-(20*distance), ZONE_WEIGHT_LIST_AUTOMATIC)
+			if(ZONE_WEIGHT_SHOTGUN)
+				def_zone = ran_zone(def_zone, 0, ZONE_WEIGHT_LIST_AUTOMATIC)
 
 	if(isturf(A) && hitsound_wall)
 		var/volume = clamp(vol_by_damage() + 20, 0, 100)

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -34,6 +34,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT * BULLET_22LR_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
 /* .22 rubber
  * DAMAGE: 1.5
@@ -55,6 +56,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT * BULLET_22LR_SPEED_MULT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* .22 EMP
  * DAMAGE: 0.75
@@ -119,6 +121,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
 /* 9mm handload
  * DAMAGE: 15
@@ -160,6 +163,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 9mm acid
  * DAMAGE: 10
@@ -305,6 +309,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT * BULLET_38SPECIAL_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
 /obj/item/projectile/bullet/c38/rubber
 	name = ".38 rubber bullet"
@@ -319,6 +324,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT * BULLET_38SPECIAL_SPEED_MULT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /obj/item/projectile/bullet/c38/improv
 	name = ".38 improvised bullet"
@@ -428,6 +434,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_LIGHT * BULLET_NEEDLE_SPEED_MULT
 	var/piercing = FALSE // not sure what this does
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
 #undef BULLET_NEEDLE_DAMAGE_MULT
 #undef BULLET_NEEDLE_STAMINA_MULT
@@ -467,6 +474,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_MEDIUM
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_MEDIUM
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_MEDIUM
 
 /* 10mm handload
  * DAMAGE: 18
@@ -528,6 +536,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_MEDIUM
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 10mm fire
  * DAMAGE: 12.5
@@ -596,6 +605,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_MEDIUM
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_MEDIUM * BULLET_45ACP_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_MEDIUM
 
 /* 10mm simplemob
  * DAMAGE: 25
@@ -657,6 +667,7 @@
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_MEDIUM * BULLET_45ACP_SPEED_MULT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 10mm fire
  * DAMAGE: 12.5
@@ -725,6 +736,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_HEAVY
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_HEAVY
 
 /* 357 handload
  * DAMAGE: 30
@@ -870,6 +882,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_HEAVY * BULLET_44MAG_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_HEAVY
 
 /* 44 simple
  * DAMAGE: 44
@@ -962,6 +975,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_PISTOL_HEAVY * BULLET_14MM_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_HEAVY
 
 /* 14mm poison
  * DAMAGE: 24
@@ -1048,6 +1062,7 @@
 	ricochet_decay_chance = 11
 	ricochet_chance = 80 //100% if you have the vet's trait
 	ricochet_auto_aim_range = 4
+	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_MEDIUM
 
 ////////////////
 //CODE ARCHIVE//
@@ -1062,7 +1077,6 @@ SYNDIE AMMO
 	knockdown = 100
 	dismemberment = 50
 	armour_penetration = 0.85
-	zone_accuracy_factor = 100		//guarunteed 100%
 	var/breakthings = TRUE
 
 /obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -30,6 +30,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_LIGHT
 
 /* 5.56 match
  * DAMAGE: 31.25
@@ -111,6 +112,7 @@
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 5.56 embed
  * DAMAGE: 12.5
@@ -226,6 +228,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_LIGHT
 
 /* 4.73 rubber
  * DAMAGE: 2.5
@@ -247,6 +250,7 @@
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 4.73 fire
  * DAMAGE: 12.5
@@ -269,7 +273,6 @@
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT
 	sharpness = SHARP_NONE
 	var/fire_stacks = 3
-	zone_accuracy_factor = 100
 
 /obj/item/projectile/bullet/a473/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -411,6 +414,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_LIGHT
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_LIGHT * 2
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_LIGHT
 
 /* 5mm simple
  * DAMAGE: 31.25
@@ -516,6 +520,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_MEDIUM
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_MEDIUM
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_MEDIUM
 
 /* 7.62mm surplus
  * DAMAGE: 45
@@ -577,6 +582,7 @@
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_MEDIUM
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* 7.62mm embed
  * DAMAGE: 12
@@ -664,7 +670,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY
-	zone_accuracy_factor = 100
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY
 
 /* .50MG surplus
  * DAMAGE: 60
@@ -685,7 +691,6 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY
-	zone_accuracy_factor = 100
 
 /* .50MG improv
  * DAMAGE: 45
@@ -706,7 +711,6 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY
-	zone_accuracy_factor = 100
 
 /* .50MG fire
  * DAMAGE: 30
@@ -729,7 +733,6 @@
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY
 	sharpness = SHARP_NONE
 	var/fire_stacks = 4
-	zone_accuracy_factor = 100
 
 /obj/item/projectile/bullet/a50MG/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -782,6 +785,7 @@
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
 /* .50MG rubber-penetrator
  * DAMAGE: 6
@@ -890,6 +894,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY * BULLET_4570_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY
 
 /* .45-70 surplus
  * DAMAGE: 45
@@ -1058,6 +1063,7 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_RIFLE_HEAVY
 	
 	pixels_per_second = BULLET_SPEED_RIFLE_HEAVY * BULLET_GAUSS_SPEED_MULT
+	damage_falloff = BULLET_FALLOFF_DEFAULT_RIFLE_HEAVY
 
 /* 2mmEC blender
  * DAMAGE: 150

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,6 +17,8 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_SHOTGUN_PELLET
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_PELLET
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET
+	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
 /* rubber pellet
  * DAMAGE: 1
@@ -39,6 +41,8 @@
 	pixels_per_second = BULLET_SPEED_SHOTGUN_PELLET
 	sharpness = SHARP_NONE
 	embedding = null
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION
 
 /* handload pellet
  * DAMAGE: 8
@@ -58,6 +62,8 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_SHOTGUN_PELLET
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_PELLET
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET
+	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
 /obj/item/projectile/bullet/pellet/shotgun_improvised/Initialize()
 	. = ..()
@@ -91,6 +97,8 @@
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_SHOTGUN_SLUG
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /* 12g slug
  * DAMAGE: 50
@@ -112,6 +120,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	sharpness = SHARP_EDGED
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /* 12g slug
  * DAMAGE: 50
@@ -133,7 +143,9 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	sharpness = SHARP_NONE
-	
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
+
 /* 12g beanbag
  * DAMAGE: 5
  * STAMIN: 100
@@ -154,6 +166,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	sharpness = SHARP_NONE
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION
 
 #define BULLET_TRAINSLUG_DAMAGE_MULT 0.4 // 3 shots, 1.2x damage? sure
 #define BULLET_TRAINSLUG_STAMINA_MULT 0.4
@@ -180,6 +194,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG * BULLET_TRAINSLUG_SPEED_MULT
 	sharpness = SHARP_NONE //crunch
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /obj/item/projectile/bullet/pellet/trainshot/on_hit(atom/target)
 	. = ..()
@@ -214,6 +230,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	sharpness = SHARP_NONE
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /* 12g pellet fire
  * DAMAGE: 5
@@ -236,6 +254,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_PELLET
 	sharpness = SHARP_NONE
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET
+	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
 /* 12g pellet fire
  * DAMAGE: 5
@@ -262,6 +282,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_PELLET
 	sharpness = SHARP_NONE
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_PELLET
+	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
 /obj/item/projectile/incendiary/flamethrower/on_hit(atom/target)
 	. = ..()
@@ -290,6 +312,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	sharpness = SHARP_NONE
+	zone_accuracy_type = ZONE_WEIGHT_PRECISION
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
 
 	stutter = 5
 	jitter = 20
@@ -343,6 +367,8 @@
 	sharpness = SHARP_NONE
 	knockdown = 80
 	hitsound = 'sound/effects/meteorimpact.ogg'
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /obj/item/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -381,6 +407,8 @@
 	
 	pixels_per_second = BULLET_SPEED_SHOTGUN_SLUG
 	knockdown = 50
+	damage_falloff = BULLET_FALLOFF_DEFAULT_SHOTGUN_SLUG
+	zone_accuracy_type = ZONE_WEIGHT_SEMI_AUTO
 
 /obj/item/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request

Manually cycled guns can be racked by just clicking again, so you can just keep clicking to rack your gun.

Pumping the gun is no longer tied to the gun's firing rate, so you can pump/rack it immediately after firing. However, the firing rate itself still limits how often the gun can be fired. 

Messed with the ranged click delay so that you'll cock your gun quickly after firing, instead of just before firing. Just some feely things.

Fun fact, the rifleman trait didnt really do much in the new system! Now it does, it reduces the refire rate on manual rifles and shotguns by 20%. I know its a lot less than 50% faster, but, now it actually works.

Certain guns have different chances to hit specific zones on people. Most semiauto guns work as they did, but automatic guns have a much lower chance to hit your chest or head beyond a few tiles, and shotguns heavily favor hitting limbs if not point blank. However, manual / precision guns will always hit your selected zone, unless its the head, which requires you to be within 7 tiles for a guaranteed hit, otherwise its just a 20ish% chance to hit the head (and like 60% to hit the torso instead).

Complicated, but tldr, less precise guns fuck up limbs more, precision guns fuck up what you aim for.

Also rubber ammo typically forces precision limb aiming, if it isnt shot through an automatic.

Also added in support for damage falloff. Its currently unused, but if yall dont behave, I'm turning this PR right around!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Manual guns are racked by clicking too.
add: Rifleman skill actually works now, reduces fire delay on manual guns by 20%
tweak: Imprecise guns aim for limbs more, precise guns aim for what you picked more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
