### PR TITLE
Ooops all eguns + Ckey item (Loadout wild ride)

### DIFF
--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -443,7 +443,7 @@ Follower Volunteer
 	outfit = /datum/outfit/job/followers/f13followerguard
 
 	loadout_options = list(/datum/outfit/loadout/guard_ranged,
-	/datum/outfit/loadout/guard_close
+	/datum/outfit/loadout/guard_close, /datum/outfit/loadout/guard_energy
 	)
 	access = list(ACCESS_FOLLOWER, ACCESS_MILITARY)
 	minimal_access = list(ACCESS_FOLLOWER, ACCESS_MILITARY)
@@ -485,4 +485,11 @@ Follower Volunteer
 		/obj/item/ammo_box/shotgun/bean = 1,
 		/obj/item/ammo_box/shotgun/buck = 1,
 		/obj/item/ammo_box/shotgun/slug = 1,
+	)
+
+/datum/outfit/loadout/guard_energy
+	name = "Followers Energy Protection Guard"
+	suit_store = /obj/item/gun/energy/laser/scatter
+	backpack_contents = list(
+		/obj/item/stock_parts/cell/ammo/mfc = 1,
 	)

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -252,7 +252,8 @@ Mayor
 
 	loadout_options = list(
 	/datum/outfit/loadout/thelaw,
-	/datum/outfit/loadout/thechief
+	/datum/outfit/loadout/thechief,
+	/datum/outfit/loadout/thedictator
 	)
 
 	access = list(ACCESS_BAR, ACCESS_CLONING, ACCESS_GATEWAY, ACCESS_CARGO_BOT, ACCESS_MINT_VAULT, ACCESS_KITCHEN, ACCESS_MINING, ACCESS_FORENSICS_LOCKERS)
@@ -312,6 +313,15 @@ Mayor
 	backpack_contents = list(/obj/item/ammo_box/shotgun/slug = 1,
 		/obj/item/ammo_box/shotgun/buck = 2
 		)
+
+/datum/outfit/loadout/thedictator
+	name = "The Dictator"
+	uniform = /obj/item/clothing/under/f13/police/chief
+	suit = /obj/item/clothing/suit/armor/medium/duster/town/sheriff
+	r_hand = /obj/item/gun/energy/laser/scatter
+	backpack_contents = list(/obj/item/stock_parts/cell/ammo/mfc = 1,
+		)
+
 /*
 /datum/outfit/loadout/pew
 	name = "Tactical"
@@ -354,7 +364,8 @@ Mayor
 	loadout_options = list(
 	/datum/outfit/loadout/frontierjustice,
 	/datum/outfit/loadout/police,
-	/datum/outfit/loadout/swat,)
+	/datum/outfit/loadout/swat,
+	/datum/outfit/loadout/energy)
 
 	outfit = /datum/outfit/job/den/f13deputy
 	access = list(ACCESS_BAR, ACCESS_GATEWAY)
@@ -429,6 +440,16 @@ Mayor
 		/obj/item/gun/ballistic/automatic/pistol/mk23=1,
 		/obj/item/ammo_box/magazine/m5mm=1,
 		/obj/item/flashlight/seclite = 1
+		)
+
+/datum/outfit/loadout/energy
+	name = "High Tech Officer"
+	uniform = /obj/item/clothing/under/f13/police/officer
+	suit = /obj/item/clothing/suit/armor/heavy/metal/polished
+	gloves = /obj/item/clothing/gloves/f13/military
+	suit_store = /obj/item/gun/energy/laser/aer9
+	backpack_contents = list(
+		/obj/item/stock_parts/cell/ammo/mfc = 1
 		)
 
 /datum/outfit/job/den/f13deputy/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -115,6 +115,25 @@
 /obj/item/storage/box/large/custom_kit/brimcon/PopulateContents()
 	new /obj/item/clothing/suit/armor/light/tribal/cloak(src)
 
+/datum/gear/donator/kits/bwoincognito
+	name = "Tasald's Kit"
+	path = /obj/item/storage/box/large/custom_kit/bwoincognito
+	ckeywhitelist = list("bwoincognito")
+
+/obj/item/storage/box/large/custom_kit/bwoincognito/PopulateContents()
+	new /obj/item/clothing/head/helmet/f13/brahmincowboyhat(src)
+	new /obj/item/clothing/under/f13/ranger/modif_ranger(src)
+	new /obj/item/clothing/accessory/kevlar(src)
+	new /obj/item/clothing/shoes/combat(src)
+	new /obj/item/melee/onehanded/knife/trench(src)
+	new /obj/item/shovel/trench(src)
+	new /obj/item/storage/belt/legholster(src)
+	new /obj/item/gun/ballistic/revolver/revolver45/gunslinger(src)
+	new /obj/item/tool_upgrade/refinement/ported_barrel(src)
+	new /obj/item/ammo_box/a45lcrev(src)
+	new /obj/item/ammo_box/a45lcrev(src)
+	new /obj/item/ammo_box/a45lcbox(src)
+
 // C
 
 /datum/gear/donator/kits/caseapollo58143


### PR DESCRIPTION
Loadout kit locked to ckey BWOIncognito.

Adds an egun loadout to the follower guard, sheriff, and deputy.

Guard and Sheriff gets a scatter rifle. Reason for guard is they are designed to be protecting the hospital with effectiveness. That and it's no different the police shotgun, if not slightly weaker far away.

Deputy gets an aer9 which is admittadely stronger than the scatter if not all bullets hit.

Info about the scatter: Has massive spread. Lacks armor penetration %. Fires extremely slow. Has terrible cell charge shot amount. Does good damage point black (up in the targets face). Good pvp wise versus someone lacking energy protection armor, but not all too great for pve.