### PR TITLE
Cargo Expansion

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -405,3 +405,13 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	desc = "A standard Nuka-Cola bottle cap featuring 21 crimps and ridges,\
 					A common unit of exchange, backed by water in the Hub."
 	sheet_type = /obj/item/stack/f13Cash/caps
+
+/datum/material/deathclawhide
+	name = "deathclaw leather"
+	desc = "A glorious hunting trophy."
+	sheet_type = /obj/item/stack/sheet/animalhide/deathclaw
+
+/* /datum/material/prewar
+	name = "prewar alloy"
+	desc = "This sheet was manufactured by using advanced smelting techniques before the war."
+	sheet_type = /obj/item/stack/sheet/prewar */

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -185,6 +185,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	strength_modifier = 0.8
 	value_per_unit = 0.025
 
+
 /datum/material/wood
 	name = "wood"
 	desc = "Flexible, durable, but flamable. Hard to come across in space."
@@ -364,12 +365,11 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	return ..()
 
 /datum/material/bone
-	name = "bone"
-	desc = "Man, building with this will make you the coolest caveman on the block."
+	name = "bones"
+	desc = "Someone's been drinking their milk."
 	color = "#e3dac9"
-	categories = list(MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/bone
-	value_per_unit = 0.05
+	categories = list(MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	armor_modifiers = list("melee" = 1.2, "bullet" = 0.75, "laser" = 0.75, "energy" = 1.2, "bomb" = 1, "bio" = 1, "rad" = 1.5, "fire" = 1.5, "acid" = 1.5)
 	beauty_modifier = -0.2
 
@@ -384,3 +384,24 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.2
 	turf_sound_override = FOOTSTEP_WOOD
 	texture_layer_icon_state = "bamboo"
+
+/datum/material/leather
+	name = "leather"
+	desc = "The by-product of mob grinding."
+	sheet_type = /obj/item/stack/sheet/leather
+
+/datum/material/sinew
+	name = "sinew"
+	desc = "Long stringy filaments, presumably from some kind of animal."
+	sheet_type = /obj/item/stack/sheet/sinew
+
+/datum/material/chitin
+	name = "chitin"
+	desc = "Thick insect chitin, tough but light."
+	sheet_type = /obj/item/stack/sheet/animalhide/chitin
+
+/datum/material/f13cash
+	name = "caps"
+	desc = "A standard Nuka-Cola bottle cap featuring 21 crimps and ridges,\
+					A common unit of exchange, backed by water in the Hub."
+	sheet_type = /obj/item/stack/f13Cash/caps

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -556,7 +556,7 @@
 	loot = list(
 				/obj/item/reagent_containers/pill/patch/jet,
 				/obj/item/reagent_containers/pill/patch/turbo,
-				/obj/item/reagent_containers/pill/healingpowder,
+				// /obj/item/reagent_containers/pill/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
 				/obj/item/reagent_containers/hypospray/medipen/medx,
 				/obj/item/storage/pill_bottle/chem_tin/buffout,
@@ -2169,18 +2169,8 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7,
 		/obj/item/book/granter/crafting_recipe/blueprint/scoutcarbine,
 		/obj/item/book/granter/crafting_recipe/blueprint/sniper,
-	)
+	)		
 
-/obj/effect/spawner/lootdrop/f13/blueprintEnergyMid
-	name = "blueprint-energy-tier(Low) item spawner"
-	icon_state = "blueprint_loot"
-	lootcount = 1
-	loot = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/aer9,
-		// /obj/item/book/granter/crafting_recipe/blueprint/wattz2k,
-		/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
-		// /obj/item/book/granter/crafting_recipe/blueprint/ionrifle
-		)
 
 /obj/effect/spawner/lootdrop/f13/blueprintHigh
 	name = "blueprint-tier(High) item spawner"
@@ -2197,16 +2187,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/book/granter/crafting_recipe/blueprint/brushgun,
 	)
 
-/obj/effect/spawner/lootdrop/f13/blueprintEnergyHigh
-	name = "blueprint-energy-tier(High) item spawner"
-	icon_state = "blueprint_loot"
-	lootcount = 1
-	loot = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle,
-		// /obj/item/book/granter/crafting_recipe/blueprint/wattz2kext,
-		/obj/item/book/granter/crafting_recipe/blueprint/tribeam,
-		// /obj/item/book/granter/crafting_recipe/blueprint/rcw
-	)
+
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh
 	name = "blueprint-tier(VHigh) item spawner"
 	icon_state = "blueprint_loot"

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2171,6 +2171,17 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/book/granter/crafting_recipe/blueprint/sniper,
 	)
 
+/obj/effect/spawner/lootdrop/f13/blueprintEnergyMid
+	name = "blueprint-energy-tier(Low) item spawner"
+	icon_state = "blueprint_loot"
+	lootcount = 1
+	loot = list(
+		/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+		// /obj/item/book/granter/crafting_recipe/blueprint/wattz2k,
+		/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
+		// /obj/item/book/granter/crafting_recipe/blueprint/ionrifle
+		)
+
 /obj/effect/spawner/lootdrop/f13/blueprintHigh
 	name = "blueprint-tier(High) item spawner"
 	icon_state = "blueprint_loot"
@@ -2186,6 +2197,16 @@ obj/effect/spawner/bundle/f13/combat_rifle
 		/obj/item/book/granter/crafting_recipe/blueprint/brushgun,
 	)
 
