### PR TITLE
No. More. Mosin.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -215,7 +215,7 @@ GLOBAL_LIST_INIT(trash_craft, list(
 GLOBAL_LIST_INIT(trash_gun, list(
 	/obj/item/gun/ballistic/automatic/hobo/zipgun = 2,
 	/obj/item/gun/ballistic/revolver/hobo/pepperbox = 2,
-	/obj/item/gun/ballistic/rifle/mosin = 1,
+	/obj/item/gun/ballistic/automatic/varmint = 1,
 	/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
 	/obj/item/gun/ballistic/automatic/pistol/pistol22 = 1,
 	/obj/item/gun/ballistic/revolver/widowmaker = 1

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -818,7 +818,7 @@
 	name = "very low tier non-hobo ballistic gun"
 	loot = list(/obj/effect/spawner/bundle/f13/ninemil,
 				/obj/effect/spawner/bundle/f13/caravan_shotgun,
-				//obj/effect/spawner/bundle/f13/mosin, No. More. Mosin.
+				/obj/item/gun/ballistic/rifle/hunting, //No. More. Mosin.
 				/obj/effect/spawner/bundle/f13/remington,
 				/obj/effect/spawner/bundle/f13/widowmaker,
 				/obj/effect/spawner/bundle/f13/varmint
@@ -959,7 +959,7 @@
 				)
 
 /obj/effect/spawner/bundle/f13/remington
-	name = "remington rifle and ammo spawner"
+	name = "hunting rifle and ammo spawner"
 	items = list(
 				/obj/item/gun/ballistic/rifle/hunting,
 				/obj/item/ammo_box/a308

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -818,7 +818,7 @@
 	name = "very low tier non-hobo ballistic gun"
 	loot = list(/obj/effect/spawner/bundle/f13/ninemil,
 				/obj/effect/spawner/bundle/f13/caravan_shotgun,
-				/obj/effect/spawner/bundle/f13/mosin,
+				//obj/effect/spawner/bundle/f13/mosin, No. More. Mosin.
 				/obj/effect/spawner/bundle/f13/remington,
 				/obj/effect/spawner/bundle/f13/widowmaker,
 				/obj/effect/spawner/bundle/f13/varmint

--- a/code/game/objects/effects/spawners/themed_loot_tables.dm
+++ b/code/game/objects/effects/spawners/themed_loot_tables.dm
@@ -179,7 +179,7 @@
 		/obj/item/gun/ballistic/rifle/hunting = 20,
 		/obj/item/gun/ballistic/revolver/widowmaker = 17,
 		/obj/item/gun/ballistic/shotgun/hunting = 10,
-		//obj/effect/spawner/bundle/f13/mosin = 8,
+		/obj/effect/spawner/bundle/f13/remington = 8,
 		/obj/effect/spawner/bundle/f13/varmint = 8,
 		/obj/effect/spawner/bundle/f13/cowboy = 5,
 		/obj/effect/spawner/bundle/f13/trail = 4,

--- a/code/game/objects/effects/spawners/themed_loot_tables.dm
+++ b/code/game/objects/effects/spawners/themed_loot_tables.dm
@@ -179,7 +179,7 @@
 		/obj/item/gun/ballistic/rifle/hunting = 20,
 		/obj/item/gun/ballistic/revolver/widowmaker = 17,
 		/obj/item/gun/ballistic/shotgun/hunting = 10,
-		/obj/effect/spawner/bundle/f13/mosin = 8,
+		//obj/effect/spawner/bundle/f13/mosin = 8,
 		/obj/effect/spawner/bundle/f13/varmint = 8,
 		/obj/effect/spawner/bundle/f13/cowboy = 5,
 		/obj/effect/spawner/bundle/f13/trail = 4,


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Pulls Mosin Nagants from the Trash and low tier gun spawning pools. This should technically remove them from most rounds for the time being but that's only until we can decide on where they really should go.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Deleted the Mosin Nagant from the loot tables of trash piles and low tier guns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
