### PR TITLE
changes the FEV trait melee bonus from a flat 20 bonus to 35%

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -92,7 +92,7 @@
 		return
 
 	var/bigleagues = 10 //flat additive
-	var/FEVbonus = 20 //flat additive of 20. Makes a LOT of melee weapons better, AND hurts like a bitch
+	var/FEVbonus = force*0.35 //used to be a flat additive of 20. changed after someone beat someone to death with a book. TODO: balance this further, possibly with a switch statement depending on force value
 	var/buffout = force*0.25
 	var/smutant = force*0.25 //Not using this for FEV mutated as this could let you do a lot of trolling.
 	var/ghoulmelee = force*0.25 //negative trait, this will cut 25% of the damage done by melee


### PR DESCRIPTION
## About The Pull Request
anything over 36 damage gets a bonus over just big leagues. you can also stack big leagues with this so uh it'll probably be fine, you will live somehow, i am sure of it.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: fev melee damag eargh
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