+/obj/effect/spawner/lootdrop/f13/blueprintEnergyHigh
+	name = "blueprint-energy-tier(High) item spawner"
+	icon_state = "blueprint_loot"
+	lootcount = 1
+	loot = list(
+		/obj/item/book/granter/crafting_recipe/blueprint/plasmarifle,
+		// /obj/item/book/granter/crafting_recipe/blueprint/wattz2kext,
+		/obj/item/book/granter/crafting_recipe/blueprint/tribeam,
+		// /obj/item/book/granter/crafting_recipe/blueprint/rcw
+	)
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh
 	name = "blueprint-tier(VHigh) item spawner"
 	icon_state = "blueprint_loot"

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(xeno_recipes, list (
 	merge_type = /obj/item/stack/sheet/wetleather
 
 /*
- * Leather SHeet
+ * Leather Sheet
  */
 /obj/item/stack/sheet/leather
 	name = "leather"
@@ -161,7 +161,8 @@ GLOBAL_LIST_INIT(xeno_recipes, list (
 	singular_name = "leather piece"
 	icon_state = "sheet-leather"
 	item_state = "sheet-leather"
-	merge_type = /obj/item/stack/sheet/leather
+	custom_materials = list(/datum/material/leather=MINERAL_MATERIAL_AMOUNT) //mineral_material_amount is used for cargo compatability
+	//merge_type = /obj/item/stack/sheet/leather
 
 GLOBAL_LIST_INIT(leather_recipes, list (
 	new/datum/stack_recipe("farmers gloves", /obj/item/clothing/gloves/botanic_leather, 3),
@@ -212,8 +213,9 @@ GLOBAL_LIST_INIT(leather_recipes, list (
 	desc = "Long stringy filaments, presumably from some kind of animal."
 	singular_name = "sinew"
 	icon_state = "sinew"
+	custom_materials = list(/datum/material/sinew=MINERAL_MATERIAL_AMOUNT)
 	novariants = TRUE
-	merge_type = /obj/item/stack/sheet/sinew
+	// merge_type = /obj/item/stack/sheet/sinew
 
 GLOBAL_LIST_INIT(sinew_recipes, list (
 	new/datum/stack_recipe("sinew restraints", /obj/item/restraints/handcuffs/sinew, 1),
@@ -252,8 +254,9 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 	desc = "Thick insect chitin, tough but light."
 	singular_name = "piece of insect chitin"
 	icon_state = "sheet-chitin"
+	custom_materials = list(/datum/material/chitin=MINERAL_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/sodium = 3, /datum/reagent/chlorine = 3)
-	merge_type = /obj/item/stack/sheet/animalhide/chitin
+	// merge_type = /obj/item/stack/sheet/animalhide/chitin
 
 /obj/item/stack/sheet/animalhide/ashdrake
 	name = "ash drake hide"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -810,8 +810,8 @@ GLOBAL_LIST_INIT(bone_recipes, list(
 	throw_speed = 1
 	throw_range = 3
 	grind_results = list(/datum/reagent/carbon = 10)
-	merge_type = /obj/item/stack/sheet/bone
-	material_type = /datum/material/bone
+	//merge_type = /obj/item/stack/sheet/bone
+	//material_type = /datum/material/bone
 
 /obj/item/stack/sheet/bone/get_main_recipes()
 	. = ..()

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -17,7 +17,6 @@
 	cost = 100
 	unit_name = "large wooden crate"
 	export_types = list(/obj/structure/closet/crate/large)
-	exclude_types = list()
 
 /datum/export/large/crate/wooden/ore
 	unit_name = "ore box"
@@ -27,7 +26,6 @@
 	cost = 140
 	unit_name = "wooden crate"
 	export_types = list(/obj/structure/closet/crate/wooden)
-	exclude_types = list()
 
 /datum/export/large/barrel
 	cost = 300 //double the wooden cost of a coffin.
@@ -160,6 +158,50 @@
 	cost = 12
 	unit_name = "Padded Chair"
 	export_types = list(/obj/structure/chair/comfy)
+
+/datum/export/large/adv_chem_master
+	cost = 2500
+	unit_name = "old world refinery"
+	export_types = list(/obj/machinery/chem_master/advanced)
+
+/datum/export/large/chem_dispenser
+	cost = 3000
+	unit_name = "chem dispenser"
+	export_types = list(/obj/machinery/chem_dispenser)
+
+/datum/export/large/workbench
+	cost = 1000
+	unit_name = "workbench"
+	export_types = list(/obj/machinery/workbench)
+
+/datum/export/large/adv_workbench
+	cost = 4000
+	unit_name = "advanced workbench"
+	export_types = list(/obj/machinery/workbench/advanced)
+
+/datum/export/large/ammobench
+	cost = 3500
+	unit_name = "ammo bench"
+	export_types = list(obj/machinery/autolathe/ammo)
+
+/datum/export/large/forge
+	cost = 2000
+	unit_name = "metalworking bench"
+	export_types = list(/obj/machinery/workbench/forge)
+
+/datum/export/large/grinder
+	cost = 950
+	unit_name = "all-in-one grinder"
+	export_types = list(/obj/machinery/reagentgrinder/constructed)
+
+/datum/export/large/microwave
+	cost = 750
+	unit_name = "all-in-one grinder"
+	export_types = list(/obj/machinery/microwave)
+/datum/export/large/optable
+	cost = 1000
+	unit_name = "operating table"
+	export_types = list(/obj/structure/table/optable)
 
 /datum/export/large/gas_canister
 	cost = 10 //Base cost of canister. You get more for nice gases inside.

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -81,9 +81,17 @@
 		/obj/item/shard)
 
 /datum/export/material/adamantine
-	cost = 300
+	cost = 100
 	material_id = /datum/material/adamantine
-	message = "cm3 of adamantine"
+	message = "cm3 of pre-war ingots"
+	export_types = list(/obj/item/stack/sheet/mineral/adamantine,
+	/obj/item/ingot/adamantine)
+
+/* /datum/export/material/prewar
+	cost = 15
+	material_id = /datum/material/prewar
+	message = "cm3 of prewar alloy"
+	export_types = (/obj/item/stack/sheet/prewar) */
 
 /datum/export/material/mythril
 	cost = 1000
@@ -108,7 +116,7 @@
 
 /datum/export/material/bone
 	cost = 3
-	unit_name = "bones"
+	unit_name = "bone"
 	material_id = /datum/material/bone
 	export_types = list(/obj/item/stack/sheet/bone)
 
@@ -129,3 +137,9 @@
 	unit_name = "caps"
 	material_id = /datum/material/f13cash
 	export_types = list(/obj/item/stack/f13Cash/caps)
+
+/datum/export/material/deathclawhide
+	cost = 175
+	unit_name = "deathclaw hide"
+	material_id = /datum/material/deathclawhide
+	export_types = list(/obj/item/stack/sheet/animalhide/deathclaw)

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -56,11 +56,13 @@
 	cost = 60
 	material_id = /datum/material/titanium
 	message = "cm3 of titanium"
+	export_types = list(/obj/item/stack/sheet/mineral/titanium)
 
 /datum/export/material/plastic
 	cost = 5
 	material_id = /datum/material/plastic
 	message = "cm3 of plastic"
+	export_types = list(/obj/item/stack/sheet/plastic)
 
 /datum/export/material/metal
 	cost = 3
@@ -68,7 +70,8 @@
 	material_id = /datum/material/iron
 	export_types = list(
 		/obj/item/stack/sheet/metal, /obj/item/stack/tile/plasteel,
-		/obj/item/stack/rods, /obj/item/stack/ore, /obj/item/coin)
+		/obj/item/stack/sheet/plasteel, /obj/item/stack/rods, 
+		/obj/item/stack/ore, /obj/item/coin)
 
 /datum/export/material/glass
 	cost = 3
@@ -99,30 +102,30 @@
 
 /datum/export/material/leather
 	cost = 7
-	unit_name = "cm3 of leather"
+	unit_name = "sheets of leather"
 	material_id = /datum/material/leather
 	export_types = list(/obj/item/stack/sheet/leather)
 
 /datum/export/material/bone
 	cost = 3
-	unit_name = "cm3 of bones"
+	unit_name = "bones"
 	material_id = /datum/material/bone
 	export_types = list(/obj/item/stack/sheet/bone)
 
 /datum/export/material/sinew
 	cost = 3
-	unit_name = "cm3 of sinew"
+	unit_name = "pieces of sinew"
 	material_id = /datum/material/sinew
 	export_types = list(/obj/item/stack/sheet/sinew)
 
 /datum/export/material/chitin
 	cost = 4
-	unit_name = "cm3 of chitin"
+	unit_name = "pieces of chitin"
 	material_id = /datum/material/chitin
 	export_types = list(/obj/item/stack/sheet/animalhide/chitin)
 
 /datum/export/material/f13cash
 	cost = 2
-	unit_name = "cm3 of caps"
+	unit_name = "caps"
 	material_id = /datum/material/f13cash
 	export_types = list(/obj/item/stack/f13Cash/caps)

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -35,7 +35,7 @@
 /datum/export/material/plasma
 	cost = 100
 	material_id = /datum/material/plasma
-	message = "cm3 of plasma"
+	message = "cm3 of ultracite"
 
 /datum/export/material/uranium
 	cost = 50
@@ -96,3 +96,33 @@
 	cost = 300
 	message = "cm3 of runite"
 	material_id = /datum/material/runite
+
+/datum/export/material/leather
+	cost = 7
+	unit_name = "cm3 of leather"
+	material_id = /datum/material/leather
+	export_types = list(/obj/item/stack/sheet/leather)
+
+/datum/export/material/bone
+	cost = 3
+	unit_name = "cm3 of bones"
+	material_id = /datum/material/bone
+	export_types = list(/obj/item/stack/sheet/bone)
+
+/datum/export/material/sinew
+	cost = 3
+	unit_name = "cm3 of sinew"
+	material_id = /datum/material/sinew
+	export_types = list(/obj/item/stack/sheet/sinew)
+
+/datum/export/material/chitin
+	cost = 4
+	unit_name = "cm3 of chitin"
+	material_id = /datum/material/chitin
+	export_types = list(/obj/item/stack/sheet/animalhide/chitin)
+
+/datum/export/material/f13cash
+	cost = 2
+	unit_name = "cm3 of caps"
+	material_id = /datum/material/f13cash
+	export_types = list(/obj/item/stack/f13Cash/caps)

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -52,6 +52,16 @@
 	unit_name = "energy cell"
 	export_types = list(/obj/item/stock_parts/cell/ammo/ec)
 
+/datum/export/item/mfc
+	cost = 350
+	unit_name = "microfusion cell"
+	export_types = list(/obj/item/stock_parts/cell/ammo/mfc)
+
+/datum/export/item/ecp
+	cost = 450
+	unit_name = "electron charge pack"
+	export_types = list(/obj/item/stock_parts/cell/ammo/ecp)
+
 /datum/export/item/traitbookslow
 	cost = 300
 	unit_name = "low-quality technical manual"
@@ -78,3 +88,5 @@
 				/obj/item/book/granter/crafting_recipe/gunsmith_two,
 				/obj/item/book/granter/crafting_recipe/gunsmith_three,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four)
+
+

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -2,30 +2,184 @@
 
 // medicine
 
-/datum/export/item/radaway
-	cost = 200
-	unit_name = "radaway"
-	export_types = list(/obj/item/reagent_containers/blood/radaway)
+/datum/export/item/chems
+	cost = 65
+	unit_name = "chems (low)"
+	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak,
+	/obj/item/reagent_containers/hypospray/medipen/medx,
+	/obj/item/reagent_containers/blood/radaway,
+	/obj/item/reagent_containers/hypospray/medipen/steady,
+	/obj/item/storage/pill_bottle/chem_tin/mentats,
+	/obj/item/reagent_containers/pill/healingpowder,
+	/obj/item/storage/pill_bottle/chem_tin/buffout,
+	/obj/item/reagent_containers/pill/stimulant,
+	/obj/item/storage/pill_bottle/chem_tin/radx,
+	/obj/item/reagent_containers/pill/healingpowder
+	)
 
-/datum/export/item/stimpak
-	cost = 40
-	unit_name = "stimpak"
-	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak)
+/datum/export/item/chemshigh
+	cost = 150
+	unit_name = "chems (high)"
+	export_types = list(,
+	/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+	/obj/item/reagent_containers/pill/patch/healpoultice
+	)
 
-/datum/export/item/superstimpak
+/* /datum/export/item/superstimpak
 	cost = 80
 	unit_name = "super stimpak"
-	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super)
+	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super) */
 
-/datum/export/item/tenmmpistol
-	cost = 80
-	unit_name = "n99 semiautomatic pistol"
-	export_types = list(/obj/item/gun/ballistic/automatic/pistol/n99)
+/datum/export/item/lightpistol
+	cost = 75
+	unit_name = "light pistols"
+	export_types = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99,
+		/obj/item/gun/ballistic/automatic/pistol/type17,
+		/obj/item/gun/ballistic/automatic/pistol/ninemil,
+		/obj/item/gun/ballistic/automatic/pistol/pistol22,
+		/obj/item/gun/ballistic/automatic/pistol/sig,
+		/obj/item/gun/ballistic/automatic/pistol/beretta,
+		/obj/item/gun/ballistic/revolver/detective,
+		/obj/item/gun/ballistic/revolver/colt357,
+		/obj/item/gun/ballistic/revolver/police,
+		/obj/item/gun/ballistic/automatic/pistol/m1911,
+		/obj/item/gun/ballistic/revolver/thatgun,
+		/obj/item/gun/energy/laser/wattz,
+		)
 
-/datum/export/item/tenmmpistolchinese
+/datum/export/item/heavypistol
+	cost = 150
+	unit_name = "heavy pistols"
+	export_types = list(
+		/obj/item/gun/energy/laser/wattz/magneto,
+		/obj/item/gun/energy/laser/pistol,
+		/obj/item/gun/ballistic/automatic/pistol/m1911/custom,
+		/obj/item/gun/ballistic/automatic/pistol/mk23,
+		/obj/item/gun/ballistic/automatic/pistol/deagle,
+		/obj/item/gun/ballistic/automatic/pistol/automag,
+		/obj/item/gun/ballistic/automatic/pistol/sig,
+		/obj/item/gun/ballistic/automatic/pistol/pistol14,
+		/obj/item/gun/ballistic/revolver/revolver45,
+		/obj/item/gun/ballistic/revolver/m29,
+		/obj/item/gun/ballistic/revolver/revolver44,
+		/obj/item/gun/ballistic/revolver/hunting
+		)
+
+/datum/export/item/smg
+	cost = 175
+	unit_name = "submachine guns"
+	export_types = list(
+		/obj/item/gun/energy/laser/plasma/pistol,
+		/obj/item/gun/ballistic/automatic/smg/american180,
+		/obj/item/gun/ballistic/automatic/smg/smg14,
+		/obj/item/gun/ballistic/automatic/smg/greasegun,
+		/obj/item/gun/ballistic/automatic/smg/smg10mm,
+		/obj/item/gun/ballistic/automatic/smg/mini_uzi,
+		/obj/item/gun/ballistic/automatic/smg/tommygun,
+		/obj/item/gun/ballistic/automatic/smg/p90,
+		/obj/item/gun/ballistic/automatic/smg/mp5,
+		/obj/item/gun/ballistic/automatic/smg/ppsh
+		)
+
+/datum/export/item/carbine
+	cost = 325
+	unit_name = "carbines"
+	export_types = list(
+		/obj/item/gun/ballistic/automatic/m1carbine,
+		/obj/item/gun/ballistic/automatic/delisle,
+		/obj/item/gun/ballistic/automatic/combat,
+		/obj/item/gun/ballistic/automatic/sportcarbine,
+		/obj/item/gun/ballistic/automatic/varmint,
+		/obj/item/gun/ballistic/rifle/repeater/cowboy,
+		/obj/item/gun/ballistic/rifle/repeater/trail,
+		/obj/item/gun/ballistic/rifle/hunting,
+		/obj/item/gun/ballistic/rifle/enfield,
+	)
+
+/datum/export/item/dbshotgun
+	cost = 325
+	unit_name = "double-barreled shotguns"
+	export_types = list(/obj/item/gun/ballistic/revolver/caravan_shotgun,
+	/obj/item/gun/ballistic/revolver/widowmaker,
+	)
+
+/datum/export/item/pumpshotgun
+	cost = 400
+	unit_name = "pump-action shotguns"
+	export_types = list(
+		/obj/item/gun/ballistic/shotgun/hunting,
+		/obj/item/gun/ballistic/shotgun/police,
+		/obj/item/gun/ballistic/shotgun/trench,
+		)
+
+/datum/export/item/semishotgun
+	cost = 750
+	unit_name = "semi-auto shotguns"
+	export_types = list(
+		/obj/item/gun/ballistic/shotgun/automatic/combat/auto5,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/neostead,
+		/obj/item/gun/ballistic/shotgun/automatic/combat/citykiller,
+		/obj/item/gun/ballistic/automatic/shotgun/riot,
+		/obj/item/gun/ballistic/automatic/shotgun/pancor,
+		/obj/item/gun/ballistic/revolver/grenadelauncher,
+		)
+
+/datum/export/item/semirifle
+	cost = 550
+	unit_name = "semi-automatic rifles"
+	export_types = list(
+		/obj/item/gun/ballistic/automatic/varmint/verminkiller,
+		/obj/item/gun/energy/laser/plasma/glock,
+		/obj/item/gun/energy/laser/plasma,
+		/obj/item/gun/energy/laser/wattz2k,
+		/obj/item/gun/energy/laser/aer9,
+		/obj/item/gun/ballistic/automatic/service,
+		/obj/item/gun/ballistic/automatic/marksman,
+		/obj/item/gun/ballistic/automatic/rangemaster,
+		/obj/item/gun/ballistic/automatic/slr,
+		/obj/item/gun/ballistic/automatic/m1garand,
+		/obj/item/gun/ballistic/rifle/repeater/brush,
+		/obj/item/gun/ballistic/automatic/marksman/sniper,
+		/obj/item/gun/ballistic/rifle/mag/antimateriel
+	)
+
+/datum/export/item/autorifle
+	cost = 850
+	unit_name = "automatic rifles"
+	export_types = list(
+		/obj/item/gun/ballistic/automatic/service/r82,
+		/obj/item/gun/ballistic/automatic/assault_rifle,
+		/obj/item/gun/ballistic/automatic/r93,
+		/obj/item/gun/energy/laser/scatter,
+		/obj/item/gun/energy/laser/aer12,
+		/obj/item/gun/energy/laser/rcw,
+		/obj/item/gun/ballistic/automatic/type93,
+		/obj/item/gun/ballistic/automatic/bozar,
+		/obj/item/gun/ballistic/automatic/assault_carbine,
+		/obj/item/gun/ballistic/automatic/fnfal,
+		/obj/item/gun/ballistic/automatic/bar,
+		/obj/item/gun/ballistic/automatic/g11,
+
+	)
+
+/datum/export/item/lmg
+	cost = 950
+	unit_name = "light machine guns"
+	export_types = list(
+		/obj/item/gun/ballistic/automatic/r84,
+		/obj/item/gun/ballistic/automatic/lsw,
+		/obj/item/gun/ballistic/automatic/m1919,
+		/obj/item/gun/ballistic/rocketlauncher,
+	)
+
+
+
+/* /datum/export/item/tenmmpistolchinese
 	cost = 70
 	unit_name = "type 17 semiautomatic pistol"
-	export_types = list(/obj/item/gun/ballistic/automatic/pistol/type17)
+	export_types = list()
 
 /datum/export/item/ninemmpistol
 	cost = 80
@@ -35,10 +189,10 @@
 /datum/export/item/browningmnineteen
 	cost = 50
 	unit_name = "m1911"
-	export_types = list(/obj/item/gun/ballistic/automatic/)
+	export_types = list(/obj/item/gun/ballistic/automatic/) */
 
 /datum/export/item/zipgunslist
-	cost = 30
+	cost = 40
 	unit_name = "improvised firearm"
 	export_types = list(/obj/effect/spawner/bundle/f13/pepperbox,
 				/obj/effect/spawner/bundle/weapon/piperifle,
@@ -48,22 +202,22 @@
 				/obj/effect/spawner/bundle/f13/autopipe)
 
 /datum/export/item/energycell
-	cost = 250
+	cost = 100
 	unit_name = "energy cell"
 	export_types = list(/obj/item/stock_parts/cell/ammo/ec)
 
 /datum/export/item/mfc
-	cost = 350
+	cost = 300
 	unit_name = "microfusion cell"
 	export_types = list(/obj/item/stock_parts/cell/ammo/mfc)
 
 /datum/export/item/ecp
-	cost = 450
+	cost = 400
 	unit_name = "electron charge pack"
 	export_types = list(/obj/item/stock_parts/cell/ammo/ecp)
 
 /datum/export/item/traitbookslow
-	cost = 300
+	cost = 400
 	unit_name = "low-quality technical manual"
 	export_types = list(/obj/item/book/granter/trait/lowsurgery,
 				/obj/item/book/granter/trait/chemistry,
@@ -76,7 +230,7 @@
 				/obj/item/book/granter/crafting_recipe/gunsmith_one)
 
 /datum/export/item/traitbooks
-	cost = 450
+	cost = 550
 	unit_name = "high-quality technical manual"
 	export_types = list(/obj/item/book/granter/trait/lowsurgery,
 				/obj/item/book/granter/trait/chemistry,
@@ -89,4 +243,136 @@
 				/obj/item/book/granter/crafting_recipe/gunsmith_three,
 				/obj/item/book/granter/crafting_recipe/gunsmith_four)
 
+/datum/export/item/crops
+	cost = 20
+	unit_name = "produce"
+	export_types = list(/obj/item/reagent_containers/food/snacks/grown/agave,
+		/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+		/obj/item/reagent_containers/food/snacks/grown/apple,
+		/obj/item/reagent_containers/food/snacks/grown/banana,
+		/obj/item/reagent_containers/food/snacks/grown/soybeans,
+		/obj/item/reagent_containers/food/snacks/grown/berries,
+		/obj/item/reagent_containers/food/snacks/grown/cherries,
+		/obj/item/reagent_containers/food/snacks/grown/grapes,
+		/obj/item/reagent_containers/food/snacks/grown/grapes/green,
+		/obj/item/reagent_containers/food/snacks/grown/strawberry,
+		/obj/item/reagent_containers/food/snacks/grown/broc,
+		/obj/item/reagent_containers/food/snacks/grown/buffalogourd,
+		/obj/item/reagent_containers/food/snacks/grown/wheat,
+		/obj/item/reagent_containers/food/snacks/grown/oat,
+		/obj/item/reagent_containers/food/snacks/grown/rice,
+		/obj/item/reagent_containers/food/snacks/grown/chili,
+		/obj/item/reagent_containers/food/snacks/grown/bell_pepper,
+		/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+		/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+		/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+		/obj/item/reagent_containers/food/snacks/grown/cocoapod,
+		/obj/item/reagent_containers/food/snacks/grown/corn,
+		/obj/item/grown/cotton,
+		/obj/item/reagent_containers/food/snacks/grown/coyotetobacco,
+		/obj/item/reagent_containers/food/snacks/grown/datura,
+		/obj/item/reagent_containers/food/snacks/grown/eggplant,
+		/obj/item/reagent_containers/food/snacks/grown/feracactus,
+		/obj/item/reagent_containers/food/snacks/grown/fever_blossom,
+		/obj/item/reagent_containers/food/snacks/grown/poppy,
+		/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
+		/obj/item/reagent_containers/food/snacks/grown/poppy/geranium,
+		/obj/item/reagent_containers/food/snacks/grown/poppy/geranium/forgetmenot,
+		/obj/item/reagent_containers/food/snacks/grown/harebell,
+		/obj/item/grown/sunflower,
+		/obj/item/reagent_containers/food/snacks/grown/garlic,
+		/obj/item/reagent_containers/food/snacks/grown/herbs,
+		/obj/item/reagent_containers/food/snacks/grown/horsenettle,
+		/obj/item/reagent_containers/food/snacks/grown/watermelon,
+		/obj/item/reagent_containers/food/snacks/grown/mesquite,
+		/obj/item/reagent_containers/food/snacks/grown/cabbage,
+		/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+		/obj/item/reagent_containers/food/snacks/grown/coconut,
+		/obj/item/reagent_containers/food/snacks/grown/aloe,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/reishi,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/amanita,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/libertycap,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle,
+		/obj/item/reagent_containers/food/snacks/grown/mutfruit,
+		/obj/item/reagent_containers/food/snacks/grown/nettle,
+		/obj/item/reagent_containers/food/snacks/grown/onion,
+		/obj/item/reagent_containers/food/snacks/grown/peach,
+		/obj/item/reagent_containers/food/snacks/grown/peanut,
+		/obj/item/reagent_containers/food/snacks/grown/peas,
+		/obj/item/reagent_containers/food/snacks/grown/pineapple,
+		/obj/item/reagent_containers/food/snacks/grown/pinyon,
+		/obj/item/reagent_containers/food/snacks/grown/potato,
+		/obj/item/reagent_containers/food/snacks/grown/pricklypear,
+		/obj/item/reagent_containers/food/snacks/grown/pumpkin,
+		/obj/item/reagent_containers/food/snacks/grown/pungafruit,
+		/obj/item/reagent_containers/food/snacks/grown/rainbow_flower,
+		/obj/item/reagent_containers/food/snacks/grown/carrot,
+		/obj/item/reagent_containers/food/snacks/grown/parsnip,
+		/obj/item/reagent_containers/food/snacks/grown/tato,
+		/obj/item/reagent_containers/food/snacks/grown/coffee,
+		/obj/item/reagent_containers/food/snacks/grown/tea,
+		/obj/item/reagent_containers/food/snacks/grown/tobacco,
+		/obj/item/reagent_containers/food/snacks/grown/tomato,
+		/obj/item/grown/log,
+		/obj/item/reagent_containers/food/snacks/grown/xander,
+		/obj/item/reagent_containers/food/snacks/grown/yucca,
+	)
 
+/datum/export/item/rarecrops
+	cost = 50
+	unit_name = "exotic produce"
+	export_types = list(/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+		/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+		/obj/item/reagent_containers/food/snacks/grown/apple/gold,
+		/obj/item/reagent_containers/food/snacks/grown/banana/banana_spider_spawnable,
+		/obj/item/reagent_containers/food/snacks/grown/koibeans,
+		/obj/item/reagent_containers/food/snacks/grown/berries/poison,
+		/obj/item/reagent_containers/food/snacks/grown/berries/death,
+		/obj/item/reagent_containers/food/snacks/grown/berries/glow,
+		/obj/item/reagent_containers/food/snacks/grown/bluecherries,
+		/obj/item/reagent_containers/food/snacks/grown/cherrybulbs,
+		/obj/item/reagent_containers/food/snacks/grown/cannabis,
+		/obj/item/reagent_containers/food/snacks/grown/cannabis/white,
+		/obj/item/reagent_containers/food/snacks/grown/meatwheat,
+		/obj/item/reagent_containers/food/snacks/grown/icepepper,
+		/obj/item/reagent_containers/food/snacks/grown/ghost_chili,
+		/obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d,
+		/obj/item/reagent_containers/food/snacks/grown/firelemon,
+		/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+		/obj/item/reagent_containers/food/snacks/grown/bungofruit,
+		/obj/item/reagent_containers/food/snacks/grown/bungopit,
+		/obj/item/grown/snapcorn,
+		/obj/item/grown/cotton/durathread,
+		/obj/item/reagent_containers/food/snacks/grown/shell/eggy,
+		/obj/item/reagent_containers/food/snacks/grown/trumpet,
+		/obj/item/reagent_containers/food/snacks/grown/moonflower,
+		/obj/item/grown/novaflower,
+		/obj/item/reagent_containers/food/snacks/grown/bee_balm,
+		/obj/item/grown/rose,
+		/obj/item/grown/carbon_rose,
+		/obj/item/reagent_containers/food/snacks/grown/holymelon,
+		/obj/item/reagent_containers/food/snacks/grown/cherry_bomb,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/angel,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/walkingmushroom,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/jupitercup,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap,
+		/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/shadowshroom,
+		/obj/item/reagent_containers/food/snacks/grown/nettle/death,
+		/obj/item/reagent_containers/food/snacks/grown/onion/red,
+		/obj/item/reagent_containers/food/snacks/grown/laugh,
+		/obj/item/reagent_containers/food/snacks/grown/peace,
+		/obj/item/reagent_containers/food/snacks/grown/potato/sweet,
+		/obj/item/reagent_containers/food/snacks/grown/blumpkin,
+		/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+		/obj/item/reagent_containers/food/snacks/grown/redbeet,
+		/obj/item/reagent_containers/food/snacks/grown/tea/astra,
+		/obj/item/reagent_containers/food/snacks/grown/tea/catnip,
+		/obj/item/reagent_containers/food/snacks/grown/coffee/robusta,
+		/obj/item/reagent_containers/food/snacks/grown/tobacco/space,
+		/obj/item/reagent_containers/food/snacks/grown/tomato/blood,
+		/obj/item/reagent_containers/food/snacks/grown/tomato/blue,
+		/obj/item/reagent_containers/food/snacks/grown/tomato/killer,
+		/obj/item/grown/log/bamboo
+	)

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -37,9 +37,9 @@
 					/obj/item/reagent_containers/syringe/antiviral,
 					/obj/item/clothing/gloves/color/latex/nitrile,
 					/obj/item/clothing/gloves/color/latex/nitrile)
-	crate_name = "bio suit crate" */
+	crate_name = "bio suit crate"
 
-/* //atmospherics ain't a thing, here. why was it even so expensive
+//atmospherics ain't a thing, here. why was it even so expensive
 /datum/supply_pack/emergency/equipment
 	name = "Emergency Bot/Internals Crate"
 	desc = "Explosions got you down? These supplies are guaranteed to patch up holes, in stations and people alike! Comes with two floorbots, two medbots, five oxygen masks and five small oxygen tanks."
@@ -59,8 +59,7 @@
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas)
 	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/internals
-
+	crate_type = /obj/structure/closet/crate/internals */
 
 /datum/supply_pack/emergency/medicalemergency
 	name = "Emergency Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
@@ -103,7 +102,7 @@
 					/obj/item/reagent_containers/hypospray/medipen,
 					/obj/item/reagent_containers/hypospray/medipen)
 	crate_name = "medical emergency crate (lite)"
-	crate_type = /obj/structure/closet/crate/medical */
+	crate_type = /obj/structure/closet/crate/medical
 
 /* /datum/supply_pack/emergency/radiatione_emergency
 	name = "Emergency Radiation Protection Crate"
@@ -116,9 +115,9 @@
 					/obj/item/geiger_counter,
 					/obj/item/geiger_counter)
 	crate_name = "radiation protection crate"
-	crate_type = /obj/structure/closet/crate/radiation */
+	crate_type = /obj/structure/closet/crate/radiation
 
-/* //we need none of these.
+//we need none of these.
 /datum/supply_pack/emergency/bomb
 	name = "Explosive Emergency Crate"
 	desc = "Science gone bonkers? Beeping behind the airlock? Buy now and become the hero the station des... I mean needs! Time not included, but a full bomb suit and hood, as well as a mask and defusal kit are! Non-Nuclear ordnances only."
@@ -176,7 +175,7 @@
 	crate_name = "internals crate"
 	crate_type = /obj/structure/closet/crate/internals
 
- /datum/supply_pack/emergency/mre
+/datum/supply_pack/emergency/mre
 	name = "MRE Packs (Emergency Rations)"
 	desc = "Bacteria, radioactive contamination, bugs and worms, who wants to deal with that? Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu."
 	cost = 2000
@@ -187,7 +186,6 @@
 					/obj/item/storage/box/mre/menu3,
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
-
 
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
@@ -267,7 +265,7 @@
 					/obj/item/tank/jetpack/carbondioxide/eva)
 	crate_name = "eva jetpacks crate"
 	crate_type = /obj/structure/closet/crate/secure
-*/
+
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
 	desc = "(*!&@#NCL4VE DEEP-COVER-OPERATIVE SUPPLIES. CONTAINS A BOX OF FIVE EMP GRENADES, THREE SMOKEBOMBS, AN INCENDIARY GRENADE, AND A \"SLEEPY PEN\" FULL OF NICE TOXI#@*$"
@@ -282,7 +280,7 @@
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
 
-/* /datum/supply_pack/emergency/weedcontrol
+/datum/supply_pack/emergency/weedcontrol
 	name = "Weed Control Crate"
 	desc = "Keep those invasive species OUT. Contains a scythe, gasmask, two sprays of Plant-B-Gone, and two anti-weed chemical grenades. Warranty void if used on ambrosia. Requires Hydroponics access to open."
 	cost = 1800

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -175,9 +175,8 @@
 					/obj/item/tank/internals/air)
 	crate_name = "internals crate"
 	crate_type = /obj/structure/closet/crate/internals
-*/
 
- /* /datum/supply_pack/emergency/mre
+ /datum/supply_pack/emergency/mre
 	name = "MRE Packs (Emergency Rations)"
 	desc = "Bacteria, radioactive contamination, bugs and worms, who wants to deal with that? Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu."
 	cost = 2000

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -25,7 +25,7 @@
 	crate_name = "Biker Kit"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/emergency/bio
+/* /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
 	desc = "This crate holds 2 full bio suits which will protect you from viruses, along with a bio bag and two penicillin syringes."
 	cost = 2000
@@ -38,7 +38,7 @@
 					/obj/item/reagent_containers/syringe/antiviral,
 					/obj/item/clothing/gloves/color/latex/nitrile,
 					/obj/item/clothing/gloves/color/latex/nitrile)
-	crate_name = "bio suit crate"
+	crate_name = "bio suit crate" */
 
 /* //atmospherics ain't a thing, here. why was it even so expensive
 /datum/supply_pack/emergency/equipment
@@ -106,7 +106,7 @@
 	crate_name = "medical emergency crate (lite)"
 	crate_type = /obj/structure/closet/crate/medical
 
-/datum/supply_pack/emergency/radiatione_emergency
+/* /datum/supply_pack/emergency/radiatione_emergency
 	name = "Emergency Radiation Protection Crate"
 	desc = "Survive the harshest of nuclear wastelands! Each set contains a helmet, suit, and Geiger counter. Rad-X and Radaway not included."
 	cost = 2000
@@ -117,7 +117,7 @@
 					/obj/item/geiger_counter,
 					/obj/item/geiger_counter)
 	crate_name = "radiation protection crate"
-	crate_type = /obj/structure/closet/crate/radiation
+	crate_type = /obj/structure/closet/crate/radiation */
 
 /* //we need none of these.
 /datum/supply_pack/emergency/bomb
@@ -284,7 +284,7 @@
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
 
-/datum/supply_pack/emergency/weedcontrol
+/* /datum/supply_pack/emergency/weedcontrol
 	name = "Weed Control Crate"
 	desc = "Keep those invasive species OUT. Contains a scythe, gasmask, two sprays of Plant-B-Gone, and two anti-weed chemical grenades. Warranty void if used on ambrosia. Requires Hydroponics access to open."
 	cost = 1800
@@ -296,4 +296,4 @@
 					/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/spray/plantbgone)
 	crate_name = "weed control crate"
-	crate_type = /obj/structure/closet/crate/secure/hydroponics
+	crate_type = /obj/structure/closet/crate/secure/hydroponics */

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -61,7 +61,7 @@
 					/obj/item/clothing/mask/gas)
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals
-*/
+
 
 /datum/supply_pack/emergency/medicalemergency
 	name = "Emergency Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
@@ -104,7 +104,7 @@
 					/obj/item/reagent_containers/hypospray/medipen,
 					/obj/item/reagent_containers/hypospray/medipen)
 	crate_name = "medical emergency crate (lite)"
-	crate_type = /obj/structure/closet/crate/medical
+	crate_type = /obj/structure/closet/crate/medical */
 
 /* /datum/supply_pack/emergency/radiatione_emergency
 	name = "Emergency Radiation Protection Crate"
@@ -178,7 +178,7 @@
 	crate_type = /obj/structure/closet/crate/internals
 */
 
-/datum/supply_pack/emergency/mre
+ /* /datum/supply_pack/emergency/mre
 	name = "MRE Packs (Emergency Rations)"
 	desc = "Bacteria, radioactive contamination, bugs and worms, who wants to deal with that? Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu."
 	cost = 2000
@@ -190,7 +190,7 @@
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
 
-/*
+
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires EVA access to open."

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -12,8 +12,7 @@
 /datum/supply_pack/emergency/vehicle
 	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
-	cost = 2500
-	contraband = TRUE
+	cost = 5500
 	contains = list(/obj/vehicle/ridden/atv,
 					/obj/item/key,
 					/obj/item/toy/crayon/spraycan,

--- a/code/modules/cargo/packs/engine.dm
+++ b/code/modules/cargo/packs/engine.dm
@@ -6,9 +6,9 @@
 //////////////////////// Engine Construction /////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/engine
+/* /datum/supply_pack/engine
 	group = "Engine Construction"
-	crate_type = /obj/structure/closet/crate/engineering
+	crate_type = /obj/structure/closet/crate/engineering */
 /*
 /datum/supply_pack/engine/am_jar
 	name = "Antimatter Containment Jar Crate"
@@ -109,7 +109,7 @@
 	crate_name = "singularity generator crate"
 */
 
-/datum/supply_pack/engine/solar
+/* /datum/supply_pack/engine/solar
 	name = "Solar Panel Crate"
 	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."
 	cost = 2850
@@ -138,7 +138,7 @@
 					/obj/item/electronics/tracker,
 					/obj/item/paper/guides/jobs/engi/solars)
 	crate_name = "solar panel crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
+	crate_type = /obj/structure/closet/crate/engineering/electrical */
 /*
 /datum/supply_pack/engine/supermatter_shard
 	name = "Supermatter Shard Crate"

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -10,13 +10,13 @@
 	group = "Engineering"
 	crate_type = /obj/structure/closet/crate/engineering
 
-/datum/supply_pack/engineering/shieldgen
+/* /datum/supply_pack/engineering/shieldgen
 	name = "Anti-breach Shield Projector Crate"
 	desc = "Hull breaches again? Say no more with the Nanotrasen Anti-Breach Shield Projector! Uses forcefield technology to keep the air in, and the space out. Contains two shield projectors."
 	cost = 2500
 	contains = list(/obj/machinery/shieldgen,
 					/obj/machinery/shieldgen)
-	crate_name = "anti-breach shield projector crate"
+	crate_name = "anti-breach shield projector crate" */
 
 /datum/supply_pack/engineering/conveyor
 	name = "Conveyor Assembly Crate"
@@ -80,7 +80,7 @@
 					/obj/item/clothing/head/helmet/space/rad)
 	crate_name = "radiation hardsuit"
 	crate_type = /obj/structure/closet/crate/secure/engineering
-*/
+
 /datum/supply_pack/engineering/industrialrcd
 	name = "Industrial RCD"
 	desc = "An industrial RCD in case the station has gone through more then one meteor storm and the CE needs to bring out the somthing a bit more reliable. Does not contain spare ammo for the industrial RCD or any other RCD models."
@@ -88,15 +88,15 @@
 	access = ACCESS_CE
 	contains = list(/obj/item/construction/rcd/industrial)
 	crate_name = "industrial rcd"
-	crate_type = /obj/structure/closet/crate/secure/engineering
+	crate_type = /obj/structure/closet/crate/secure/engineering */
 
-/datum/supply_pack/engineering/inducers
+/* /datum/supply_pack/engineering/inducers
 	name = "NT-75 Electromagnetic Power Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-75 EPI, you can recharge any standard cell-based equipment anytime, anywhere. Contains two Inducers."
 	cost = 2300
 	contains = list(/obj/item/inducer/sci/supply, /obj/item/inducer/sci/supply)
 	crate_name = "inducer crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
+	crate_type = /obj/structure/closet/crate/engineering/electrical */
 
 /* /datum/supply_pack/engineering/pacman
 	name = "P.A.C.M.A.N Generator Crate"
@@ -154,17 +154,17 @@
 	crate_name = "toolbox crate"
 	special = TRUE //Department resupply shuttle loan event.
 
-/* /datum/supply_pack/engineering/bsa
+/datum/supply_pack/engineering/bsa
 	name = "Bluespace Artillery Parts"
 	desc = "The pride of Nanotrasen Naval Command. The legendary Bluespace Artillery Cannon is a devastating feat of human engineering and testament to wartime determination. Highly advanced research is required for proper construction. "
-	cost = 45000
+	cost = 900000
 	special = TRUE
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
 					/obj/item/circuitboard/machine/bsa/middle,
 					/obj/item/circuitboard/machine/bsa/back,
 					/obj/item/circuitboard/computer/bsa_control
 					)
-	crate_name= "bluespace artillery parts crate" */
+	crate_name= "bluespace artillery parts crate" 
 /*
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -98,15 +98,15 @@
 	crate_name = "inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/pacman
+/* /datum/supply_pack/engineering/pacman
 	name = "P.A.C.M.A.N Generator Crate"
 	desc = "Engineers can't set up the engine? Not an issue for you, once you get your hands on this P.A.C.M.A.N. Generator! Takes in plasma and spits out sweet sweet energy."
 	cost = 2250
 	contains = list(/obj/machinery/power/port_gen/pacman)
 	crate_name = "PACMAN generator crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
+	crate_type = /obj/structure/closet/crate/engineering/electrical */
 
-/datum/supply_pack/engineering/airpump
+/* /datum/supply_pack/engineering/airpump
 	name = "Portable Air Pump Crate"
 	desc = "We all know you work in a high pressure workplace. Keep it that way with two additional air pumps!"
 	cost = 3000
@@ -120,7 +120,7 @@
 	cost = 3000
 	contains = list(/obj/machinery/portable_atmospherics/scrubber,
 					/obj/machinery/portable_atmospherics/scrubber)
-	crate_name = "portable scrubber crate"
+	crate_name = "portable scrubber crate" */
 
 /datum/supply_pack/engineering/power
 	name = "Power Cell Crate"
@@ -130,7 +130,7 @@
 					/obj/item/stock_parts/cell/high,
 					/obj/item/stock_parts/cell/high)
 	crate_name = "power cell crate"
