### PR TITLE
Makes this less predictable

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -7,11 +7,11 @@
 	if(pellets == 1)
 		if(distro) //We have to spread a pixel-precision bullet. throw_proj was called before so angles should exist by now...
 			if(HAS_TRAIT(user,TRAIT_FEV)) //You really shouldn't try this at home.
-				spread += 3 //YOU AINT HITTING SHIT BROTHA. REALLY.
+				spread += rand(-3,3) //YOU AINT HITTING SHIT BROTHA. REALLY.
 			if(HAS_TRAIT(user,TRAIT_NEARSIGHT)) //Yes.
-				spread += 0.1 //You're slightly less accurate because you can't see well - as an upside, lasers don't suffer these penalties!
+				spread += rand(-0.2,0.2) //You're slightly less accurate because you can't see well - as an upside, lasers don't suffer these penalties!
 			if(HAS_TRAIT(user,TRAIT_POOR_AIM)) //You really shouldn't try this at home.
-				spread += 1.5 //This is cripplingly bad. Trust me.
+				spread += rand(-1.5,1.5)//This is cripplingly bad. Trust me.
 			if(randomspread)
 				spread *= distro
 			else //Smart spread


### PR DESCRIPTION
Fixes bullet spread for poor aim/etc

## Changelog
:cl:
fix: Poor aim/etc now actually randomise how far their projectiles spread
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
