### PR TITLE
Volumetric storage changes

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -665,7 +665,8 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 	/obj/item/storage/box
 	)))
 
-
+/// Number of rows volume storage should have
+#define STORAGE_ROWS_DEFAULT 1
 
 /* * * * * * * * * * * * * * *
  * The International Pocket
@@ -845,6 +846,8 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BIG_BOX_DEFAULT_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a bigbox
 #define STORAGE_BIG_BOX_DEFAULT_MAX_TOTAL_SPACE STORAGE_BIG_BOX_DEFAULT_MAX_ITEMS * STORAGE_BIG_BOX_DEFAULT_MAX_SIZE
+/// How many rows in a bigbox
+#define STORAGE_ROWS_BIGBOX 2
 
 /// How many items total fit in a hugebox
 #define STORAGE_HUGE_BOX_DEFAULT_MAX_ITEMS STORAGE_BIG_BOX_DEFAULT_MAX_ITEMS * 2
@@ -852,6 +855,8 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_HUGE_BOX_DEFAULT_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a hugebox
 #define STORAGE_HUGE_BOX_DEFAULT_MAX_TOTAL_SPACE STORAGE_HUGE_BOX_DEFAULT_MAX_ITEMS * STORAGE_HUGE_BOX_DEFAULT_MAX_SIZE
+/// How many rows in a hugebox
+#define STORAGE_ROWS_HUGEBOX 3
 
 /* * * * * * * * * *
  * Survival pouches
@@ -877,6 +882,8 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE WEIGHT_CLASS_TINY
 /// How much volume fits in a triple survival kit
 #define STORAGE_BOX_SURVIVAL_TRIPLE_MAX_TOTAL_SPACE STORAGE_BOX_SURVIVAL_TRIPLE_DEFAULT_MAX_ITEMS * STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE
+/// How many rows in a triple survival kit
+#define STORAGE_ROWS_SURVIVAL_TRIPLE 3 // triple after all~
 
 /* * * * * * *
  * Backpacks!
@@ -888,6 +895,8 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BACKPACK_DEFAULT_MAX_SIZE WEIGHT_CLASS_NORMAL
 /// How much volume fits in a backpack
 #define STORAGE_BACKPACK_DEFAULT_MAX_TOTAL_SPACE STORAGE_BACKPACK_DEFAULT_MAX_ITEMS * STORAGE_BACKPACK_DEFAULT_MAX_SIZE
+/// How many rows in a backpack
+#define STORAGE_ROWS_BACKPACK 2
 
 /// Duffel slowdown
 #define DUFFELBAG_SLOWDOWN 0.75 // wear the fuckin bag
@@ -899,13 +908,17 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_DUFFEL_DEFAULT_MAX_SIZE WEIGHT_CLASS_NORMAL
 /// How much volume fits in a duffel
 #define STORAGE_DUFFEL_DEFAULT_MAX_TOTAL_SPACE STORAGE_DUFFEL_DEFAULT_MAX_ITEMS * WEIGHT_CLASS_NORMAL
+/// How many rows in a duffel
+#define STORAGE_ROWS_DUFFEL 3
 
 /// How many items total fit in a duffel scav
-#define STORAGE_DUFFEL_SCAV_DEFAULT_MAX_ITEMS 14
+#define STORAGE_DUFFEL_SCAV_DEFAULT_MAX_ITEMS 16
 /// How big a thing can fit in a duffel scav
 #define STORAGE_DUFFEL_SCAV_DEFAULT_MAX_SIZE WEIGHT_CLASS_NORMAL
 /// How much volume fits in a duffel scav
 #define STORAGE_DUFFEL_SCAV_DEFAULT_MAX_TOTAL_SPACE STORAGE_DUFFEL_SCAV_DEFAULT_MAX_ITEMS * WEIGHT_CLASS_NORMAL
+/// How many rows in a duffel scav
+#define STORAGE_ROWS_DUFFEL_SCAV 4 // big bag!
 
 /* * * * *
  * Wallet

--- a/code/datums/components/storage/concrete/backpack.dm
+++ b/code/datums/components/storage/concrete/backpack.dm
@@ -6,6 +6,7 @@
 	max_combined_w_class = STORAGE_BACKPACK_DEFAULT_MAX_TOTAL_SPACE
 	max_volume = STORAGE_BACKPACK_DEFAULT_MAX_TOTAL_SPACE
 	rustle_sound = TRUE
+	number_of_rows = STORAGE_ROWS_BACKPACK
 
 /// Spearquiver
 /datum/component/storage/concrete/backpack/spear_quiver/Initialize()
@@ -19,6 +20,7 @@
 	max_combined_w_class = STORAGE_DUFFEL_DEFAULT_MAX_TOTAL_SPACE
 	max_volume = STORAGE_DUFFEL_DEFAULT_MAX_TOTAL_SPACE
 	rustle_sound = TRUE
+	number_of_rows = STORAGE_ROWS_DUFFEL
 
 /// Duffelscav
 /datum/component/storage/concrete/backpack/duffelbag/scav
@@ -27,6 +29,7 @@
 	max_combined_w_class = STORAGE_DUFFEL_SCAV_DEFAULT_MAX_TOTAL_SPACE
 	max_volume = STORAGE_DUFFEL_SCAV_DEFAULT_MAX_TOTAL_SPACE
 	rustle_sound = TRUE
+	number_of_rows = STORAGE_ROWS_DUFFEL_SCAV
 
 /// Syndiebag
 /datum/component/storage/concrete/backpack/duffelbag/syndie

--- a/code/datums/components/storage/concrete/boxes.dm
+++ b/code/datums/components/storage/concrete/boxes.dm
@@ -29,6 +29,7 @@
 	max_combined_w_class = STORAGE_BIG_BOX_DEFAULT_MAX_TOTAL_SPACE
 	max_volume = STORAGE_BIG_BOX_DEFAULT_MAX_TOTAL_SPACE
 	rustle_sound = TRUE
+	number_of_rows = STORAGE_ROWS_BIGBOX
 
 /// snap pops!
 /datum/component/storage/concrete/box/big/snap_pop
@@ -53,6 +54,7 @@
 	max_combined_w_class = STORAGE_HUGE_BOX_DEFAULT_MAX_TOTAL_SPACE
 	max_volume = STORAGE_HUGE_BOX_DEFAULT_MAX_TOTAL_SPACE
 	rustle_sound = TRUE
+	number_of_rows = STORAGE_ROWS_HUGEBOX
 
 /// Lights!
 /datum/component/storage/concrete/box/huge/lights
@@ -75,8 +77,7 @@
 	max_w_class = STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE
 	max_combined_w_class = STORAGE_BOX_SURVIVAL_TRIPLE_MAX_TOTAL_SPACE
 	max_volume = STORAGE_BOX_SURVIVAL_TRIPLE_MAX_TOTAL_SPACE
-	limited_random_access = TRUE
-	limited_random_access_stack_position = 3
+	number_of_rows = STORAGE_ROWS_SURVIVAL_TRIPLE
 
 /// Specialized kit
 /datum/component/storage/concrete/box/survivalkit/specialized

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -259,10 +259,10 @@
 
 /// Combat armor bandolier / holster
 /datum/component/storage/concrete/pockets/magpouch
-	max_items = STORAGE_BELT_SPECIALIZED_MAX_ITEMS
-	max_w_class = WEIGHT_CLASS_NORMAL
-	max_combined_w_class = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
-	max_volume = STORAGE_BELT_SPECIALIZED_MAX_TOTAL_SPACE
+	max_items = STORAGE_BELT_HOLSTER_MAX_ITEMS
+	max_w_class = STORAGE_BELT_HOLSTER_MAX_SIZE
+	max_combined_w_class = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
+	max_volume = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
 
 /datum/component/storage/concrete/pockets/magpouch/Initialize()
 	. = ..()

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -77,6 +77,9 @@
 	var/screen_start_y = 2
 	//End
 
+	/// How many rows of inventory are shown by default. Only useful for volumetric storage!
+	var/number_of_rows = STORAGE_ROWS_DEFAULT
+
 	var/limited_random_access = FALSE					//Quick if statement in accessible_items to determine if we care at all about what people can access at once.
 	var/limited_random_access_stack_position = 0					//If >0, can only access top <x> items
 	var/limited_random_access_stack_bottom_up = FALSE				//If TRUE, above becomes bottom <x> items

--- a/code/datums/components/storage/ui.dm
+++ b/code/datums/components/storage/ui.dm
@@ -109,7 +109,7 @@
 	// after this point we are sure we can somehow fit all items into our max number of rows.
 
 	// determine rows
-	var/rows = clamp(CEILING(min_pixels / horizontal_pixels, 1), 1, screen_max_rows)
+	var/rows = number_of_rows // clamp(CEILING(min_pixels / horizontal_pixels, 1), 1, screen_max_rows)
 
 	var/overrun = FALSE
 	if(used > our_volume)

--- a/code/game/objects/items/storage/survivalkit.dm
+++ b/code/game/objects/items/storage/survivalkit.dm
@@ -140,6 +140,7 @@
 	icon_state = "survivalkit_triple"
 	component_type = /datum/component/storage/concrete/box/survivalkit/triple
 	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_SUITSTORE
 
 /obj/item/storage/survivalkit/triple/PopulateContents()
 	return


### PR DESCRIPTION
## About The Pull Request

Adds in support for multiple rows of storage, so large inventories dont get smooshed into smallness.

Tweaks the combat armor's bandolier to be a bit less of a hold-everything sack.

Resizes backpacks, duffels, and scav duffels to be divisible by their rows, to minimize wierdness.