-	crate_type = /obj/structure/closet/crate/engineering/electrical
+	crate_type = /obj/structure/closet/crate/engineering/electrical 
 /*
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
@@ -154,7 +154,7 @@
 	crate_name = "toolbox crate"
 	special = TRUE //Department resupply shuttle loan event.
 
-/datum/supply_pack/engineering/bsa
+/* /datum/supply_pack/engineering/bsa
 	name = "Bluespace Artillery Parts"
 	desc = "The pride of Nanotrasen Naval Command. The legendary Bluespace Artillery Cannon is a devastating feat of human engineering and testament to wartime determination. Highly advanced research is required for proper construction. "
 	cost = 45000
@@ -164,7 +164,7 @@
 					/obj/item/circuitboard/machine/bsa/back,
 					/obj/item/circuitboard/computer/bsa_control
 					)
-	crate_name= "bluespace artillery parts crate"
+	crate_name= "bluespace artillery parts crate" */
 /*
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"

--- a/code/modules/cargo/packs/goodies.dm
+++ b/code/modules/cargo/packs/goodies.dm
@@ -4,57 +4,13 @@
 	group = "Goodies"
 	goody = PACK_GOODY_PRIVATE
 
-/datum/supply_pack/goody/traitbooks
-	name = "Technical manuals"
-	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."
-	cost = 1500
-	contains = list(/obj/effect/spawner/lootdrop/f13/traitbooks,
-					/obj/effect/spawner/lootdrop/f13/traitbooks/low,
-					/obj/effect/spawner/lootdrop/f13/traitbooks/low)
 
-/datum/supply_pack/goody/combatknives_single
-	name = "Combat Knife Single-Pack"
-	desc = "Some good ol' sharp knives. Guaranteed to fit snugly inside any cowboy-standard boot. You know what's better than one knife? Three of 'em!"
-	cost = 800
-	contains = list(/obj/item/melee/onehanded/knife/hunting,
-					/obj/item/melee/onehanded/knife/hunting,
-					/obj/item/melee/onehanded/knife/hunting)
-
-/datum/supply_pack/goody/sologamermitts
+/* /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"
 	desc = "The backbone of modern society. Oddly useful for...combat engineers, of all people."
 	cost = 800
-	contains = list(/obj/item/clothing/gloves/color/yellow)
+	contains = list(/obj/item/clothing/gloves/color/yellow) 
 
-/datum/supply_pack/goody/firstaidbruises_single
-	name = "Bruise Treatment Kit Single-Pack"
-	desc = "A single brute first-aid kit, perfect for recovering from being crushed by a super-mutant. Did you know people get crushed by super-mutants all the time? Interesting..."
-	cost = 330
-	contains = list(/obj/item/storage/firstaid/brute)
-
-/datum/supply_pack/goody/firstaidburns_single
-	name = "Burn Treatment Kit Single-Pack"
-	desc = "A single burn first-aid kit. The advertisement displays a winking Brotherhood scribe giving a thumbs up, saying \"Mistakes happen!\""
-	cost = 330
-	contains = list(/obj/item/storage/firstaid/fire)
-
-/datum/supply_pack/goody/firstaid_single
-	name = "First Aid Kit Single-Pack"
-	desc = "A single first-aid kit, fit for healing most types of bodily harm."
-	cost = 250
-	contains = list(/obj/item/storage/firstaid/regular)
-
-/datum/supply_pack/goody/firstaidoxygen_single
-	name = "Oxygen Deprivation Kit Single-Pack"
-	desc = "A single oxygen deprivation first-aid kit, marketed heavily to those with crippling fears of asphyxiation."
-	cost = 330
-	contains = list(/obj/item/storage/firstaid/o2)
-
-/datum/supply_pack/goody/firstaidtoxins_single
-	name = "Toxin Treatment Kit Single-Pack"
-	desc = "A single first aid kit focused on healing damage dealt by heavy toxins."
-	cost = 330
-	contains = list(/obj/item/storage/firstaid/toxin)
 
 /datum/supply_pack/goody/toolbox // mostly just to water down coupon probability
 	name = "Mechanical Toolbox"
@@ -66,7 +22,7 @@
 	name = "Electrical Toolbox"
 	desc = "A fully stocked electrical toolbox, for when you're too lazy to just print them out."
 	cost = 300
-	contains = list(/obj/item/storage/toolbox/electrical)
+	contains = list(/obj/item/storage/toolbox/electrical) */
 
 /datum/supply_pack/goody/valentine
 	name = "Valentine Card"

