### PR TITLE
Laser Weapons Rebalance & Cell Charger Tweaks

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -5,12 +5,16 @@
 	icon_state = "ccharger"
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 15
-	active_power_usage = 180
+	active_power_usage = 750
 	power_channel = EQUIP
 	circuit = /obj/item/circuitboard/machine/cell_charger
 	pass_flags = PASSTABLE
 	var/obj/item/stock_parts/cell/charging = null
-	var/charge_rate = 500
+	var/recharge_coeff = 1
+
+/obj/machinery/cell_charger/RefreshParts()
+	for(var/obj/item/stock_parts/capacitor/C in component_parts)
+		recharge_coeff = C.rating
 
 /obj/machinery/cell_charger/update_overlays()
 	. += ..()
@@ -29,8 +33,8 @@
 	. += "There's [charging ? "a" : "no"] cell in the charger."
 	if(charging)
 		. += "Current charge: [round(charging.percent(), 1)]%."
-	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Charge rate at <b>[charge_rate]J</b> per cycle.</span>"
+	. += span_notice("The status display reads:")
+	. += "<span class='notice'>- Recharging <b>[recharge_coeff*10]%</b> cell charge per cycle.</span>"
 
 /obj/machinery/cell_charger/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/cell) && !panel_open)
@@ -125,18 +129,11 @@
 	if(charging)
 		charging.emp_act(severity)
 
-/obj/machinery/cell_charger/RefreshParts()
-	charge_rate = 500
-	for(var/obj/item/stock_parts/capacitor/C in component_parts)
-		charge_rate *= C.rating
-
 /obj/machinery/cell_charger/process()
 	if(!charging || !anchored || (stat & (BROKEN|NOPOWER)))
 		return
 
-	if(charging.percent() >= 100)
-		return
-	use_power(charge_rate)
-	charging.give(charge_rate)	//this is 2558, efficient batteries exist
-
+	if(charging.charge < charging.maxcharge)
+		charging.give(charging.maxcharge/10 * recharge_coeff)
+		use_power(charging.maxcharge/10 * recharge_coeff)
 	update_icon()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -129,8 +129,8 @@
 		var/obj/item/stock_parts/cell/C = charging.get_cell()
 		if(C)
 			if(C.charge < C.maxcharge)
-				C.give(C.chargerate * recharge_coeff)
-				use_power(250 * recharge_coeff)
+				C.give(C.maxcharge/10 * recharge_coeff)
+				use_power(C.maxcharge/10 * recharge_coeff)
 				using_power = TRUE
 			update_icon()
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -763,29 +763,32 @@
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid
 	name = "mid tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 26,
