### PR TITLE
Nerfs supermutant behemoth

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -126,7 +126,7 @@
 				var/turf/thrownat = get_ranged_target_turf_direct(src, L, 8, rand(-10, 10))
 				L.throw_at(thrownat, 4, 1, src, TRUE)		//, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
 				if(do_damage)
-					L.apply_damage(40, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //This takes into count armor now. Also makes it damage the chest first, so he can't break your legs instantly.
+					L.apply_damage(30, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //If you're going to stealthbuff something, remove my code comment from it. Thank you. Do NOT raise this above 30 without reducing its attack damage, or normal players will get 1 shot.
 				shake_camera(L, 2, 1)
 			all_turfs -= T
 		sleep(delay)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -10,7 +10,7 @@
 	maxHealth = 2000 //used to be 3000
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 10, /obj/item/stack/sheet/bone = 6)
 	loot = list(/obj/item/card/id/dogtag/enclave/noncombatant, /obj/item/stack/f13Cash/random/med) //THIS IS FOR DUNGEON ACCESS STUFF: CHANGE IF NEEDED
-	armour_penetration = 0.7
+	armour_penetration = 0.5 //0.7 was too high in testing, since if it managed to zerg speed you into a wall; this would immediately kill you afterwards. Regardless.
 	melee_damage_lower = 50
 	melee_damage_upper = 70
 	vision_range = 9
@@ -36,11 +36,12 @@
 	/// Saves the turf the megafauna was created at (spawns exit portal here)
 	var/turf/starting
 	/// Range for behemoth stomping when it moves
-	var/stomp_range = 1
+	var/stomp_range = 0 //ALLOW THEM TO APPROACH BEFORE PHASE 2 FFS OMAIGAWD
 	/// Stores directions the mob is moving, then calls that a move has fully ended when these directions are removed in moved
 	var/stored_move_dirs = 0
 	/// If the behemoth is allowed to move
 	var/can_move = TRUE
+	var/stomp_cooldown = 150 // WOW WHO WOULD HAVE THOUGHT?
 
 /datum/action/innate/megafauna_attack/heavy_stomp
 	name = "Heavy Stomp"
@@ -63,7 +64,7 @@
 /mob/living/simple_animal/hostile/megafauna/behemoth/OpenFire()
 	SetRecoveryTime(0, 100)
 	if(health <= maxHealth*0.5)
-		stomp_range = 2
+		stomp_range = 1 //Please do not make a 4x4 death zone that goes through walls whenever it walks... Which it does... Very quickly.
 		speed = 2
 		move_to_delay = 2
 	else
@@ -74,7 +75,11 @@
 	if(client)
 		switch(chosen_attack)
 			if(1)
-				heavy_stomp()
+				if(world.time >= stomp_cooldown)
+					stomp_cooldown = world.time + 300 //Ashdrake swoop timer +50 ticks
+					heavy_stomp()
+				else
+					return
 			if(2)
 				disorienting_scream()
 		return
@@ -82,7 +87,11 @@
 	chosen_attack = rand(1, 2)
 	switch(chosen_attack)
 		if(1)
-			heavy_stomp()
+			if(world.time >= stomp_cooldown)
+				stomp_cooldown = world.time + 300 //Ashdrake swoop timer +50 ticks
+				heavy_stomp()
+			else
+				return
 		if(2)
 			disorienting_scream()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -41,7 +41,7 @@
 	var/stored_move_dirs = 0
 	/// If the behemoth is allowed to move
 	var/can_move = TRUE
-	var/stomp_cooldown = 150 // WOW WHO WOULD HAVE THOUGHT?
+	COOLDOWN_DECLARE(stomp_cooldown)
 
 /datum/action/innate/megafauna_attack/heavy_stomp
 	name = "Heavy Stomp"
@@ -75,9 +75,10 @@
 	if(client)
 		switch(chosen_attack)
 			if(1)
-				if(world.time >= stomp_cooldown)
-					stomp_cooldown = world.time + 170 // 170 ticks between each stomp
+				if(COOLDOWN_FINISHED(src, stomp_cooldown))
+					COOLDOWN_START(src, stomp_cooldown, 15 SECONDS)
 					heavy_stomp()
+					return
 				else
 					return
 			if(2)
@@ -87,9 +88,10 @@
 	chosen_attack = rand(1, 2)
 	switch(chosen_attack)
 		if(1)
-			if(world.time >= stomp_cooldown)
-				stomp_cooldown = world.time + 170 // 170 ticks between each stomp
+			if(COOLDOWN_FINISHED(src, stomp_cooldown))
+				COOLDOWN_START(src, stomp_cooldown, 15 SECONDS)
 				heavy_stomp()
+				return
 			else
 				return
 		if(2)
@@ -126,7 +128,7 @@
 				var/turf/thrownat = get_ranged_target_turf_direct(src, L, 8, rand(-10, 10))
 				L.throw_at(thrownat, 4, 1, src, TRUE)		//, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
 				if(do_damage)
-					L.apply_damage(30, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //If you're going to stealthbuff something, remove my code comment from it. Thank you. Do NOT raise this above 30 without reducing its attack damage, or normal players will get 1 shot.
+					L.apply_damage(30, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //Please do not stealth-buff things. Keep this at 30 or lower.
 				shake_camera(L, 2, 1)
 			all_turfs -= T
 		sleep(delay)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -6,11 +6,11 @@
 	icon_living = "behemoth_axe"
 	icon_dead = "behemoth_dead"
 
-	health = 2000 //used to be 3000
-	maxHealth = 2000 //used to be 3000
+	health = 2300 //used to be 3000
+	maxHealth = 2300 //I actually see why this needs to be higher. I almost killed it with a Bozar in under 20 seconds via just holding LMB at PB range
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 10, /obj/item/stack/sheet/bone = 6)
 	loot = list(/obj/item/card/id/dogtag/enclave/noncombatant, /obj/item/stack/f13Cash/random/med) //THIS IS FOR DUNGEON ACCESS STUFF: CHANGE IF NEEDED
-	armour_penetration = 0.5 //0.7 was too high in testing, since if it managed to zerg speed you into a wall; this would immediately kill you afterwards. Regardless.
+	armour_penetration = 0.6 //0.7 was too high in testing, since if it managed to zerg speed you into a wall; this would immediately kill you afterwards. Regardless.
 	melee_damage_lower = 50
 	melee_damage_upper = 70
 	vision_range = 9
@@ -36,7 +36,7 @@
 	/// Saves the turf the megafauna was created at (spawns exit portal here)
 	var/turf/starting
 	/// Range for behemoth stomping when it moves
-	var/stomp_range = 0 //ALLOW THEM TO APPROACH BEFORE PHASE 2 FFS OMAIGAWD
+	var/stomp_range = 1 //ALLOW THEM TO APPROACH BEFORE PHASE 2 FFS OMAIGAWD
 	/// Stores directions the mob is moving, then calls that a move has fully ended when these directions are removed in moved
 	var/stored_move_dirs = 0
 	/// If the behemoth is allowed to move
@@ -64,7 +64,7 @@
 /mob/living/simple_animal/hostile/megafauna/behemoth/OpenFire()
 	SetRecoveryTime(0, 100)
 	if(health <= maxHealth*0.5)
-		stomp_range = 1 //Please do not make a 4x4 death zone that goes through walls whenever it walks... Which it does... Very quickly.
+		stomp_range = 2 //Please do not make a 4x4 death zone that goes through walls whenever it walks... Which it does... Very quickly.
 		speed = 2
 		move_to_delay = 2
 	else
@@ -76,7 +76,7 @@
 		switch(chosen_attack)
 			if(1)
 				if(COOLDOWN_FINISHED(src, stomp_cooldown))
-					COOLDOWN_START(src, stomp_cooldown, 15 SECONDS)
+					COOLDOWN_START(src, stomp_cooldown, 15 SECONDS) //This is a fair and balanced thing
 					heavy_stomp()
 					return
 				else
@@ -128,7 +128,7 @@
 				var/turf/thrownat = get_ranged_target_turf_direct(src, L, 8, rand(-10, 10))
 				L.throw_at(thrownat, 4, 1, src, TRUE)		//, force = MOVE_FORCE_OVERPOWERING, gentle = TRUE)
 				if(do_damage)
-					L.apply_damage(30, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //Please do not stealth-buff things. Keep this at 30 or lower.
+					L.apply_damage(40, BRUTE, BODY_ZONE_CHEST, armor_block, wound_bonus = CANT_WOUND) //This actually isn't that threatening in testing anymore because I changed it to be gentle
 				shake_camera(L, 2, 1)
 			all_turfs -= T
 		sleep(delay)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/behemoth.dm
@@ -76,7 +76,7 @@
 		switch(chosen_attack)
 			if(1)
 				if(world.time >= stomp_cooldown)
-					stomp_cooldown = world.time + 300 //Ashdrake swoop timer +50 ticks
+					stomp_cooldown = world.time + 170 // 170 ticks between each stomp
 					heavy_stomp()
 				else
 					return
@@ -88,7 +88,7 @@
 	switch(chosen_attack)
 		if(1)
 			if(world.time >= stomp_cooldown)
-				stomp_cooldown = world.time + 300 //Ashdrake swoop timer +50 ticks
+				stomp_cooldown = world.time + 170 // 170 ticks between each stomp
 				heavy_stomp()
 			else
 				return


### PR DESCRIPTION
Bearrr did not fix the issue with stomps being spammed.
Infact, past the 300 hp decrease they basically buffed it as they gave it the extra damage without debuffing its AP

Essentially fixes the fact Bearrr stealth-buffed its damage output without fixing the actual bug with the Behemoths 'admittedly' peabrained AI.

Come on, man.


AAAAAAAAAAAA
## Changelog
:cl:
fix: Stomps can no longer be spammed by the player, or by the mobs. Now on a 150 tick CD
tweak: You're not supposed to be 1 shot through heavy armor, even at range. Prevents the walk stomp from going through walls, massively increases player chance against it by removing the stomping in phase 1; reverts the stealth-buff done to its strength.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