--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -6,7 +6,7 @@
 ////////////////////////////// Livestock /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/critter
+/* /datum/supply_pack/critter
 	group = "Livestock"
 	crate_type = /obj/structure/closet/crate/critter
 
@@ -180,3 +180,4 @@
 					/mob/living/simple_animal/hostile/retaliate/bat/secbat,
 					/mob/living/simple_animal/hostile/retaliate/bat/secbat)
 	crate_name = "security bat crate"
+*/

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -62,11 +62,21 @@
 	cost = 400 // 6-7 planks shy from having equal import/export prices
 	contains = list(/obj/item/stack/sheet/mineral/wood/twenty)
 
+/datum/supply_pack/materials/prewaralloyingot
+	goody = PACK_GOODY_PUBLIC
+	name = "4 Pre-War Ingots"
+	desc = "Ingots salvaged from a Pre-War factory, valuable in the right hands."
+	cost = 3775
+	contains = list(/obj/item/ingot/adamantine,
+					/obj/item/ingot/adamantine,
+					/obj/item/ingot/adamantine
+					)
+
 /datum/supply_pack/materials/weaponparts
 	goody = PACK_GOODY_PUBLIC
 	name = "Weapon Parts"
 	desc = "A random collection of recovered weapon parts. A gunsmith's wet dream."