-				/obj/effect/spawner/bundle/f13/aer12 = 13,
-				/obj/effect/spawner/bundle/f13/wattz2k = 26,
-				/obj/effect/spawner/bundle/f13/wattz2kext = 15,
-				/obj/effect/spawner/bundle/f13/plasmapistol = 15,
-				/obj/effect/spawner/bundle/f13/ionrifle = 5
+	loot = list(/obj/effect/spawner/bundle/f13/aer9 = 35,
+				///obj/effect/spawner/bundle/f13/aer12 = 13, Now a high tier gun.
+				/obj/effect/spawner/bundle/f13/wattz2k = 30,
+				///obj/effect/spawner/bundle/f13/wattz2kext = 10, Now a high tier gun.
+				/obj/effect/spawner/bundle/f13/plasmapistol = 20,
+				/obj/effect/spawner/bundle/f13/ionrifle = 15
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh //overlaps with midtier
 	name = "mid-high tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/aer12,
-				/obj/effect/spawner/bundle/f13/plasmapistol,
-				/obj/effect/spawner/bundle/f13/wattz2kext,
-				/obj/effect/spawner/bundle/f13/ionrifle,
-				/obj/effect/spawner/bundle/f13/aer14
+	loot = list(/obj/effect/spawner/bundle/f13/aer12 = 15,
+				/obj/item/gun/energy/laser/aer9/focused = 20,
+				/obj/effect/spawner/bundle/f13/plasmapistol = 25,
+				/obj/effect/spawner/bundle/f13/wattz2kext = 15,
+				/obj/effect/spawner/bundle/f13/ionrifle = 25
+				///obj/effect/spawner/bundle/f13/aer14 //die
 				)
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high
 	name = "high tier energy gun"
-	loot = list(/obj/effect/spawner/bundle/f13/plasmarifle = 25,
-				/obj/effect/spawner/bundle/f13/tribeam = 10,
+	loot = list(/obj/effect/spawner/bundle/f13/plasmarifle = 20,
+				/obj/effect/spawner/bundle/f13/aer12 = 10,
+				/obj/effect/spawner/bundle/f13/tribeam = 20,
 				/obj/effect/spawner/bundle/f13/rcw = 20,
-				/obj/effect/spawner/bundle/f13/aer14 = 20,
-				/obj/effect/spawner/bundle/f13/plasmaglock = 25
+				/obj/effect/spawner/bundle/f13/wattz2kext = 10, //Now a high tier gun.
+				///obj/effect/spawner/bundle/f13/aer14, kill
+				/obj/effect/spawner/bundle/f13/plasmaglock = 20
 				)
 
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/superhigh

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -463,7 +463,7 @@
 	desc = "An energy cell, typically used as ammunition for small-arms energy weapons."
 	icon = 'icons/fallout/objects/powercells.dmi'
 	icon_state = "ec-full"
-	maxcharge = 1600
+	maxcharge = 1500
 
 // Microfusion breeder? Okay, sure.
 /obj/item/stock_parts/cell/ammo/breeder

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -90,9 +90,9 @@
 */
 
 /* here are the ammo sizes since nobody ever wrote these down
-electron chargepack = 2400, this is currently only used in the RCW
+electron chargepack = 2500, this is currently only used in the RCW Changed by ZNA because multiple of 2's is ass for math. It'll calm down the weird ass decimals.
 mfc = 2000
-ec = 1600
+ec = 1500 Changed by ZNA because multiple of 2's is ass for math. It'll calm down the weird ass decimals.
 
 each one goes up by 4,000 power. why? nobody fucking knows lmao
 
@@ -121,11 +121,12 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/pistol/hitscan //25 damage per, with 0 near 0 AP-4 shot crit on unarmored target, significantly less useful against armored
 	projectile_type = /obj/item/projectile/beam/laser/pistol/hitscan
-	e_cost = 53.33 //30 shots, as per FNV
+	e_cost = 50 //30 shots, as per FNV
+	damage_threshold_penetration = 4 // Doesn't pierce as much armor or hit as hard, but has more ammo capacity than the 1k
 
 /obj/item/ammo_casing/energy/laser/ultra_pistol
 	projectile_type = /obj/item/projectile/beam/laser/ultra_pistol
-	e_cost = 80 //20 shots
+	e_cost = 75 //20 shots
 	fire_sound = 'sound/f13weapons/aep7fire.ogg'
 
 /obj/item/ammo_casing/energy/laser/ultra_rifle
@@ -135,7 +136,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/pistol/recharger/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/recharger/hitscan
-	e_cost = 100 //20 shots
+	e_cost = 75 //20 shots
 	fire_sound = 'sound/f13weapons/aep7fire.ogg'
 
 /obj/item/ammo_casing/energy/laser/stun  //compliance regulator
@@ -145,7 +146,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz
-	e_cost = 100 //16 shots
+	e_cost = 100 //15 shots Civilian gun hits harder but has less charge.
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz/magneto
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto
@@ -153,15 +154,16 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/hitscan
-	e_cost = 53.33 //30 shots, as per FNV
+	e_cost = 100 //15 Shots. More than enough to kill anything that moves. The wattz 1k isn't even in FNV.
+	damage_threshold_penetration = 3 // Better against lightly armored targets. 
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
-	e_cost = 53.33 //30 shots, as per FNV
+	e_cost = 150 //10 Shots. That extra Armor pen has to come out of somewhere.
 
 /obj/item/ammo_casing/energy/laser/lasgun
 	projectile_type = /obj/item/projectile/beam/laser/lasgun
-	e_cost = 100 //20 shots
+	e_cost = 80 //25 shots
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 
 /obj/item/ammo_casing/energy/laser/lasgun/hitscan
@@ -170,7 +172,8 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/lasgun/hitscan/focused
 	projectile_type = /obj/item/projectile/beam/laser/lasgun/hitscan/focused
-	e_cost = 400 //5 shots
+	e_cost = 400 //5 shots. Better hope you're accurate with this thing.
+	damage_threshold_penetration = 10 //Overcharged AF, lets at minimum 1/3rd of the damage it puts out burn through armor.
 
 /obj/item/ammo_casing/energy/laser/solar
 	projectile_type = /obj/item/projectile/beam/laser/solar
@@ -218,8 +221,9 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/laser/aer12/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/aer12/hitscan
-	e_cost = 100 //20 shots
+	e_cost = 80 //25 shots
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
+	damage_threshold_penetration = 6 //Upgraded gun lets more damage through than a typical rifle.
 
 /obj/item/ammo_casing/energy/gammagun
 	projectile_type = /obj/item/projectile/beam/gamma
@@ -232,22 +236,23 @@ also: most hitscan weapons have more charge than their normal projectile counter
 
 /obj/item/ammo_casing/energy/wattz2k/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/wattz2k/hitscan
-	e_cost = 166.6 //12 shots
+	e_cost = 160 //12.5 shots, yes there'll be some charge left over. Intentional.
+	damage_threshold_penetration = 7 //You're a sniper laser, act like it.
 
 /obj/item/ammo_casing/energy/wattz2k/extended
 	projectile_type = /obj/item/projectile/beam/laser/wattz2k
-	e_cost = 83.3 //24
+	e_cost = 80 //25
 
 /obj/item/ammo_casing/energy/wattz2k/extended/hitscan
-	projectile_type = /obj/item/projectile/beam/laser/wattz2k/hitscan
-
+	projectile_type = /obj/item/projectile/beam/laser/wattz2k/hitscan/weak
+	damage_threshold_penetration = 4 //The prices you pay for ammo efficiency.
 //musket
 
 /obj/item/ammo_casing/energy/laser/musket
 	projectile_type = /obj/item/projectile/beam/laser/musket
 	e_cost = 250
 	fire_sound = 'sound/weapons/laser3.ogg'
-	
+
 //autolasers
 
 /obj/item/ammo_casing/energy/laser/autolaser

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -155,11 +155,11 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/hitscan
 	e_cost = 100 //15 Shots. More than enough to kill anything that moves. The wattz 1k isn't even in FNV.
-	damage_threshold_penetration = 3 // Better against lightly armored targets. 
+	damage_threshold_penetration = 3 // Better against lightly armored targets.
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
-	e_cost = 150 //10 Shots. That extra Armor pen has to come out of somewhere.
+	e_cost = 100 //10 Shots. That extra Armor pen has to come out of somewhere.
 
 /obj/item/ammo_casing/energy/laser/lasgun
 	projectile_type = /obj/item/projectile/beam/laser/lasgun

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -359,7 +359,7 @@
 
 	slowdown = GUN_SLOWDOWN_PISTOL_LIGHT
 	force = GUN_MELEE_FORCE_PISTOL_LIGHT
-	weapon_weight = GUN_ONE_HAND_ONLY
+	weapon_weight = GUN_ONE_HAND_AKIMBO
 	draw_time = GUN_DRAW_NORMAL
 	fire_delay = GUN_FIRE_DELAY_NORMAL
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -329,7 +329,7 @@
 
 /obj/item/projectile/beam/laser/lasgun/hitscan //hitscan aer9 test
 	name = "laser beam"
-	damage = 33
+	damage = 32
 	armour_penetration = 0.02 //mostly just to allow scratch damage, so you arent SOL just mostly fucced
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -406,8 +406,8 @@
 	damage = 31
 
 /obj/item/projectile/beam/laser/pistol/wattz/hitscan //hitscan wattz
-	name = "weak laser beam"
-	damage = 20
+	name = "laser beam"
+	damage = 28 // Civilian gun hits harder but has less charge now.
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
@@ -420,7 +420,7 @@
 
 /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
 	name = "penetrating laser beam"
-	damage = 20
+	damage = 26 // Hits less than the W1K but has innate AP/DT reduction.
 	hitscan = TRUE
 	armour_penetration = 0.2 //rare laser to keep its AP, since base model is so bad
 	tracer_type = /obj/effect/projectile/tracer/laser
@@ -586,7 +586,7 @@
 
 /obj/item/projectile/beam/laser/aer12 //AER12
 	name = "laser beam"
-	damage = 34
+	damage = 36
 	armour_penetration = 0.55
 	icon_state = "xray"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
@@ -594,7 +594,7 @@
 
 /obj/item/projectile/beam/laser/aer12/hitscan
 	name = "laser beam"
-	damage = 28
+	damage = 36
 	hitscan = TRUE
 	armour_penetration = 0.02
 	tracer_type = /obj/effect/projectile/tracer/xray
@@ -617,10 +617,20 @@
 
 /obj/item/projectile/beam/laser/wattz2k/hitscan
 	name = "sniper laser bolt"
-	damage = 28
+	damage = 52
 	wound_bonus = 10
 	bare_wound_bonus = 20
 	armour_penetration = 0.2
+	tracer_type = /obj/effect/projectile/tracer/heavy_laser
+	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
+	impact_type = /obj/effect/projectile/impact/heavy_laser
+	hitscan = TRUE
+/obj/item/projectile/beam/laser/wattz2k/hitscan/weak //Hits less than the main wattz2k with less AP but has more shots comparable to an aer9
+	name = "weak sniper laser bolt"
+	damage = 40
+	wound_bonus = 10
+	bare_wound_bonus = 20
+	armour_penetration = 0.1
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -350,11 +350,11 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/pistol //AEP7
+/obj/item/projectile/beam/laser/pistol
 	name = "laser beam"
 	damage = 35
 
-/obj/item/projectile/beam/laser/pistol/hitscan //hitscan AEP7
+/obj/item/projectile/beam/laser/pistol/hitscan //Actual AEP7
 	name = "laser beam"
 	damage = 26
 	hitscan = TRUE


### PR DESCRIPTION
## About The Pull Request
This will be modifying the laser weapon damages, tweaking what guns are in what tier. 

The new tier list, ranked in order of damage output per ammo cell is as follows.

Wattz 1000 - 28 Damage - 15 Shots - 3 DT Pen - 420 DPC
Wattz 1000 Magneto - 26 Damage - 15 shots - 7 DT Pen - 390 DPC
AEP7 - 24 Damage - 30 shots - 4 DT Pen - 720 DPC
Wattz 2000 - 52 Damage - 12.5 shots - 7 DT Pen - 780 DPC
AER9 - 32 Damage - 25 Shots - 5 DT Pen - 800 DPC
AER9 Overcharged - 34 Damage - 5 shots - 10 DT Pen - 136 DPC
AER12 - 36 Damage - 25 shots - 6 DT Pen - 900 DPC
Wattz 2000e - 40 Damage - 25 shots - 4 DT Pen - 1000 DPC

Cell chargers now charge 10% of whatever cell is in them per cycle, leading to more even charge times across the board.
Weapon chargers now charge 10% of Fallout style cells per cycle now. They now correctly function as advertised. Previously they were only charging 100 power per cycle.

Small Energy Cells had their capacity reduced by 100 to make shot/energy calculations easier and more accurate.

Loot tables have been tweaked to remove the AER-14 from the drop table as well as shuffle weapons across to fill in the gaps. 
The changes are as follows.

AER9 Overcharged is now obtainable as a mid-high tier gun.
AER12 is now a mid-high/high tier gun.
Wattz 2000e is now a mid-high/high tier gun.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added the AER9 Overcharged to the spawn pool.
del: Deleted the AER14 from the spawn pool.
tweak: Brought Cell chargers down to the weapon charger recharge rates.
balance: Rebalanced laser weapon damage values
fix: Fixed weapon chargers not charging small energy cells and Microfusion cells at 10% per cycle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
