### PR TITLE
Reworks how spawners work sorta

### DIFF
--- a/code/__DEFINES/random_mob_spawner.dm
+++ b/code/__DEFINES/random_mob_spawner.dm
@@ -458,23 +458,26 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/ghoul = 1
+		/mob/living/simple_animal/hostile/ghoul = 10,
+		/mob/living/simple_animal/hostile/ghoul/reaver = 1,
+		/mob/living/simple_animal/hostile/ghoul/glowing = 1
 		)
-	num_mobs_to_spawn_medium = 7
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/ghoul = 5,
-		/mob/living/simple_animal/hostile/ghoul/reaver = 3
+		/mob/living/simple_animal/hostile/ghoul = 10,
+		/mob/living/simple_animal/hostile/ghoul/reaver = 3,
+		/mob/living/simple_animal/hostile/ghoul/glowing = 1
 		)
-	num_mobs_to_spawn_hard = 8
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/ghoul = 5,
-		/mob/living/simple_animal/hostile/ghoul/reaver = 3,
-		/mob/living/simple_animal/hostile/ghoul/glowing = 1
+		/mob/living/simple_animal/hostile/ghoul/reaver = 10,
+		/mob/living/simple_animal/hostile/ghoul/glowing = 5
 		)
 
 /// Mirelurks
@@ -485,22 +488,25 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 10
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/mirelurk/baby = 1
+		/mob/living/simple_animal/hostile/mirelurk = 1,
+		/mob/living/simple_animal/hostile/mirelurk/hunter = 1,
+		/mob/living/simple_animal/hostile/mirelurk/baby = 10
 		)
-	num_mobs_to_spawn_medium = 10
+	num_mobs_to_spawn_medium = 4
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/mirelurk = 2,
-		/mob/living/simple_animal/hostile/mirelurk/baby = 5
+		/mob/living/simple_animal/hostile/mirelurk = 4,
+		/mob/living/simple_animal/hostile/mirelurk/hunter = 2,
+		/mob/living/simple_animal/hostile/mirelurk/baby = 10
 		)
-	num_mobs_to_spawn_hard = 10
+	num_mobs_to_spawn_hard = 5
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/mirelurk = 2,
-		/mob/living/simple_animal/hostile/mirelurk/hunter = 1,
+		/mob/living/simple_animal/hostile/mirelurk = 10,
+		/mob/living/simple_animal/hostile/mirelurk/hunter = 6,
 		/mob/living/simple_animal/hostile/mirelurk/baby = 5
 		)
 
@@ -512,21 +518,21 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 10
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONGEST
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/deathclaw = 2
+		/mob/living/simple_animal/hostile/deathclaw = 1
 		)
-	num_mobs_to_spawn_medium = 10
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_LONGEST
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/deathclaw/mother = 1,
-		/mob/living/simple_animal/hostile/deathclaw = 5
+		/mob/living/simple_animal/hostile/deathclaw = 1
 		)
-	num_mobs_to_spawn_hard = 10
+	num_mobs_to_spawn_hard = 2
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_LONGEST
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/deathclaw/mother = 5,
+		/mob/living/simple_animal/hostile/deathclaw/mother = 1,
 		/mob/living/simple_animal/hostile/deathclaw/legendary = 1
 		)
 
@@ -543,15 +549,15 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	mob_list_easy = list(
 		/mob/living/simple_animal/hostile/hellpig = 1
 		)
-	num_mobs_to_spawn_medium = 3
+	num_mobs_to_spawn_medium = 1
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_LONGEST
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/hellpig = 1
+		/mob/living/simple_animal/hostile/hellpig = 2
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 2
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_LONGEST
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/hellpig = 1
+		/mob/living/simple_animal/hostile/hellpig = 3
 		)
 
 /// Roachie~
@@ -562,20 +568,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/radroach = 1
+		/mob/living/simple_animal/hostile/radroach = 20
 		)
-	num_mobs_to_spawn_medium = 7
+	num_mobs_to_spawn_medium = 4
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICK
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/radroach = 1
+		/mob/living/simple_animal/hostile/radroach = 20
 		)
-	num_mobs_to_spawn_hard = 9
+	num_mobs_to_spawn_hard = 5
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKER
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/radroach = 1
+		/mob/living/simple_animal/hostile/radroach = 20
 		)
 
 /// Geckos (that arent bold)
@@ -586,20 +592,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/gecko = 1
+		/mob/living/simple_animal/hostile/gecko = 10
 		)
-	num_mobs_to_spawn_medium = 7
+	num_mobs_to_spawn_medium = 4
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICK
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/gecko = 1
+		/mob/living/simple_animal/hostile/gecko = 15
 		)
-	num_mobs_to_spawn_hard = 9
+	num_mobs_to_spawn_hard = 5
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKER
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/gecko = 1
+		/mob/living/simple_animal/hostile/gecko = 20
 		)
 
 /// Bloatfly (Dan in an airplane)
@@ -610,20 +616,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/bloatfly = 1
+		/mob/living/simple_animal/hostile/bloatfly = 5
 		)
-	num_mobs_to_spawn_medium = 7
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICK
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/bloatfly = 1
+		/mob/living/simple_animal/hostile/bloatfly = 7
 		)
