### PR TITLE
Replaces mapped instances of MF Breeders with Energy Cells

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -9933,8 +9933,8 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/breeder,
 /obj/effect/spawner/lootdrop/ammo/military,
+/obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1576,13 +1576,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"gSj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell/ammo/breeder,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/massfusion)
 "gZe" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
@@ -59057,7 +59050,7 @@ oVn
 oDo
 tXx
 ygG
-gSj
+qMs
 oDo
 oDo
 oDo


### PR DESCRIPTION
## About The Pull Request
Removes a couple of instances of Microfusion Breeders which are only used in the recharger pistols and replaces them with usable Energy Cells.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds 2 instances of Energy Cells to the map.
del: Removes 2 instances of Microfusion Breeders from the map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
