### PR TITLE
Final edition of the leather coat + Ckey kit fix

### DIFF
--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -1652,8 +1652,8 @@
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/khaans.dmi'
 	icon_state = "khan_heavy"
 	item_state = "khan_heavy"
-	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T2, ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_DOWN_ENV_T1, ARMOR_MODIFIER_DOWN_DT_T1)
+	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT
+	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T4, ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_DOWN_ENV_T1, ARMOR_MODIFIER_DOWN_DT_T1)
 
 /obj/item/clothing/suit/armor/medium/vest/breastplate/light
 	name = "light armor plates"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -347,7 +347,7 @@
 	new /obj/item/gun/ballistic/automatic/pistol/n99/crusader(src)
 	new /obj/item/reagent_containers/food/drinks/flask/vault113(src)
 	new /obj/item/lighter/fusion(src)
-	new /obj/item/clothing/under/syndicate/brotherhood(src)
+	new /obj/item/clothing/under/f13/bos/fatigues(src)
 	new /obj/item/gun/energy/laser/pistol(src)
 
 /datum/gear/donator/kits/mrsanderp

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -336,7 +336,7 @@
 	new /obj/item/clothing/suit/armor/medium/combat/swat(src)
 	new /obj/item/clothing/shoes/combat/swat(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/medical(src)
-	new /obj/item/clothing/under/rank/medical/doctor(src)
+	new /obj/item/clothing/under/rank/medical/doctor/skirt(src)
 
 /datum/gear/donator/kits/merek2
 	name = "Brotherhood Kit"


### PR DESCRIPTION
Ooopsy'd his loadout. That's fixed!

While this leather battle coat will let you go faster baseline than ordinary medium armor, and protect against melee...bullets will destroy you, whilst laser weapons will destroy you (but not as much as bullets). Good luck fighting anything that doesn't punch you. Adds the tier 4 down tag to the bullets which effective lowers the base medium armor listing of 26 down to 35% of the value. Laser weapon wise it's baseline protection for medium armor, while the armor is finetuned to protect heavily against melee trauma.

PS. The main gimmick of the armor is its speed to dodge shots. Granted the slowdown is only effectively lowered to 80% of its normal slowdown.