### PR TITLE
[WIP] adds cargo to shopkeep

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -1035,6 +1035,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/museum)
+"bdZ" = (
+/obj/structure/fluff/rails{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "bef" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -3872,6 +3878,7 @@
 /area/f13/building)
 "bOH" = (
 /obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/blueprintLowMid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bOI" = (
@@ -4125,6 +4132,8 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/crafting,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bPj" = (
@@ -5121,6 +5130,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"bZf" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/subway{
+	name = "stone floor"
+	},
+/area/f13/caves)
 "bZk" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6104,6 +6119,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"cvn" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 5;
+	height = 7;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "cvq" = (
 /obj/machinery/button/door{
 	id = "salad";
@@ -6927,6 +6953,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"dlA" = (
+/obj/structure/rack,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dlE" = (
 /obj/structure/table/booth,
 /obj/effect/decal/waste{
@@ -7027,8 +7059,6 @@
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
 /obj/item/reagent_containers/glass/bottle/blackpowder,
@@ -7072,8 +7102,8 @@
 	},
 /area/f13/tunnel)
 "duv" = (
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "duF" = (
 /obj/structure/rack,
@@ -7121,6 +7151,16 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"dwU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "dxt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_master,
@@ -7399,7 +7439,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/item/minigunpackbal5mm,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -9067,6 +9106,16 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"fvh" = (
+/obj/structure/barricade/bars,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/building)
 "fvp" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
@@ -9216,6 +9265,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/caves)
+"fEI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/water,
 /area/f13/caves)
 "fET" = (
 /obj/structure/table,
@@ -9542,6 +9597,11 @@
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
+"gbC" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/gun/ballistic/automatic/assault_rifle,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "gbK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9716,6 +9776,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"gkl" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/r_wall/rust,
+/area/f13/building)
 "gkt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11630,6 +11694,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
+"irN" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "isn" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -11770,6 +11840,9 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ixO" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "iyM" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
@@ -12027,6 +12100,15 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"iHV" = (
+/obj/structure/rack,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "iIr" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -12142,6 +12224,10 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/clinic)
+"iNG" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/f13/tunnel,
+/area/f13/caves)
 "iNR" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -12556,6 +12642,10 @@
 "jmO" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"jmY" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/water,
 /area/f13/caves)
 "jnp" = (
 /obj/effect/decal/waste{
@@ -13537,8 +13627,8 @@
 /area/f13/building/massfusion)
 "knX" = (
 /obj/structure/ladder/unbreakable{
-	id = "followersbasement";
-	height = 1
+	height = 1;
+	id = "followersbasement"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
@@ -14077,6 +14167,12 @@
 	name = "vines"
 	},
 /turf/closed/wall/f13/wood,
+/area/f13/caves)
+"kUp" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/water,
 /area/f13/caves)
 "kUz" = (
 /mob/living/simple_animal/hostile/raider/baseball{
@@ -15719,8 +15815,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "myu" = (
@@ -15985,6 +16080,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"mOi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mPz" = (
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
@@ -16221,6 +16323,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
+"nbE" = (
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nbQ" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/indestructible/ground/inside/subway,
@@ -16316,6 +16422,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
+"ngl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "ngw" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -16904,6 +17017,10 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"nNV" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/f13/tunnel,
+/area/f13/building)
 "nOj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
@@ -17101,6 +17218,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"nXC" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/water,
 /area/f13/caves)
 "nYd" = (
 /obj/structure/kitchenspike,
@@ -17553,6 +17676,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/caves)
+"owS" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/r_wall,
+/area/f13/building)
 "owV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -17842,6 +17969,10 @@
 "oMP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/caves)
+"oMS" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/r_wall,
 /area/f13/caves)
 "oMU" = (
 /obj/structure/lattice/catwalk,
@@ -18855,7 +18986,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pJc" = (
@@ -18898,6 +19028,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pMC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "pMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -20334,6 +20473,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/caves)
+"red" = (
+/obj/structure/barricade/bars,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "ref" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -20868,6 +21011,12 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"rLV" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/water,
+/area/f13/caves)
 "rLW" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib2-old"
@@ -21214,6 +21363,12 @@
 "sdo" = (
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/caves)
+"sdX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/water,
 /area/f13/caves)
 "sed" = (
 /obj/effect/decal/cleanable/glass,
@@ -21805,6 +21960,16 @@
 /obj/item/mine/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"sKb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/grass/coyote/twelve,
+/turf/open/water,
+/area/f13/building)
 "sKq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -21855,6 +22020,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"sMz" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/water,
+/area/f13/caves)
 "sNR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -22172,6 +22343,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/tunnel)
+"tck" = (
+/obj/machinery/door/unpowered/securedoor,
+/turf/open/floor/plasteel/f13/vault_floor/plating{
+	name = "plating"
+	},
+/area/f13/building)
 "tcl" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
@@ -23848,6 +24025,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/caves)
+"uSq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/inside/subway{
+	name = "stone floor"
+	},
+/area/f13/caves)
 "uTw" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23992,6 +24177,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vaB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vaR" = (
 /obj/structure/simple_door/wood,
 /obj/structure/barricade/wooden/planks,
