### PR TITLE
RedRiver Map Bug fix

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -13178,12 +13178,6 @@
 "jCj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/mirror{
 	pixel_x = 27
 	},
 /obj/structure/sink{
@@ -49060,8 +49054,8 @@ rYb
 rYb
 rYb
 rYb
-gMW
-gMW
+rYb
+rYb
 rYb
 rYb
 gMW


### PR DESCRIPTION
## About The Pull Request
This PR fixes what bug I have made in redriver map setting.
![image](https://user-images.githubusercontent.com/29418371/185771228-cd49eeb6-bf77-4872-b49b-fbc2db11547e.png)
only one mirror now not three.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: two mirrors gone only one remains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
