### PR TITLE
Enable Saturnite research node

### DIFF
--- a/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -6,7 +6,6 @@
 	description = "The absolute cutting edge."
 	prereq_ids = list("biotech","engineering")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	hidden = TRUE
 	design_ids = list("alienalloy")
 
 /datum/techweb_node/alientech/New()


### PR DESCRIPTION
## About The Pull Request
The [research materials overhaul](https://github.com/ARF-SS13/coyote-bayou/pull/609) implemented Saturnite research recipes to pursue, but never enabled the technology necessary to do so. Testing with the technology node available for research shows everything working as expected, making it possible to fabricate the highest-grade machine parts and tools again.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
config: made Saturnite tech available for research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
