### PR TITLE
Add minimum flavortext length, always let ghosts see flavortexts

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -85,6 +85,7 @@
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			4096		//Citadel edit: What's the WORST that could happen?
 #define MAX_FLAVOR_LEN			4096
+#define MIN_FLAVOR_LEN			100
 #define MAX_TASTE_LEN			40
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 			remove_verb(M, /mob/proc/manage_flavor_tests)
 
 /datum/element/flavor_text/proc/show_flavor(atom/target, mob/user, list/examine_list)
-	if(!always_show && isliving(target))
+	if(!always_show && isliving(target) && !isobserver(user))
 		var/mob/living/L = target
 		var/unknown = L.get_visible_name() == "Unknown"
 		if(!unknown && iscarbon(target))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -178,9 +178,12 @@
 		//This is likely not an actual issue but I don't have time to prove that this
 		//no longer is required
 		if(SSticker.current_state <= GAME_STATE_PREGAME)
+			if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+				to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
+				return
 			ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
-		if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
+		if(SSticker.current_state >= GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
 			ready = tready
 			make_me_an_observer()
 			return
@@ -195,6 +198,10 @@
 	if(href_list["late_join"])
 		if(!SSticker || !SSticker.IsRoundInProgress())
 			to_chat(usr, span_danger("The round is either not ready, or has already finished..."))
+			return
+
+		if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+			to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
 			return
 
 		if(href_list["late_join"] == "override")
@@ -452,6 +459,10 @@
 
 	if(SSticker.late_join_disabled)
 		alert(src, "An administrator has disabled late join spawning.")
+		return FALSE
+	
+	if((length_char(client.prefs.features["flavor_text"])) < MIN_FLAVOR_LEN)
+		to_chat(client.mob, span_danger("Your flavortext does not meet the minimum of [MIN_FLAVOR_LEN] characters."))
 		return FALSE
 
 	var/arrivals_docked = TRUE


### PR DESCRIPTION
## About The Pull Request
Rewrites #764 for better code quality and to fix the inverted checks.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds a minimum flavortext length
tweak: Allows ghosts to always see character flavortext, even when someone is wearing a mask.
/:cl: