### PR TITLE
Gear Harness to Loadout

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -25,8 +25,31 @@
 	check_friendly_fire = TRUE
 	status_flags = CANPUSH
 	del_on_death = FALSE
-	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/stack/f13Cash/random/med)
+	loot = list(
+	/obj/item/stack/f13Cash/random/low,
+	/obj/effect/decal/cleanable/blood,
+	)
 	footstep_type = FOOTSTEP_MOB_SHOE
+	guaranteed_butcher_results = list(
+	/obj/item/reagent_containers/food/snacks/meat/slab/human = 3, 
+	/obj/item/stack/sheet/bone = 2
+	)
+	butcher_results = list(
+	/obj/item/bodypart/l_arm,
+	/obj/item/bodypart/r_arm,
+	/obj/item/bodypart/l_leg,
+	/obj/item/bodypart/r_leg,
+	/obj/item/organ/appendix,
+	/obj/item/organ/ears,
+	/obj/item/organ/eyes,
+	/obj/item/organ/heart,
+	/obj/item/organ/liver,
+	/obj/item/organ/lungs,
+	/obj/item/organ/tongue,
+	/obj/item/organ/stomach
+	)
+	butcher_difficulty = 1
+
 
 /obj/effect/mob_spawn/human/corpse/raider
 	name = "Raider"

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -502,6 +502,10 @@
 /datum/gear/uniform/bathrobe
 	name = "bathrobe"
 	path = /obj/item/clothing/under/misc/bathrobe
+
+/datum/gear/uniform/gear_harness
+	name = "Gear Harness"
+	path = /obj/item/clothing/under/misc/gear_harness
 /*
 /datum/gear/uniform/kimono
 	name = "Kimono"


### PR DESCRIPTION

## About The Pull Request
Adds gear harness to loadout, still needs to be made craftable.


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds Gear Harness to loadout for birthday suit shenanigans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
