### PR TITLE
You can stick your survival kit back in your pocket

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -419,7 +419,7 @@ GLOBAL_LIST_INIT(servicebelt_allowed, typecacheof(list(
 	/obj/item/soap,
 	/obj/item/holosign_creator,
 	/obj/item/forcefield_projector,
-	/obj/item/key/janitor,
+	/obj/item/key,
 	/obj/item/clothing/gloves,
 	/obj/item/melee/flyswatter,
 	/obj/item/broom,
@@ -460,6 +460,13 @@ GLOBAL_LIST_INIT(medibelt_allowed, typecacheof(list(
 	/obj/item/reagent_containers/medspray,
 	/obj/item/reagent_containers/hypospray,
 	/obj/item/reagent_containers/chem_pack,
+	/obj/item/reagent_containers/blood,
+	/obj/item/reagent_containers/food/snacks/deadmouse,
+	/obj/item/reagent_containers/food/snacks/cube,
+	/obj/item/reagent_containers/food/snacks/meat,
+	/obj/item/slime_extract,
+	/obj/item/organ,
+	/obj/item/bodypart
 	/obj/item/lighter,
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/storage/pill_bottle,
@@ -533,6 +540,8 @@ GLOBAL_LIST_INIT(ammobelt_allowed, typecacheof(list(
 	/obj/item/restraints/handcuffs,
 	/obj/item/tank/internals,
 	/obj/item/restraints/legcuffs/bola,
+	/obj/item/melee/classic_baton
+	/obj/item/melee/onehanded/knife
 	/obj/item/toy)))
 
 /// Things allowed in a scabbard
@@ -659,24 +668,6 @@ GLOBAL_LIST_INIT(storage_salvage_storage_bag_can_hold, typecacheof(list(
 	/obj/item/blueprint/research,
 	/obj/item/multitool/advanced
 )))
-
-GLOBAL_LIST_INIT(storage_bio_bag_can_hold, typecacheof(list(
-	/obj/item/slime_extract,
-	/obj/item/reagent_containers/blood,
-	/obj/item/reagent_containers/food/snacks/deadmouse,
-	/obj/item/reagent_containers/food/snacks/cube,
-	/obj/item/organ,
-	/obj/item/reagent_containers/food/snacks/meat/slab,
-	/obj/item/bodypart
-	)))
-
-GLOBAL_LIST_INIT(storage_chemistry_bag_can_hold, typecacheof(list(
-	/obj/item/reagent_containers/hypospray/medipen,
-	/obj/item/reagent_containers/syringe,
-	/obj/item/reagent_containers/pill,
-	/obj/item/reagent_containers/glass/beaker,
-	/obj/item/reagent_containers/glass/bottle,
-	/obj/item/reagent_containers/chem_pack)))
 
 GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 	/obj/item/reagent_containers/food,

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -704,7 +704,7 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE STORAGE_BELT_SPECIALIZED_MAX_SIZE * STORAGE_BELT_SPECIALIZED_MAX_ITEMS
 
 /// How many items total fit in a generic belt
-#define STORAGE_BELT_GENERIC_MAX_ITEMS 4
+#define STORAGE_BELT_GENERIC_MAX_ITEMS 5
 /// How big a thing can fit in a generic belt
 #define STORAGE_BELT_GENERIC_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a generic belt
@@ -722,21 +722,21 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
  * * * * * * * * * * * * * * */
 
 /// How many items total fit in a specialized neckpron
-#define STORAGE_NECKPRON_SPECIALIZED_MAX_ITEMS 4
+#define STORAGE_NECKPRON_SPECIALIZED_MAX_ITEMS 5
 /// How big a thing can fit in a specialized neckpron
 #define STORAGE_NECKPRON_SPECIALIZED_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a specialized neckpron
 #define STORAGE_NECKPRON_SPECIALIZED_MAX_TOTAL_SPACE STORAGE_NECKPRON_SPECIALIZED_MAX_SIZE * STORAGE_NECKPRON_SPECIALIZED_MAX_ITEMS
 
 /// How many items total fit in a generic neckpron
-#define STORAGE_NECKPRON_GENERIC_MAX_ITEMS 2
+#define STORAGE_NECKPRON_GENERIC_MAX_ITEMS 3
 /// How big a thing can fit in a generic neckpron
 #define STORAGE_NECKPRON_GENERIC_MAX_SIZE WEIGHT_CLASS_TINY
 /// How much volume fits in a generic neckpron
 #define STORAGE_NECKPRON_GENERIC_MAX_TOTAL_SPACE STORAGE_NECKPRON_GENERIC_MAX_SIZE * STORAGE_NECKPRON_GENERIC_MAX_ITEMS
 
 /// How many items total fit in a holster neckpron
-#define STORAGE_NECKPRON_HOLSTER_MAX_ITEMS 3
+#define STORAGE_NECKPRON_HOLSTER_MAX_ITEMS 4
 /// How big a thing can fit in a holster neckpron
 #define STORAGE_NECKPRON_HOLSTER_MAX_SIZE WEIGHT_CLASS_NORMAL
 /// How much volume fits in a holster neckpron

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -395,7 +395,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.insert_preposition = "in"
-	STR.can_hold = GLOB.storage_chemistry_bag_can_hold
+	STR.can_hold = GLOB.medibelt_allowed
 
 /*	Now in tribal mode!*/
 
@@ -421,7 +421,7 @@ obj/item/storage/bag/chemistry/tribal
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.insert_preposition = "in"
-	STR.can_hold = GLOB.storage_bio_bag_can_hold
+	STR.can_hold = GLOB.medibelt_allowed
 
 /obj/item/storage/bag/bio/holding
 	name = "bio bag of holding"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -313,19 +313,54 @@
 	new /obj/item/ammo_box/a357(src)
 	new /obj/item/ammo_box/a357(src)
 
+///////////////////
+/// Belt bandolier
+
+/obj/item/storage/belt/military
+	name = "chest rig"
+	desc = "A mean-looking belt sack for holding lots of ammo."
+	icon_state = "militarywebbing"
+	item_state = "militarywebbing"
+	slot_flags = ITEM_SLOT_BELT
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+
+/obj/item/storage/belt/military/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = STORAGE_BELT_SPECIALIZED_MAX_ITEMS
+	STR.max_w_class = STORAGE_BELT_SPECIALIZED_MAX_SIZE
+	STR.max_combined_w_class = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
+	STR.can_hold = GLOB.ammobelt_allowed
+
+/obj/item/storage/belt/military/alt
+	icon_state = "explorer2"
+	item_state = "explorer2"
+
+/obj/item/storage/belt/military/reconbandolier
+	name = "NCR recon ranger bandolier"
+	desc = "A belt with many pockets, now at an angle."
+	icon_state = "reconbandolier"
+	item_state = "reconbandolier"
+
+/obj/item/storage/belt/military/NCR_Bandolier
+	name = "NCR bandolier"
+	desc = "A standard issue NCR bandolier."
+	icon_state = "ncr_bandolier"
+	item_state = "ncr_bandolier"
+
 /obj/item/storage/belt/army
 	name = "army belt"
-	desc = "A robust belt for holding things like guns."
+	desc = "A robust belt for holding things like ammo."
 	icon_state = "grenadebeltold"
 	item_state = "security"
 
 /obj/item/storage/belt/army/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = STORAGE_BELT_HOLSTER_MAX_ITEMS
-	STR.max_w_class = STORAGE_BELT_HOLSTER_MAX_SIZE
-	STR.max_combined_w_class = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
-	STR.can_hold = GLOB.gunbelt_allowed
+	STR.max_items = STORAGE_BELT_SPECIALIZED_MAX_ITEMS
+	STR.max_w_class = STORAGE_BELT_SPECIALIZED_MAX_SIZE
+	STR.max_combined_w_class = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
+	STR.can_hold = GLOB.ammobelt_allowed
 
 /obj/item/storage/belt/army/followers
 	name = "follower belt"
@@ -386,41 +421,6 @@
 	desc = "A standard issue robust duty belt for the NCR."
 	icon_state = "ncr_belt"
 	item_state = "ncr_belt"
-
-///////////////////
-/// Belt bandolier
-
-/obj/item/storage/belt/military
-	name = "chest rig"
-	desc = "A mean-looking belt sack for holding lots of ammo."
-	icon_state = "militarywebbing"
-	item_state = "militarywebbing"
-	slot_flags = ITEM_SLOT_BELT
-	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-
-/obj/item/storage/belt/military/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = STORAGE_BELT_SPECIALIZED_MAX_ITEMS
-	STR.max_w_class = STORAGE_BELT_SPECIALIZED_MAX_SIZE
-	STR.max_combined_w_class = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
-	STR.can_hold = GLOB.ammobelt_allowed
-
-/obj/item/storage/belt/military/alt
-	icon_state = "explorer2"
-	item_state = "explorer2"
-
-/obj/item/storage/belt/military/reconbandolier
-	name = "NCR recon ranger bandolier"
-	desc = "A belt with many pockets, now at an angle."
-	icon_state = "reconbandolier"
-	item_state = "reconbandolier"
-
-/obj/item/storage/belt/military/NCR_Bandolier
-	name = "NCR bandolier"
-	desc = "A standard issue NCR bandolier."
-	icon_state = "ncr_bandolier"
-	item_state = "ncr_bandolier"
 
 /* * * * * * *
  * NECKPRONS

--- a/code/game/objects/items/storage/survivalkit.dm
+++ b/code/game/objects/items/storage/survivalkit.dm
@@ -2,7 +2,7 @@
 	name = "survival kit"
 	desc = "A robust leather pouch containing the essentials for wasteland survival."
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit/PopulateContents()
 	. = ..()
@@ -18,7 +18,7 @@
 	desc = "A robust leather pouch containing essentials a Khan might need in the wasteland."
 	icon = 'icons/fallout/clothing/khans.dmi'
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_khan/PopulateContents()
 	. = ..()
@@ -33,7 +33,7 @@
 	name = "tribal survival kit"
 	desc = "A robust leather pouch containing the essentials for wasteland survival."
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_tribal/PopulateContents() //used by legion
 	. = ..()
@@ -48,7 +48,7 @@
 	name = "survival kit"
 	desc = "A robust leather pouch containing the essentials for wasteland survival."
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_outlaw/PopulateContents()
 	. = ..()
@@ -74,7 +74,7 @@
 	name = "survival kit"
 	desc = "A robust leather pouch containing the essentials for wasteland survival."
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_adv/PopulateContents()
 	. = ..()
@@ -91,7 +91,7 @@
 	name = "individual first aid kit"
 	desc = "A robust leather pouch containing the essentials for trauma care."
 	icon_state = "ifak"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_aid/ComponentInitialize()
 	. = ..()
@@ -111,7 +111,7 @@
 	name = "advanced-individual first aid kit"
 	desc = "A robust leather pouch containing the essentials for trauma care."
 	icon_state = "ifak"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_aid_adv/ComponentInitialize()
 	. = ..()
@@ -130,7 +130,7 @@
 	name = "survival kit"
 	desc = "A robust leather pouch containing the essentials for wasteland survival."
 	icon_state = "survivalkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/survivalkit_triple_empty
 	name = "large survival kit"


### PR DESCRIPTION
## About The Pull Request

Whatever, put the kit back in your pocket.

Increased storage spaces in most belts and neck-things by 1 slot.

Also:

Bio and chem bags use the same storage allowed stuff as medibelts, so you can put your whole kit in there.

Assault and army belts are bandoliers now.