-	num_mobs_to_spawn_hard = 9
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKER
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/bloatfly = 1
+		/mob/living/simple_animal/hostile/bloatfly = 9
 		)
 
 /// Bloatfly and gecko nest (they're friends turns out)
@@ -634,23 +640,23 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/gecko = 5,
-		/mob/living/simple_animal/hostile/bloatfly = 1
+		/mob/living/simple_animal/hostile/gecko = 10,
+		/mob/living/simple_animal/hostile/bloatfly = 5
 		)
-	num_mobs_to_spawn_medium = 7
+	num_mobs_to_spawn_medium = 4
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICK
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/gecko = 5,
-		/mob/living/simple_animal/hostile/bloatfly = 3
+		/mob/living/simple_animal/hostile/gecko = 10,
+		/mob/living/simple_animal/hostile/bloatfly = 10
 		)
-	num_mobs_to_spawn_hard = 9
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKER
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/gecko = 1,
-		/mob/living/simple_animal/hostile/bloatfly = 1
+		/mob/living/simple_animal/hostile/gecko = 10,
+		/mob/living/simple_animal/hostile/bloatfly = 10
 		)
 
 /// Molerats
@@ -661,20 +667,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 9
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_QUICK
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/molerat = 1
+		/mob/living/simple_animal/hostile/molerat = 10
 		)
-	num_mobs_to_spawn_medium = 12
+	num_mobs_to_spawn_medium = 5
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICKER
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/molerat = 1
+		/mob/living/simple_animal/hostile/molerat = 15
 		)
-	num_mobs_to_spawn_hard = 15
+	num_mobs_to_spawn_hard = 7
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKEST
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/molerat = 1
+		/mob/living/simple_animal/hostile/molerat = 20
 		)
 
 /// Cazadores
@@ -685,23 +691,23 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
 		/mob/living/simple_animal/hostile/cazador/young = 10,
 		/mob/living/simple_animal/hostile/cazador = 1
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/cazador/young = 5,
-		/mob/living/simple_animal/hostile/cazador = 1
+		/mob/living/simple_animal/hostile/cazador = 2
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/cazador/young = 3,
-		/mob/living/simple_animal/hostile/cazador = 1
+		/mob/living/simple_animal/hostile/cazador = 5
 		)
 
 /// Scorpins!
@@ -715,21 +721,21 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/radscorpion = 1
+		/mob/living/simple_animal/hostile/radscorpion = 10
 		)
 	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/radscorpion = 5,
-		/mob/living/simple_animal/hostile/radscorpion/black = 1,
-		/mob/living/simple_animal/hostile/radscorpion/blue = 1
+		/mob/living/simple_animal/hostile/radscorpion/black = 5,
+		/mob/living/simple_animal/hostile/radscorpion/blue = 5
 		)
 	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/radscorpion = 5,
-		/mob/living/simple_animal/hostile/radscorpion/black = 4,
-		/mob/living/simple_animal/hostile/radscorpion/blue = 4
+		/mob/living/simple_animal/hostile/radscorpion = 3,
+		/mob/living/simple_animal/hostile/radscorpion/black = 7,
+		/mob/living/simple_animal/hostile/radscorpion/blue = 7
 		)
 
 /// Ant
@@ -740,22 +746,22 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/giantant = 1
+		/mob/living/simple_animal/hostile/giantant = 10
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_medium = MOB_SPAWNER_TIME_QUICK
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/giantant = 5,
+		/mob/living/simple_animal/hostile/giantant = 10,
 		/mob/living/simple_animal/hostile/fireant = 2
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_hard = MOB_SPAWNER_TIME_QUICKER
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/giantant = 2,
-		/mob/living/simple_animal/hostile/fireant = 5
+		/mob/living/simple_animal/hostile/giantant = 10,
+		/mob/living/simple_animal/hostile/fireant = 10
 		)
 
 /// Nightstalker hissawoo
@@ -766,22 +772,23 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/stalker = 3
+		/mob/living/simple_animal/hostile/stalker = 1,
+		/mob/living/simple_animal/hostile/stalkeryoung = 10
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/stalker = 5,
-		/mob/living/simple_animal/hostile/stalkeryoung = 5
+		/mob/living/simple_animal/hostile/stalker = 3,
+		/mob/living/simple_animal/hostile/stalkeryoung = 10
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/stalker = 5,
-		/mob/living/simple_animal/hostile/stalkeryoung = 5
+		/mob/living/simple_animal/hostile/stalker = 10,
+		/mob/living/simple_animal/hostile/stalkeryoung = 3
 		)
 
 /// Domestic robots (Handies, protectrons, eyebots, and the odd robobrain)
@@ -792,20 +799,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_ROBOT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
 		/mob/living/simple_animal/hostile/handy/protectron = 5,
 		/mob/living/simple_animal/hostile/eyebot = 5
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
 			/mob/living/simple_animal/hostile/handy/protectron = 5,
