### PR TITLE
behemoth no longer gibs people

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -20,6 +20,7 @@
 	rapid_melee = 16
 	melee_queue_distance = 20 // as far as possible really, need this because of charging
 	ranged = TRUE
+	stat_attack = CONSCIOUS
 	pixel_x = -16
 	wander = FALSE
 	movement_type = GROUND
@@ -62,10 +63,18 @@
 
 /mob/living/simple_animal/hostile/megafauna/behemoth/OpenFire()
 	SetRecoveryTime(0, 100)
-	if(health <= maxHealth*0.5)
+	if(health <= maxHealth*0.25)
 		stomp_range = 2
 		speed = 2
 		move_to_delay = 2
+	if(health <= maxHealth*0.50)
+		stomp_range = 2
+		speed = 4
+		move_to_delay = 4
+	if(health <= maxHealth*0.75)
+		stomp_range = initial(stomp_range)
+		speed = 6
+		move_to_delay = 6
 	else
 		stomp_range = initial(stomp_range)
 		speed = initial(speed)


### PR DESCRIPTION
## About The Pull Request
behemoths no longer attack people in crit or dead, thus stopping them from devouring you and gibbing you. additionally, changes scaling to be smoother.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: behemoth scales more linearly instead of hard enraging, now reaching 'full' enrage at 25%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
