### PR TITLE
Cleaning radioactive goo with Abraxo

### DIFF
--- a/code/modules/fallout/obj/crafting.dm
+++ b/code/modules/fallout/obj/crafting.dm
@@ -144,8 +144,8 @@
 	icon_state = "turpentine"
 
 /obj/item/crafting/abraxo
-	name = "abraxo"
-	desc = "A pre-War cleaning agent produced by Abraxodyne Chemical."
+	name = "Abraxo"
+	desc = "A pre-War cleaning agent produced by Abraxodyne Chemical.<br>Its powdery flakes seem useful for dealing with toxic spills."
 	icon_state = "abraxo"
 
 /obj/item/circuitboard/machine/autolathe/ammo/improvised

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -32,6 +32,18 @@
 	for(var/mob/living/carbon/human/victim in view(src,range))
 		if(istype(victim) && victim.stat != DEAD)
 			victim.rad_act(intensity)
+			
+/obj/effect/decal/waste/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/crafting/abraxo))
+		user.show_message(span_notice("You start sprinkling \the [I.name] onto the puddle of goo..."), MSG_VISUAL)
+		if(do_after(user, 30, target = src))
+			user.show_message(span_notice("You neutralize the radioactive goo!"), MSG_VISUAL)
+			new /obj/effect/decal/cleanable/chem_pile(src.loc) //Leave behind some cleanable chemical powder
+			STOP_PROCESSING(SSradiation,src)
+			qdel(src)
+			qdel(I)
+	else
+		return ..()
 
 /obj/effect/decal/marking
 	name = "road marking"


### PR DESCRIPTION
## About The Pull Request
Adds the oft-requested ability to remove puddles of radioactive goo, the bane of construction- and restoration-minded wastelanders since the dawn of man. Sprinkling a full box of Abraxo cleaner onto a puddle will absorb and neutralize it, leaving behind an easily-cleaned pile of mostly harmless powdered chemical waste. The flavor text for Abraxo has also been modified to hint towards this ability, reducing the amount of code diving necessary to learn such terrible power.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added the ability to clean up puddles of goo with Abraxo
tweak: Tweaked Abraxo's flavor text to hint towards its new goo-obliterating powers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