-			/mob/living/simple_animal/hostile/handy = 5,
+			/mob/living/simple_animal/hostile/handy = 2,
 			/mob/living/simple_animal/hostile/eyebot/floatingeye = 5
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/handy/robobrain = 5,
@@ -821,26 +828,26 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_ROBOT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/handy/protectron = 2,
+		/mob/living/simple_animal/hostile/handy/protectron = 5,
 		/mob/living/simple_animal/hostile/eyebot = 5
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/handy/protectron = 10,
 		/mob/living/simple_animal/hostile/securitron = 3,
 		/mob/living/simple_animal/hostile/securitron/sentrybot/nsb/riot = 1
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/handy/robobrain = 10,
 		/mob/living/simple_animal/hostile/securitron = 5,
 		/mob/living/simple_animal/hostile/securitron/sentrybot/nsb/riot = 5,
-		/mob/living/simple_animal/hostile/securitron/sentrybot = 2
+		/mob/living/simple_animal/hostile/securitron/sentrybot = 4
 		)
 
 /// Military robots (Securitrons, protectrons, eyebots, and the odd robobrain)
@@ -851,26 +858,28 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_ROBOT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 5
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/handy/robobrain = 1,
-		/mob/living/simple_animal/hostile/securitron = 5,
-		/mob/living/simple_animal/hostile/handy/protectron = 10
+		/mob/living/simple_animal/hostile/handy/robobrain = 5,
+		/mob/living/simple_animal/hostile/securitron = 10,
+		/mob/living/simple_animal/hostile/securitron/sentrybot = 4
 		)
-	num_mobs_to_spawn_medium = 5
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/handy/assaultron = 1,
+		/mob/living/simple_animal/hostile/handy/assaultron = 5,
 		/mob/living/simple_animal/hostile/handy/robobrain = 5,
-		/mob/living/simple_animal/hostile/securitron = 10
+		/mob/living/simple_animal/hostile/securitron = 10,
+		/mob/living/simple_animal/hostile/securitron/sentrybot = 4
 		)
-	num_mobs_to_spawn_hard = 5
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/handy/assaultron = 5,
-		/mob/living/simple_animal/hostile/handy/gutsy = 2,
-		/mob/living/simple_animal/hostile/securitron = 10
+		/mob/living/simple_animal/hostile/handy/gutsy = 10,
+		/mob/living/simple_animal/hostile/securitron = 5,
+		/mob/living/simple_animal/hostile/securitron/sentrybot = 4
 		)
 
 /// Supermutants
@@ -881,23 +890,23 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 3
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/supermutant/meleemutant = 1,
-		/mob/living/simple_animal/hostile/supermutant = 5
+		/mob/living/simple_animal/hostile/supermutant/meleemutant = 3,
+		/mob/living/simple_animal/hostile/supermutant = 3
 		)
-	num_mobs_to_spawn_medium = 3
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/supermutant/meleemutant = 5,
-		/mob/living/simple_animal/hostile/supermutant/rangedmutant = 2
+		/mob/living/simple_animal/hostile/supermutant/rangedmutant = 5
 		)
-	num_mobs_to_spawn_hard = 3
+	num_mobs_to_spawn_hard = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/supermutant/nightkin = 5,
-		/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant = 2,
+		/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant = 5,
 		/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant = 1
 		)
 
@@ -909,26 +918,26 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/centaur = 5,
+		/mob/living/simple_animal/hostile/centaur = 10,
 		/mob/living/simple_animal/hostile/supermutant/meleemutant = 2,
-		/mob/living/simple_animal/hostile/supermutant = 5
+		/mob/living/simple_animal/hostile/supermutant = 3
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/centaur = 5,
-		/mob/living/simple_animal/hostile/supermutant/meleemutant = 5,
-		/mob/living/simple_animal/hostile/supermutant/rangedmutant = 2
+		/mob/living/simple_animal/hostile/centaur = 10,
+		/mob/living/simple_animal/hostile/supermutant/meleemutant = 8,
+		/mob/living/simple_animal/hostile/supermutant/rangedmutant = 4
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 4
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/centaur = 5,
-		/mob/living/simple_animal/hostile/supermutant/nightkin = 5,
-		/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant = 2,
+		/mob/living/simple_animal/hostile/centaur = 15,
+		/mob/living/simple_animal/hostile/supermutant/nightkin = 8,
+		/mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant = 5,
 		/mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant = 1
 		)
 
@@ -940,20 +949,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/centaur = 1
+		/mob/living/simple_animal/hostile/centaur = 10
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/centaur = 1
+		/mob/living/simple_animal/hostile/centaur = 10
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/centaur = 1
+		/mob/living/simple_animal/hostile/centaur = 10
 		)
 
 /// melee raiders
@@ -964,27 +973,31 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_VENT // RAIDER VENTED
 	sound_to_play = MOB_SPAWNER_SOUND_VENT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/raider = 1
+		/mob/living/simple_animal/hostile/raider = 5,
+		/mob/living/simple_animal/hostile/raider/firefighter = 2,
+		/mob/living/simple_animal/hostile/raider/baseball = 2,
+		/mob/living/simple_animal/hostile/raider/tribal = 2
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/raider = 1,
-		/mob/living/simple_animal/hostile/raider/baseball = 1,
-		/mob/living/simple_animal/hostile/raider/tribal = 1
+		/mob/living/simple_animal/hostile/raider = 10,
+		/mob/living/simple_animal/hostile/raider/firefighter = 5,
+		/mob/living/simple_animal/hostile/raider/baseball = 5,
+		/mob/living/simple_animal/hostile/raider/tribal = 5
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/raider = 5,
+		/mob/living/simple_animal/hostile/raider = 10,
 		/mob/living/simple_animal/hostile/raider/firefighter = 5,
 		/mob/living/simple_animal/hostile/raider/baseball = 5,
 		/mob/living/simple_animal/hostile/raider/tribal = 5,
 		/mob/living/simple_animal/hostile/raider/legendary = 1,
