### PR TITLE
Tweaks mob burstfire and securitron grenades

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -146,6 +146,4 @@
 /obj/item/grenade/flashbang/sentry
 	name = "defensive flashbang" //for sentrybots
 	desc = "Why are you staring at this?!"
-	flashbang_range = 7
-	det_time = 1 SECONDS
-
+	flashbang_range = 3

--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -18,7 +18,6 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	move_to_delay = 5
-	stat_attack = SOFT_CRIT
 	robust_searching = TRUE
 	maxHealth = 120
 	health = 120
@@ -35,6 +34,8 @@
 	minimum_distance = 1
 	retreat_distance = 4
 	extra_projectiles = 2
+	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOW
+	ranged_ignores_vision = TRUE
 	attack_verb_simple = "punches"
 	attack_sound = "punch"
 	a_intent = "harm"
@@ -59,12 +60,20 @@
 	if(!Proj)
 		CRASH("[src] securitron invoked bullet_act() without a projectile")
 	if(prob(5) && health > 1)
-		visible_message(span_danger("\The [src] releases a defensive flashbang!"))
 		var/flashbang_turf = get_turf(src)
 		if(!flashbang_turf)
 			return
-		var/obj/item/grenade/flashbang/sentry/S = new /obj/item/grenade/flashbang/sentry(flashbang_turf)
+		var/obj/item/grenade/S
+		switch(rand(1,10))
+			if(1)
+				S = new /obj/item/grenade/flashbang/sentry(flashbang_turf)
+			if(2)
+				S = new /obj/item/grenade/stingbang(flashbang_turf)
+			if(3 to 10)
+				S = new /obj/item/grenade/smokebomb(flashbang_turf)
+		visible_message(span_danger("\The [src] releases a defensive [S]!"))
 		S.preprime(user = null)
+
 	if(prob(75) || Proj.damage > 26) //prob(x) = chance for proj to actually do something, adjust depending on how OP you want sentrybots to be
 		return ..()
 	else

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -16,7 +16,6 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	move_to_delay = 3
-	stat_attack = 1
 	robust_searching = 1
 	maxHealth = 56
 	health = 56
@@ -152,6 +151,7 @@
 	health = 100
 	faction = list("raider", "wastebot")
 	extra_projectiles = 1
+	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOWER
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	minimum_distance = 4

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -20,6 +20,7 @@
 	maxHealth = 104
 	healable = FALSE
 	stat_attack = CONSCIOUS
+	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOWER
 	melee_damage_lower = 14
 	melee_damage_upper = 28
 	robust_searching = TRUE
@@ -89,8 +90,8 @@
 	projectiletype = /obj/item/projectile/f13plasma/scatter
 	extra_projectiles = 1
 	ranged = TRUE
-	retreat_distance = 2
-	minimum_distance = 2
+	retreat_distance = 4
+	minimum_distance = 4
 	check_friendly_fire = TRUE
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/crafting/electronicparts/three, /obj/item/stock_parts/cell/ammo/mfc)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -17,6 +17,8 @@
 	var/sidestep_per_cycle = 1 //How many sidesteps per npcpool cycle when in melee
 
 	var/extra_projectiles = 0 //how many projectiles above 1?
+	/// How long to wait between shots?
+	var/auto_fire_delay = GUN_AUTOFIRE_DELAY_NORMAL
 	var/projectiletype	//set ONLY it and NULLIFY casingtype var, if we have ONLY projectile
 	var/projectilesound
 	var/casingtype		//set ONLY it and NULLIFY projectiletype, if we have projectile IN CASING
@@ -71,6 +73,8 @@
 	if(!targets_from)
 		targets_from = src
 	wanted_objects = typecacheof(wanted_objects)
+	if((auto_fire_delay * extra_projectiles) < ranged_cooldown_time)
+		ranged_cooldown_time = (auto_fire_delay * (extra_projectiles + 1))
 
 
 /mob/living/simple_animal/hostile/Destroy()
@@ -453,7 +457,7 @@
 	else
 		Shoot(A)
 		for(var/i in 1 to extra_projectiles)
-			addtimer(CALLBACK(src, .proc/Shoot, A), i * 2)
+			addtimer(CALLBACK(src, .proc/Shoot, A), i * auto_fire_delay)
 	ranged_cooldown = world.time + ranged_cooldown_time
 
 

--- a/code/modules/mob/living/simple_animal/hostile/synth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/synth.dm
@@ -13,7 +13,6 @@
 	response_disarm_simple = "shoves"
 	response_harm_simple = "hits"
 	move_to_delay = 3
-	stat_attack = 1
 	robust_searching = 1
 	maxHealth = 150
 	health = 150


### PR DESCRIPTION
## About The Pull Request

Mobs with extra projectiles can have the delay between their projectiles adjusted. Defaults to about 2-3 times slower than usual.

If a mob has an autofire delay shorter than one burst, it's changed to be just one long continuous spray. Like sentrybots, they fire slower, but they dont stop shooting.

Securitrons and sentrybots stop shooting when you're downed. Fuckers.

Nerfed the defensive flashbang to go off several seconds later, and have about half the bang range.

Securitrons can now also drop stingbangs and smokebombs. Its mostly smokebombs, with a 10% chance to be a flash or stingbang instead.

Gutsies should be a bit more fair.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Securitrons can prime smokebombs and stingbangs too. Mostly smokebombs.
tweak: Ranged mobs can have their burst fire rate adjusted.
balance: Secbots stop shooting you when you're downed.
balance: Most auto-fire mobs shoot more slowly between each shot. Sentrybots just dont stop shooting~