### PR TITLE
Fix Barrel Tea temperature requirement

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -1412,7 +1412,7 @@
 	id = "feratea"
 	results = list(/datum/reagent/consumable/tea/feratea = 3)
 	required_reagents = list(/datum/reagent/consumable/ferajuice = 1, /datum/reagent/water = 2)
-	required_temp = 315315
+	required_temp = 315
 
 /datum/chemical_reaction/daturatea
 	name = "Datura Tea"


### PR DESCRIPTION
## About The Pull Request
Fixes a funny typo in the recipe for barrel tea stemming from #697 that makes brewing it impossible

## Changelog
:cl:
fix: Fixes typo in barrel tea recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
