### PR TITLE
Ckey item and NCR/Legion reference removal

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1146,14 +1146,14 @@
 
 /obj/item/card/id/rusted
 	name = "rusted tags"
-	desc = "Decrepit uncared for NCR dogtags, kept as a reminder to something."
+	desc = "Decrepit uncared for dogtags, kept as a reminder to something."
 	icon_state = "rustedncrtag"
 	item_state = "rustedncrtag"
 	uses_overlays = FALSE
 
 /obj/item/card/id/rusted/rustedmedallion
 	name = "rusted medallion"
-	desc = "A battered and unkempt legion medallion, kept as a reminder to something."
+	desc = "A battered and unkempt medallion, kept as a reminder to something."
 	icon_state = "rustedmedallion"
 	item_state = "rustedmedallion"
 	uses_overlays = FALSE

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -351,6 +351,21 @@
 
 // N
 
+/datum/gear/donator/kits/nightmare6669
+	name = "Chadsune"
+	path = /obj/item/storage/box/large/custom_kit/nightmare6669
+	ckeywhitelist = list("nightmare6669")
+
+/obj/item/storage/box/large/custom_kit/nightmare6669/PopulateContents()
+	new /obj/item/gun/ballistic/revolver/m29/alt(src)
+	new /obj/item/ammo_box/m44(src)
+	new /obj/item/ammo_box/m44(src)
+	new /obj/item/storage/belt/shoulderholster(src)
+	new /obj/item/melee/onehanded/knife/trench(src)
+	new /obj/item/clothing/head/helmet/f13/combat/swat(src)
+	new /obj/item/clothing/suit/armor/medium/combat/swat(src)
+	new /obj/item/melee/onehanded/machete/spatha(src)
+
 /datum/gear/donator/kits/nirzak
 	name = "Vas Kit"
 	path = /obj/item/storage/box/large/custom_kit/nirzak


### PR DESCRIPTION
Loadout kit locked to ckey Nightmare6669

Removes an old reference of NCR on an heirloom item, and legion reference from another. No glitch in the matrix here I swear!!!