### PR TITLE
Spawner runtime fixes

### DIFF
--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset-Lower.dmm
@@ -861,7 +861,6 @@
 "aBP" = (
 /obj/structure/nest/deathclaw/mother{
 	infinite = 1;
-	spawn_once = null;
 	spawn_time = 400
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -6345,7 +6344,6 @@
 	},
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/floor/plasteel/barber{
@@ -11383,7 +11381,6 @@
 "gjC" = (
 /obj/structure/nest/deathclaw/mother{
 	infinite = 1;
-	spawn_once = null;
 	spawn_time = 400
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -16990,7 +16987,6 @@
 "jPz" = (
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -39304,7 +39300,6 @@
 /obj/effect/decal/waste,
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,

--- a/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Old/Pahrump-Sunset.dmm
@@ -21819,7 +21819,6 @@
 "iYf" = (
 /obj/structure/nest/securitron{
 	max_mobs = 1;
-	spawn_once = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -16104,7 +16104,6 @@
 "mgL" = (
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -21700,7 +21699,6 @@
 /obj/effect/decal/waste,
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -24832,7 +24830,6 @@
 "uNC" = (
 /obj/structure/nest/deathclaw/mother{
 	infinite = 1;
-	spawn_once = null;
 	spawn_time = 400
 	},
 /turf/open/indestructible/ground/inside/mountain,

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset - Outdated.dmm
@@ -22169,7 +22169,6 @@
 "iYf" = (
 /obj/structure/nest/securitron{
 	max_mobs = 1;
-	spawn_once = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"

--- a/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
+++ b/_maps/map_files/Temp Map Storage/Pahrump-Sunset-Lower - Outdated.dmm
@@ -861,7 +861,6 @@
 "aBP" = (
 /obj/structure/nest/deathclaw/mother{
 	infinite = 1;
-	spawn_once = null;
 	spawn_time = 400
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -6344,7 +6343,6 @@
 	},
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/floor/plasteel/barber{
@@ -11389,7 +11387,6 @@
 "gjC" = (
 /obj/structure/nest/deathclaw/mother{
 	infinite = 1;
-	spawn_once = null;
 	spawn_time = 400
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -17007,7 +17004,6 @@
 "jPz" = (
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
@@ -39380,7 +39376,6 @@
 /obj/effect/decal/waste,
 /obj/structure/nest/supermutant/melee{
 	max_mobs = 3;
-	spawn_once = 1;
 	spawn_time = 10
 	},
 /turf/open/indestructible/ground/inside/subway,


### PR DESCRIPTION
## About The Pull Request

So several spawners were set to spawn_once, but spawn_once is no longer a thing (and is instead done by setting its mob_types to have one mob in it, use that!), so it just runtimed. No more!