### PR TITLE
Lazily disables sprint

### DIFF
--- a/code/_onclick/hud/screen_objects/sprint.dm
+++ b/code/_onclick/hud/screen_objects/sprint.dm
@@ -10,9 +10,10 @@
 
 
 /obj/screen/sprintbutton/Click()
-	if(ishuman(usr))
+	return
+	/*if(ishuman(usr))
 		var/mob/living/carbon/human/H = usr
-		H.default_toggle_sprint()
+		H.default_toggle_sprint()*/
 
 
 /obj/screen/sprintbutton/update_icon_state()
@@ -44,7 +45,7 @@
 
 /obj/screen/sprint_buffer
 	name = "sprint buffer"
-	icon = 'icons/fallout/UI/sprintbar.dmi'
+	//icon = 'icons/fallout/UI/sprintbar.dmi'
 	icon_state = "prog_bar_100"
 
 /obj/screen/sprint_buffer/Click()

--- a/code/modules/keybindings/keybind/movement.dm
+++ b/code/modules/keybindings/keybind/movement.dm
@@ -132,7 +132,7 @@
 	var/list/client/is_down = list()
 
 /datum/keybinding/living/hold_sprint/can_use(client/user)
-	return ishuman(user.mob) || iscyborg(user.mob)
+	return iscyborg(user.mob) // Coyote Bayou Change
 
 /datum/keybinding/living/hold_sprint/down(client/user)
 	var/mob/living/L = user.mob
@@ -155,7 +155,7 @@
 	var/list/client/is_down = list()
 
 /datum/keybinding/living/toggle_sprint/can_use(client/user)
-	return ishuman(user.mob) || iscyborg(user.mob)
+	return iscyborg(user.mob) // Coyote Bayou Change
 
 /datum/keybinding/living/toggle_sprint/down(client/user)
 	is_down |= user


### PR DESCRIPTION
## About The Pull Request

**Disables sprint**. Lazy change intended for test merge rather than a permanent thing, requires proper sprint removal if actually merged down the line. 

Figured I would make a PR so people can actually organise ideas re: this rather than just flooding #good-idea-discussion. Sprint issues:

- Combat is not balanced for sprint and so CQC and automatic/burst weapons absolutely shit on semi-auto, dumping many bullets in the direction of a fast moving target is way more effective than individual shots.
- Completely trivialises all mobs and removes danger from the map. There is absolutely nothing you cannot just sprint away from.
- Far too easy to sprint away from someone whilst they are mid escalation emote, exploiting the nature of the server, escalation, CI. Incredibly metagamey.
- IC, it makes the map feel incredibly small given how quickly players move around.

## Pre-Merge Checklist

- [y] You tested this on a local server.
- [y] This code did not runtime during testing.
- [y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Sprint
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
