### PR TITLE
Chem Cartridge balance pass

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -306,4 +306,3 @@
 	time = 100
 	tools = list(TOOL_AWORKBENCH, TOOL_HEMOSTAT, TOOL_ANALYZER)
 	category = CAT_MEDICAL
-	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -283,29 +283,25 @@
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/crafted_chem_cartridge
-	name = "Improvised chemical Cartridge"
-	result = /obj/item/stock_parts/chem_cartridge/crafted
+	name = "Refill chemical Cartridge"
+	result = /obj/item/stock_parts/chem_cartridge/garbage
 	reqs = list(
-	/obj/item/stack/sheet/metal = 5,
-	/obj/item/stack/sheet/glass = 2,
-	/obj/item/stack/crafting/electronicparts = 1,
-	/obj/item/crafting/duct_tape = 1,
-	/datum/reagent/consumable/nutriment = 60
+	/obj/item/stock_parts/chem_cartridge/garbage = 1,
+	/datum/reagent/consumable/nutriment = 30
 	)
 	time = 100
 	tools = list(TOOL_WORKBENCH, TOOL_SCREWDRIVER, TOOL_CROWBAR)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/crafted_adv_chem_cartridge
-	name = "pristine chemical Cartridge"
-	result = /obj/item/stock_parts/chem_cartridge/pristine
+	name = "Crafted chemical Cartridge"
+	result = /obj/item/stock_parts/chem_cartridge/crafted
 	reqs = list(
 	/obj/item/stack/sheet/metal = 5,
 	/obj/item/stack/sheet/glass = 5,
 	/obj/item/stack/sheet/mineral/plasma = 5,
 	/obj/item/stack/crafting/electronicparts = 5,
-	/obj/item/crafting/duct_tape = 1,
-	/datum/reagent/consumable/nutriment = 120
+	/datum/reagent/consumable/nutriment = 60
 	)
 	time = 100
 	tools = list(TOOL_AWORKBENCH, TOOL_HEMOSTAT, TOOL_ANALYZER)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -724,10 +724,10 @@
 		/obj/item/stock_parts/capacitor = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stack/sheet/glass = 1,
-		/obj/item/stock_parts/cell = 1,
+		///obj/item/stock_parts/cell = 1,
 		/obj/item/stock_parts/chem_cartridge = 1)
 	def_components = list(
-		/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high,
+		///obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high,
 		/obj/item/stock_parts/chem_cartridge = /obj/item/stock_parts/chem_cartridge/simple)
 	needs_anchored = FALSE
 /obj/item/circuitboard/machine/chem_dispenser/apothecary

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -893,7 +893,8 @@
 		/datum/crafting_recipe/superstimpak,
 		/datum/crafting_recipe/superstimpak5,
 		/datum/crafting_recipe/buffout,
-		/datum/crafting_recipe/steady)
+		/datum/crafting_recipe/steady,
+		/datum/crafting_recipe/crafted_adv_chem_cartridge)
 
 /obj/item/book/granter/trait/bigleagues
 	name = "Grognak the Barbarian"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -893,8 +893,7 @@
 		/datum/crafting_recipe/superstimpak,
 		/datum/crafting_recipe/superstimpak5,
 		/datum/crafting_recipe/buffout,
-		/datum/crafting_recipe/steady,
-		/datum/crafting_recipe/crafted_adv_chem_cartridge)
+		/datum/crafting_recipe/steady)
 
 /obj/item/book/granter/trait/bigleagues
 	name = "Grognak the Barbarian"

--- a/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
@@ -49,7 +49,7 @@
 	desc = "A casing holding a mix of raw material for use in chem dispensors. This one is a crudely fabricated imitation."
 	icon_state = "crafted" //placeholder
 	item_state = "crafted" //placeholder
-	maxCharge = 5000
+	maxCharge = 1500
 	custom_materials = list(/datum/material/iron=1000, /datum/material/glass=500)
 
 /obj/item/stock_parts/chem_cartridge/simple

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -40,12 +40,6 @@ export const ChemDispenser = (props, context) => {
             </Box>
           )}>
           <LabeledList>
-            <LabeledList.Item label="Energy">
-              <ProgressBar
-                value={data.energy / data.maxEnergy}>
-                {toFixed(data.energy) + ' units'}
-              </ProgressBar>
-            </LabeledList.Item>
             <LabeledList.Item label="Chemical Storage">
               <ProgressBar
                 value={data.cartridgeCharge / data.maxCartridgeCharge}>


### PR DESCRIPTION
## About The Pull Request
### **This update will see some revisions for the new Funny Chem Toob mechanic.**
**Chemical Dispensers no longer need power cells to be constructed or dispense chemicals.** In the past chemical dispensers where balanced by having their recharge rates for their cells severely nerfed. This may have made sense in the past but given the proximity and ease of access to heavy cell chargers this has more or less morphed into needless busywork for the chemist. This gets lamp shaded even harder by the addition of the cartridge mechanic further adding more to the list o things a doctor already has to do. Removing it also cuts down on the perceived complexity of how dispensers actually work, and over all the cartridge system now more or less supplants the power cells used by these machines. Dispensers will still require power in the area they're in in order to operate though.

**Crafted Cartridges have had their recipes tweaked to be easier for players to craft.** The initial method of crafting cartridges wasn't as well developed as it otherwise could have been. Improvised cartridges weren't worth the materials they costed and an oversight in development left higher end cartridges impossible to craft. Improvised cartridges now no longer require duct tape. Improvised cartridges can now also be refilled, and contain almost twice amount of potential reagents then they did previously. To compensate for this the cartridges now use considerably more materials to craft.

### Overall Goals.
**Overall, the goals of this change in mechanics is to address the fact that in their classical state, Chemistry made medicines have no inherent value outside of Lore or RP.** This is because in their normal configuration, SS13 chemical dispensers turn power, a functionally infinite and worthless resource, directly into medicine. The only time power scarcity becomes a concern is in the case of engine failure or sabotage. Even then a chemist will probably have had plenty of time to stockpile more then enough medicine to last the rest of the shift. On coyote, there is no engine. There's no scarcity of electricity. Any area on the map that starts powered will remain that way. Even if it's compromised, there's plenty of other areas to move your dispenser to. The only thing that stands between a doctor and infinite medicine is the time they spend pushing the buttons on the machine. There's no reason to sell them, as you have unlimited reagents. There's no reason to rob a doctor who's already flat giving away the medicine you need. It's boring and a poor reflection of the state of medicine in a post apocalyptic setting, let alone the fallout setting.

**How the cartridge system addresses this.** The goal of this system is to move the cost of creating drugs and medicine into something tangible. Something players can buy, sell, or barter with. Doctors now have to be cognizant of the resources that go into creating medicine. If they want to continue mass producing medicines at the rates they do they'll need to figure out a way to source these canisters. There's plenty of ways to get these resources and in the future I'm sure even more will end up being added. Currently doctors have the option to find them in trash piles, craft them with materials from salvage and hunting, loot them from medical vendors, and trade/buy them off players who've found them. In the future I intend to have them added as loot for some PoI's, and added as things the Nash shopkeeper can buy from their cargo terminal.

**As it stands the current implementation, and through the coming update, the cartridges are abundant and don't actually effect the medical metagame all that much.** This is, for now, by design. The cartridges are easy to find and make and provide plenty of reagents before needing to be replaced. This is to ease players into and get them used to the new mechanic before tuning their associated values. Eventually I'd like to get them to a balance where they're a concern for players but not completely oppressive to their ability to fabricate medicine.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: chem dispensers no longer require power cells
tweak: Crafted chem cartridges buffed to contain almost twice as many materials
tweak: Craftable chemical cartridges are now refillable via crafting.
tweak: Craftable cartridge no longer requires duct tape, but is overall more expensive to craft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