-		/mob/living/simple_animal/hostile/raider/sulphite = 1
+		/mob/living/simple_animal/hostile/raider/sulphite = 2
 		)
 
 /// ranged raiders (rangeders?)
@@ -995,55 +1008,65 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_VENT
 	sound_to_play = MOB_SPAWNER_SOUND_VENT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/raider = 1,
-		/mob/living/simple_animal/hostile/raider/ranged = 1
+		/mob/living/simple_animal/hostile/raider/ranged = 5,
+		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 1,
+		/mob/living/simple_animal/hostile/raider/ranged/biker = 1
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/raider/ranged = 5,
-		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 3
-		)
-	num_mobs_to_spawn_hard = 6
-	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
-	mob_list_hard = list(
 		/mob/living/simple_animal/hostile/raider/ranged = 5,
 		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 3,
 		/mob/living/simple_animal/hostile/raider/ranged/biker = 3
 		)
+	num_mobs_to_spawn_hard = 3
+	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
+	mob_list_hard = list(
+		/mob/living/simple_animal/hostile/raider/ranged = 5,
+		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 7,
+		/mob/living/simple_animal/hostile/raider/ranged/biker = 7
+		)
 
 /// mixed raiders (ranged / melee)
 /datum/random_mob_spawner/raider_mixed
-	nest_tag = MOB_SPAWNER_RAIDER_RANGED
+	nest_tag = MOB_SPAWNER_RAIDER_MIXED
 	nest_name = "narrow tunnel"
 	nest_desc = "A crude tunnel used by raiders to travel across the wasteland."
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_VENT
 	sound_to_play = MOB_SPAWNER_SOUND_VENT
 	
-	num_mobs_to_spawn_easy = 12
+	num_mobs_to_spawn_easy = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/raider/ranged = 5
-		)
-	num_mobs_to_spawn_medium = 12
-	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
-	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/raider = 1,
-		/mob/living/simple_animal/hostile/raider/baseball = 1,
-		/mob/living/simple_animal/hostile/raider/tribal = 1,
-		/mob/living/simple_animal/hostile/raider/ranged = 1,
-		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 1
-		)
-	num_mobs_to_spawn_hard = 12
-	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
-	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/raider/ranged = 1,
+		/mob/living/simple_animal/hostile/raider/ranged = 3,
 		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 1,
 		/mob/living/simple_animal/hostile/raider/ranged/biker = 1,
-		/mob/living/simple_animal/hostile/raider = 1,
+		/mob/living/simple_animal/hostile/raider = 3,
+		/mob/living/simple_animal/hostile/raider/firefighter = 2,
+		/mob/living/simple_animal/hostile/raider/baseball = 2,
+		/mob/living/simple_animal/hostile/raider/tribal = 2
+		)
+	num_mobs_to_spawn_medium = 3
+	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
+	mob_list_medium = list(
+		/mob/living/simple_animal/hostile/raider/ranged = 5,
+		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 3,
+		/mob/living/simple_animal/hostile/raider/ranged/biker = 3,
+		/mob/living/simple_animal/hostile/raider = 10,
+		/mob/living/simple_animal/hostile/raider/firefighter = 5,
+		/mob/living/simple_animal/hostile/raider/baseball = 5,
+		/mob/living/simple_animal/hostile/raider/tribal = 5
+		)
+	num_mobs_to_spawn_hard = 4
+	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
+	mob_list_hard = list(
+		/mob/living/simple_animal/hostile/raider/ranged = 5,
+		/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 10,
+		/mob/living/simple_animal/hostile/raider/ranged/biker = 10,
+		/mob/living/simple_animal/hostile/raider = 5,
 		/mob/living/simple_animal/hostile/raider/firefighter = 5,
 		/mob/living/simple_animal/hostile/raider/baseball = 5,
 		/mob/living/simple_animal/hostile/raider/tribal = 5,
@@ -1059,20 +1082,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/trog/tunneler = 1
+		/mob/living/simple_animal/hostile/trog/tunneler = 5
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/trog/tunneler = 1
+		/mob/living/simple_animal/hostile/trog/tunneler = 5
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/trog/tunneler = 1
+		/mob/living/simple_animal/hostile/trog/tunneler = 5
 		)
 
 /// spore carriers
@@ -1083,20 +1106,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/trog/sporecarrier = 1
+		/mob/living/simple_animal/hostile/trog/sporecarrier = 5
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/trog/sporecarrier = 1
+		/mob/living/simple_animal/hostile/trog/sporecarrier = 7
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_SOUND_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/trog/sporecarrier = 1
+		/mob/living/simple_animal/hostile/trog/sporecarrier = 9
 		)
 
 /// yaoguai mcbeevis
