### PR TITLE
Storage changes again

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(
 	/obj/item/flashlight,
 	/obj/item/gun/ballistic,
 	/obj/item/gun/energy,
-	/obj/item/melee/onehanded/knife/hunting,
+	/obj/item/melee/onehanded/knife,
 	/obj/item/melee/baton,
 	/obj/item/melee/classic_baton/telescopic,
 	/obj/item/reagent_containers/spray/pepper,
@@ -581,6 +581,43 @@ GLOBAL_LIST_INIT(storage_treasurer_can_hold, typecacheof(list(
 	/obj/item/melee/smith/dagger,
 	)))
 
+GLOBAL_LIST_INIT(storage_wallet_can_hold, typecacheof(list(
+	/obj/item/stack/spacecash,
+	/obj/item/holochip,
+	/obj/item/card,
+	/obj/item/clothing/mask/cigarette,
+	/obj/item/flashlight/pen,
+	/obj/item/seeds,
+	/obj/item/stack/medical,
+	/obj/item/toy/crayon,
+	/obj/item/coin,
+	/obj/item/dice,
+	/obj/item/disk,
+	/obj/item/implanter,
+	/obj/item/lighter,
+	/obj/item/lipstick,
+	/obj/item/match,
+	/obj/item/paper,
+	/obj/item/pen,
+	/obj/item/photo,
+	/obj/item/reagent_containers/dropper,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/screwdriver,
+	/obj/item/valentine,
+	/obj/item/stamp,
+	/obj/item/key,
+	/obj/item/cartridge,
+	/obj/item/camera_film,
+	/obj/item/stack/ore/bluespace_crystal,
+	/obj/item/reagent_containers/food/snacks/grown/poppy,
+	/obj/item/instrument/harmonica,
+	/obj/item/mining_voucher,
+	/obj/item/suit_voucher,
+	/obj/item/reagent_containers/pill,
+	/obj/item/coin,
+	/obj/item/stack/f13Cash
+)))
+
 GLOBAL_LIST_INIT(storage_holdout_can_hold, typecacheof(list(
 	/obj/item/gun/ballistic/automatic/pistol/sig,
 	/obj/item/gun/ballistic/revolver/detective,
@@ -590,7 +627,7 @@ GLOBAL_LIST_INIT(storage_holdout_can_hold, typecacheof(list(
 	/obj/item/gun/ballistic/revolver/colt357/lucky,
 	/obj/item/gun/ballistic/revolver/m29/snub,
 	/obj/item/gun/ballistic/revolver/needler,
-	/obj/item/gun/energy/laser/wattz,
+	/obj/item/gun/energy/laser/wattz
 )))
 
 GLOBAL_LIST_INIT(storage_produce_bag_can_hold, typecacheof(list(
@@ -738,7 +775,7 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_SUIT_DUSTER_MAX_TOTAL_SPACE STORAGE_SUIT_DUSTER_MAX_SIZE * STORAGE_SUIT_DUSTER_MAX_ITEMS
 
 /// How many items total fit in a duster armor
-#define STORAGE_SUIT_DUSTER_ARMOR_MAX_ITEMS 2
+#define STORAGE_SUIT_DUSTER_ARMOR_MAX_ITEMS 3
 /// How big a thing can fit in a duster armor
 #define STORAGE_SUIT_DUSTER_ARMOR_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a duster armor

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -392,7 +392,7 @@
 
 /obj/item/storage/belt/military
 	name = "chest rig"
-	desc = "A mean-looking chest accessory for holding lots of ammo."
+	desc = "A mean-looking belt sack for holding lots of ammo."
 	icon_state = "militarywebbing"
 	item_state = "militarywebbing"
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -387,6 +387,41 @@
 	icon_state = "ncr_belt"
 	item_state = "ncr_belt"
 
+///////////////////
+/// Belt bandolier
+
+/obj/item/storage/belt/military
+	name = "chest rig"
+	desc = "A mean-looking chest accessory for holding lots of ammo."
+	icon_state = "militarywebbing"
+	item_state = "militarywebbing"
+	slot_flags = ITEM_SLOT_BELT
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+
+/obj/item/storage/belt/military/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = STORAGE_BELT_SPECIALIZED_MAX_ITEMS
+	STR.max_w_class = STORAGE_BELT_SPECIALIZED_MAX_SIZE
+	STR.max_combined_w_class = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
+	STR.can_hold = GLOB.ammobelt_allowed
+
+/obj/item/storage/belt/military/alt
+	icon_state = "explorer2"
+	item_state = "explorer2"
+
+/obj/item/storage/belt/military/reconbandolier
+	name = "NCR recon ranger bandolier"
+	desc = "A belt with many pockets, now at an angle."
+	icon_state = "reconbandolier"
+	item_state = "reconbandolier"
+
+/obj/item/storage/belt/military/NCR_Bandolier
+	name = "NCR bandolier"
+	desc = "A standard issue NCR bandolier."
+	icon_state = "ncr_bandolier"
+	item_state = "ncr_bandolier"
+
 /* * * * * * *
  * NECKPRONS
  * * * * * * */
@@ -417,38 +452,6 @@
 	slot_flags = ITEM_SLOT_NECK
 	resistance_flags = FIRE_PROOF
 
-/obj/item/storage/belt/military
-	name = "chest rig"
-	desc = "A mean-looking chest accessory for holding lots of ammo."
-	icon_state = "militarywebbing"
-	item_state = "militarywebbing"
-	slot_flags = ITEM_SLOT_NECK
-	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-
-/obj/item/storage/belt/military/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = STORAGE_NECKPRON_SPECIALIZED_MAX_ITEMS
-	STR.max_w_class = STORAGE_NECKPRON_SPECIALIZED_MAX_SIZE
-	STR.max_combined_w_class = STORAGE_NECKPRON_SPECIALIZED_MAX_TOTAL_SPACE
-	STR.can_hold = GLOB.ammobelt_allowed
-
-/obj/item/storage/belt/military/alt
-	icon_state = "explorer2"
-	item_state = "explorer2"
-
-/obj/item/storage/belt/military/reconbandolier
-	name = "NCR recon ranger bandolier"
-	desc = "A belt with many pockets, now at an angle."
-	icon_state = "reconbandolier"
-	item_state = "reconbandolier"
-
-/obj/item/storage/belt/military/NCR_Bandolier
-	name = "NCR bandolier"
-	desc = "A standard issue NCR bandolier."
-	icon_state = "ncr_bandolier"
-	item_state = "ncr_bandolier"
-
 /////////////////
 /// Neck Gunbelt
 /obj/item/storage/belt/shoulderholster
@@ -464,9 +467,9 @@
 /obj/item/storage/belt/shoulderholster/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = STORAGE_NECKPRON_SPECIALIZED_MAX_ITEMS
-	STR.max_w_class = STORAGE_NECKPRON_SPECIALIZED_MAX_SIZE
-	STR.max_combined_w_class = STORAGE_NECKPRON_SPECIALIZED_MAX_TOTAL_SPACE
+	STR.max_items = STORAGE_NECKPRON_HOLSTER_MAX_ITEMS
+	STR.max_w_class = STORAGE_NECKPRON_HOLSTER_MAX_SIZE
+	STR.max_combined_w_class = STORAGE_NECKPRON_HOLSTER_MAX_TOTAL_SPACE
 	STR.can_hold = GLOB.gunbelt_allowed
 
 /obj/item/storage/belt/shoulderholster/full/PopulateContents()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,6 +13,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 4
+	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	STR.can_hold = GLOB.storage_wallet_can_hold
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,41 +13,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 4
-	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power))
-	STR.can_hold = typecacheof(list(
-		/obj/item/stack/spacecash,
-		/obj/item/holochip,
-		/obj/item/card,
-		/obj/item/clothing/mask/cigarette,
-		/obj/item/flashlight/pen,
-		/obj/item/seeds,
-		/obj/item/stack/medical,
-		/obj/item/toy/crayon,
-		/obj/item/coin,
-		/obj/item/dice,
-		/obj/item/disk,
-		/obj/item/implanter,
-		/obj/item/lighter,
-		/obj/item/lipstick,
-		/obj/item/match,
-		/obj/item/paper,
-		/obj/item/pen,
-		/obj/item/photo,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/screwdriver,
-		/obj/item/valentine,
-		/obj/item/stamp,
-		/obj/item/key,
-		/obj/item/cartridge,
-		/obj/item/camera_film,
-		/obj/item/stack/ore/bluespace_crystal,
-		/obj/item/reagent_containers/food/snacks/grown/poppy,
-		/obj/item/instrument/harmonica,
-		/obj/item/mining_voucher,
-		/obj/item/suit_voucher,
-		/obj/item/reagent_containers/pill,
-		/obj/item/stack/f13Cash))
+	STR.can_hold = GLOB.storage_wallet_can_hold
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -48,6 +48,7 @@
 	STR.max_w_class = WEIGHT_CLASS_TINY
 	STR.max_items = 6
 	STR.max_combined_w_class = 6
+	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	STR.can_hold = GLOB.storage_wallet_can_hold
 
 // Legion reserves. Spawns with the Centurion.

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -4,6 +4,7 @@
 /obj/item/storage/bag/money
 	name = "money bag"
 	icon_state = "moneybag"
+	desc = "This thing holds money!"
 	force = 10
 	throwforce = 0
 	resistance_flags = FLAMMABLE
@@ -16,7 +17,7 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_items = 40
 	STR.max_combined_w_class = 40
-	STR.can_hold = typecacheof(list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/holochip))
+	STR.can_hold = GLOB.storage_wallet_can_hold
 
 /obj/item/storage/bag/money/vault/PopulateContents()
 	new /obj/item/coin/silver(src)
@@ -44,9 +45,10 @@
 /obj/item/storage/bag/money/small/Initialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.max_items = 20
-	STR.can_hold = typecacheof(list(/obj/item/coin, /obj/item/stack/spacecash, /obj/item/stack/f13Cash))
+	STR.max_w_class = WEIGHT_CLASS_TINY
+	STR.max_items = 6
+	STR.max_combined_w_class = 6
+	STR.can_hold = GLOB.storage_wallet_can_hold
 
 // Legion reserves. Spawns with the Centurion.
 /obj/item/storage/bag/money/small/legion/PopulateContents()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -286,7 +286,7 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "wattz1000"
 	item_state = "laser-pistol"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
@@ -308,6 +308,7 @@
 	icon_state = "magnetowattz"
 	item_state = "laser-pistol"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan)
+	w_class = WEIGHT_CLASS_SMALL
 
 	slowdown = GUN_SLOWDOWN_PISTOL_LIGHT
 	force = GUN_MELEE_FORCE_PISTOL_LIGHT


### PR DESCRIPTION
## About The Pull Request

Fixed the shoulder holster being too small. still has 4 slots.

Chest rig, the bandolier, goes on the belt, and has 7 slots for small ammo.

Fixed money pouch's throbbing red text, and made it hold anything a wallet can, including screwdrivers and keys.

Wattz 1000 is a small gun.

Combat dusters get 3 small slots.