### PR TITLE
Updates discord link in hub description

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -310,7 +310,7 @@ GLOBAL_LIST(topic_status_cache)
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"https://discord.gg/xCgEwJTppx\">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"https://discord.gg/Xmg7Sb3kSD\">" //Change this to wherever you want the hub to link to.
 	s += "Discord"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"
 	s += ")\]" //CIT CHANGE - encloses the server title in brackets to make the hub entry fancier
@@ -321,8 +321,8 @@ GLOBAL_LIST(topic_status_cache)
 	if(SSmapping.config) // this just stops the runtime, honk.
 		features += "[SSmapping.config.map_name]"	//CIT CHANGE - makes the hub entry display the current map
 
-	if(NUM2SECLEVEL(GLOB.security_level))//CIT CHANGE - makes the hub entry show the security level
-		features += "[NUM2SECLEVEL(GLOB.security_level)] alert"
+	//if(NUM2SECLEVEL(GLOB.security_level)) // Coyote Bayou - We don't use alert levels.
+	//	features += "[NUM2SECLEVEL(GLOB.security_level)] alert"
 
 	var/popcaptext = ""
 	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))

--- a/config/config.txt
+++ b/config/config.txt
@@ -21,7 +21,7 @@ $include policy.txt
 # There are various options which are hard-locked for security reasons.
 
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
-# SERVERNAME Coyote Bayou
+@SERVERNAME Coyote Bayou
 
 ## Server tagline: This will appear right below the server's title.
 SERVERTAGLINE [18+] Fallout 1/Wasteland Inspired HRP Furry PVE/PVP experience with high amounts of replayability and systems for anonymity in game.  Join our discord to get whitelisted at, https://discord.gg/YV9JjUAvJS


### PR DESCRIPTION
Not tested, as I'd have to host my testing server on the hub lmao.

Should have no adverse effect, though.

I also uncommented and locked the server name in `confix.txt`, so it'll appear in places.