@@ -1107,20 +1130,20 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_easy = list(
 		/mob/living/simple_animal/hostile/bear/yaoguai = 1
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/bear/yaoguai = 1
+		/mob/living/simple_animal/hostile/bear/yaoguai = 3
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/bear/yaoguai = 1
+		/mob/living/simple_animal/hostile/bear/yaoguai = 5
 		)
 
 /// wolf doggos
@@ -1131,22 +1154,22 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_easy = list(
-		/mob/living/simple_animal/hostile/wolf = 1
+		/mob/living/simple_animal/hostile/wolf = 10
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 4
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_medium = list(
 		/mob/living/simple_animal/hostile/wolf = 10,
 		/mob/living/simple_animal/hostile/wolf/alpha = 1
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 5
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_DEFAULT
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/wolf = 3,
-		/mob/living/simple_animal/hostile/wolf/alpha = 1
+		/mob/living/simple_animal/hostile/wolf = 10,
+		/mob/living/simple_animal/hostile/wolf/alpha = 5
 		)
 
 /// alien wannamingos
@@ -1157,18 +1180,18 @@ GLOBAL_LIST_EMPTY(random_mob_nest_spawner_datums)
 	nest_icon_state = MOB_SPAWNER_ICONSTATE_DEFAULT
 	sound_to_play = MOB_SPAWNER_SOUND_DEFAULT
 	
-	num_mobs_to_spawn_easy = 6
+	num_mobs_to_spawn_easy = 1
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_easy = list(
 		/mob/living/simple_animal/hostile/alien = 1
 		)
-	num_mobs_to_spawn_medium = 6
+	num_mobs_to_spawn_medium = 2
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_medium = list(
-		/mob/living/simple_animal/hostile/alien = 1
+		/mob/living/simple_animal/hostile/alien = 2
 		)
-	num_mobs_to_spawn_hard = 6
+	num_mobs_to_spawn_hard = 3
 	mob_respawn_time_easy = MOB_SPAWNER_TIME_LONG
 	mob_list_hard = list(
-		/mob/living/simple_animal/hostile/alien = 1
+		/mob/living/simple_animal/hostile/alien = 3
 		)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -467,6 +467,14 @@
 		. = pickweight(L, base_weight)
 		L.Remove(.)
 
+//Pick a random element from the list by weight and reduce its weight by one.
+//Result is returned as a list in the format list(key, value)
+/proc/pickweight_n_reduce(list/L, base_weight = 1)
+	if (L.len)
+		. = pickweight(L, base_weight)
+		if((L[.]-= 1) <= 0)
+			L.Remove(.)
+
 //Returns the top(last) element from the list and removes it from the list (typical stack function)
 /proc/pop(list/L)
 	if(L.len)

--- a/code/controllers/subsystem/mob_spawners.dm
+++ b/code/controllers/subsystem/mob_spawners.dm
@@ -6,8 +6,7 @@ SUBSYSTEM_DEF(mobspawners)
 	for(var/obj/structure/nest/N in GLOB.mob_nests)
 		if(QDELETED(N))
 			GLOB.mob_nests -= N
-		if(N.can_fire)
-			N.spawn_mob()
+		N.process()
 	for(var/mob/living/simple_animal/hostile/giantantqueen/Q in GLOB.mob_nests)
 		if(QDELETED(Q) || !get_turf(Q))
 			GLOB.mob_nests -= Q

--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -5,21 +5,30 @@
 	icon = 'icons/mob/nest_new.dmi'
 	icon_state = "hole"
 	var/list/spawned_mobs = list()
-	var/max_mobs = 3
 	var/can_fire = TRUE
 	var/mob_types = list(/mob/living/simple_animal/hostile/carp)
 	//make spawn_time's multiples of 10. The SS runs on 10 seconds.
 	var/spawn_time = 20 SECONDS
 	var/coverable = TRUE
+	/// spawner can be covered by dense things
+	var/coverable_by_dense_things = TRUE
 	var/covered = FALSE
 	var/obj/covertype
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/spawn_text = "emerges from"
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
+	/// Is something covering us?
+	var/datum/weakref/covering_object
+	/// Range to check for other mobs to see if there's too many around
+	var/overpopulation_range = 5
+	/// max mobs that can be alive and nearby before it refuses to spawn more
+	var/max_mobs = 3
 	var/radius = 10
 	var/spawnsound //specify an audio file to play when a mob emerges from the spawner
 	var/spawn_once
+	/// Needs a living, cliented player around to spawn stuff
+	var/needs_player = TRUE
 	var/infinite = FALSE
 	var/mobs_to_spawn = 1 //number of mobs to spawn at once, for swarms
 	/// The ID of our randomizer, so all spawners with this ID will spawn from the same list. Leave null to skip global randomization for this thing
@@ -28,6 +37,7 @@
 	var/randomizer_kind
 	/// Which difficulties to pick from - its a bitfield!
 	var/randomizer_difficulty
+	COOLDOWN_DECLARE(spawner_cooldown)
 
 /obj/structure/nest/Initialize()
 	initialize_random_mob_spawners()
@@ -40,58 +50,97 @@
 	GLOB.mob_nests -= src
 	playsound(src, 'sound/effects/break_stone.ogg', 100, 1)
 	visible_message("[src] collapses!")
+	covering_object = null
+	for(var/mob/living/simple_animal/our_spawned_mob in spawned_mobs)
+		our_spawned_mob?.nest = null
+		spawned_mobs -= our_spawned_mob
 	. = ..()
 
-/obj/structure/nest/proc/spawn_mob()
-	var/turf/our_turf = get_turf(src) //if you want to stop mobs from not spawning due to dense things on burrows, remove this...
+/obj/structure/nest/process()
+	if(!has_mobs_left())
+		qdel(src)
+		return FALSE
+	if(!can_spawn_mob())
+		return FALSE
+	spawn_mob()
+	
+/// Do we have any mobs left?
+/obj/structure/nest/proc/has_mobs_left()
+	var/has_mobs_left
+	for(var/mob_in_list in mob_types)
+		if(mob_types[mob_in_list] >= 1)
+			has_mobs_left = TRUE
+			break
+	if(!has_mobs_left)
+		return FALSE
+	return TRUE
+
+/// Basic checks to see if we can spawn something
+/obj/structure/nest/proc/can_spawn_mob()
 	if(!can_fire)
 		return FALSE
+	if(COOLDOWN_TIMELEFT(src, spawner_cooldown))
+		return FALSE
 	if(covered)
-		can_fire = FALSE
 		return FALSE
-	for(var/atom/maybe_heavy_thing in our_turf.contents) //...and this
-		if(maybe_heavy_thing.density == TRUE)
+	if(coverable_by_dense_things)
+		var/turf/our_turf = get_turf(src)
+		var/atom/movable/previous_heavy_thing = covering_object?.resolve()
+		if(previous_heavy_thing)
+			if(get_turf(previous_heavy_thing) == our_turf)
+				return FALSE
+			else
+				covering_object = null // mustve wandered off
+		/// Accounts for anything dense, which includes mobs, mechs, lockers, etc
+		for(var/atom/movable/maybe_heavy_thing in our_turf.contents)
+			if(maybe_heavy_thing.density == TRUE)
+				covering_object = WEAKREF(maybe_heavy_thing)
+				return FALSE
+	if(max_mobs >= 1)
+		var/mobs_in_range
+		for(var/mob/living/living_mob in view(overpopulation_range, get_turf(src)))
+			if(living_mob.stat != DEAD)
+				if(mobs_in_range++ >= max_mobs)
+					return FALSE
+	if(needs_player)
+		var/player_found = FALSE
+		for(var/mob/living/carbon/human/humie in range(radius, get_turf(src)))
+			if(humie?.client) // good enough
+				player_found = TRUE
+				break
+		if(!player_found)
 			return FALSE
-	CHECK_TICK
-	if(spawned_mobs.len >= max_mobs)
-		return FALSE
-	var/mob/living/carbon/human/H = locate(/mob/living/carbon/human) in range(radius, get_turf(src))
-	var/obj/mecha/M = locate(/obj/mecha) in range(radius, get_turf(src))
-	if(!H?.client && !M?.occupant)
-		return FALSE
-	toggle_fire(FALSE)
-	addtimer(CALLBACK(src, .proc/toggle_fire), spawn_time)
-	var/chosen_mob_type
-	var/mob/living/simple_animal/L
+	return TRUE
+
+/obj/structure/nest/proc/spawn_mob()
+	var/chosen_mob
+	var/mob/living/simple_animal/output_mob
 	for(var/i = 1 to mobs_to_spawn)
-		chosen_mob_type = pickweight(mob_types)
-		L = new chosen_mob_type(src.loc)
-		L.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)	//If we were admin spawned, lets have our children count as that as well.
-		spawned_mobs += L
-		L.nest = src
-		visible_message(span_danger("[L] [spawn_text] [src]."))
+		if(infinite)
+			chosen_mob = pickweight(mob_types)
+		else
+			chosen_mob = pickweight_n_reduce(mob_types)
+		if(chosen_mob)
+			output_mob = new chosen_mob(get_turf(src))
+			output_mob.flags_1 |= (flags_1 & ADMIN_SPAWNED_1) //If we were admin spawned, lets have our children count as that as well.
+			spawned_mobs += output_mob
+			output_mob.nest = src
+			visible_message(span_danger("[output_mob] [spawn_text] [src]."))
+		else
+			qdel(src)
+			return
 	if(spawnsound)
 		playsound(src, spawnsound, 30, 1)
