### PR TITLE
Loadout kit stuff!

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -306,15 +306,6 @@
 	max_fuel = 40
 	custom_materials = list(/datum/material/glass=60)
 
-/obj/item/weldingtool/largetank/cylphie
-	name = "Cylphie's welding tool"
-	desc = "A heavily altered industrial welding tool stolen from the brotherhood."
-	icon = 'icons/obj/abductor.dmi'
-	icon_state = "welder"
-	toolspeed = 0.5
-	max_fuel = 40
-	custom_materials = list(/datum/material/glass=60)
-
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
 	desc = "An advanced welder designed to be used in robotic systems."

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -306,6 +306,15 @@
 	max_fuel = 40
 	custom_materials = list(/datum/material/glass=60)
 
+/obj/item/weldingtool/largetank/cylphie
+	name = "Cylphie's welding tool"
+	desc = "A heavily altered industrial welding tool stolen from the brotherhood."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "welder"
+	toolspeed = 0.5
+	max_fuel = 40
+	custom_materials = list(/datum/material/glass=60)
+
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
 	desc = "An advanced welder designed to be used in robotic systems."

--- a/code/modules/fallout/obj/smelling_salts.dm
+++ b/code/modules/fallout/obj/smelling_salts.dm
@@ -1,7 +1,7 @@
 //smelling salts
 /obj/item/smelling_salts
 	name = "smelling salts"
-	desc = "A large glass phial of pungent smelling salts, used to revive those who have fainted.<br>It is bound in cord marking the colors of Caesars Legion,"
+	desc = "A large glass phial of pungent smelling salts, used to revive those who have fainted."
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/fallout/objects/medicine/primitivedefib.dmi'
 	icon_state = "smelling_salts"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -231,3 +231,22 @@
 	new /obj/item/gun/ballistic/bow/xbow(src)
 	new /obj/item/storage/bag/tribe_quiver/archer(src)
 	new /obj/item/smelling_salts/wayfarer(src)
+
+/datum/gear/donator/kits/thingpony
+	name = "The Ultra Cutie Kit"
+	path = /obj/item/storage/box/large/custom_kit/thingpony
+	ckeywhitelist = list("thingpony")
+
+/obj/item/storage/box/large/custom_kit/thingpony/PopulateContents()
+	new /obj/item/clothing/suit/hooded/outcast(src)
+	new /obj/item/gun/ballistic/automatic/pistol/ninemil/maria(src)
+	new /obj/item/gun/ballistic/automatic/pistol/n99/crusader(src)
+
+/datum/gear/donator/kits/baticon
+	name = "Laser Bat Kit"
+	path = /obj/item/storage/box/large/custom_kit/baticon
+	ckeywhitelist = list("baticon")
+
+/obj/item/storage/box/large/custom_kit/baticon/PopulateContents()
+	new /obj/item/gun/energy/laser/pistol(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -209,3 +209,25 @@
 /obj/item/storage/box/large/custom_kit/aerodynamique/PopulateContents()
 	new /obj/item/gun/ballistic/rifle/repeater/trail(src)
 	new /obj/item/gun_upgrade/scope/watchman(src)
+
+/datum/gear/donator/kits/truedark
+	name = "Stolen Brotherhood Supplies"
+	path = /obj/item/storage/box/large/custom_kit/truedark
+	ckeywhitelist = list("truedark")
+
+/obj/item/storage/box/large/custom_kit/truedark/PopulateContents()
+	new /obj/item/gun/energy/laser/pistol(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)
+	new /obj/item/stock_parts/cell/ammo/ec(src)
+	new /obj/item/stack/cable_coil/thirty(src)
+	new /obj/item/weldingtool/largetank/cylphie(src)
+
+/datum/gear/donator/kits/truedark2
+	name = "Alaskan Survival Kit"
+	path = /obj/item/storage/box/large/custom_kit/truedark2
+	ckeywhitelist = list("truedark")
+
+/obj/item/storage/box/large/custom_kit/truedark2/PopulateContents()
+	new /obj/item/gun/ballistic/bow/xbow(src)
+	new /obj/item/storage/bag/tribe_quiver/archer(src)
+	new /obj/item/smelling_salts/wayfarer(src)

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -20,7 +20,7 @@
 	path = /obj/item/clothing/accessory/cia_badge
 	ckeywhitelist = list("monke1818")
 
-// SUNSET FLUFF ITEMS
+// COYOTE FLUFF ITEMS
 
 /datum/gear/donator/mrsanderp
 	name = "Happy Sharky Company Cuisine Book"
@@ -29,6 +29,15 @@
 	category = LOADOUT_CATEGORY_BACKPACK
 	ckeywhitelist = list("mr.sanderp")
 	cost = 0
+
+/obj/item/weldingtool/largetank/cylphie //Virtually the same as an industrial but slightly faster
+	name = "Cylphie's welding tool"
+	desc = "A heavily altered industrial welding tool stolen from the brotherhood."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "welder"
+	toolspeed = 0.5
+	max_fuel = 40
+	custom_materials = list(/datum/material/glass=60)
 
 /* /// Fluff for fuzzy
 /datum/gear/donator/fuz_card


### PR DESCRIPTION
Two loadout kits locked to ckey truedark, as well as a custom item that's basically a reskinned industrial welder that's slightly better. (Item currently in the donator file)

Loadout kit locked to thingpony.

Loadout kit locked to baticon.

Removes the reference to Caesar's legion from the smelling salts.

Changed the // from SUNSET FLUFF ITEMS to COYOTE FLUFF ITEMS.