### PR TITLE
Fixes Nash Curtains + Shifts Upstairs Showers

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -151,11 +151,7 @@
 "and" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+	dir = 9
 	},
 /turf/open/transparent/openspace,
 /area/f13/building)
@@ -5181,8 +5177,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "tgl" = (
-/obj/machinery/shower,
 /obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
 /turf/open/floor/plasteel/f13,
 /area/f13/building)
 "tik" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1975,10 +1975,6 @@
 /area/f13/building)
 "ahH" = (
 /obj/machinery/photocopier,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ahI" = (
@@ -14719,6 +14715,10 @@
 /obj/structure/curtain{
 	color = "#845f58"
 	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "aZl" = (
@@ -18552,15 +18552,17 @@
 	},
 /area/f13/building/museum)
 "bqy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/wood{
+	layer = 3
+	},
 /obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32;
-	pixel_y = 0
+	color = "#845f58"
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
 	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "bqB" = (
 /obj/structure/chair/stool{
@@ -18590,6 +18592,13 @@
 "bqN" = (
 /obj/structure/window/fulltile/wood{
 	layer = 3
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
 	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
@@ -18695,10 +18704,6 @@
 "brA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = 32
-	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
 "brC" = (
@@ -18996,10 +19001,6 @@
 /area/f13/wasteland)
 "bui" = (
 /obj/item/kirbyplants/random,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
-	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
 "buj" = (
@@ -19260,6 +19261,13 @@
 /area/f13/ncr)
 "bwi" = (
 /obj/structure/window/fulltile/house,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "bwr" = (
@@ -19499,13 +19507,15 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/building/museum)
 "byt" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
-	},
+/obj/structure/window/fulltile/house,
 /obj/structure/curtain{
 	color = "#845f58"
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
+	},
+/turf/open/floor/wood_common,
 /area/f13/building)
 "byx" = (
 /obj/machinery/vending/autodrobe,
@@ -21716,6 +21726,9 @@
 "cmP" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/spacevine,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
 "cmS" = (
@@ -22551,6 +22564,9 @@
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbrokenvertical"
 	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "csZ" = (
@@ -23038,14 +23054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/mall)
-"cEy" = (
-/obj/structure/table/wood,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
-	},
-/turf/open/floor/wood_wide,
-/area/f13/building)
 "cEF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -24665,10 +24673,6 @@
 "dwN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /obj/structure/chair/wood{
 	dir = 8
 	},
@@ -24771,10 +24775,6 @@
 /obj/machinery/light/small{
 	dir = 8;
 	light_color = "#d8b1b1"
-	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -33
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet/blue,
@@ -25144,14 +25144,6 @@
 "dJr" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/mineral/wood/nonmetal,
-/area/f13/building)
-"dJD" = (
-/obj/structure/dresser,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "dJE" = (
 /obj/effect/landmark/start/f13/followersdoctor,
@@ -28717,13 +28709,13 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "fBn" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = 32
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -29134,6 +29126,13 @@
 	layer = 3
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
 "fMN" = (
@@ -30280,10 +30279,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gwD" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -30885,11 +30880,15 @@
 /turf/open/water,
 /area/f13/caves)
 "gJl" = (
+/obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -33
+	color = "#845f58"
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gJs" = (
 /obj/structure/barricade/wooden,
@@ -32035,6 +32034,13 @@
 "hpb" = (
 /obj/structure/spacevine,
 /obj/structure/window/fulltile/house,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
 /turf/open/floor/wood_common,
 /area/f13/building)
 "hpS" = (
@@ -33605,10 +33611,6 @@
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "igF" = (
@@ -36818,16 +36820,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"jQQ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
-	},
-/turf/open/floor/wood_common,
-/area/f13/building)
 "jRC" = (
 /obj/structure/simple_door/room{
 	name = "Morgue";
@@ -37747,16 +37739,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
-"kso" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "ksw" = (
 /obj/structure/fence{
 	dir = 4
@@ -38749,6 +38731,13 @@
 "kUp" = (
 /obj/structure/window/fulltile/wood,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kUw" = (
@@ -38853,6 +38842,9 @@
 "kWz" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindow"
+	},
+/obj/structure/curtain{
+	color = "#845f58"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -39251,11 +39243,6 @@
 /area/f13/wasteland)
 "lhQ" = (
 /obj/structure/table/wood,
-/obj/structure/curtain{
-	color = "#845f58";
-	layer = 2.85;
-	pixel_y = 32
-	},
 /obj/item/reagent_containers/food/drinks/bottle/brown/wine{
 	pixel_x = 5;
 	pixel_y = 11
@@ -40331,13 +40318,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
-"lJy" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
-/turf/open/floor/wood_wide,
-/area/f13/building)
 "lJz" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -40753,12 +40733,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lTt" = (
+/obj/structure/window/fulltile/house,
 /obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = -32
+	color = "#845f58"
 	},
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
 "lTw" = (
 /obj/structure/barricade/bars,
@@ -43722,6 +43705,9 @@
 "npt" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/spacevine,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "npv" = (
@@ -45193,10 +45179,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
 "oev" = (
@@ -49797,6 +49779,13 @@
 /obj/structure/window/fulltile/wood{
 	layer = 3
 	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qFw" = (
@@ -50242,10 +50231,6 @@
 /area/f13/wasteland)
 "qQP" = (
 /obj/structure/table/wood/settler,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qQY" = (
@@ -51125,10 +51110,6 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "rrw" = (
@@ -51438,14 +51419,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"rCW" = (
-/obj/machinery/microwave/stove,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_x = 32
-	},
-/turf/open/floor/wood_wide,
-/area/f13/building)
 "rDs" = (
 /obj/structure/car/rubbish3,
 /obj/structure/flora/grass/wasteland{
@@ -53701,6 +53674,10 @@
 /obj/structure/window/fulltile/wood{
 	max_integrity = 140
 	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
 /turf/open/floor/wood_common,
 /area/f13/building)
 "sSy" = (
@@ -54308,14 +54285,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
-"til" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "tiw" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -54602,14 +54571,6 @@
 /obj/item/clothing/under/f13/raiderharness,
 /obj/item/clothing/under/f13/raiderharness,
 /turf/open/floor/f13,
-/area/f13/building)
-"trD" = (
-/obj/structure/table,
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = 33
-	},
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "trF" = (
 /obj/structure/flora/grass/jungle,
@@ -55595,12 +55556,15 @@
 	},
 /area/f13/building)
 "tOk" = (
-/obj/structure/dresser,
+/obj/structure/window/fulltile/house,
 /obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = 33
+	color = "#845f58"
 	},
-/turf/open/floor/carpet/blue,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/floor/wood_common,
 /area/f13/building)
 "tOJ" = (
 /obj/structure/flora/grass/wasteland{
@@ -58888,11 +58852,6 @@
 	},
 /area/f13/wasteland)
 "vBW" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	layer = 2.85;
-	pixel_y = 32
-	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
 	pixel_y = 6
@@ -62116,10 +62075,6 @@
 /obj/structure/mirror{
 	pixel_x = -32
 	},
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
-	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/building)
 "xtI" = (
@@ -62662,12 +62617,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xGe" = (
-/obj/structure/curtain{
-	color = "#845f58";
-	pixel_y = -32
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 2
+	},
+/turf/open/floor/wood_common,
 /area/f13/building)
 "xGl" = (
 /obj/machinery/autolathe,
@@ -62686,6 +62647,13 @@
 /obj/structure/window/fulltile/wood{
 	layer = 2.8;
 	max_integrity = 140
+	},
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -65431,13 +65399,13 @@ aOk
 aOk
 abP
 abP
-rgx
+lTt
 cmP
 biV
 abP
 biV
 cmP
-rgx
+lTt
 abP
 abP
 abP
@@ -65688,18 +65656,18 @@ aOk
 aOk
 abP
 tfH
-bqy
-bqy
+ukR
+ukR
 ttz
 abP
 cnr
-kso
-kso
+ahj
+ahj
 oly
 abP
 vQJ
-bqy
-bqy
+ukR
+ukR
 bzw
 biV
 www
@@ -66472,7 +66440,7 @@ xyA
 bbp
 oql
 dAp
-baZ
+byt
 www
 bbx
 clY
@@ -66715,7 +66683,7 @@ oNw
 aOk
 nHY
 hpb
-trD
+lPc
 bbp
 bbp
 ekI
@@ -66728,8 +66696,8 @@ abP
 lPc
 oql
 oql
-gJl
-baZ
+oql
+byt
 www
 bbx
 clY
@@ -66971,8 +66939,8 @@ blg
 blg
 aOk
 xZb
-baZ
 tOk
+bgV
 oql
 ivb
 aKI
@@ -68487,7 +68455,7 @@ baa
 hsj
 xyU
 qQP
-kUK
+xGe
 aOk
 oMN
 pfV
@@ -68983,7 +68951,7 @@ abP
 hlS
 ier
 igw
-bpW
+gJl
 ctx
 oMN
 aOk
@@ -69240,7 +69208,7 @@ abP
 oTf
 uHO
 rre
-bpW
+gJl
 cFK
 mFl
 aOk
@@ -69781,7 +69749,7 @@ oSH
 wow
 xUm
 ahH
-bpW
+gJl
 kWi
 hfd
 hEG
@@ -70037,8 +70005,8 @@ xaz
 beI
 meQ
 xyU
-til
-bpW
+kVQ
+gJl
 esE
 kDp
 vGN
@@ -70778,7 +70746,7 @@ fzM
 fzM
 xtI
 mHR
-fBn
+mHR
 xhv
 xyU
 xTd
@@ -71035,7 +71003,7 @@ fzM
 fzM
 abP
 xtI
-bpW
+fBn
 abP
 cQa
 abP
@@ -73619,13 +73587,13 @@ oMN
 oNw
 aDP
 bui
-cEy
+neN
 acl
 lbN
 qVJ
 nim
 iwQ
-jQQ
+iwQ
 bwc
 acl
 abu
@@ -73909,7 +73877,7 @@ jQm
 rMX
 vHB
 rMX
-lJy
+iXi
 bqN
 aOk
 abP
@@ -74163,7 +74131,7 @@ btL
 acl
 rNg
 brA
-rCW
+byA
 bqO
 eTA
 bjd
@@ -74919,7 +74887,7 @@ kVQ
 bcF
 xUm
 rOp
-xGe
+pgO
 qEJ
 aOk
 huu
@@ -77233,7 +77201,7 @@ kVQ
 wDf
 xyU
 xyU
-aZk
+bqy
 aOk
 huu
 etg
@@ -77490,7 +77458,7 @@ xyU
 xyU
 kVQ
 dus
-aZk
+bqy
 aOk
 huu
 etg
@@ -77747,7 +77715,7 @@ xyU
 kVQ
 mCB
 cDf
-aZk
+bqy
 aOk
 huu
 aOk
@@ -78775,7 +78743,7 @@ xyU
 kVQ
 kVQ
 xyU
-byt
+qEJ
 aOk
 aOk
 bjb
@@ -100132,11 +100100,11 @@ bdj
 tpP
 aQZ
 kWz
-dJD
+aNS
 xip
 asg
 iME
-lTt
+rOp
 bkP
 bgt
 abP


### PR DESCRIPTION
## About The Pull Request
The pixel shifted curtains in Nash have been replaced with proper curtains. Railings have been placed underneath the windows to prevent outsiders from opening the curtains.
I also shifted the showers up in the Heaven's Night bar second floor to be easier to reach.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added railings underneath Nash windows to prevent them from opening on the outside.
tweak: Changed Pixel shifted curtains with normal curtains
tweak: pixel shifted the showers in Nash's bar up to be easier reached when on the same tile.
/:cl: