### PR TITLE
More mods in the trash loot!

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -281,7 +281,11 @@ GLOBAL_LIST_INIT(trash_attachment, list(
 	/obj/item/tool_upgrade/refinement/stabilized_grip = 1,
 	/obj/item/tool_upgrade/refinement/laserguide = 1,
 	/obj/item/tool_upgrade/productivity/booster = 1,
-	/obj/item/tool_upgrade/productivity/red_paint = 2
+	/obj/item/tool_upgrade/productivity/red_paint = 2,
+	/obj/item/gun_upgrade/mechanism/overdrive = 1,
+	/obj/item/gun_upgrade/mechanism/battery_shunt = 1,
+	/obj/item/gun_upgrade/mechanism/overshooter = 1,
+	/obj/item/gun_upgrade/barrel/excruciator = 1
 ))
 
 GLOBAL_LIST_INIT(loot_prewar_clothing, list(

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -463,7 +463,7 @@
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
 
-// Greatly increase firerate at the cost of lower damage
+// Slightly increases firerate and massively lowers cell charge usage at the cost of lower damage
 /obj/item/gun_upgrade/mechanism/overdrive
 	name = "REPCONN overdrive chip"
 	desc = "This experimental chip is a cutting edge tool attachment which bypasses power management protocols to dramatically increase the rate of fire at the cost of a reduced stopping power."
@@ -475,10 +475,10 @@
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_RECOIL = 2,
 	GUN_UPGRADE_DAMAGE_MULT = 0.66,
-	GUN_UPGRADE_FIRE_DELAY_MULT = 0.33,
+	GUN_UPGRADE_FIRE_DELAY_MULT = 0.9,
 	GUN_UPGRADE_FULLAUTO = TRUE,
 	GUN_UPGRADE_CHARGECOST = 0.5,
-	GUN_UPGRADE_FIRE_DELAY_MULT = 0.33)
+	GUN_UPGRADE_FIRE_DELAY_MULT = 0.9)
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -466,7 +466,7 @@
 // Slightly increases firerate and massively lowers cell charge usage at the cost of lower damage
 /obj/item/gun_upgrade/mechanism/overdrive
 	name = "REPCONN overdrive chip"
-	desc = "This experimental chip is a cutting edge tool attachment which bypasses power management protocols to dramatically increase the rate of fire at the cost of a reduced stopping power."
+	desc = "This experimental chip is a cutting edge tool attachment which bypasses power management protocols to dramatically increase battery cell potential at the cost of a reduced stopping power."
 	icon_state = "overdrive"
 
 /obj/item/gun_upgrade/mechanism/overdrive/New()


### PR DESCRIPTION
DO YOU EVEN MOD, BRUH?!

Adds the overdrive, battery shunt, giga lens, and overshooter to the loot table.

Lowers the fire rate increase of the overdrive mod and edits its // description as well as the mods description to convey the change.