### PR TITLE
nests with dense objects on top of them no longer spawn

### DIFF
--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -34,11 +34,15 @@
 	. = ..()
 
 /obj/structure/nest/proc/spawn_mob()
+	var/turf/our_turf = get_turf(src) //if you want to stop mobs from not spawning due to dense things on burrows, remove this...
 	if(!can_fire)
 		return FALSE
 	if(covered)
 		can_fire = FALSE
 		return FALSE
+	for(var/atom/maybe_heavy_thing in our_turf.contents) //...and this
+		if(maybe_heavy_thing.density == TRUE)
+			return FALSE
 	CHECK_TICK
 	if(spawned_mobs.len >= max_mobs)
 		return FALSE
@@ -79,7 +83,7 @@
 		return Seal(user, I, I.type, "rods", 2 HOURS)
 	if(istype(I, /obj/item/stack/sheet/mineral/wood))
 		return Seal(user, I, I.type, "planks", 30 MINUTES)
-	
+
 	if(covered) // allow you to interact only when it's sealed
 		..()
 	else
@@ -91,7 +95,7 @@
 	if(!coverable)
 		to_chat(user, span_warning("The hole is unable to be covered!"))
 		return
-	
+
 	if(covered)
 		to_chat(user, span_warning("The hole is already covered!"))
 		return
@@ -126,7 +130,7 @@
 		toggle_fire()
 		spawned_mobs.Cut()
 		return
- 
+
 	if(user)
 		if(!I)
 			return
@@ -137,7 +141,7 @@
 		Unseal(TRUE)
 		return
 
-	
+
 
 //the nests themselves
 /*


### PR DESCRIPTION
## About The Pull Request
standing on top of a mob next/putting a dense object on top blocks it from spawning

todo in a future PR: probably have mobs inside simulate an attack on what is blocking them?

fine with this being reverted if it's a bad change idk, it's experimental basically. this may involve some remapping 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: standing on top of/dragging a dense object on top of a mob nest blocks its spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
