### PR TITLE
fixes behemoth enrage, my behated

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -63,14 +63,10 @@
 
 /mob/living/simple_animal/hostile/megafauna/behemoth/OpenFire()
 	SetRecoveryTime(0, 100)
-	if(health <= maxHealth*0.33)
+	if(health <= maxHealth*0.5)
 		stomp_range = 2
 		speed = 2
 		move_to_delay = 2
-	if(health <= maxHealth*0.66)
-		stomp_range = 2
-		speed = 4
-		move_to_delay = 4
 	else
 		stomp_range = initial(stomp_range)
 		speed = initial(speed)


### PR DESCRIPTION
## About The Pull Request
behemoth rage now activates at 1.5k hp and is at full enrage. turns out it was that way for a reason. who fucking knew.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: the behemoth hates corn syrup and refuses to drink it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
