### PR TITLE
Restore hay recipes and correct basket material

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -987,9 +987,9 @@ GLOBAL_LIST_INIT(hay_recipes, list ( \
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	merge_type = /obj/item/stack/sheet/hay
 
-/obj/item/stack/sheet/hay/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.hay_recipes
-	return ..()
+/obj/item/stack/sheet/hay/get_main_recipes()
+	. = ..()
+	. += GLOB.hay_recipes
 
 /obj/item/stack/sheet/hay/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins shoving hay up [user.p_their()] arse! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/farming/farming_tools.dm
+++ b/code/modules/farming/farming_tools.dm
@@ -226,6 +226,8 @@
 	icon = 'icons/fallout/farming/farming_tools.dmi'
 	icon_state = "basket"
 	resistance_flags = FLAMMABLE
+	material_drop = /obj/item/stack/sheet/hay
+	material_drop_amount = 15
 
 
 


### PR DESCRIPTION
## About The Pull Request
Makes the hay recipes, straw hats and baskets, available for crafting. Changes baskets to drop hay when destroyed or dismantled rather than plasteel. Tribal and homesteader storage enthusiasts rejoice.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked a few things
fix: hay sheet recipes now craftable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
