### PR TITLE
Moves a pig so it doesn't blow up the north Nash Wall

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -14142,7 +14142,6 @@
 "aWD" = (
 /obj/item/clothing/suit/armor/light/duster/brahmin,
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
-/obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "aWF" = (
@@ -69413,7 +69412,7 @@ cFK
 aGg
 hkV
 xlF
-nAl
+aOk
 hkV
 cFK
 aOk
@@ -70694,8 +70693,8 @@ iXx
 xOD
 ixn
 uKe
-hhC
-oUj
+tRL
+lFu
 oUj
 vRK
 aaQ
@@ -71984,7 +71983,7 @@ hhC
 hhC
 oUj
 aAf
-lFu
+oUj
 avR
 aaQ
 fzM
@@ -73259,7 +73258,7 @@ cFK
 qyV
 cFK
 biO
-aOk
+nAl
 byG
 bdo
 hXV


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/7198283/193650115-e77bed12-036a-4d2f-93b6-1b48437989e0.png)
Also moves a few barrels so the north wall doesn't explode constantly.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Moved a pig and two barrels around from the north Nash Wall
/:cl: