### PR TITLE
Loadout item ckey locked to Brimcon

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -196,3 +196,11 @@
 	new /obj/item/gun_upgrade/trigger/dangerzone(src)
 	new /obj/item/gun_upgrade/barrel/forged(src)
 	new /obj/item/tool_upgrade/refinement/stabilized_grip(src)
+
+/datum/gear/donator/kits/brimcon
+	name = "Gift from Claws"
+	path = /obj/item/storage/box/large/custom_kit/risingstarslash2
+	ckeywhitelist = list("Brimcon")
+
+/obj/item/storage/box/large/custom_kit/risingstarslash2/PopulateContents()
+	new /obj/item/clothing/suit/armor/light/tribal/cloak(src)


### PR DESCRIPTION
Adds the tribal cloak to his loadout choices!

item is ckey locked and only he will get it.