-	cost = 3500
+	cost = 2500
 	contains = list(/obj/effect/spawner/lootdrop/f13/advcrafting,
 					/obj/effect/spawner/lootdrop/f13/advcrafting,
 					/obj/effect/spawner/lootdrop/f13/advcrafting,

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -66,7 +66,7 @@
 	goody = PACK_GOODY_PUBLIC
 	name = "4 Pre-War Ingots"
 	desc = "Ingots salvaged from a Pre-War factory, valuable in the right hands."
-	cost = 3775
+	cost = 2775
 	contains = list(/obj/item/ingot/adamantine,
 					/obj/item/ingot/adamantine,
 					/obj/item/ingot/adamantine

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -62,6 +62,16 @@
 	cost = 400 // 6-7 planks shy from having equal import/export prices
 	contains = list(/obj/item/stack/sheet/mineral/wood/twenty)
 
+/datum/supply_pack/materials/weaponparts
+	goody = PACK_GOODY_PUBLIC
+	name = "Weapon Parts"
+	desc = "A random collection of recovered weapon parts. A gunsmith's wet dream."
+	cost = 3500
+	contains = list(/obj/effect/spawner/lootdrop/f13/advcrafting,
+					/obj/effect/spawner/lootdrop/f13/advcrafting,
+					/obj/effect/spawner/lootdrop/f13/advcrafting,
+					/obj/effect/spawner/lootdrop/f13/advcrafting)
+					
 /* /datum/supply_pack/materials/rcdammo
 	goody = PACK_GOODY_PUBLIC
 	name = "Large RCD ammo Single-Pack"

--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -62,12 +62,12 @@
 	cost = 400 // 6-7 planks shy from having equal import/export prices
 	contains = list(/obj/item/stack/sheet/mineral/wood/twenty)
 
-/datum/supply_pack/materials/rcdammo
+/* /datum/supply_pack/materials/rcdammo
 	goody = PACK_GOODY_PUBLIC
 	name = "Large RCD ammo Single-Pack"
 	desc = "A single large compressed RCD matter pack, to help with any holes or projects people might be working on."
 	cost = 600
-	contains = list(/obj/item/rcd_ammo/large)
+	contains = list(/obj/item/rcd_ammo/large) */
 
 //datum/supply_pack/materials/rawlumber
 //	name = "50 Towercap Logs"
@@ -85,7 +85,7 @@
 ///////////////////////////// Canisters //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/materials/bz
+/* /datum/supply_pack/materials/bz
 	name = "BZ Canister Crate"
 	desc = "Contains a canister of BZ. Requires Toxins access to open."
 	cost = 7500 // Costs 3 credits more than what you can get for selling it.
@@ -133,7 +133,7 @@
 	cost = 2500
 	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
 	crate_name = "water vapor canister crate"
-	crate_type = /obj/structure/closet/crate/large
+	crate_type = /obj/structure/closet/crate/large */
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Tanks ////////////////////////////////////////
@@ -155,13 +155,13 @@
 	crate_name = "water tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/materials/foamtank
+/* /datum/supply_pack/materials/foamtank
 	name = "Firefighting Foam Tank Crate"
 	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
 	cost = 1500
 	contains = list(/obj/structure/reagent_dispensers/foamtank)
 	crate_name = "foam tank crate"
-	crate_type = /obj/structure/closet/crate/large
+	crate_type = /obj/structure/closet/crate/large */
 
 /datum/supply_pack/materials/hightank
 	name = "Large Water Tank Crate"

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -257,20 +257,22 @@
 	crate_name = "medipen crate"
 */
 
-/datum/supply_pack/medical/stimpak5
-	name = "Stimpak"
-	desc = "The humble stimpak, about five."
-	cost = 250
-	contains = list(/obj/item/reagent_containers/hypospray/medipen/stimpak,
-					/obj/item/reagent_containers/hypospray/medipen/stimpak,
-					/obj/item/reagent_containers/hypospray/medipen/stimpak,
-					/obj/item/reagent_containers/hypospray/medipen/stimpak,
-					/obj/item/reagent_containers/hypospray/medipen/stimpak)
+/datum/supply_pack/medical/chems
+	name = "Mixed Chems"
+	desc = "A raiders dream, contains five random chems."
+	cost = 1300
+	contains = list(/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+					/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+					/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+					/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+					/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug)
+	crate_name = "chem crate"
 
 /datum/supply_pack/medical/radaway
 	name = "Radaway"
 	desc = "It burns like hell, but it flushes the rads out, for sure. About three."
-	cost = 750
+	cost = 900
 	contains = list(/obj/item/reagent_containers/blood/radaway,
 					/obj/item/reagent_containers/blood/radaway,
-					/obj/item/reagent_containers/blood/radaway)
+					/obj/item/reagent_containers/blood/radaway,
+					/obj/item/storage/pill_bottle/chem_tin/radx)

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -70,6 +70,79 @@
 					/obj/item/defibrillator/loaded)
 	crate_name = "defibrillator crate"
 
+/datum/supply_pack/medical/firstaidbruises_single
+	name = "Bruise Treatment Kit Single-Pack"
+	desc = "A single brute first-aid kit, perfect for recovering from being crushed by a super-mutant. Did you know people get crushed by super-mutants all the time? Interesting..."
+	cost = 330
+	contains = list(/obj/item/storage/firstaid/brute)
+
+/datum/supply_pack/medical/firstaidburns_single
+	name = "Burn Treatment Kit Single-Pack"
+	desc = "A single burn first-aid kit. The advertisement displays a winking Brotherhood scribe giving a thumbs up, saying \"Mistakes happen!\""
+	cost = 330
+	contains = list(/obj/item/storage/firstaid/fire)
+
+/datum/supply_pack/medical/firstaid_single
+	name = "First Aid Kit Single-Pack"
+	desc = "A single first-aid kit, fit for healing most types of bodily harm."
+	cost = 250
+	contains = list(/obj/item/storage/firstaid/regular)
+
+/datum/supply_pack/medical/firstaidoxygen_single
+	name = "Oxygen Deprivation Kit Single-Pack"
+	desc = "A single oxygen deprivation first-aid kit, marketed heavily to those with crippling fears of asphyxiation."
+	cost = 330
+	contains = list(/obj/item/storage/firstaid/o2)
+
+/datum/supply_pack/medical/firstaidtoxins_single
+	name = "Toxin Treatment Kit Single-Pack"
+	desc = "A single first aid kit focused on healing damage dealt by heavy toxins."
+	cost = 330
+	contains = list(/obj/item/storage/firstaid/toxin)
+
+/datum/supply_pack/emergency/medicalemergency
+	name = "Emergency Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
+	desc = "Emergency supplies for a front-line medic. Contains two boxes of body bags, a medical HUD, a defib unit, medical belt, toxin bottles, epipens, and several types of medical kits."
+	cost = 10000
+	contains = list(/obj/item/storage/box/bodybags,
+					/obj/item/storage/box/bodybags,
+					/obj/item/clothing/glasses/hud/health,
+					/obj/item/defibrillator/loaded,
+					/obj/item/storage/belt/medical,
+					/obj/item/storage/firstaid/toxin,
+					/obj/item/storage/firstaid/o2,
+					/obj/item/storage/firstaid/brute,
+					/obj/item/storage/firstaid/fire,
+					/obj/item/reagent_containers/glass/bottle/toxin,
+					/obj/item/reagent_containers/glass/bottle/toxin,
+					/obj/item/storage/box/medipens)
+	crate_name = "medical emergency crate"
+	crate_type = /obj/structure/closet/crate/medical
+
+/datum/supply_pack/emergency/medemergencylite
+	name = "Emergency Medical Supplies (Lite)"
+	desc = "A less than optimal, but still effective, set of tools for emergency care. Contains a box of bodybags, some normal (and advanced) health analyzers, healing sprays, a single first aid kit, charcoal, some gauze, a bottle of toxins, and some spare medipens."
+	cost = 2800
+	contains = list(/obj/item/storage/box/bodybags,
+					/obj/item/stack/medical/gauze,
+					/obj/item/stack/medical/gauze,
+					/obj/item/healthanalyzer,
+					/obj/item/healthanalyzer,
+					/obj/item/healthanalyzer/advanced,
+					/obj/item/storage/firstaid/regular,
+					/obj/item/reagent_containers/medspray/styptic,
+					/obj/item/reagent_containers/medspray/silver_sulf,
+					/obj/item/reagent_containers/medspray/synthflesh,
+					/obj/item/reagent_containers/glass/bottle/charcoal,
+					/obj/item/reagent_containers/glass/bottle/charcoal,
+					/obj/item/reagent_containers/glass/bottle/toxin,
+					/obj/item/reagent_containers/hypospray/medipen,
+					/obj/item/reagent_containers/hypospray/medipen,
+					/obj/item/reagent_containers/hypospray/medipen,
+					/obj/item/reagent_containers/hypospray/medipen)
+	crate_name = "medical emergency crate (lite)"
+	crate_type = /obj/structure/closet/crate/medical
+
 /datum/supply_pack/medical/iv_drip
 	name = "IV Drip Crate"
 	desc = "Contains a single IV drip stand for intravenous delivery."

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -174,7 +174,6 @@
 	name = "Elimination Dueling Pistols"
 	desc = "It's high noon."
 	cost = 5000
-	hidden = TRUE
 	contains = list(/obj/item/storage/lockbox/dueling)
 	crate_name = "dueling pistols (elimination)"
 
@@ -252,7 +251,7 @@
 
 /datum/supply_pack/misc/jukebox
 	name = "Jukebox"
-	cost = 10000
+	cost = 5000
 	contains = list(/obj/machinery/jukebox)
 	crate_name = "Jukebox"
 
@@ -281,7 +280,7 @@
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
 	desc = "Keep your local chaplain happy and well-supplied, lest they call down judgement upon your cargo bay. Contains two bottles of holywater, bibles, chaplain robes, and burial garmets."
