### PR TITLE
Allows javelins made from blacksmithing to fit in the Spear Quiver

### DIFF
--- a/code/datums/components/storage/concrete/backpack.dm
+++ b/code/datums/components/storage/concrete/backpack.dm
@@ -11,7 +11,7 @@
 /// Spearquiver
 /datum/component/storage/concrete/backpack/spear_quiver/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(/obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola))
+	can_hold = typecacheof(list(/obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/melee/smith/javelin))
 
 /// Duffelbag
 /datum/component/storage/concrete/backpack/duffelbag


### PR DESCRIPTION
## About The Pull Request
Adds the ability to fit javelins made from blacksmithing to fit in a javelin 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Javelins made from blacksmithing now fit in the appropriate quiver
/:cl:
