### PR TITLE
Fixes loadouts freaking out over missing stuff

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -696,18 +696,20 @@ SUBSYSTEM_DEF(job)
 	if(!the_mob)
 		the_mob = M // cause this doesn't get assigned if player is a latejoiner
 	var/list/chosen_gear = the_mob.client.prefs.loadout_data["SAVE_[the_mob.client.prefs.loadout_slot]"]
+	var/datum/preferences/the_prefs = the_mob.client.prefs
 	if(the_mob.client && the_mob.client.prefs && (chosen_gear && chosen_gear.len))
 		if(!ishuman(M))//no silicons allowed
 			return
 		for(var/i in chosen_gear)
 			var/datum/gear/G = istext(i[LOADOUT_ITEM]) ? text2path(i[LOADOUT_ITEM]) : i[LOADOUT_ITEM]
-			G = GLOB.loadout_items[initial(G.category)][initial(G.subcategory)][initial(G.name)]
-			if(!G)
+			if(!G) // aint there? ditch it
+				the_prefs.remove_gear_from_loadout(the_prefs.loadout_slot, i[LOADOUT_ITEM])
 				continue
+			G = GLOB.loadout_items[initial(G.category)][initial(G.subcategory)][initial(G.name)]
 			var/permitted = TRUE
 			if(!bypass_prereqs && G.restricted_roles && G.restricted_roles.len && !(M.mind.assigned_role in G.restricted_roles))
 				permitted = FALSE
-			if(G.donoritem && !G.donator_ckey_check(the_mob.client.ckey))
+			if(G.donoritem && !G.donator_ckey_check(ckey(the_mob.client.ckey)))
 				permitted = FALSE
 			if(!equipbackpackstuff && G.slot == SLOT_IN_BACKPACK)//snowflake check since plopping stuff in the backpack doesnt work for pre-job equip loadout stuffs
 				permitted = FALSE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -709,7 +709,7 @@ SUBSYSTEM_DEF(job)
 			var/permitted = TRUE
 			if(!bypass_prereqs && G.restricted_roles && G.restricted_roles.len && !(M.mind.assigned_role in G.restricted_roles))
 				permitted = FALSE
-			if(G.donoritem && !G.donator_ckey_check(ckey(the_mob.client.ckey)))
+			if(G.donoritem && !G.donator_ckey_check(the_mob.client.ckey))
 				permitted = FALSE
 			if(!equipbackpackstuff && G.slot == SLOT_IN_BACKPACK)//snowflake check since plopping stuff in the backpack doesnt work for pre-job equip loadout stuffs
 				permitted = FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -960,7 +960,7 @@ Records disabled until a use for them is found
 					for(var/name in GLOB.loadout_items[gear_category][gear_subcategory])
 						var/datum/gear/gear = GLOB.loadout_items[gear_category][gear_subcategory][name]
 						var/donoritem = gear.donoritem
-						if(donoritem && !gear.donator_ckey_check(user.ckey))
+						if(donoritem && !gear.donator_ckey_check(ckey(user.ckey)))
 							continue
 						var/class_link = ""
 						var/list/loadout_item = has_loadout_gear(loadout_slot, "[gear.type]")
@@ -2886,7 +2886,7 @@ Records disabled until a use for them is found
 					to_chat(user, span_danger("You cannot take this loadout, as you've already chosen too many of the same category!"))
 					return
 				*/
-				if(G.donoritem && !G.donator_ckey_check(user.ckey))
+				if(G.donoritem && !G.donator_ckey_check(ckey(user.ckey)))
 					to_chat(user, span_danger("This is an item intended for donator use only. You are not authorized to use this item."))
 					return
 				if(gear_points >= initial(G.cost))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -960,7 +960,7 @@ Records disabled until a use for them is found
 					for(var/name in GLOB.loadout_items[gear_category][gear_subcategory])
 						var/datum/gear/gear = GLOB.loadout_items[gear_category][gear_subcategory][name]
 						var/donoritem = gear.donoritem
-						if(donoritem && !gear.donator_ckey_check(ckey(user.ckey)))
+						if(donoritem && !gear.donator_ckey_check(user.ckey))
 							continue
 						var/class_link = ""
 						var/list/loadout_item = has_loadout_gear(loadout_slot, "[gear.type]")
@@ -2886,7 +2886,7 @@ Records disabled until a use for them is found
 					to_chat(user, span_danger("You cannot take this loadout, as you've already chosen too many of the same category!"))
 					return
 				*/
-				if(G.donoritem && !G.donator_ckey_check(ckey(user.ckey)))
+				if(G.donoritem && !G.donator_ckey_check(user.ckey))
 					to_chat(user, span_danger("This is an item intended for donator use only. You are not authorized to use this item."))
 					return
 				if(gear_points >= initial(G.cost))

--- a/modular_citadel/code/modules/client/loadout/_loadout.dm
+++ b/modular_citadel/code/modules/client/loadout/_loadout.dm
@@ -84,4 +84,4 @@ GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
 		for(var/needed_key in ckeywhitelist)
 			if(ckey(needed_key) == ckey(key))
 				return TRUE
-	return IS_CKEY_DONATOR_GROUP(key, donator_group_id)
+	//return IS_CKEY_DONATOR_GROUP(key, donator_group_id)

--- a/modular_citadel/code/modules/client/loadout/_loadout.dm
+++ b/modular_citadel/code/modules/client/loadout/_loadout.dm
@@ -80,6 +80,8 @@ GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
 
 //ckey only check
 /datum/gear/proc/donator_ckey_check(key)
-	if(ckeywhitelist && ckeywhitelist.Find(key))
-		return TRUE
+	if(LAZYLEN(ckeywhitelist))
+		for(var/needed_key in ckeywhitelist)
+			if(ckey(needed_key) == ckey(key))
+				return TRUE
 	return IS_CKEY_DONATOR_GROUP(key, donator_group_id)

--- a/modular_citadel/code/modules/client/loadout/donor.dm
+++ b/modular_citadel/code/modules/client/loadout/donor.dm
@@ -27,6 +27,19 @@
 	name = "Happy Sharky Company Cuisine Book"
 	slot = SLOT_IN_BACKPACK
 	path = /obj/item/book/granter/crafting_recipe/happysharky
-	category = LOADOUT_CATEGORY_BACKPACK
 	ckeywhitelist = list ("ExoticJazz")
 	cost = 0
+
+/datum/gear/donator/debug_thing
+	name = "Debug Bingus"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/autosurgeon/penis
+	ckeywhitelist = list("Super lAGG")
+	cost = 1
+
+/datum/gear/donator/debug_thing_2
+	name = "Debingus Bungus"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/autosurgeon/penis
+	ckeywhitelist = list("superlagg")
+	cost = 1


### PR DESCRIPTION
## About The Pull Request

So used to be that if you had something in your loadout, and that thing had its type changed or deleted, it'd ruin everything in your loadout and only load like half of it on your mob. Now, if something's in your loadout that doesnt exist, instead of runtiming, it'll just remove that entry from your loadout.

Also, made the item ckey checker check the ckey version of its required key against your ckeyed ckey. Now you can capitalize whatever you want and it'll still work.

And that's all I did, honest.