-	cost = 4000	// it costs so much because the Space Church needs funding to build a cathedral
+	cost = 1250	// it costs so much because the Space Church needs funding to build a cathedral
 	contains = list(/obj/item/reagent_containers/food/drinks/bottle/holywater,
 					/obj/item/reagent_containers/food/drinks/bottle/holywater,
 					/obj/item/storage/book/bible/booze,
@@ -293,7 +292,7 @@
 /datum/supply_pack/misc/shower
 	name = "Shower Supplies"
 	desc = "Everyone needs a bit of R&R. Make sure you get can get yours by ordering this crate filled with towels, rubber duckies, and some soap!"
-	cost = 1000
+	cost = 900
 	contains = list(/obj/item/reagent_containers/rag/towel,
 					/obj/item/reagent_containers/rag/towel,
 					/obj/item/reagent_containers/rag/towel,

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -169,27 +169,6 @@
 	for(var/i in 1 to 9)
 		new /obj/item/coin/silver(.)
 
-/datum/supply_pack/misc/dueling_stam
-	name = "Dueling Pistols"
-	desc = "Resolve all your quarrels with some nonlethal fun."
-	cost = 2000
-	contains = list(/obj/item/storage/lockbox/dueling/hugbox/stamina)
-	crate_name = "dueling pistols"
-
-/datum/supply_pack/misc/dueling_stam/generate()
-	. = ..()
-	for(var/i in 1 to 3)
-		new /obj/item/storage/lockbox/dueling/hugbox/stamina(.)
-
-/datum/supply_pack/misc/dueling_lethal
-	name = "Lethal Dueling Pistols"
-	desc = "Settle your differences the true spaceman way."
-	cost = 3000
-	/* contraband = TRUE */
-	contains = list(/obj/item/storage/lockbox/dueling/hugbox,
-	/obj/item/storage/lockbox/dueling/hugbox,
-	/obj/item/storage/lockbox/dueling/hugbox)
-	crate_name = "dueling pistols (lethal)"
 
 /datum/supply_pack/misc/dueling_death
 	name = "Elimination Dueling Pistols"

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -185,7 +185,7 @@
 	name = "Lethal Dueling Pistols"
 	desc = "Settle your differences the true spaceman way."
 	cost = 3000
-	contraband = TRUE
+	/* contraband = TRUE */
 	contains = list(/obj/item/storage/lockbox/dueling/hugbox,
 	/obj/item/storage/lockbox/dueling/hugbox,
 	/obj/item/storage/lockbox/dueling/hugbox)

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -22,7 +22,7 @@
 //////////////////////////////// Meals ///////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/organic/combomeal2
+/* /datum/supply_pack/organic/combomeal2
 	name = "Burger Combo #2"
 	desc = "We value our customers at the Greasy Griddle, so much so that we're willing to deliver -just for you.- This combo meal contains two burgers, a soda, fries, a toy, and some chicken nuggets."
 	cost = 3200
@@ -37,7 +37,7 @@
 					/obj/item/reagent_containers/food/snacks/nugget,
 					/obj/effect/spawner/lootdrop/plush)
 	crate_name = "combo meal w/toy"
-	crate_type = /obj/structure/closet/crate/wooden
+	crate_type = /obj/structure/closet/crate/wooden */
 
 /datum/supply_pack/organic/randomized/candy
 	name = "Candy Crate"
@@ -84,7 +84,7 @@
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
 
-/datum/supply_pack/organic/fiestatortilla
+/* /datum/supply_pack/organic/fiestatortilla
 	name = "Fiesta Crate"
 	desc = "Spice up the kitchen with this fiesta themed food order! Contains 8 tortilla based food items, as well as a sombrero, moustache, and cloak!"
 	cost = 2750
@@ -100,12 +100,12 @@
 					/obj/item/reagent_containers/food/snacks/carneburrito,
 					/obj/item/reagent_containers/food/snacks/cheesyburrito,
 					/obj/item/reagent_containers/glass/bottle/capsaicin,
-					/obj/item/reagent_containers/glass/bottle/capsaicin)
+					/obj/item/reagent_containers/glass/bottle/capsaicin) */
 	crate_name = "fiesta crate"
 
 /datum/supply_pack/organic/pizza
 	name = "Pizza Crate"
-	desc = "Best prices on this side of the galaxy. All deliveries are guaranteed to be 99% anomaly-free!"
+	desc = "Best prices on this side of the Alamo. All deliveries are guaranteed to be 99% rad-free!"
 	cost = 6000 // Best prices this side of the galaxy.
 	contains = list(/obj/item/pizzabox/margherita,
 					/obj/item/pizzabox/mushroom,
@@ -186,7 +186,7 @@
 					/obj/item/reagent_containers/food/snacks/grown/strawberry)
 	crate_name = "fruit crate"
 
-/datum/supply_pack/organic/randomized
+/* /datum/supply_pack/organic/randomized
 	name = "Meat Crate (Exotic)"
 	desc = "The best cuts in the whole galaxy. Contains 15 assorted exotic meats."
 	cost = 2000
@@ -199,7 +199,7 @@
 					/obj/item/reagent_containers/food/snacks/meat/rawcrab,
 					/obj/item/reagent_containers/food/snacks/spiderleg,
 					/obj/item/reagent_containers/food/snacks/fishmeat/carp,
-					/obj/item/reagent_containers/food/snacks/meat/slab/human)
+					/obj/item/reagent_containers/food/snacks/meat/slab/human) 
 	crate_name = "exotic meat crate"
 
 /datum/supply_pack/organic/monkeydripmeat
@@ -233,7 +233,7 @@
 					/obj/item/reagent_containers/food/snacks/fishmeat/carp/imitation,
 					/obj/item/reagent_containers/food/snacks/fishmeat/carp/imitation,
 					/obj/item/reagent_containers/food/snacks/fishmeat/carp/imitation,
-					/obj/item/reagent_containers/food/snacks/fishmeat/carp/imitation)
+					/obj/item/reagent_containers/food/snacks/fishmeat/carp/imitation) 
 	crate_name = "meaty crate"
 	crate_type = /obj/structure/closet/crate/freezer
 
@@ -246,7 +246,7 @@
 					/obj/item/storage/box/ingredients/wildcard,
 					/obj/item/storage/box/ingredients/wildcard)
 	crate_name = "wildcard food crate"
-	crate_type = /obj/structure/closet/crate/freezer
+	crate_type = /obj/structure/closet/crate/freezer */
 
 /datum/supply_pack/organic/randomized/vegetables
 	name = "Vegetable Crate"
@@ -561,7 +561,7 @@
 
 /datum/supply_pack/organic/party
 	name = "Party Equipment"
-	desc = "Celebrate both life and death on the station with Nanotrasen's Party Essentials(tm)! Contains seven colored glowsticks, four beers, two ales, a drinking shaker, and a bottle of patron & goldschlager!"
+	desc = "Celebrate both life and death in the wastes! Contains seven colored glowsticks, four beers, two ales, a drinking shaker, and a bottle of patron & goldschlager!"
 	cost = 2000
 	contains = list(/obj/item/storage/box/drinkingglasses,
 					/obj/item/reagent_containers/food/drinks/shaker,

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -72,6 +72,18 @@
 					/obj/item/storage/fancy/donut_box)
 	crate_name = "candy crate"
 
+/datum/supply_pack/emergency/mre
+	name = "MRE Packs (Emergency Rations)"
+	desc = "Bacteria, radioactive contamination, bugs and worms, who wants to deal with that? Order our NT branded MRE kits today! This pack contains 5 MRE packs with a randomized menu."
+	cost = 2000
+	contains = list(/obj/item/storage/box/mre/menu1/safe,
+					/obj/item/storage/box/mre/menu1/safe,
+					/obj/item/storage/box/mre/menu2/safe,
+					/obj/item/storage/box/mre/menu2/safe,
+					/obj/item/storage/box/mre/menu3,
+					/obj/item/storage/box/mre/menu4/safe)
+	crate_name = "MRE crate (emergency rations)"
+
 /datum/supply_pack/organic/fiestatortilla
 	name = "Fiesta Crate"
 	desc = "Spice up the kitchen with this fiesta themed food order! Contains 8 tortilla based food items, as well as a sombrero, moustache, and cloak!"

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -7,7 +7,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/organic
-	group = "Food & Hydroponics"
+	group = "Agriculture and Food"
 	crate_type = /obj/structure/closet/crate/freezer
 
 /datum/supply_pack/organic/randomized
@@ -289,7 +289,7 @@
 	crate_name = "hydroponics backpack crate"
 	crate_type = /obj/structure/closet/crate/secure
 
-/datum/supply_pack/organic/hydroponics/maintgarden
+/* /datum/supply_pack/organic/hydroponics/maintgarden
 	name = "Maintenance Garden Crate"
 	desc = "Set up your own tiny paradise with do-it-yourself botany kit. Contains sandstone for dirt plots, pest spray, ammonia, a portable seed generator, basic botanical tools, and some seeds to start off with."
 	cost = 2700
@@ -313,7 +313,7 @@
 					/obj/item/seeds/grass,
 					/obj/item/seeds/grass)
 	crate_name = "maint garden crate"
-	crate_type = /obj/structure/closet/crate/hydroponics
+	crate_type = /obj/structure/closet/crate/hydroponics */
 
 /datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
@@ -352,6 +352,196 @@
 					/obj/item/seeds/random)
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
+
+/datum/supply_pack/organic/wastelandseeds
+	name = "Seeds Crate (Wasteland)"
+	desc = "A choice selection of the most medicinal herb seeds the wastes have to offer."
+	cost = 1500
+	contains = list(/obj/item/seeds/poppy/broc,
+					/obj/item/seeds/poppy/broc,
+					/obj/item/seeds/buffalogourd,
+					/obj/item/seeds/coyotetobacco,
+					/obj/item/seeds/mutfruit,
+					/obj/item/seeds/xander,
+					/obj/item/seeds/xander,
+					/obj/item/seeds/datura)
+	crate_name = "wasteland seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////////// Livestock ///////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/organic/animal_feed
+	name = "Animal Feed Crate"
+	desc = "Feed for livestock, like cows and hens. Contains fifty Wheat bundles and fifty Oat bundles."
+	cost = 1500
+	contains = list(/obj/item/reagent_containers/food/snacks/grown/wheat,
+					/obj/item/reagent_containers/food/snacks/grown/oat)
+	crate_name = "animal feed crate"
+	crate_type = /obj/structure/closet/crate/freezer
+
+/datum/supply_pack/organic/animal_feed/generate()
+	. = ..()
+	for(var/i in 1 to 49)
+		new /obj/item/reagent_containers/food/snacks/grown/wheat(.)
+
+
+/datum/supply_pack/organic/parrot
+	name = "Bird Crate"
+	desc = "Contains five expert telecommunication birds."
+	cost = 4000
+	contains = list(/mob/living/simple_animal/parrot)
+	crate_name = "parrot crate"
+
+/datum/supply_pack/organic/parrot/generate()
+	. = ..()
+	for(var/i in 1 to 4)
+		new /mob/living/simple_animal/parrot(.)
+	if(prob(1))
+		new /mob/living/simple_animal/parrot/clock_hawk(.)
+
+/datum/supply_pack/organic/butterfly
+	name = "Butterflies Crate"
+	desc = "Not a very dangerous insect, but they do give off a better image than, say, flies or cockroaches."//is that a motherfucking worm reference
+	contraband = TRUE
+	cost = 5000
+	contains = list(/mob/living/simple_animal/butterfly)
+	crate_name = "entomology samples crate"
+
+/datum/supply_pack/organic/butterfly/generate()
+	. = ..()
+	for(var/i in 1 to 49)
+		new /mob/living/simple_animal/butterfly(.)
+
+/datum/supply_pack/organic/cat
+	name = "Cat Crate"
+	desc = "The cat goes meow! Comes with a collar and a nice cat toy! Cheeseburger not included."//i can't believe im making this reference
+	cost = 5000 //Cats are worth as much as corgis.
+	contains = list(/mob/living/simple_animal/pet/cat,
+					/obj/item/clothing/neck/petcollar,
+					/obj/item/toy/cattoy)
+	crate_name = "cat crate"
+
+/datum/supply_pack/organic/cat/generate()
+	. = ..()
+	if(prob(50))
+		var/mob/living/simple_animal/pet/cat/C = locate() in .
+		qdel(C)
+		new /mob/living/simple_animal/pet/cat/Proc(.)
+
+/datum/supply_pack/organic/chick
+	name = "Chicken Crate"
+	desc = "The chicken goes bwaak!"
+	cost = 2000
+	contains = list(/mob/living/simple_animal/chick)
+	crate_name = "chicken crate"
+
+/* /datum/supply_pack/organic/crab
+	name = "Crab Rocket"
+	desc = "CRAAAAAAB ROCKET. CRAB ROCKET. CRAB ROCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROCKET. CRAFT. ROCKET. BUY. CRAFT ROCKET. CRAB ROOOCKET. CRAB ROOOOCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROOOOOOOOOOOOOOOOOOOOOOCK EEEEEEEEEEEEEEEEEEEEEEEEE EEEETTTTTTTTTTTTAAAAAAAAA AAAHHHHHHHHHHHHH. CRAB ROCKET. CRAAAB ROCKEEEEEEEEEGGGGHHHHTT CRAB CRAB CRAABROCKET CRAB ROCKEEEET."//fun fact: i actually spent like 10 minutes and transcribed the entire video.
+	cost = 5000
+	contains = list(/mob/living/simple_animal/crab)
+	crate_name = "look sir free crabs"
+	DropPodOnly = TRUE 
+
+/datum/supply_pack/organic/crab/generate()
+	. = ..()
+	for(var/i in 1 to 49)
+		new /mob/living/simple_animal/crab(.) */
+
+/datum/supply_pack/organic/corgi
+	name = "Corgi Crate"
+	desc = "Considered the optimal dog breed by thousands of research scientists, this Corgi is but one dog from the millions of Ian's noble bloodline. Comes with a cute collar!"
+	cost = 5000
+	contains = list(/mob/living/simple_animal/pet/dog/corgi,
+					/obj/item/clothing/neck/petcollar)
+	crate_name = "corgi crate"
+
+/datum/supply_pack/organic/corgi/generate()
+	. = ..()
+	if(prob(50))
+		var/mob/living/simple_animal/pet/dog/corgi/D = locate() in .
+		if(D.gender == FEMALE)
+			qdel(D)
+			new /mob/living/simple_animal/pet/dog/corgi/Lisa(.)
+
+/datum/supply_pack/organic/corgis/exotic
+	name = "Exotic Corgi Crate"
+	desc = "Corgis fit for a king, these corgis come in a unique color to signify their superiority. Comes with a cute collar!"
+	cost = 5500
+	contains = list(/mob/living/simple_animal/pet/dog/corgi/exoticcorgi,
+					/obj/item/clothing/neck/petcollar)
+	crate_name = "exotic corgi crate"
+
+/datum/supply_pack/organic/cow
+	name = "Cow Crate"
+	desc = "The cow goes moo!"
+	cost = 3000
+	contains = list(/mob/living/simple_animal/cow)
+	crate_name = "cow crate"
+
+/datum/supply_pack/organic/fox
+	name = "Fox Crate"
+	desc = "The fox goes...? Comes with a collar!"//what does the fox say
+	cost = 5000
+	contains = list(/mob/living/simple_animal/pet/fox,
+					/obj/item/clothing/neck/petcollar)
+	crate_name = "fox crate"
+
+/datum/supply_pack/organic/goat
+	name = "Goat Crate"
+	desc = "The goat goes baa! Warranty void if used as a replacement for Pete."
+	cost = 2500
+	contains = list(/mob/living/simple_animal/hostile/retaliate/goat)
+	crate_name = "goat crate"
+
+/datum/supply_pack/organic/goose
+	name = "Goose Crate"
+	desc = "Angry and violent birds. Evil, evil creatures."
+	cost = 2500
+	contains = list(/mob/living/simple_animal/hostile/retaliate/goose)
+	crate_name = "goose crate"
+
+/datum/supply_pack/organic/pug
+	name = "Pug Crate"
+	desc = "Like a normal dog, but... squished. Comes with a nice collar!"
+	cost = 5000
+	contains = list(/mob/living/simple_animal/pet/dog/pug,
+					/obj/item/clothing/neck/petcollar)
+	crate_name = "pug crate"
+
+/datum/supply_pack/organic/snake
+	name = "Snake Crate"
+	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes."
+	cost = 3000
+	contains = list(/mob/living/simple_animal/hostile/retaliate/poison/snake,
+					/mob/living/simple_animal/hostile/retaliate/poison/snake,
+					/mob/living/simple_animal/hostile/retaliate/poison/snake)
+	crate_name = "snake crate"
+
+/datum/supply_pack/organic/mouse
+	name = "Mouse Crate"
+	desc = "Good for snakes and lizards of all ages. Contains ~12 feeder mice."
+	cost = 2000
+	contains = list(/mob/living/simple_animal/mouse,)
+	crate_name = "mouse crate"
+
+/datum/supply_pack/organic/mouse/generate()
+	. = ..()
+	for(var/i in 1 to 11)
+		new /mob/living/simple_animal/mouse(.)
+
+/* /datum/supply_pack/organic/secbat
+	name = "Security Bat Crate"
+	desc = "Contains five security bats, perfect to Bat-up any security officer."
+	cost = 2500
+	contains = list(/mob/living/simple_animal/hostile/retaliate/bat/secbat,
+					/mob/living/simple_animal/hostile/retaliate/bat/secbat,
+					/mob/living/simple_animal/hostile/retaliate/bat/secbat,
+					/mob/living/simple_animal/hostile/retaliate/bat/secbat,
+					/mob/living/simple_animal/hostile/retaliate/bat/secbat)
+	crate_name = "security bat crate" */
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -117,7 +117,7 @@
 					/obj/item/assembly/timer)
 	crate_name = "plasma assembly crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-*/
+
 /datum/supply_pack/science/relic
 	name = "Relic Crate"
 	desc = "Ever wanted to play with old discounted toys? Look no further. Contains two relics."
