### PR TITLE
Put lighters and two different loadout kits!

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -143,6 +143,7 @@
 	new /obj/item/ammo_box/a45lcrev(src)
 	new /obj/item/ammo_box/a45lcrev(src)
 	new /obj/item/ammo_box/a45lcbox(src)
+	new /obj/item/lighter/fusion(src)
 
 // C
 
@@ -415,6 +416,7 @@
 
 /obj/item/storage/box/large/custom_kit/risingstarslash2/PopulateContents()
 	new /obj/item/book/granter/crafting_recipe/slimecookie(src)
+	new /obj/item/lighter/slime(src)
 
 // S
 

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -342,6 +342,8 @@
 
 /obj/item/storage/box/large/custom_kit/merek2/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/pistol/n99/crusader(src)
+	new /obj/item/reagent_containers/food/drinks/flask/vault113(src)
+	new /obj/item/lighter/fusion(src)
 
 /datum/gear/donator/kits/mrsanderp
 	name = "Happy Sharky Co. Business Bundle"


### PR DESCRIPTION
The fusion lighter and Slime lighter just has the special component of heating much hotter than a normal one. The slime one can even be ground up it seems too! Yay for fluff!

Loadout ckey's affected: Bwo/tasald, risingstar/blue (don't shoot for shameless self add plz)
Also gave Merek2 a fusion lighter/vault113 flask!