@@ -24504,9 +24695,8 @@
 	},
 /area/f13/tunnel)
 "vAm" = (
-/obj/structure/flora/wasteplant/wild_fungus,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/building)
 "vBc" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -25960,6 +26150,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"xgB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway{
+	name = "stone floor"
+	},
+/area/f13/caves)
 "xgE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26310,6 +26508,12 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"xAD" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "xAG" = (
 /obj/machinery/light{
 	dir = 4
@@ -27044,6 +27248,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"yjd" = (
+/obj/effect/turf_decal/vg_decals/numbers/nine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "yjg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal,
@@ -29602,17 +29810,17 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-boU
-boU
-aae
 aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aak
@@ -29862,12 +30070,12 @@ aae
 aae
 aae
 aae
-boU
+aae
+aae
+aae
 aak
-aak
-bpO
-boU
-boU
+aae
+aae
 aae
 aae
 aae
@@ -30116,16 +30324,16 @@ aae
 aae
 aae
 aae
-aak
 aae
-boU
-boU
-aak
-boU
-boU
-cao
-boU
-boU
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -30374,15 +30582,15 @@ aae
 aae
 aae
 aae
-boU
-duv
-boU
-boU
-boU
-boU
-boU
-boU
-boU
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -30631,14 +30839,14 @@ aae
 aae
 aae
 aae
-boU
-boU
-cdn
-boU
-boU
+aae
+aak
+aae
+aae
 aak
 aak
-boU
+aae
+aae
 aae
 aae
 aae
@@ -30887,11 +31095,11 @@ aae
 aae
 aae
 aae
-boU
-boU
-boU
-caY
-boU
+aae
+aae
+aae
+aae
+aae
 aak
 aak
 aae
@@ -31145,12 +31353,12 @@ aae
 aae
 aae
 aae
-boU
-boU
-boU
-vAm
 aae
-aak
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -31402,13 +31610,13 @@ aae
 aae
 aae
 aae
-boU
-boU
-boU
-boU
-boU
 aae
 aae
+aae
+aak
+aae
+aae
+aak
 aae
 aae
 aae
@@ -31657,12 +31865,12 @@ aak
 aak
 aae
 aae
-aak
 aae
 aae
 aae
-boU
-cdn
+aae
+aae
+aae
 aae
 aae
 aae
@@ -31917,9 +32125,9 @@ aae
 aae
 aae
 aae
-boU
-boU
-boU
+aae
+aae
+aae
 aae
 aae
 aae
@@ -32175,10 +32383,10 @@ aae
 aae
 aae
 aae
-boU
 aae
 aae
-aak
+aae
+aae
 aae
 aae
 aae
@@ -32435,7 +32643,7 @@ aae
 aae
 aae
 aae
-aak
+aae
 aae
 aae
 aae
@@ -32937,9 +33145,9 @@ aae
 aae
 aae
 aae
-bMU
-boU
-aak
+aae
+aae
+aae
 aae
 aae
 aae
@@ -33194,9 +33402,9 @@ aae
 aae
 aae
 aae
-boU
-bNH
-boU
+aae
+aae
+aae
 aae
 aae
 aae
@@ -33451,9 +33659,9 @@ aae
 aae
 aae
 aae
-boU
-boU
-bNH
+aae
+aae
+aae
 aae
 aae
 aae
@@ -33686,24 +33894,24 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+iNG
 aae
 aae
 aae
@@ -33943,24 +34151,24 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+uUw
+vAm
+ixO
+xAD
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+oMS
 aae
 aae
 aae
@@ -34200,24 +34408,24 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bOD
+vAm
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+oMS
 aae
 aae
 aae
@@ -34457,24 +34665,24 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
+uUw
+vAm
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+red
 aae
 aae
 aae
@@ -34714,24 +34922,24 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aak
+uUw
+vAm
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+red
 aae
 aae
 aae
@@ -34971,8 +35179,31 @@ aae
 aae
 aak
 aak
+bPe
+vAm
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+red
+aae
+aae
+aae
+aae
+aae
+aae
 aak
-aak
 aae
 aae
 aae
@@ -34980,15 +35211,6 @@ aae
 aae
 aae
 aae
-aak
-aae
-aae
-aak
-aak
-aak
-aak
-aak
-aak
 aae
 aae
 aae
@@ -35008,21 +35230,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aak
 aae
 aae
 aae
@@ -35228,24 +35436,24 @@ aae
 aae
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bPe
+vAm
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+bdZ
+oMS
 aae
 aae
 aae
@@ -35485,24 +35693,24 @@ aae
 aae
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
+bPe
+vAm
+ixO
+irN
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+cvn
+ixO
+ixO
+ixO
+ixO
+ixO
+ixO
+red
 aak
 aae
 aae
@@ -35741,6 +35949,25 @@ aae
 aae
 aae
 aak
+aae
+nNV
+nNV
+nNV
+nNV
+nNV
+nNV
+uUw
+dwU
+vaB
+vaB
+pMC
+vaB
+vaB
+mOi
+nNV
+nNV
+nNV
+iNG
 aak
 aae
 aae
@@ -35753,26 +35980,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -36005,6 +36213,36 @@ aae
 aae
 aae
 aae
+uUw
+nbE
+bLL
+bLL
+bLL
+bLL
+bLL
+bLL
+owS
+rLV
+fEI
+sMz
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -36013,36 +36251,6 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -36262,18 +36470,18 @@ aak
 aak
 aak
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
-aae
-aae
-aae
-aae
+bOD
+nbE
+bLL
+bLL
+bLL
+bLL
+bLL
+dlA
+gkl
+sdX
+gGV
+jmY
 aae
 aae
 aae
@@ -36519,20 +36727,20 @@ aak
 aak
 aak
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bPe
+yjd
+bLL
+bLL
+bLL
+bLL
+bLL
+iHV
+owS
+sdX
+gGV
+kUp
+xgB
+ejI
 aae
 aae
 aae
@@ -36564,7 +36772,7 @@ aae
 aae
 aae
 aae
-aae
+aak
 aae
 aae
 aae
@@ -36776,6 +36984,33 @@ aak
 aak
 aak
 aak
+bPe
+bLL
+bLL
+bLL
+mNK
+bLL
+ngl
+sKb
+fvh
+nXC
+kUp
+uSq
+bZf
+ejI
+aak
+aae
+aak
+aak
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -36786,33 +37021,6 @@ aae
 aae
 aae
 aak
-aae
-aae
-aae
-aae
-aak
-aae
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -37038,29 +37246,29 @@ uUw
 bPe
 uUw
 bPe
-uUw
-uUw
-bPe
-bPe
+tck
 uUw
 bPe
+bPe
 uUw
+bPe
+uUw
+ejI
+ejI
+aae
+aae
+aae
 aak
 aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
 aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -37302,27 +37510,27 @@ bLL
 bOL
 hOu
 bPe
+ejI
+ejI
+aae
+aak
 aak
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -37559,8 +37767,8 @@ pIT
 bLL
 bPx
 uUw
-aae
-aae
+ejI
+ejI
 aae
 aae
 aae
@@ -37817,8 +38025,8 @@ bOA
 bPx
 uUw
 aak
-aae
-aae
+ejI
+ejI
 aae
 aae
 aak
@@ -38074,8 +38282,8 @@ bOA
 bPx
 bPe
 aak
-aae
-aae
+ejI
+ejI
 aae
 aae
 aak
@@ -38330,8 +38538,8 @@ pii
 bOA
 xqd
 bPe
-aak
-aae
+ejI
+ejI
 aae
 aae
 aae
@@ -38588,7 +38796,7 @@ bOA
 dte
 uUw
 aae
-aae
+ejI
 aae
 aae
 aae
@@ -39353,7 +39561,7 @@ bOB
 omO
 uTw
 bLL
-mBz
+gbC
 omO
 omO
 aae
@@ -69652,7 +69860,7 @@ aae
 aae
 bsC
 aah
-aah
+duv
 bsC
 aae
 aae

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(economy)
 
 
 /datum/controller/subsystem/economy/proc/car_payout()
-	var/cargo_cash = 500
+	var/cargo_cash = 250
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_CAR)
 	if(D)
 		D.adjust_money(cargo_cash)

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -27,7 +27,7 @@
 
 /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
-	desc = "This crate holds 2 full bio suits which will protect you from viruses, along with a bio bag and two spaceacillin syringes."
+	desc = "This crate holds 2 full bio suits which will protect you from viruses, along with a bio bag and two penicillin syringes."
 	cost = 2000
 	contains = list(/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/head/bio_hood,
@@ -40,6 +40,7 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "bio suit crate"
 
+/* //atmospherics ain't a thing, here. why was it even so expensive
 /datum/supply_pack/emergency/equipment
 	name = "Emergency Bot/Internals Crate"
 	desc = "Explosions got you down? These supplies are guaranteed to patch up holes, in stations and people alike! Comes with two floorbots, two medbots, five oxygen masks and five small oxygen tanks."
@@ -60,6 +61,7 @@
 					/obj/item/clothing/mask/gas)
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
+*/
 
 /datum/supply_pack/emergency/medicalemergency
 	name = "Emergency Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
@@ -106,28 +108,18 @@
 
 /datum/supply_pack/emergency/radiatione_emergency
 	name = "Emergency Radiation Protection Crate"
-	desc = "Survive the Nuclear Apocalypse and Supermatter Engine alike with two sets of Radiation suits. Each set contains a helmet, suit, and Geiger counter. We'll even throw in a few pill bottles that are able to handles radiation and the affects of the poisoning."
-	cost = 2500
+	desc = "Survive the harshest of nuclear wastelands! Each set contains a helmet, suit, and Geiger counter. Rad-X and Radaway not included."
+	cost = 2000
 	contains = list(/obj/item/clothing/head/radiation,
 					/obj/item/clothing/head/radiation,
 					/obj/item/clothing/suit/radiation,
 					/obj/item/clothing/suit/radiation,
 					/obj/item/geiger_counter,
-					/obj/item/geiger_counter,
-					/obj/item/storage/pill_bottle/mutarad,
-					/obj/item/storage/firstaid/radbgone)
+					/obj/item/geiger_counter)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
 
-/datum/supply_pack/emergency/rcds
-	name = "Emergency RCDs"
-	desc = "Bombs going off on station? SME blown and now you need to fix the hole it left behind? Well this crate has a pare of RCDs to be able to easily fix up any problem you may have!"
-	cost = 1500
-	contains = list(/obj/item/construction/rcd,
-					/obj/item/construction/rcd)
-	crate_name = "emergency rcds"
-	crate_type = /obj/structure/closet/crate/internals
-
+/* //we need none of these.
 /datum/supply_pack/emergency/bomb
 	name = "Explosive Emergency Crate"
 	desc = "Science gone bonkers? Beeping behind the airlock? Buy now and become the hero the station des... I mean needs! Time not included, but a full bomb suit and hood, as well as a mask and defusal kit are! Non-Nuclear ordnances only."
@@ -184,18 +176,11 @@
 					/obj/item/tank/internals/air)
 	crate_name = "internals crate"
 	crate_type = /obj/structure/closet/crate/internals
-
-/datum/supply_pack/emergency/metalfoam
-	name = "Metal Foam Grenade Crate"
-	desc = "Seal up those pesky hull breaches with 14 Metal Foam Grenades."
-	cost = 1500
-	contains = list(/obj/item/storage/box/metalfoam,
-					/obj/item/storage/box/metalfoam)
-	crate_name = "metal foam grenade crate"
+*/
 
 /datum/supply_pack/emergency/mre
 	name = "MRE Packs (Emergency Rations)"
-	desc = "The lights are out. Oxygen's running low. You've run out of food except space weevils. Don't let this be you! Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu and an oxygen tank."
+	desc = "Bacteria, radioactive contamination, bugs and worms, who wants to deal with that? Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu."
 	cost = 2000
 	contains = list(/obj/item/storage/box/mre/menu1/safe,
 					/obj/item/storage/box/mre/menu1/safe,
@@ -205,6 +190,7 @@
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
 
+/*
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires EVA access to open."
@@ -244,7 +230,7 @@
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
-/*
+
 /datum/supply_pack/emergency/spacesuit
 	name = "Space Suit Crate"
 	desc = "Contains two aging suits from Space-Goodwill. Requires EVA access to open."
@@ -286,7 +272,7 @@
 */
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
-	desc = "(*!&@#NEED SOMETHING TO DEAL WITH THE GREYTIDE, HUH OPERATIVE? WELL, THIS LITTLE ORDER CAN HELP YOU OUT IN A PINCH. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXINS!#@*$"
+	desc = "(*!&@#NCL4VE DEEP-COVER-OPERATIVE SUPPLIES. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXI#@*$"
 	hidden = TRUE
 	cost = 2200
 	contains = list(/obj/item/storage/box/emps,

--- a/code/modules/cargo/packs/engine.dm
+++ b/code/modules/cargo/packs/engine.dm
@@ -50,7 +50,7 @@
 	crate_name = "emitter crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE
-*/
+
 /datum/supply_pack/engine/field_gen
 	name = "Field Generator Crate"
 	desc = "Typically the only thing standing between the station and a messy death. Powered by emitters. Contains two field generators."
@@ -69,7 +69,7 @@
 					/obj/machinery/power/grounding_rod)
 	crate_name = "grounding rod crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
-/*
+
 /datum/supply_pack/engine/mason
 	name = "M.A.S.O.N RIG Crate"
 	desc = "The rare M.A.S.O.N RIG. Requires CE access to open."
@@ -91,7 +91,7 @@
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
 	crate_name = "particle accelerator crate"
-*/
+
 /datum/supply_pack/engine/collector
 	name = "Radiation Collector Crate"
 	desc = "Contains three radiation collectors. Useful for collecting energy off nearby Supermatter Crystals, Singularities or Teslas!"
@@ -100,7 +100,7 @@
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
 	crate_name = "collector crate"
-/*
+
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
@@ -108,6 +108,7 @@
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
 */
+
 /datum/supply_pack/engine/solar
 	name = "Solar Panel Crate"
 	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
@@ -160,7 +161,7 @@
 					/obj/machinery/power/tesla_coil)
 	crate_name = "tesla coil crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
-*/	
+*/
 /*
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -212,3 +212,12 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 */
+
+/datum/supply_pack/emergency/metalfoam
+	name = "Metal Foam Grenade Crate"
+	desc = "Seal up those pesky perimiter breaches with 14 Metal Foam Grenades. Or be a pain in someone's ass. We don't care."
+	cost = 1500
+	contains = list(/obj/item/storage/box/metalfoam,
+					/obj/item/storage/box/metalfoam)
+	crate_name = "metal foam grenade crate"
+

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -120,14 +120,13 @@
 	crate_name = "medical supplies crate"
 
 /datum/supply_pack/medical/adv_surgery_tools
-	name = "Med-Co Advanced Surgery Tools"
-	desc = "A full set of Med-Co advanced surgery tools, this crate also comes with a spay of synth flesh as well as a can of . Requires Surgery access to open."
+	name = "Med-Tek Advanced Surgery Tools"
+	desc = "A full set of Med-Co advanced surgery tools, this crate also comes with a spay of synth flesh as well as a can of sterilizine. Requires Surgery access to open."
 	cost = 5500
-	access = ACCESS_SURGERY
 	contains = list(/obj/item/storage/belt/medical/surgery_belt_adv,
 					/obj/item/reagent_containers/medspray/synthflesh,
 					/obj/item/reagent_containers/medspray/sterilizine)
-	crate_name = "medco surgery tools"
+	crate_name = "medtek surgery tools"
 	crate_type = /obj/structure/closet/crate/secure/medical
 
 /datum/supply_pack/medical/surgery
@@ -143,6 +142,7 @@
 ///////////////////////////// Medical Kits ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
+/*
 /datum/supply_pack/medical/sprays
 	name = "Medical Sprays"
 	desc = "Contains two cans of Styptic Spray, Silver Sulfadiazine Spray, Synthflesh Spray and Sterilizer Compound Spray."
@@ -159,7 +159,7 @@
 
 /datum/supply_pack/medical/advrad
 	name = "Radiation Treatment Crate Deluxe"
-	desc = "A crate for when radiation is out of hand... Contains two rad-b-gone kits, one bottle of anti radiation deluxe pills, as well as a radiation treatment deluxe pill bottle!"
+	desc = "A crate for when radiation is out of hand... Contains two radaway pouches, one bottle of radx, as well as a radiation treatment deluxe pill bottle!"
 	cost = 3500
 	contains = list(/obj/item/storage/pill_bottle/antirad_plus,
 					/obj/item/storage/pill_bottle/mutarad,
@@ -169,6 +169,7 @@
 					/obj/item/geiger_counter)
 	crate_name = "radiation protection crate"
 	crate_type = /obj/structure/closet/crate/radiation
+
 
 /datum/supply_pack/medical/medipen_variety
 	name = "Medipen Variety-Pak"
@@ -184,3 +185,16 @@
 					/obj/item/reagent_containers/hypospray/medipen/blood_loss)
 
 	crate_name = "medipen crate"
+*/
+
+/datum/supply_pack/medical/stimpak5
+	name = "Stimpak"
+	desc = "The humble stimpak, in a box of five."
+	cost = 250
+	contains = /obj/item/storage/box/medicine/stimpaks/stimpaks5
+
+/datum/supply_pack/medical/radaway
+	name = "Radaway"
+	desc = "It burns like hell, but it flushes the rads out, for sure."
+	cost = 250
+	contains = /obj/item/reagent_containers/blood/radaway

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -28,9 +28,7 @@
 	name = "Blood Pack Variety Crate"
 	desc = "Contains nine different blood packs for reintroducing blood to patients, plus two universal synthetic blood packs."
 	cost = 3000
-	contains = list(/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/synthetics,
-					/obj/item/reagent_containers/blood/random,
+	contains = list(/obj/item/reagent_containers/blood/random,
 					/obj/item/reagent_containers/blood/APlus,
 					/obj/item/reagent_containers/blood/AMinus,
 					/obj/item/reagent_containers/blood/BPlus,
@@ -92,7 +90,7 @@
 */
 /datum/supply_pack/medical/supplies
 	name = "Medical Supplies Crate"
-	desc = "Contains seven beakers, syringes, and bodybags. Three morphine bottles, four insulin pills. Two charcoal bottles, epinephrine bottles, antitoxin bottles, and large beakers. Finally, a single roll of medical gauze, as well as a bottle of stimulant pills for long, hard work days. German doctor not included."
+	desc = "Contains seven beakers, syringes, and bodybags. Three morphine bottles, four insulin pills. Two charcoal bottles, epinephrine bottles, antitoxin bottles, and large beakers. Finally, a single roll of medical gauze."
 	cost = 2500
 	contains = list(/obj/item/reagent_containers/glass/bottle/charcoal,
 					/obj/item/reagent_containers/glass/bottle/charcoal,
@@ -114,7 +112,6 @@
 					/obj/item/storage/box/medsprays,
 					/obj/item/storage/box/syringes,
 					/obj/item/storage/box/bodybags,
-					/obj/item/storage/pill_bottle/stimulant,
 					/obj/item/stack/medical/bone_gel,
 					/obj/item/stack/medical/bone_gel)
 	crate_name = "medical supplies crate"

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -16,8 +16,8 @@
 
 /datum/supply_pack/misc/anvil
 	name = "Anvil Crate"
-	desc = "An anvil in a crate, we had to dig this out of the old warehouse. It's got wheels on it so you can move it."
-	cost = 7500
+	desc = "An anvil in a crate. It's got wheels on it so you can move it."
+	cost = 2500
 	contains = list(/obj/structure/anvil/obtainable/basic)
 
 /datum/supply_pack/misc/artsupply
@@ -42,7 +42,7 @@
 
 /datum/supply_pack/misc/book_crate
 	name = "Book Crate"
-	desc = "Surplus from the Nanotrasen Archives, these five books are sure to be good reads."
+	desc = "Surplus from the Brotherhood Archives, these five books are sure to be good reads."
 	cost = 1500
 	contains = list(/obj/item/book/codex_gigas,
 					/obj/item/book/manual/random/,
@@ -76,6 +76,7 @@
 					/obj/item/storage/briefcase)
 	crate_name = "bureaucracy crate"
 
+/*
 /datum/supply_pack/misc/captain_pen
 	name = "Captain Pen"
 	desc = "A spare Captain fountain pen."
@@ -84,6 +85,7 @@
 	contains = list(/obj/item/pen/fountain/captain)
 	crate_name = "captain pen"
 	crate_type = /obj/structure/closet/crate/secure/weapon //It is a combat pen
+*/
 
 /datum/supply_pack/misc/fountainpens
 	name = "Calligraphy Crate"


### PR DESCRIPTION
## About The Pull Request
Adds the ability for the shopkeep to order from cargo using the ol' 009 Tunnel, aka 'two railroad tracks underground that disappear'. _**Don't merge this yet :)**_

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: shopkeep cargo arggb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