@@ -125,7 +125,7 @@
 	contraband = TRUE
 	contains = list(/obj/item/relic,
 					/obj/item/relic)
-	crate_name = "relic crate"
+	crate_name = "relic crate" */
 
 /* /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -10,14 +10,14 @@
 	group = "Science"
 	crate_type = /obj/structure/closet/crate/science
 
-/datum/supply_pack/science/ape  //Ape out!
+/* /datum/supply_pack/science/ape  //Ape out!
 	name = "Ape Cube Crate"
 	desc = "Pss what a new test subject with supper strangth, speed, and love for bananas all at the same time? Say no more... Contains a single ape cube. Dont add water!"
 	contraband = TRUE
 	cost = 2500
 	contains = list (/obj/item/reagent_containers/food/snacks/cube/ape)
 	crate_name = "ape cube crate"
-	can_private_buy = FALSE
+	can_private_buy = FALSE */
 
 /datum/supply_pack/science/beakers
 	name = "Chemistry Beakers Crate"
@@ -41,7 +41,7 @@
 					/obj/item/clothing/gloves/color/latex)
 	crate_name = "chemistry beaker crate"
 
-/datum/supply_pack/science/robotics/mecha_odysseus
+/* /datum/supply_pack/science/robotics/mecha_odysseus
 	name = "Circuit Crate (Odysseus)"
 	desc = "Ever wanted to build your own giant medical robot? Well, now you can! Contains the Odysseus main control board and Odysseus peripherals board. Requires Robotics access to open."
 	cost = 1500
@@ -49,9 +49,9 @@
 	contains = list(/obj/item/circuitboard/mecha/odysseus/peripherals,
 					/obj/item/circuitboard/mecha/odysseus/main)
 	crate_name = "\improper Odysseus circuit crate"
-	crate_type = /obj/structure/closet/crate/secure/science
+	crate_type = /obj/structure/closet/crate/secure/science */
 
-/datum/supply_pack/science/robotics/mecha_ripley
+/* /datum/supply_pack/science/robotics/mecha_ripley
 	name = "Circuit Crate (Ripley APLU)"
 	desc = "Rip apart rocks and xenomorphs alike with the Ripley APLU. Contains the Main Ripley control board, as well as the Ripley Peripherals board. Requires Robotics access to open."
 	cost = 1200
@@ -60,7 +60,7 @@
 					/obj/item/circuitboard/mecha/ripley/main,
 					/obj/item/circuitboard/mecha/ripley/peripherals)
 	crate_name = "\improper APLU Ripley circuit crate"
-	crate_type = /obj/structure/closet/crate/secure/science
+	crate_type = /obj/structure/closet/crate/secure/science */
 
 /datum/supply_pack/science/circuitry
 	name = "Circuitry Starter Pack Crate"
@@ -82,12 +82,12 @@
 					/obj/item/glasswork/blowing_rod)
 	crate_name = "glassblower gear crate"
 
-/datum/supply_pack/science/monkey
+/* /datum/supply_pack/science/monkey
 	name = "Monkey Cube Crate"
 	desc = "Stop monkeying around! Contains seven monkey cubes. Just add water!"
 	cost = 1500
 	contains = list (/obj/item/storage/box/monkeycubes)
-	crate_name = "monkey cube crate"
+	crate_name = "monkey cube crate" */
 
 /datum/supply_pack/science/nitrilegloves
 	name = "Nitrile Gloves Crate"
@@ -127,7 +127,7 @@
 					/obj/item/relic)
 	crate_name = "relic crate"
 
-/datum/supply_pack/science/robotics
+/* /datum/supply_pack/science/robotics
 	name = "Robotics Assembly Crate"
 	desc = "The tools you need to replace those finicky humans with a loyal robot army! Contains three proximity sensors, two high-powered cells, six flashes, and an electrical toolbox. Requires Robotics access to open."
 	cost = 1500
@@ -190,7 +190,7 @@
 					/obj/item/transfer_valve)
 	crate_name = "tank transfer valves crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-	dangerous = TRUE
+	dangerous = TRUE */
 
 //////// RAW ANOMALY CORES
 /*

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -12,14 +12,14 @@
 	crate_type = /obj/structure/closet/crate/footlocker
 	can_private_buy = FALSE
 
-/datum/supply_pack/security/ammosurplus
+/* /datum/supply_pack/security/ammosurplus
 	name = "Ammo Crate - Grab-Bag"
 	desc = "Contains a whole stuffing of bullets, magazines, casings. Probably overpriced."
 	cost = 2000
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3)
-	crate_name = "ammo crate"
+	crate_name = "ammo crate" */
 
 /datum/supply_pack/security/helmets
 	name = "Armor - Metal Helmets"
@@ -55,7 +55,7 @@
 	can_private_buy = TRUE
 */
 
-/datum/supply_pack/security/russianclothing
+/* /datum/supply_pack/security/russianclothing
 	name = "Russian Surplus Clothing"
 	desc = "An old russian crate full of surplus armor that they used to use! Has two sets of bulletproff armor, a few union suits and some warm hats! The Hub is not liable for any friendly fire incidents."
 	contraband = TRUE
@@ -75,7 +75,7 @@
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas)
 	crate_name = "surplus russian clothing"
-	crate_type = /obj/structure/closet/crate/internals
+	crate_type = /obj/structure/closet/crate/internals */
 /*
 /datum/supply_pack/security/sechardsuit
 	name = "Sec Hardsuit"
@@ -200,14 +200,14 @@
 	crate_name = "stingbang grenade pack crate"
 
 /datum/supply_pack/security/mosinpack
-	name = "Weapons - Mosin-Nagant Pack"
-	desc = "Arm your militia. Five Mosin Rifles, preloaded, ready to kill. A solid weapon for any defense or guerilla force. Does not come with spare ammo, so you might wanna get that sorted out, pardner."
+	name = "Weapons - Hunting Rifle Pack"
+	desc = "Arm your militia. Five Hunting Rifles, preloaded, ready to kill. A solid weapon for any defense or guerilla force. Does not come with spare ammo, so you might wanna get that sorted out, pardner."
 	cost = 750
-	contains = list(/obj/item/gun/ballistic/rifle/mosin,
-					/obj/item/gun/ballistic/rifle/mosin,
-					/obj/item/gun/ballistic/rifle/mosin,
-					/obj/item/gun/ballistic/rifle/mosin,
-					/obj/item/gun/ballistic/rifle/mosin)
+	contains = list(/obj/item/gun/ballistic/rifle/hunting,
+					/obj/item/gun/ballistic/rifle/hunting,
+					/obj/item/gun/ballistic/rifle/hunting,
+					/obj/item/gun/ballistic/rifle/hunting,
+					/obj/item/gun/ballistic/rifle/hunting)
 
 /datum/supply_pack/security/laserlowtier
 	name = "Weapons - Laser Grab-Bag"
@@ -218,14 +218,14 @@
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low)
 	crate_name = "laser crate"
 
-/datum/supply_pack/security/disabler
+/* /datum/supply_pack/security/disabler
 	name = "Weapons - Disabler Crate"
 	desc = "Three stamina-draining disabler weapons, for a more civilized place, where killing isn't the answer. In other words, probably not here. But it's nice you're trying!"
 	cost = 1300
 	contains = list(/obj/item/gun/energy/disabler,
 					/obj/item/gun/energy/disabler,
 					/obj/item/gun/energy/disabler)
-	crate_name = "disabler crate"
+	crate_name = "disabler crate" */
 
 /datum/supply_pack/security/minigun5mm
 	name = "Weapons - Minigun"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -8,9 +8,8 @@
 
 /datum/supply_pack/security
 	group = "Munitions"
-	access = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/footlocker
-	can_private_buy = FALSE
+	can_private_buy = 1
 
 /* /datum/supply_pack/security/ammosurplus
 	name = "Ammo Crate - Grab-Bag"
@@ -30,7 +29,7 @@
 					/obj/item/clothing/head/helmet/armyhelmet)
 	crate_name = "helmet crate"
 
-/datum/supply_pack/security/armor //one tier 2 armor from the raider boss, as a treat...
+/datum/supply_pack/security/raiderarmor //one tier 2 armor from the raider boss, as a treat...
 	name = "Armor - Raider Scraps"
 	desc = "Four sets of armor stripped off of raiders. Cheap, dirty, and quickly supplied. Some of it might even be worthwhile."
 	cost = 1500
@@ -40,6 +39,70 @@
 					/obj/effect/spawner/lootdrop/f13/armor/tier2)
 	crate_name = "armor crate"
 
+/datum/supply_pack/security/armor
+	name = "Armor - Surplus"
+	desc = "Three sets of refurbished armor, straight from the Dallas Miltia's own armory."
+	cost = 3000
+	contains = list(/obj/effect/spawner/lootdrop/f13/armor/tier3,
+					/obj/effect/spawner/lootdrop/f13/armor/tier3,
+					/obj/effect/spawner/lootdrop/f13/armor/tier3)
+	crate_name = "armor crate"
+
+/datum/supply_pack/security/ec
+	name = "Ammo - Energy Cell"
+	desc = "Three fully charged energy cells."
+	cost = 900
+	contains = list(/obj/item/stock_parts/cell/ammo/ec,
+					/obj/item/stock_parts/cell/ammo/ec,
+					/obj/item/stock_parts/cell/ammo/ec)
+	crate_name = "cell crate"
+
+/datum/supply_pack/security/mfc
+	name = "Ammo - Microfusion Cell"
+	desc = "Three fully charged microfusion cells."
+	cost = 1300
+	contains = list(/obj/item/stock_parts/cell/ammo/mfc,
+					/obj/item/stock_parts/cell/ammo/mfc,
+					/obj/item/stock_parts/cell/ammo/mfc)
+	crate_name = "microfusion crate"
+
+/datum/supply_pack/security/ecp
+	name = "Ammo - Electron Charge Pack"
+	desc = "Three fully charged electron charge packs."
+	cost = 2000
+	contains = list(/obj/item/stock_parts/cell/ammo/ecp,
+					/obj/item/stock_parts/cell/ammo/ecp,
+					/obj/item/stock_parts/cell/ammo/ecp)
+	crate_name = "electron charge crate"
+
+/datum/supply_pack/security/combatknives_single
+	name = "Combat Knife Single-Pack"
+	desc = "Some good ol' sharp knives. Guaranteed to fit snugly inside any cowboy-standard boot. You know what's better than one knife? Three of 'em!"
+	cost = 750
+	contains = list(/obj/item/melee/onehanded/knife/hunting,
+					/obj/item/melee/onehanded/knife/hunting,
+					/obj/item/melee/onehanded/knife/hunting)
+					
+/* /datum/supply_pack/security/dueling_stam
+	name = "Dueling Pistols"
+	desc = "Resolve all your quarrels with some nonlethal fun."
+	cost = 1500
+	contains = list(/obj/item/storage/lockbox/dueling/hugbox/stamina)
+	crate_name = "dueling pistols"
+
+/datum/supply_pack/security/dueling_stam/generate() 
+	. = ..()
+	for(var/i in 1 to 3)
+		new /obj/item/storage/lockbox/dueling/hugbox/stamina(.)
+
+/datum/supply_pack/misc/dueling_lethal
+	name = "Lethal Dueling Pistols"
+	desc = "Settle your differences the true cowboy way."
+	cost = 3000
+	contains = list(/obj/item/storage/lockbox/dueling/hugbox,
+	/obj/item/storage/lockbox/dueling/hugbox,
+	/obj/item/storage/lockbox/dueling/hugbox)
+	crate_name = "dueling pistols (lethal)" */
 /*
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
@@ -145,7 +208,6 @@
 					/obj/item/clothing/mask/gas/sechailer)
 	crate_name = "security clothing crate"
 	can_private_buy = TRUE
-*/
 
 /datum/supply_pack/security/baton
 	name = "Stun Batons Crate"
@@ -154,7 +216,7 @@
 	contains = list(/obj/item/melee/baton/loaded,
 					/obj/item/melee/baton/loaded,
 					/obj/item/melee/baton/loaded)
