### PR TITLE
Magneto Wattz buff

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -313,7 +313,7 @@
 	force = GUN_MELEE_FORCE_PISTOL_LIGHT
 	weapon_weight = GUN_ONE_HAND_AKIMBO
 	draw_time = GUN_DRAW_NORMAL
-	fire_delay = GUN_FIRE_DELAY_NORMAL
+	fire_delay = GUN_FIRE_DELAY_FAST
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1


### PR DESCRIPTION
## About The Pull Request
Just improves the fire rate of the Magneto Wattz to be equal to that of the regular Wattz pistol. Magneto is meant to be an upgraded version but was probably worse with the fire delay.

## Pre-Merge Checklist
- [y] You tested this on a local server.
- [y] This code did not runtime during testing.
- [y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: buff to magneto
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