-	if(!infinite)
-		if(spawned_mobs.len >= max_mobs)
-			Destroy()
-	if(spawn_once) //if the subtype has TRUE, call destroy() after we spawn our first mob
-		qdel(src)
-		return
-
-
-/obj/structure/nest/proc/toggle_fire(fire = TRUE)
-	can_fire = fire
+	COOLDOWN_START(src, spawner_cooldown, spawn_time)
 
 /obj/structure/nest/attackby(obj/item/I, mob/living/user, params)
-
 	if(I.tool_behaviour == TOOL_CROWBAR)
-		return Unseal(FALSE, user, I)
+		return try_unseal(FALSE, user, I)
 
 	if(istype(I, /obj/item/stack/rods))
-		return Seal(user, I, I.type, "rods", 2 HOURS)
+		return try_seal(user, I, I.type, "rods", 2 HOURS)
 	if(istype(I, /obj/item/stack/sheet/mineral/wood))
-		return Seal(user, I, I.type, "planks", 30 MINUTES)
+		return try_seal(user, I, I.type, "planks", 30 MINUTES)
 
 	if(covered) // allow you to interact only when it's sealed
 		..()
@@ -100,15 +149,16 @@
 			to_chat(user, span_warning("You feel it is impossible to destroy this without covering it with something."))
 			return
 
