### PR TITLE
Advanced workbenches are no longer wrenchable

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -61,11 +61,22 @@
 	layer = BELOW_OBJ_LAYER
 	anchored = TRUE
 	machine_tool_behaviour = TOOL_WORKBENCH
-	var/wrenchable = 1
+	var/wrenchable = TRUE
 
+/obj/machinery/workbench/examine(mob/user)
+	. = ..()
+	if(anchored)
+		if(wrenchable)
+			. += span_notice("The bolts holding it to the floor look loose enough to be removed with a wrench.")
+		else
+			. += span_notice("It looks to be so securely fastened to the floor that not even a wrench could loosen it.")
+	else if(wrenchable)
+		. += span_notice("It has a set of bolts at the base that could be wrenched to secure it to the floor.")
 
 /obj/machinery/workbench/can_be_unfasten_wrench(mob/user, silent)
 	if (!wrenchable)  // case also covered by NODECONSTRUCT checks in default_unfasten_wrench
+		if(user && !silent)
+			to_chat(user, span_alert("[src] is too securely fastened in place to be moved! Looks like it isn't going anywhere."))
 		return CANT_UNFASTEN
 
 	return ..()
@@ -110,6 +121,7 @@
 	icon_state = "advanced_bench"
 	desc = "A large and advanced pre-war workbench to tackle any project!"
 	machine_tool_behaviour = list(TOOL_AWORKBENCH, TOOL_WORKBENCH)
+	wrenchable = FALSE
 
 /obj/machinery/workbench/mbench
 	name = "machine workbench"

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -127,20 +127,20 @@
 	name = "machine workbench"
 	//icon_state = "advanced_bench"
 	desc = "A machining bench, useful for producing complex machined parts."
-	machine_tool_behaviour = list(TOOL_MWORKBENCH)
+	machine_tool_behaviour = list(TOOL_WORKBENCH, TOOL_MWORKBENCH)
 
 /obj/machinery/workbench/assbench
 	name = "assembly workbench"
 	//icon_state = "advanced_bench"
 	desc = "An assembly bench, useful for assembling complex parts into semi-finished products."
-	machine_tool_behaviour = list(TOOL_ASSWORKBENCH)
+	machine_tool_behaviour = list(TOOL_WORKBENCH, TOOL_ASSWORKBENCH)
 
 /obj/machinery/workbench/fbench
 	var/obj/item/prefabs/mould
 	name = "moulding workbench"
 	icon_state = "moulding"
 	desc = "A moulding bench, used for superheating metal into its molten form and moulding it."
-	machine_tool_behaviour = list(TOOL_FWORKBENCH)
+	machine_tool_behaviour = list(TOOL_WORKBENCH, TOOL_FWORKBENCH)
 	wrenchable = FALSE
 
 /obj/machinery/workbench/bottler
@@ -155,7 +155,7 @@
 	icon = 'icons/fallout/machines/64x32.dmi'
 	icon_state = "bench_metal"
 	bound_width = 64
-	machine_tool_behaviour = list(TOOL_FORGE)
+	machine_tool_behaviour = list(TOOL_WORKBENCH, TOOL_FORGE)
 
 /obj/item/weaponcrafting/receiver
 	name = "modular receiver"


### PR DESCRIPTION
## About The Pull Request

advanced workbenches are super duper stationary.

Also certain other workbench-looking things also function as basic workbenches, like the machine workbench that did nothing.