### PR TITLE
Removes a second nest on the same tile as another.

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -2026,11 +2026,6 @@
 	randomizer_tag = "Nash East Road";
 	randomizer_difficulty = 1
 	},
-/obj/structure/nest/randomized{
-	randomizer_kind = "trash mobs";
-	randomizer_tag = "Nash East Road";
-	randomizer_difficulty = 1
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ahQ" = (


### PR DESCRIPTION
Who did this?

## About The Pull Request
Removes a duplicate spawner nest from the same tile.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Removed an erroneous nest that occupied the same tile as another nest.
/:cl:
