### PR TITLE
Various Loadout Stuff

### DIFF
--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -1012,7 +1012,7 @@ Mayor
 	/obj/item/clothing/glasses/welding = 1,
 	/obj/item/t_scanner/adv_mining_scanner = 1,
 	/obj/item/ammo_box/m44 = 2,
-	/obj/item/gun/ballistic/revolver/m29/snub
+	/obj/item/gun/ballistic/revolver/m29/snub = 1
 	)
 /*----------------------------------------------------------------
 --							Detective							--

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -125,7 +125,7 @@ Mayor
 		/obj/item/clothing/under/f13/vault = 1,
 		/obj/item/clothing/shoes/jackboots = 1,
 		/obj/item/clothing/suit/armor/light/duster/battlecoat/vault/overseer = 1,
-		/obj/item/reagent_containers/food/drinks/flask/vault113,
+		/obj/item/reagent_containers/food/drinks/flask/vault113 = 1,
 		/obj/item/gun/ballistic/automatic/pistol/beretta/automatic = 1,
 		/obj/item/ammo_box/magazine/m9mm/doublestack = 1
 		)

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -428,4 +428,14 @@
 // W
 // X
 // Y
+
+/datum/gear/donator/kits/yawet
+	name = "Tribal Drip"
+	path = /obj/item/storage/box/large/custom_kit/yawet
+	ckeywhitelist = list("yawet330")
+
+/obj/item/storage/box/large/custom_kit/yawet/PopulateContents()
+	new /obj/item/clothing/suit/hooded/outcast(src)
+	new /obj/item/twohanded/sledgehammer/simple(src)
+
 // Z

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -356,6 +356,7 @@
 	ckeywhitelist = list("swirlby")
 
 /obj/item/storage/box/large/custom_kit/swirlby/PopulateContents()
+	new /obj/item/clothing/under/f13/exile/vault(src)
 	new /obj/item/gun/ballistic/rifle/hunting(src)
 	new /obj/item/clothing/suit/armor/light/tribal/rustwalkers(src)
 	new /obj/item/clothing/suit/armor/medium/tribal/deadhorses(src)


### PR DESCRIPTION
Edits Swirlby's loadout kit, giving the vault exile jumpsuit.

Loadout kit locked to ckey yawet330.

Fixed a loadout option for nash citizen, the snub for prospector wasn't set up properly to actually fill the bag.

Fixed a loadout option for the mayor, first citizen loadout didn't give the flash like it should have.