-	crate_name = "stun baton crate"
+	crate_name = "stun baton crate" */
 /*
 /datum/supply_pack/security/taser
 	name = "Taser Crate"
@@ -199,15 +261,14 @@
 	contains = list(/obj/item/storage/box/stingbangs)
 	crate_name = "stingbang grenade pack crate"
 
-/datum/supply_pack/security/mosinpack
-	name = "Weapons - Hunting Rifle Pack"
-	desc = "Arm your militia. Five Hunting Rifles, preloaded, ready to kill. A solid weapon for any defense or guerilla force. Does not come with spare ammo, so you might wanna get that sorted out, pardner."
-	cost = 750
-	contains = list(/obj/item/gun/ballistic/rifle/hunting,
-					/obj/item/gun/ballistic/rifle/hunting,
-					/obj/item/gun/ballistic/rifle/hunting,
-					/obj/item/gun/ballistic/rifle/hunting,
-					/obj/item/gun/ballistic/rifle/hunting)
+/datum/supply_pack/security/traitbooks
+	name = "Technical manuals"
+	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."
+	cost = 2000
+	contains = list(/obj/effect/spawner/lootdrop/f13/traitbooks,
+					/obj/effect/spawner/lootdrop/f13/traitbooks/low,
+					/obj/effect/spawner/lootdrop/f13/traitbooks/low)
+
 
 /datum/supply_pack/security/laserlowtier
 	name = "Weapons - Laser Grab-Bag"
@@ -217,6 +278,24 @@
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low)
 	crate_name = "laser crate"
+
+/datum/supply_pack/security/lasermidtier
+	name = "Weapons - Energy Grab-Bag"
+	desc = "Contains two energy guns, probably in need of some love. Batteries included!"
+	cost = 4500
+	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh)
+	crate_name = "energy crate"
+
+/datum/supply_pack/security/mods
+	name = "Weapons - Gun Mods"
+	desc = "Contains four random gun and energy weapon mods, fun for the whole family!"
+	cost = 1200
+	contains = list(/obj/effect/spawner/lootdrop/f13/attachments,
+					/obj/effect/spawner/lootdrop/f13/attachments,
+					/obj/effect/spawner/lootdrop/f13/attachments,
+					/obj/effect/spawner/lootdrop/f13/attachments)
+	crate_name = "gun mods crate"
 
 /* /datum/supply_pack/security/disabler
 	name = "Weapons - Disabler Crate"
@@ -230,20 +309,35 @@
 /datum/supply_pack/security/minigun5mm
 	name = "Weapons - Minigun"
 	desc = "Holy moly, it's here. A refurbished minigun chambered in US five-aught. Heavy, impractical, expensive to buy, expensive to fire, expensive to maintain, and an absolute killer."
-	cost = 9000
+	cost = 20000
 	contains = list(/obj/item/minigunpackbal5mm)
-	crate_name = "laser crate"
+	crate_name = "minigun crate"
+
+/datum/supply_pack/security/gunsuperhightier
+	name = "Weapons - Prewar Gun"
+	desc = "A sealed crate of a Prewar firearm, an exceptional weapon machined with lost technology."
+	cost = 8000
+	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh)
+	crate_name = "prewar gun crate"
+
+/datum/supply_pack/security/gunhightier
+	name = "Weapons - High-Tier Guns"
+	desc = "Two high-powered ballistics, perfect for taking down the meanest of muties."
+	cost = 4000
+	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high)
+	crate_name = "gun crate"
 
 /datum/supply_pack/security/ballisticstrash
 	name = "Weapons - Ballistics Grab-Bag"
 	desc = "Grab-bag is just a polite way of saying pile of junk. It's...a pile of junk. A mixture of around ten civillian and homemade firearms. Comes with an ABSURD amount of surplus ammo."
 	cost = 1350
-	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
-					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
-					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo)
-	crate_name = "laser crate"
+					)
+	crate_name = "gun grab-bag crate"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -283,7 +283,7 @@
 /datum/supply_pack/security/traitbooks
 	name = "Technical manuals"
 	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."
-	cost = 2000
+	cost = 2200
 	contains = list(/obj/effect/spawner/lootdrop/f13/traitbooks,
 					/obj/effect/spawner/lootdrop/f13/traitbooks/low,
 					/obj/effect/spawner/lootdrop/f13/traitbooks/low)
@@ -292,7 +292,7 @@
 /datum/supply_pack/security/laserlowtier
 	name = "Weapons - Laser Grab-Bag"
 	desc = "Contains three low-powered laser guns, probably in need of some love. Batteries included in shocking excess! Don't want 'em? Sell 'em back! Seriously! We don't judge!"
-	cost = 2000
+	cost = 1600
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low)
@@ -301,7 +301,7 @@
 /datum/supply_pack/security/lasermidtier
 	name = "Weapons - Energy Grab-Bag"
 	desc = "Contains two energy guns, probably in need of some love. Batteries included!"
-	cost = 4000
+	cost = 3750
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh)
 	crate_name = "energy crate"
@@ -309,7 +309,7 @@
 /datum/supply_pack/security/mods
 	name = "Weapons - Gun Mods"
 	desc = "Contains four random gun and energy weapon mods, fun for the whole family!"
-	cost = 1200
+	cost = 1000
 	contains = list(/obj/effect/spawner/lootdrop/f13/attachments,
 					/obj/effect/spawner/lootdrop/f13/attachments,
 					/obj/effect/spawner/lootdrop/f13/attachments,
@@ -328,21 +328,21 @@
 /datum/supply_pack/security/minigun5mm
 	name = "Weapons - Minigun"
 	desc = "Holy moly, it's here. A refurbished minigun chambered in US five-aught. Heavy, impractical, expensive to buy, expensive to fire, expensive to maintain, and an absolute killer."
-	cost = 20000
+	cost = 25000
 	contains = list(/obj/item/minigunpackbal5mm)
 	crate_name = "minigun crate"
 
 /datum/supply_pack/security/gunsuperhightier
 	name = "Weapons - Prewar Gun"
 	desc = "A sealed crate of a Prewar firearm, an exceptional weapon machined with lost technology."
-	cost = 6000
+	cost = 6250
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh)
 	crate_name = "prewar gun crate"
 
 /datum/supply_pack/security/gunhightier
 	name = "Weapons - High-Tier Guns"
 	desc = "Two high-powered ballistics, perfect for taking down the meanest of muties."
-	cost = 4000
+	cost = 3500
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high)
 	crate_name = "gun crate"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -42,7 +42,7 @@
 /datum/supply_pack/security/armor
 	name = "Armor - Surplus"
 	desc = "Three sets of refurbished armor, straight from the Dallas Miltia's own armory."
-	cost = 3000
+	cost = 2500
 	contains = list(/obj/effect/spawner/lootdrop/f13/armor/tier3,
 					/obj/effect/spawner/lootdrop/f13/armor/tier3,
 					/obj/effect/spawner/lootdrop/f13/armor/tier3)
@@ -74,6 +74,25 @@
 					/obj/item/stock_parts/cell/ammo/ecp,
 					/obj/item/stock_parts/cell/ammo/ecp)
 	crate_name = "electron charge crate"
+
+/datum/supply_pack/security/blueprint
+	name = "Blueprints - Basic"
+	desc = "A set of three basic weapon blueprints, parts not included!"
+	cost = 2750
+	contains = list(/obj/effect/spawner/lootdrop/f13/blueprintMid,
+					/obj/effect/spawner/lootdrop/f13/blueprintMid,
+					/obj/effect/spawner/lootdrop/f13/blueprintMid
+					)
+	crate_name = "blueprint crate"
+
+/datum/supply_pack/security/blueprintadv
+	name = "Blueprints - Advanced"
+	desc = "A set of two advanced weapon blueprints, parts not included!"
+	cost = 4250
+	contains = list(/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+					/obj/effect/spawner/lootdrop/f13/blueprintHigh
+					)
+	crate_name = "blueprint crate"
 
 /datum/supply_pack/security/combatknives_single
 	name = "Combat Knife Single-Pack"
@@ -282,7 +301,7 @@
 /datum/supply_pack/security/lasermidtier
 	name = "Weapons - Energy Grab-Bag"
 	desc = "Contains two energy guns, probably in need of some love. Batteries included!"
-	cost = 4500
+	cost = 4000
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 					/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh)
 	crate_name = "energy crate"
@@ -316,7 +335,7 @@
 /datum/supply_pack/security/gunsuperhightier
 	name = "Weapons - Prewar Gun"
 	desc = "A sealed crate of a Prewar firearm, an exceptional weapon machined with lost technology."
-	cost = 8000
+	cost = 6000
 	contains = list(/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh)
 	crate_name = "prewar gun crate"
 

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -146,7 +146,7 @@
 /datum/supply_pack/service/cutlery
 	name = "Kitchen Cutlery Deluxe Set"
 	desc = "Need to slice and dice away those \"Tomatoes\"? Well we got what you need! From a nice set of knifes, forks, plates, glasses, and a whetstone for when you got some grizzle that is a bit harder to slice then normal."
-	cost = 10000
+	cost = 7750
 	contraband = TRUE
 	contains = list(/obj/item/sharpener, //Deluxe for a reason
 					/obj/item/trash/plate,
@@ -177,7 +177,7 @@
 /datum/supply_pack/service/advlighting
 	name = "Advanced Lighting crate"
 	desc = "Thanks to advanced lighting tech we here at the Lamp Factory have be able to produce more lamps and lamp items! This crate has three lamps, a box of lights and a state of the art rapid-light-device!"
-	cost = 2750
+	cost = 1800
 	contains = list(/obj/item/construction/rld,
 					/obj/item/flashlight/lamp,
 					/obj/item/flashlight/lamp,

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -43,13 +43,13 @@
 					/obj/item/stack/packageWrap)
 	crate_name = "cargo supplies crate"
 
-/datum/supply_pack/service/mule
+/* /datum/supply_pack/service/mule
 	name = "MULEbot Crate"
 	desc = "Pink-haired Quartermaster not doing her job? Replace her with this tireless worker, today!"
 	cost = 2000
 	contains = list(/mob/living/simple_animal/bot/mulebot)
 	crate_name = "\improper MULEbot Crate"
-	crate_type = /obj/structure/closet/crate/large
+	crate_type = /obj/structure/closet/crate/large 
 
 /datum/supply_pack/service/minerkit
 	name = "Shaft Miner Starter Kit"
@@ -64,9 +64,9 @@
 			/obj/item/clothing/suit/hooded/explorer,
 			/obj/item/clothing/mask/gas/explorer)
 	crate_name = "shaft miner starter kit"
-	crate_type = /obj/structure/closet/crate/secure
+	crate_type = /obj/structure/closet/crate/secure */
 
-/datum/supply_pack/service/snowmobile
+/* /datum/supply_pack/service/snowmobile
 	name = "Snowmobile kit"
 	desc = "trapped on a frigid wasteland? need to get around fast? purchase a refurbished snowmobile, with a FREE 10 microsecond warranty!"
 	cost = 1500 // 1000 points cheaper than ATV
@@ -74,7 +74,7 @@
 			/obj/item/key = 1,
 			/obj/item/clothing/mask/gas/explorer = 1)
 	crate_name = "Snowmobile kit"
-	crate_type = /obj/structure/closet/crate/large
+	crate_type = /obj/structure/closet/crate/large */
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Chef, Botanist, Bartender ////////////////////////////
@@ -160,7 +160,7 @@
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass)
 	crate_name = "kitchen cutlery deluxe set"
 
-/datum/supply_pack/service/replacementdb
+/* /datum/supply_pack/service/replacementdb
 	name = "Replacement Defensive Bar"
 	desc = "Someone stole the Bartender's twin-barreled possession? Give them another one at a significant markup. Comes with one unused double-barrel shotgun, shells not included. Requires bartender access to open."
 	cost = 2200
@@ -168,7 +168,7 @@
 	contraband = TRUE
 	contains = list(/obj/item/kitchen/knife/butcher)
 	crate_name = "replacement double-barrel crate"
-	crate_type = /obj/structure/closet/crate/secure
+	crate_type = /obj/structure/closet/crate/secure */
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Janitor //////////////////////////////////////
@@ -196,7 +196,7 @@
 					/obj/item/lightreplacer)
 	crate_name = "replacement lights"
 
-/datum/supply_pack/service/janitor/advanced
+/* /datum/supply_pack/service/janitor/advanced
 	name = "Advanced Sanitation Crate"
 	desc = "Contains all the essentials for an advanced spacefaring cleanup crew. This kit includes a trashbag, an advanced mop, a bottle of space cleaner, a floor buffer, and a holosign projector. Requires Janitorial Access to Open"
 	cost = 5700
@@ -208,7 +208,7 @@
 					/obj/item/janiupgrade,
 					/obj/item/holosign_creator)
 	crate_name = "advanced santation crate"
-	crate_type = /obj/structure/closet/crate/secure
+	crate_type = /obj/structure/closet/crate/secure 
 
 /datum/supply_pack/service/janitor/janpimp
 	name = "Custodial Cruiser"
@@ -271,5 +271,5 @@
 	contains = list(/obj/structure/janitorialcart,
 					/obj/item/clothing/shoes/galoshes)
 	crate_name = "janitorial cart crate"
-	crate_type = /obj/structure/closet/crate/large
+	crate_type = /obj/structure/closet/crate/large */
 

--- a/code/modules/fallout/obj/stack/f13Cash.dm
+++ b/code/modules/fallout/obj/stack/f13Cash.dm
@@ -56,6 +56,7 @@
 	var/coinflip
 	var/list/sideslist = list("heads","tails")
 	merge_type = /obj/item/stack/f13Cash
+	custom_materials = list(/datum/material/f13cash=MINERAL_MATERIAL_AMOUNT)
 
 /obj/item/stack/f13Cash/attack_self(mob/user)
 	if (flippable)

--- a/code/modules/fallout/obj/stack/hide.dm
+++ b/code/modules/fallout/obj/stack/hide.dm
@@ -23,6 +23,7 @@
 	icon = 'icons/fallout/objects/items.dmi'
 	icon_state = "sheet-deathclaw"
 	merge_type = /obj/item/stack/sheet/animalhide/deathclaw
+	custom_materials = list(/datum/material/deathclawhide=MINERAL_MATERIAL_AMOUNT)
 
 /obj/item/stack/sheet/animalhide/wolf
 	name = "dog skin"


### PR DESCRIPTION
## About The Pull Request
This PR greatly expands the list of both what is importable and exportable through cargo, making it a stronger tool at the hands of the Shopkeeper. What this DOESN'T fix is Large Object exports, which don't work at all currently, this means that crate selling - the old backbone of cargo, is currently defunct. I think our cargo train could work without crates, but I don't want to make this a full PR until we've decided what to do about large objects.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added a ton of new crates to cargo, 
add: Greatly expanded the list of exports to cargo, most notably in the form of guns, caps, and produce now being exportable.
del: Commented out crates that no longer fit the server
tweak: Swapped categories of crates to make more sense 
balance: Adjusted cargo crate values to reflect our codebase
fix: fixed SOME of the broken materials in cargo's material dm
spellcheck: fixed a few typos, removed some references to NT
code: added the the MINERAL_MATERIAL_AMOUNT flag to Caps, (deathclaw) leather, chitin, and bones to make them compatible with cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
