### PR TITLE
Removes the Supermutant BullshitTM

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -152,7 +152,7 @@
 	health = 144
 	retreat_distance = 2 //Ditto.
 	minimum_distance = 5 //These guys really shouldn't sit at max-range.
-	projectiletype = /obj/item/projectile/bullet/a762/improvised/supermutant
+	projectiletype = /obj/item/projectile/bullet/a762/sport/simple
 	projectilesound = 'sound/f13weapons/hunting_rifle.ogg'
 	loot = list(/obj/item/ammo_box/a308, /obj/item/gun/ballistic/rifle/hunting)
 	footstep_type = FOOTSTEP_MOB_HEAVY
@@ -172,6 +172,9 @@
 	icon_state = icon_dead
 	anchored = FALSE
 	..()
+	
+/mob/living/simple_animal/hostile/supermutant/rangedmutant/weak
+	projectiletype = /obj/item/projectile/bullet/a762/improvised/supermutant
 
 /mob/living/simple_animal/hostile/supermutant/legendary
 	name = "legendary super mutant"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Literally just sets their bullet damage to 60%, reduces their wound chance to a decent level, and reduces their disengage range to make them less frustrating.

The fact that someone unnamed added these atop of turrets to an already extremely difficult boss fight is just...

## Changelog
:cl:
tweak: Supermutants no longer shoot you with 7.62 rounds that bleed you out regardless of heavy armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
