### PR TITLE
Loadout Kit and Followers Administrator Stuff

### DIFF
--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -110,16 +110,14 @@ Administrator
 	name =	"Surgical Specialist"
 	backpack_contents = list(
 		/obj/item/storage/belt/medical/surgery_belt_adv = 1,
-		/obj/item/stack/medical/suture/medicated = 1,
-		/obj/item/stack/medical/gauze/adv = 1,
-		/obj/item/stack/medical/mesh/advanced = 1,
+		/obj/item/gun/medbeam,
 	)
 
 /datum/outfit/loadout/chemical_specialist
 	name =	"Chemical Specialist"
 	backpack_contents = list(
 		/obj/item/circuitboard/machine/chem_master/advanced = 1,
-		/obj/item/reagent_containers/glass/beaker/bluespace = 1,
+		/obj/item/storage/hypospraykit/cmo,
 	)
 
 /datum/outfit/loadout/research_specialist

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -366,6 +366,17 @@
 	new /obj/item/storage/bag/tribe_quiver/archer(src)
 	new /obj/item/smelling_salts/wayfarer(src)
 
+/datum/gear/donator/kits/truedark3
+	name = "Junker's Kit"
+	path = /obj/item/storage/box/large/custom_kit/truedark3
+	ckeywhitelist = list("truedark")
+
+/obj/item/storage/box/large/custom_kit/truedark3/PopulateContents()
+	new /obj/item/clothing/suit/armor/light/leather/rig(src)
+	new /obj/item/gun/ballistic/revolver/hobo/piperifle(src)
+	new /obj/item/ammo_box/a556(src)
+	new /obj/item/toy/plush/lampplushie(src)
+
 // U
 // V
 // W


### PR DESCRIPTION
Loadout kit locked to ckey trueDARK. (third one)

Changes the followers administrators loadouts like this:
Surgery specialist gets a medibeam gun instead of the medical treatment stuff.
Chemistry specialist gets a cmo hypospray kit instead of a bluespace beaker.