-/obj/structure/nest/proc/Seal(mob/user, obj/item/I, itempath, cover_state, timer)
+/obj/structure/nest/proc/try_seal(mob/user, obj/item/stack/S, itempath, cover_state, timer)
 	if(!coverable)
 		to_chat(user, span_warning("The hole is unable to be covered!"))
 		return
-
 	if(covered)
 		to_chat(user, span_warning("The hole is already covered!"))
 		return
-	var/obj/item/stack/S = I
+	if(!istype(S))
+		to_chat(user, span_warning("You cant cover this with that!"))
+		return
 	if(S.amount < 4)
 		to_chat(user, span_warning("You need four of [S.name] in order to cover the hole!"))
 		return
@@ -116,39 +166,36 @@
 		to_chat(user, span_warning("You must stand still to build the cover!"))
 		return
 	S.use(4)
-
 	if(!covered)
 		new /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low(src.loc)
-		to_chat(user, span_warning("You find something while covering the hole!"))
+		if(istype(user))
+			to_chat(user, span_warning("You find something while covering the hole!"))
+	do_seal(itempath, cover_state, timer)
 
+/obj/structure/nest/proc/do_seal(itempath, cover_state, timer)
+	can_fire = FALSE
 	covered = TRUE
 	covertype = itempath
-
 	var/image/overlay_image = image(icon, icon_state = cover_state)
 	add_overlay(overlay_image)
+	addtimer(CALLBACK(src, .proc/do_unseal), timer)
 
-//	QDEL_IN(src, 2 MINUTES)
-	addtimer(CALLBACK(src, .proc/Unseal), timer)
-	return
-
-/obj/structure/nest/proc/Unseal(override = TRUE, mob/user = null, obj/item/I = null)
-	if(override)
-		covered = initial(covered)
-		covertype = initial(covertype)
-		cut_overlays()
-		toggle_fire()
-		spawned_mobs.Cut()
+/obj/structure/nest/proc/try_unseal(mob/user = null, obj/item/I = null)
+	if(!istype(user))
 		return
-
-	if(user)
-		if(!I)
-			return
-		I.play_tool_sound(src, 50)
-		if(!do_after(user, 5 SECONDS, FALSE, src))
-			to_chat(user, span_warning("You must stand still to unseal the cover!"))
-			return
-		Unseal(TRUE)
+	if(!istype(I))
 		return
+	I.play_tool_sound(src, 50)
+	if(!do_after(user, 5 SECONDS, FALSE, src))
+		to_chat(user, span_warning("You must stand still to unseal the cover!"))
+		return
+	do_unseal()
+
+/obj/structure/nest/proc/do_unseal()
+	covered = initial(covered)
+	covertype = initial(covertype)
+	cut_overlays()
+	can_fire = TRUE
 
 /obj/structure/nest/proc/setup_random_nest()
 	if(!randomizer_tag)
@@ -261,7 +308,7 @@
 */
 /obj/structure/nest/ghoul
 	name = "ghoul nest"
-	max_mobs = 5
+	max_mobs = 3
 	mob_types = list(/mob/living/simple_animal/hostile/ghoul = 5,
 					/mob/living/simple_animal/hostile/ghoul/reaver = 3,
 					/mob/living/simple_animal/hostile/ghoul/glowing = 1)
@@ -271,56 +318,56 @@
 	max_mobs = 1
 	spawn_once = TRUE
 	spawn_time = 60 SECONDS
-	mob_types = list(/mob/living/simple_animal/hostile/deathclaw = 5)
+	mob_types = list(/mob/living/simple_animal/hostile/deathclaw = 1)
 
 /obj/structure/nest/deathclaw/mother
 	name = "mother deathclaw nest"
 	max_mobs = 1
 	spawn_time = 120 SECONDS
-	mob_types = list(/mob/living/simple_animal/hostile/deathclaw/mother = 5)
+	mob_types = list(/mob/living/simple_animal/hostile/deathclaw/mother = 1)
 
 /obj/structure/nest/scorpion
 	name = "scorpion nest"
 	spawn_time = 40 SECONDS
 	max_mobs = 2
-	mob_types = list(/mob/living/simple_animal/hostile/radscorpion = 1,
-					/mob/living/simple_animal/hostile/radscorpion/black = 1)
+	mob_types = list(/mob/living/simple_animal/hostile/radscorpion = 5,
+					/mob/living/simple_animal/hostile/radscorpion/black = 5)
 
 /obj/structure/nest/radroach
 	name = "radroach nest"
 	max_mobs = 15
-	mobs_to_spawn = 1
-	mob_types = list(/mob/living/simple_animal/hostile/radroach = 1)
+	mobs_to_spawn = 3
+	mob_types = list(/mob/living/simple_animal/hostile/radroach = 15)
 
 /obj/structure/nest/fireant
 	name = "fireant nest"
-	max_mobs = 5
-	mob_types = list(/mob/living/simple_animal/hostile/fireant = 1,
-					/mob/living/simple_animal/hostile/giantant = 1)
+	max_mobs = 2
+	mob_types = list(/mob/living/simple_animal/hostile/fireant = 3,
+					/mob/living/simple_animal/hostile/giantant = 6)
 
 /obj/structure/nest/wanamingo
 	name = "wanamingo nest"
 	spawn_time = 40 SECONDS
-	max_mobs = 2
-	mob_types = list(/mob/living/simple_animal/hostile/alien = 1)
+	max_mobs = 1
+	mob_types = list(/mob/living/simple_animal/hostile/alien = 3)
 
 /obj/structure/nest/molerat
 	name = "molerat nest"
 	max_mobs = 5
-	mob_types = list(/mob/living/simple_animal/hostile/molerat = 1)
+	mob_types = list(/mob/living/simple_animal/hostile/molerat = 20)
 	spawn_time = 10 SECONDS //They just love tunnelin'.. And are pretty soft
 
 /obj/structure/nest/mirelurk
 	name = "mirelurk nest"
-	max_mobs = 5
+	max_mobs = 2
 	mob_types = list(/mob/living/simple_animal/hostile/mirelurk = 2,
 					/mob/living/simple_animal/hostile/mirelurk/hunter = 1,
-					/mob/living/simple_animal/hostile/mirelurk/baby = 5)
+					/mob/living/simple_animal/hostile/mirelurk/baby = 8)
 
 /obj/structure/nest/raider
 	name = "narrow tunnel"
 	desc = "A crude tunnel used by raiders to travel across the wasteland."
-	max_mobs = 5
+	max_mobs = 2
 	icon_state = "ventblue"
 	spawnsound = 'sound/effects/bin_close.ogg'
 	mob_types = list(/mob/living/simple_animal/hostile/raider = 5,
@@ -339,24 +386,22 @@
 
 /obj/structure/nest/raider/ranged
 	max_mobs = 3
-	mob_types = list(/mob/living/simple_animal/hostile/raider/ranged = 2,
-					/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 1,
-					/mob/living/simple_animal/hostile/raider/ranged/biker = 1)
+	mob_types = list(/mob/living/simple_animal/hostile/raider/ranged = 4,
+					/mob/living/simple_animal/hostile/raider/ranged/sulphiteranged = 2,
+					/mob/living/simple_animal/hostile/raider/ranged/biker = 2)
 
 /obj/structure/nest/raider/boss
 	max_mobs = 1
-	spawn_once = TRUE
-	mob_types = list(/mob/living/simple_animal/hostile/raider/ranged/boss = 5)
+	mob_types = list(/mob/living/simple_animal/hostile/raider/ranged/boss = 1)
 
 /obj/structure/nest/raider/legendary
 	max_mobs = 1
-	spawn_once = TRUE
 	mob_types = list(/mob/living/simple_animal/hostile/raider/legendary = 1)
 
 /obj/structure/nest/protectron
 	name = "protectron pod"
 	desc = "An old robot storage system. This one looks like it is connected to space underground."
-	max_mobs = 3
+	max_mobs = 2
 	icon_state = "scanner_modified"
 	mob_types = list(/mob/living/simple_animal/hostile/handy/protectron = 5)
 
@@ -384,7 +429,7 @@
 /obj/structure/nest/gecko
 	name = "gecko nest"
 	max_mobs = 5
-	mob_types = list(/mob/living/simple_animal/hostile/gecko = 5)
+	mob_types = list(/mob/living/simple_animal/hostile/gecko = 10)
 
 /obj/structure/nest/wolf
 	name = "wolf den"
@@ -426,8 +471,8 @@
 /obj/structure/nest/tunneler
 	name = "tunneler tunnel"
 	desc = "A tunnel which leads to an underground network of even more tunnels, made by the dangerous tunnelers."
-	max_mobs = 5
-	mob_types = list(/mob/living/simple_animal/hostile/trog/tunneler = 1)
+	max_mobs = 2
+	mob_types = list(/mob/living/simple_animal/hostile/trog/tunneler = 10)
 	spawn_time = 20 SECONDS
 
 /obj/structure/nest/randomized


### PR DESCRIPTION
## About The Pull Request

Reworks spawners, again.

Now, the mob list is how many of each mob the spawner can spawn total. When a mob is spawned, it is decremented from the list. This way, ghoul spawners can spawn 10 ghouls, 1 reaver, and 1 glowing one before collapsing.

Spawners have a limit to how many of any mob can be around it, depending on the spawner's difficulty generally. If there are that many living simplemobs around, it'll skip spawning until there are less than that many around.

Most spawners require a player to be around to spawn anything. Should prevent huge clouds of mobs everywhere.

Reworks the dense object thing to use a weakref to improve performance a little bit if something's on the spawner for multiple fires.

Makes spawned mobs stop referencing this nest if its destroyed before they all die. Might fix some hard dels? Or does nothing, one of those.