### PR TITLE
Yeets the Constructionlathe from Parhump

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -40614,7 +40614,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building/hospital)
 "lcf" = (
-/obj/machinery/autolathe/constructionlathe,
+/obj/machinery/autolathe,
 /obj/item/stack/sheet/metal/twenty,
 /obj/item/stack/sheet/glass/ten,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -61427,10 +61427,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"vkh" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/f13/wood,
-/area/f13/village)
 "vkl" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -66320,7 +66316,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xGl" = (
-/obj/machinery/autolathe/constructionlathe,
+/obj/machinery/autolathe,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
@@ -103312,7 +103308,7 @@ hEG
 oHM
 vsg
 azh
-vkh
+vNZ
 oJz
 ada
 azh


### PR DESCRIPTION
## About The Pull Request
Don't use /constructionlathe anymore.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Removes /constructionlathe from maps.
/:cl:

