### PR TITLE
Runtime fixenings

### DIFF
--- a/code/_onclick/hud/screen_objects/storage.dm
+++ b/code/_onclick/hud/screen_objects/storage.dm
@@ -67,9 +67,13 @@
 	return ..()
 
 /obj/screen/storage/volumetric_box/Click(location, control, params)
+	if(!our_item)
+		return
 	return our_item.Click(location, control, params)
 
 /obj/screen/storage/volumetric_box/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(!our_item)
+		return
 	return our_item.MouseDrop(over, src_location, over_location, src_control, over_control, params)
 
 /obj/screen/storage/volumetric_box/MouseExited(location, control, params)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -441,7 +441,8 @@
 	. = FALSE
 
 	if(QDELETED(src))
-		CRASH("Qdeleted thing being thrown around.")
+		log_qdel("[thrower] attempted to throw [src], but it's being deleted!.")
+		return
 
 	if (!target || speed <= 0)
 		return

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -14,7 +14,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), LIGHT_COLOR_WHITE, 4, 2)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), 4, LIGHT_COLOR_WHITE, 2)
 	flashbang_mobs(flashbang_turf, flashbang_range)
 	qdel(src)
 
@@ -83,7 +83,7 @@
 		return
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 50, TRUE, 8, 0.9)
-	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), LIGHT_COLOR_WHITE, 2, 1)
+	new /obj/effect/dummy/lighting_obj (flashbang_turf, (flashbang_range + 2), 2, LIGHT_COLOR_WHITE, 1)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		pop(get_turf(M), M)
 	qdel(src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -2,7 +2,7 @@
 //the essential proc to call when an obj must receive damage of any kind.
 /obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
-		stack_trace("[src] taking damage after deletion")
+		log_qdel("[src] taking damage after deletion")
 		return
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -413,6 +413,8 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	return TRUE
 
 /atom/proc/hasSiliconAccessInArea(mob/user, flags = PRIVILEDGES_SILICON)
+	if(!istype(user, /mob))
+		return
 	return user.silicon_privileges & (flags) || (user.siliconaccesstoggle && (get_area(src) in user.siliconaccessareas))
 
 /mob/proc/toggleSiliconAccessArea(area/area)


### PR DESCRIPTION
## About The Pull Request
Fix for some runtimes I found while testing for The Mining Bug (tm)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Runtime when non-mob atoms try to open doors
fix: Runtime caused by arguments being given incorrectly by flashbangs/stingbangs.
fix: Qdeleted items no longer runtime when thrown. They'll log to qdel_log instead.
fix: Qdeleted items no longer runtime when somehow taking damage. They'll log to qdel_log instead.
fix: Runtime in volumetric_box objects not having an item associated tot hem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
