### PR TITLE
re-adds the bos spawns to redwater. moves the bunker

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -634,6 +634,13 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker)
+"ayk" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Head Knight's Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "ayY" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -995,6 +1002,12 @@
 	icon_state = "redmark"
 	},
 /area/f13/brotherhood/operations)
+"aRB" = (
+/obj/structure/sign/poster/prewar/poster68,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/caves)
 "aSq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
@@ -1016,6 +1029,19 @@
 "aSH" = (
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/rnd)
+"aTm" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5
+	},
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_y = 31
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "aTA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -1250,6 +1276,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"bcK" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "bcQ" = (
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white/bos,
@@ -1301,6 +1331,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"bfx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "bfM" = (
 /turf/closed/wall/f13/wood,
 /area/f13/underground/cave)
@@ -1519,12 +1556,27 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"bpv" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "bpQ" = (
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "bpX" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood/dorms)
+"bqd" = (
+/obj/machinery/light,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "bqf" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -2394,6 +2446,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
+"ceO" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress4";
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "cfl" = (
 /obj/item/paper/crumpled/ruins,
 /obj/structure/table{
@@ -2500,6 +2559,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/enclave)
+"cjk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "cjn" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -2981,6 +3046,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"cGH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "cHc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3007,6 +3079,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/enclave)
+"cHV" = (
+/obj/effect/overlay/junk/oldpipes{
+	dir = 4
+	},
+/obj/effect/overlay/junk/oldpipes,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "cIa" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating/f13/inside,
@@ -3205,6 +3289,16 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"cQj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "cQp" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Science";
@@ -3212,6 +3306,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"cQw" = (
+/obj/item/gun/ballistic/automatic/sportcarbine,
+/obj/item/gun/ballistic/automatic/sportcarbine,
+/obj/item/gun/ballistic/automatic/sportcarbine,
+/obj/structure/shelf_wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "cQy" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -3261,6 +3365,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
+"cSb" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "cTL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3392,6 +3500,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
+"cYI" = (
+/obj/structure/shelf_wood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "cYW" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -3443,6 +3558,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"daP" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "daT" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -3599,6 +3723,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"dgK" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile/store{
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/caves)
 "dhl" = (
 /obj/structure/table{
 	layer = 2.9
@@ -3606,6 +3739,14 @@
 /obj/item/storage/firstaid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"dhu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/frame/machine,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "dhF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3626,6 +3767,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
+"did" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "diI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -4139,6 +4287,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"dDb" = (
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "dDc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -4381,6 +4533,10 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/offices1st)
+"dJK" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "dJM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4445,10 +4601,28 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"dLj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/obj/structure/grille/broken,
+/obj/item/seeds/grass{
+	desc = "You should probably grow this and touch some grass for once."
+	},
+/obj/structure/wreck/trash/secway,
+/obj/structure/glowshroom,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "dLp" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault)
+"dLC" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "dLJ" = (
 /obj/effect/decal/remains/robot,
 /turf/open/floor/plating/tunnel{
@@ -4658,6 +4832,10 @@
 /obj/structure/rack,
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"dSt" = (
+/obj/machinery/msgterminal/brotherhood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "dSW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/decoration/fire,
@@ -4874,6 +5052,10 @@
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"ebH" = (
+/obj/machinery/workbench/forge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "ebU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -5623,6 +5805,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"eCp" = (
+/obj/structure/grille,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/caves)
 "eCx" = (
 /obj/structure/vaultdoor{
 	name = "vault 113 door";
@@ -6266,6 +6454,12 @@
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"fiN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "fjn" = (
 /obj/structure/lattice{
 	density = 1
@@ -7034,6 +7228,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"fLC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "fLG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "No Mans Land";
@@ -7962,6 +8170,17 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"gwo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/remains/robot,
+/obj/effect/overlay/junk/oldpipes/end,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "gxg" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/structure/stone_tile/center,
@@ -8175,6 +8394,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault)
+"gFD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/autolathe/ammo,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "gGg" = (
 /obj/structure/closet,
 /obj/item/storage/box/gloves,
@@ -8401,6 +8630,32 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
+"gPJ" = (
+/obj/machinery/computer/terminal{
+	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
+	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself and your brothers. Those who cast us out are not our true brothers, and may be regarded with the dignity of lesser men.";
+	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> So has the Elder rejected the rule of our foolish old family who outcasted us, so shall you.";
+	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it benefits the brotherhood. ";
+	doc_content_4 = "Theft from other brothers is for lesser men. Theft from lesser men shall go to your brothers. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
+	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text. <br> <br> Those who desperately cling to the flawed ideals of the brotherhood that outcasted us may not walk among us until they have renounced their false ideals!";
+	doc_title_1 = "Doctrine pt. 1";
+	doc_title_2 = "Doctrine pt. 2";
+	doc_title_3 = "Doctrine pt. 3";
+	doc_title_4 = "Doctrine pt. 4";
+	doc_title_5 = "Doctrine pt. 5";
+	icon_screen = null;
+	icon_state = "ratvarcomputer1";
+	idle_power_usage = 1;
+	light_color = "#6e1722";
+	light_power = 2;
+	light_range = 3;
+	max_integrity = 1000;
+	name = "The Codex";
+	note = "Scribe Note of the Week:";
+	termtag = "Codex"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "gPL" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -8647,6 +8902,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"gYO" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "gZn" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -8984,6 +9243,16 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker)
+"hlD" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"hlU" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "hnJ" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/enclave/officer,
@@ -9076,6 +9345,9 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"hqd" = (
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "hqv" = (
 /obj/effect/decal/cleanable/ash/large,
 /obj/effect/decal/cleanable/ash/crematorium,
@@ -9216,6 +9488,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"hwb" = (
+/obj/effect/overlay/junk{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "hwn" = (
 /obj/structure/sign/poster/official/safety_report,
 /turf/closed/wall/r_wall,
@@ -9595,6 +9873,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"hPQ" = (
+/obj/item/twohanded/sledgehammer/simple,
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "hPR" = (
 /obj/structure/sink{
 	dir = 8
@@ -9674,6 +9956,10 @@
 /obj/structure/sign/poster/prewar/poster71,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/dorms)
+"hSe" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "hSv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/paladin,
@@ -9724,6 +10010,12 @@
 /obj/item/wirerod,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"hVs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "hWe" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -9760,6 +10052,18 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault)
+"hXH" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "hYl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -9809,6 +10113,16 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"hZH" = (
+/obj/structure/ladder/unbreakable{
+	height = 1;
+	id = "cardboardbunker"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "iau" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -9867,6 +10181,13 @@
 /obj/effect/landmark/start/f13/vaultdoctor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/vault)
+"ieA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "ieF" = (
 /obj/machinery/shower{
 	dir = 8
@@ -10046,6 +10367,21 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
+"imX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
+	max_integrity = 10000;
+	name = "bunker entry";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "ini" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/neck/apron/chef,
@@ -10061,6 +10397,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"inM" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "inT" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -10506,6 +10846,21 @@
 	icon_state = "grass2"
 	},
 /area/f13/bunker)
+"iJR" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 12
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "iJT" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/nest/tunneler,
@@ -10615,6 +10970,12 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
+"iNY" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/caves)
 "iOY" = (
 /obj/item/flag/bos,
 /turf/open/floor/carpet/black,
@@ -10822,6 +11183,21 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
+"iZu" = (
+/obj/effect/overlay/junk/toilet{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
+"iZU" = (
+/obj/machinery/light/floor,
+/obj/structure/decoration/smokeold{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "jaa" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -11078,6 +11454,14 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"jiX" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "jjv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -11241,6 +11625,19 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/bunker)
+"jpe" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "jpj" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -11439,6 +11836,15 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/bunker)
+"jzU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "jBt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
@@ -11538,6 +11944,13 @@
 	dir = 1
 	},
 /area/f13/vault)
+"jFJ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/decoration/vent/rusty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "jGS" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -11578,6 +11991,16 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"jHJ" = (
+/obj/structure/kitchenspike_frame{
+	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
+	name = "Power Armor Frame"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "jIi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12123,6 +12546,13 @@
 	dir = 6
 	},
 /area/f13/brotherhood/mining)
+"kkr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "kkB" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/green,
@@ -13096,6 +13526,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
+"kUM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "kVx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13342,6 +13776,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
+"leT" = (
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Knight's PipBoy"
+	},
+/obj/structure/table/wood/junk,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "lfD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -14833,6 +15277,15 @@
 /obj/item/clothing/suit/armor/medium/vest/capcarapace/alt,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"muS" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "mvo" = (
 /obj/structure/sink{
 	dir = 8;
@@ -15117,6 +15570,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/underground/cave)
+"mDl" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "mDs" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
@@ -15139,6 +15599,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/enclave)
+"mEp" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "mEz" = (
 /obj/structure/sign/directions/cells{
 	dir = 1
@@ -15657,6 +16122,15 @@
 	icon_state = "r_wall"
 	},
 /area/f13/caves)
+"nab" = (
+/obj/effect/overlay/junk/oldpipes,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "nan" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -15883,6 +16357,14 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/rnd)
+"niM" = (
+/obj/structure/table/wood/junk,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "njw" = (
 /obj/structure/rack{
 	dir = 8;
@@ -16140,6 +16622,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/offices2nd)
+"nvj" = (
+/obj/structure/glowshroom,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "nwu" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/underground/cave)
@@ -16238,6 +16724,15 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/brotherhood/leisure)
+"nBj" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowtop"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/caves)
 "nBk" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -16520,6 +17015,14 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"nOe" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "nOl" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/inside/dirt,
@@ -16595,6 +17098,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/vault)
+"nRr" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "nRI" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -17049,6 +17556,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"oiZ" = (
+/obj/structure/decoration/vent,
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "ojM" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/f13{
@@ -18462,6 +18973,10 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/underground/cave)
+"pkt" = (
+/obj/structure/glowshroom/single,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "pkv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18726,6 +19241,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"prj" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "prq" = (
 /obj/item/detective_scanner,
 /obj/structure/closet,
@@ -19583,10 +20108,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/brotherhood/leisure)
+"qez" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "qfg" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault)
+"qfj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "qfr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19833,6 +20374,24 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qmz" = (
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/storage/belt/army,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/under/f13/recon/outcast,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
+"qmB" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "qmN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -20252,6 +20811,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/vault)
+"qCB" = (
+/obj/machinery/door/airlock/maintenance/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "qCH" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -20458,6 +21021,13 @@
 	name = "vault floor"
 	},
 /area/f13/enclave)
+"qKq" = (
+/obj/structure/table/wood/junk,
+/obj/structure/decoration/smokeold{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "qKw" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
@@ -20909,6 +21479,20 @@
 "rck" = (
 /turf/open/space/basic,
 /area/f13/underground/cave)
+"rcu" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/computer/terminal{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "rcx" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "proctorbathroom";
@@ -20950,6 +21534,13 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"rdt" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 33
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "rdB" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -21228,6 +21819,19 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/offices1st)
+"roI" = (
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = -6;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"rpx" = (
+/obj/structure/decoration/cctv,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/caves)
 "rpZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/candle/tribal_torch,
@@ -21407,6 +22011,20 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/vault)
+"rzz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "rzD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21457,6 +22075,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
+"rAX" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "rBQ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -21875,6 +22503,17 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/enclave)
+"rTE" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 33
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "rUl" = (
 /obj/machinery/computer/upload/ai{
 	dir = 8
@@ -22102,6 +22741,12 @@
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/bunker)
+"shf" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/caves)
 "shy" = (
 /obj/machinery/light/broken,
 /turf/open/floor/f13{
@@ -22791,6 +23436,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"sEP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "sFa" = (
 /obj/machinery/light{
 	dir = 8;
@@ -22894,10 +23545,32 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/stairs,
 /area/f13/brotherhood/operating)
+"sKj" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"sKl" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/chem_pile,
+/obj/structure/glowshroom,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "sKU" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault)
+"sLi" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "sLj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Chemical Lab";
@@ -22944,6 +23617,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/f13/enclave)
+"sMR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/decoration/hatch{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "sMT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/iv_drip,
@@ -22979,6 +23661,11 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/leisure)
+"sOW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "sOZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -23095,6 +23782,11 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/bunker)
+"sUE" = (
+/turf/closed/indestructible/f13vaultrusted{
+	name = "rusty reinforced wall"
+	},
+/area/f13/caves)
 "sUR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23244,6 +23936,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/enclave)
+"taD" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1";
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "taT" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/f13{
@@ -23821,6 +24523,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"tzZ" = (
+/obj/structure/grille,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "tCz" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex/nitrile{
@@ -23942,6 +24649,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/vault)
+"tGN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/computer,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "tGX" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -23962,6 +24676,16 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/rnd)
+"tHR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/autolathe,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "tHW" = (
 /obj/machinery/light{
 	dir = 1
@@ -24076,6 +24800,10 @@
 /obj/structure/flora/grass/coyote/five,
 /turf/open/floor/plasteel/cult,
 /area/f13/underground/cave)
+"tLc" = (
+/obj/item/stack/rods/ten,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "tLA" = (
 /obj/machinery/plantgenes,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -24163,6 +24891,19 @@
 	icon_state = "darkyellowfull"
 	},
 /area/f13/brotherhood/rnd)
+"tRi" = (
+/obj/item/clothing/head/bomb_hood/security,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
+/obj/item/clothing/under/f13/recon/outcast,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "tRA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/f13/instamash,
@@ -24371,6 +25112,15 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/leisure)
+"uaO" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "uaR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -25425,6 +26175,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/offices1st)
+"uMq" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/caves)
 "uMV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -25680,6 +26436,12 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/operations)
+"uWa" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "uWw" = (
 /obj/machinery/light/floor,
 /obj/structure/lattice{
@@ -25773,6 +26535,12 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/vault)
+"vbL" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/caves)
 "vbX" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
@@ -26737,6 +27505,17 @@
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/cult,
 /area/f13/underground/cave)
+"vOO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#d9cdb9";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/caves)
 "vOS" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -27058,6 +27837,17 @@
 "wdV" = (
 /turf/open/floor/carpet/black,
 /area/f13/enclave)
+"weO" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/caves)
 "weW" = (
 /obj/structure/statue_fal{
 	color = "#3e3e3e";
@@ -27090,6 +27880,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"wfM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "wgF" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -27924,6 +28721,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"wUc" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "wUU" = (
 /obj/structure/table{
 	layer = 2.9
@@ -28323,6 +29125,13 @@
 	icon_state = "casino"
 	},
 /area/f13/brotherhood/offices2nd)
+"xlL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "xlW" = (
 /obj/structure/table{
 	layer = 2.9
@@ -28396,6 +29205,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/vault)
+"xov" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/caves)
 "xoy" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -28782,6 +29596,10 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/f13/wood,
 /area/f13/vault)
+"xFj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "xFw" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -29289,6 +30107,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/tunnel,
 /area/f13/brotherhood/operations)
+"yeA" = (
+/obj/machinery/light/small{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "yeL" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -84974,37 +85798,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -85231,37 +86055,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -85488,37 +86312,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+hrZ
+jFJ
+sUE
+sUE
+hrZ
+hrZ
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -85745,37 +86569,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+wUc
+sKj
+sKj
+sUE
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -86002,37 +86826,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+leT
+dDb
+yeA
+sUE
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
+hrZ
 shC
 shC
 shC
@@ -86259,37 +87083,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+sUE
+sUE
+sUE
+oiZ
+hqd
+sUE
+sUE
+sUE
+ayk
+sUE
+hqd
+sUE
+hqd
+aRB
+sUE
+hqd
+sUE
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+iba
+hrZ
 shC
 shC
 shC
@@ -86516,37 +87340,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+bcK
+cSb
+nRr
+inM
+ieA
+bcK
+hqd
+gPJ
+sKj
+niM
+sUE
+hlD
+rAX
+cjk
+wfM
+rAX
+tHR
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+iba
 shC
 shC
 shC
@@ -86773,37 +87597,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+hqd
+iZU
+sKj
+cjk
+sKj
+hSe
+dJK
+hqd
+dSt
+hSe
+qKq
+hqd
+ebH
+cjk
+wfM
+did
+jiX
+gFD
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -87030,37 +87854,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+hqd
+hqd
+sUE
+sUE
+hqd
+hqd
+bcK
+bcK
+cjk
+sKj
+sKj
+bcK
+hqd
+hSe
+sKj
+jiX
+hqd
+sKj
+weO
+kUM
+cjk
+sKj
+bqd
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -87287,37 +88111,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+hqd
+hZH
+cjk
+sKj
+pkt
+hqd
+hqd
+sUE
+hqd
+gYO
+hqd
+hqd
+hqd
+sUE
+qCB
+hqd
+sUE
+muS
+qez
+qez
+tLc
+cjk
+sKj
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -87544,37 +88368,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+sUE
+bpv
+sKj
+bpv
+bpv
+dgK
+prj
+sKj
+sOW
+sKj
+vbL
+sUE
+jzU
+jzU
+sKj
+shf
+sUE
+sUE
+sUE
+jiX
+jiX
+sUE
+jzU
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -87801,37 +88625,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+hqd
+bpv
+bpv
+uaO
+uaO
+imX
+cjk
+cjk
+cjk
+sKj
+sKj
+qCB
+jzU
+xFj
+sEP
+sKj
+sUE
+cHV
+nab
+sUE
+fiN
+qfj
+hrZ
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -88058,37 +88882,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+sUE
+bpv
+sKj
+rcu
+iJR
+eCp
+xlL
+rdt
+cjk
+sMR
+vbL
+hrZ
+hrZ
+xFj
+sKj
+xFj
+xFj
+rTE
+fiN
+sKj
+sKj
+hVs
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC
@@ -88315,37 +89139,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+sUE
+qmB
+cjk
+kkr
+cjk
+hqd
+shf
+iNY
+tzZ
+sUE
+hrZ
+hrZ
+hqd
+nBj
+gYO
+nBj
+nBj
+hPQ
+hqd
+hqd
+uMq
+hqd
+hqd
+hqd
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+vUU
 shC
 shC
 shC
@@ -88572,37 +89396,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+hqd
+sUE
+rpx
+eCp
+eCp
+hqd
+sUE
+sKl
+dhu
+gwo
+hrZ
+sUE
+sUE
+uWa
+uWa
+cQj
+bfx
+qmz
+hqd
+mEp
+xov
+mEp
+dLC
+rzz
+hqd
+sUE
+shf
+sUE
+hrZ
+vUU
 shC
 shC
 shC
@@ -88829,37 +89653,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+tGN
+cGH
+dLj
+sUE
+sUE
+jpe
+uWa
+bfx
+vOO
+uWa
+tRi
+hqd
+dLC
+fiN
+dLC
+cjk
+cjk
+gYO
+nOe
+hlU
+sUE
+hrZ
+vUU
 shC
 shC
 shC
@@ -89086,37 +89910,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+vUU
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+sUE
+sUE
+sUE
+sUE
+sUE
+hXH
+bfx
+uWa
+uWa
+sLi
+jHJ
+hqd
+hwb
+nvj
+mDl
+roI
+cjk
+hqd
+fLC
+iZu
+sUE
+hrZ
+vUU
 shC
 shC
 shC
@@ -89343,37 +90167,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+sUE
+cQw
+cYI
+cYI
+cYI
+hqd
+hqd
+aTm
+sKj
+daP
+taD
+ceO
+hqd
+sUE
+sUE
+sUE
+hrZ
+vUU
 shC
 shC
 shC
@@ -89600,37 +90424,37 @@ shC
 shC
 shC
 shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
-shC
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
+sUE
+sUE
+sUE
+sUE
+sUE
+hqd
+hqd
+hqd
+hqd
+hqd
+hqd
+hqd
+hrZ
+hrZ
+hrZ
+hrZ
+hrZ
 shC
 shC
 shC

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -696,15 +696,6 @@
 "avo" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/village)
-"avt" = (
-/obj/effect/overlay/junk/oldpipes,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "avE" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/effect/decal/cleanable/dirt,
@@ -742,11 +733,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
-"axh" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "axt" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
@@ -857,12 +843,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"aBk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "aBs" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/reagent_containers/spray/pepper,
@@ -950,16 +930,6 @@
 "aEo" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
-"aEu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe/ammo,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "aEv" = (
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/village/overpass_lower)
@@ -1400,15 +1370,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
-"aQE" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/caves)
 "aRr" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/decal/cleanable/dirt,
@@ -1517,16 +1478,16 @@
 "aTh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/effect/overlay/junk/sink{
-	pixel_y = 23;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 23
 	},
 /obj/effect/overlay/junk/mirror{
-	pixel_y = 32;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 32
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -2097,6 +2058,7 @@
 	dir = 1;
 	pixel_y = 8
 	},
+/obj/effect/landmark/start/f13/initiate,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "biN" = (
@@ -2620,13 +2582,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"buh" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "bui" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -2958,12 +2913,6 @@
 /obj/effect/landmark/start/f13/villager,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"bBY" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "bCj" = (
 /obj/structure/table/booth{
 	color = "#C59B9B"
@@ -3135,15 +3084,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bFx" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "bFB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/repaired,
@@ -3175,12 +3115,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"bGA" = (
-/obj/structure/grille,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/caves)
 "bGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -3203,10 +3137,6 @@
 	name = "stagnant water"
 	},
 /area/f13/building)
-"bHc" = (
-/obj/effect/landmark/start/f13/knightcap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "bHQ" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
@@ -4132,8 +4062,8 @@
 "cdZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink{
@@ -4190,17 +4120,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"ceE" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "ceH" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/wood_common,
@@ -4647,8 +4566,8 @@
 /area/f13/caves)
 "coQ" = (
 /obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -30;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -30
 	},
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland)
@@ -4721,13 +4640,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
-"cqw" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "cqy" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -4929,15 +4841,6 @@
 /obj/structure/flora/grass/coyote/nine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"cvd" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/caves)
 "cvv" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -5126,20 +5029,11 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
-"czb" = (
-/obj/structure/glowshroom/single,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "czE" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"czJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "cAl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6268,10 +6162,6 @@
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"dcy" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "dcK" = (
 /obj/structure/bed/wooden,
 /obj/effect/decal/cleanable/dirt{
@@ -6852,13 +6742,6 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
-"dsc" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "dsd" = (
 /obj/structure/fence{
 	dir = 8
@@ -7906,15 +7789,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
-"dVz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "dVR" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -9219,8 +9093,8 @@
 	pixel_y = 8
 	},
 /obj/item/flag/bos{
-	pixel_y = 14;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 14
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
@@ -9291,10 +9165,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"eEG" = (
-/obj/item/twohanded/sledgehammer/simple,
-/turf/closed/wall/r_wall,
-/area/f13/caves)
 "eEM" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13{
@@ -9466,15 +9336,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/village/overpass_lower)
-"eJn" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "eJq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10366,12 +10227,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"fcG" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
-	},
-/area/f13/caves)
 "fcZ" = (
 /obj/structure/stone_tile/block{
 	dir = 8;
@@ -11079,8 +10934,8 @@
 "fvn" = (
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
@@ -11274,32 +11129,6 @@
 	icon_state = "crossborderroundmid"
 	},
 /area/f13/wasteland)
-"fBQ" = (
-/obj/machinery/computer/terminal{
-	desc = "A pre-war high security terminal. There's virtually no way to hack into this thing; it holds the most secure information the Brotherhood has to offer.";
-	doc_content_1 = "The preservation of technology is our primary goal, all others are secondary. <br> <br>  Shield yourself from those not bound to you by steel, for they are the blind. Aid them when you can, but lose not sight of yourself and your brothers. Those who cast us out are not our true brothers, and may be regarded with the dignity of lesser men.";
-	doc_content_2 = "Give way your suspicions to the wisdom of thine Elder. Where he shows trust, so shall you. <br> <br> So has the Elder rejected the rule of our foolish old family who outcasted us, so shall you.";
-	doc_content_3 = "Through discourse, we gain the strength of our Brothers' minds. Deceit and lies of all ilk serve only to harm that strength. <br> <br> Your caste and duties mean everything, you will follow your leader and your leader will lead you. <br> <br> You may only follow the orders of another if it benefits the brotherhood. ";
-	doc_content_4 = "Theft from other brothers is for lesser men. Theft from lesser men shall go to your brothers. <br> <br>  What lesser men see as fashionable shall be shunned. Foreign garment and practice will do nothing but shame your fellow brothers.  ";
-	doc_content_5 = "The Blind can not read, only those who have taken the Oath of Fraternity may read this text. <br> <br> Those who desperately cling to the flawed ideals of the brotherhood that outcasted us may not walk among us until they have renounced their false ideals!";
-	doc_title_1 = "Doctrine pt. 1";
-	doc_title_2 = "Doctrine pt. 2";
-	doc_title_3 = "Doctrine pt. 3";
-	doc_title_4 = "Doctrine pt. 4";
-	doc_title_5 = "Doctrine pt. 5";
-	icon_screen = null;
-	icon_state = "ratvarcomputer1";
-	idle_power_usage = 1;
-	light_color = "#6e1722";
-	light_power = 2;
-	light_range = 3;
-	max_integrity = 1000;
-	name = "The Codex";
-	note = "Scribe Note of the Week:";
-	termtag = "Codex"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "fCa" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -11820,14 +11649,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/wasteland)
-"fPt" = (
-/obj/structure/table/wood/junk,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "fPH" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -12257,8 +12078,8 @@
 	pixel_y = 2
 	},
 /obj/structure/junk/small/bed2{
-	pixel_y = 1;
-	layer = 1
+	layer = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -12356,20 +12177,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"gei" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/computer,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
-"gem" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "geA" = (
 /obj/structure/flora/twig2,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12513,21 +12320,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"gis" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 12
-	},
-/obj/structure/grille/broken,
-/obj/item/seeds/grass{
-	desc = "You should probably grow this and touch some grass for once."
-	},
-/obj/structure/wreck/trash/secway,
-/obj/structure/glowshroom,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "giv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -13630,21 +13422,6 @@
 	icon_state = "bar"
 	},
 /area/f13/village)
-"gLX" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 12
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "gMB" = (
 /obj/structure/reagent_dispensers/fueltank{
 	anchored = 1;
@@ -14480,17 +14257,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"hii" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "hir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -14604,16 +14370,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"hkh" = (
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Knight's PipBoy"
-	},
-/obj/structure/table/wood/junk,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "hkO" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -15629,9 +15385,9 @@
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
 	dir = 4;
+	icon_state = "tube-burned";
 	light_color = "#BC8F8F";
-	name = "bar light";
-	icon_state = "tube-burned"
+	name = "bar light"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -16545,10 +16301,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
-"ieH" = (
-/obj/item/stack/rods/ten,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "ieN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16922,15 +16674,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ipG" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/decoration/hatch{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "ipO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17188,12 +16931,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"iwK" = (
-/obj/structure/decoration/cctv,
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
-	},
-/area/f13/caves)
 "iwW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/booth,
@@ -17470,8 +17207,8 @@
 	icon_state = "mattress5"
 	},
 /obj/structure/junk/small/bed2{
-	pixel_y = 1;
-	layer = 1
+	layer = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -18440,12 +18177,6 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
-"iVK" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "iVP" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt,
@@ -18609,13 +18340,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"iZj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "iZC" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile,
@@ -19073,9 +18797,9 @@
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
 	dir = 4;
+	icon_state = "tube-burned";
 	light_color = "#BC8F8F";
-	name = "bar light";
-	icon_state = "tube-burned"
+	name = "bar light"
 	},
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19527,12 +19251,6 @@
 /obj/item/trash/f13/yumyum,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"jur" = (
-/obj/effect/overlay/junk{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "jvr" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -19578,9 +19296,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"jwr" = (
-/turf/closed/wall/r_wall,
-/area/f13/caves)
 "jws" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -19708,12 +19423,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building)
-"jAY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "jBb" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -19758,8 +19467,8 @@
 "jCc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/structure/sink{
 	pixel_x = -7;
@@ -19780,12 +19489,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"jCs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "jCw" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19821,12 +19524,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"jDx" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "jDI" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -20581,10 +20278,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
-"jYS" = (
-/obj/machinery/door/airlock/maintenance/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "jYT" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -21260,10 +20953,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"ksp" = (
-/obj/structure/glowshroom,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "ksH" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -10;
@@ -21418,10 +21107,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/wasteland)
-"kwq" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "kwK" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -21501,6 +21186,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/redwaterwatcher,
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "kBf" = (
@@ -21803,8 +21489,8 @@
 	},
 /obj/structure/bed/old,
 /obj/item/blanket{
-	pixel_y = 15;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 15
 	},
 /obj/item/blanket{
 	pixel_x = 8
@@ -21837,13 +21523,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
-"kLj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "kLr" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21960,18 +21639,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"kNu" = (
-/obj/effect/overlay/junk/oldpipes{
-	dir = 4
-	},
-/obj/effect/overlay/junk/oldpipes,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "kNv" = (
 /obj/structure/decoration/clock/old/active{
 	pixel_y = 28
@@ -23185,16 +22852,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/building)
-"lqV" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "lrz" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -23680,10 +23337,10 @@
 	color = "#3c2c21"
 	},
 /obj/item/reagent_containers/food/drinks/bottle/brown/lightbrown{
-	name = "Tribal Urn";
+	color = "#816A5E";
 	desc = "A homemade and hand-crafted brown ceramic urn, used to hold the ashes of a loved one.";
-	pixel_y = 10;
-	color = "#816A5E"
+	name = "Tribal Urn";
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
@@ -25859,12 +25516,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"mIV" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "mIW" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26245,10 +25896,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mSK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "mSS" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#d9b51c"
@@ -26296,14 +25943,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"mUP" = (
-/obj/effect/overlay/junk/toilet{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "mVn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -26617,8 +26256,8 @@
 "ngc" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -30;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -30
 	},
 /obj/structure/flora/tree/jungle/small{
 	color = "#d9b51c";
@@ -26801,20 +26440,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
-"nlg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "nln" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13{
@@ -27417,11 +27042,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"nAW" = (
-/obj/structure/grille,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "nBo" = (
 /obj/machinery/light/broken,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -27546,13 +27166,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"nEI" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 33
-	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "nEP" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -28140,8 +27753,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish2{
 	icon_state = "car_rubish3";
-	pixel_y = -20;
-	pixel_x = 14
+	pixel_x = 14;
+	pixel_y = -20
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
@@ -28392,18 +28005,6 @@
 /obj/structure/destructible/tribal_torch/wall,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"oaf" = (
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/storage/belt/army,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/f13/recon/outcast,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "oas" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -28698,19 +28299,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"ohc" = (
-/obj/item/clothing/head/bomb_hood/security,
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/obj/effect/spawner/lootdrop/f13/armor/tier2,
-/obj/item/clothing/under/f13/recon/outcast,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "ohf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -29068,14 +28656,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"otF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "otM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2left"
@@ -29508,8 +29088,8 @@
 	},
 /obj/structure/bed/old,
 /obj/item/blanket{
-	pixel_y = 15;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 15
 	},
 /obj/item/blanket{
 	pixel_x = 8
@@ -30098,15 +29678,6 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
-"oQa" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "oQk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -30188,8 +29759,8 @@
 /obj/effect/decal/cleanable/cum,
 /obj/structure/table/wood/club,
 /obj/item/reagent_containers/rag{
-	name = "cum rag";
-	desc = "Why is it sticky?"
+	desc = "Why is it sticky?";
+	name = "cum rag"
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
@@ -30262,6 +29833,7 @@
 /area/f13/wasteland)
 "oVE" = (
 /obj/effect/landmark/start/redwateresident,
+/obj/effect/landmark/start/f13/initiate,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "oVH" = (
@@ -31176,10 +30748,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/village)
-"puk" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "put" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -31639,10 +31207,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"pIC" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "pIP" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt{
@@ -31799,10 +31363,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"pMt" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "pMu" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/burger/chicken,
@@ -32141,11 +31701,6 @@
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/caves)
-"pYi" = (
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "pYs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -32253,8 +31808,8 @@
 /obj/effect/decal/cleanable/chem_pile,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -32543,12 +32098,6 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
-"qiT" = (
-/obj/structure/decoration/vent/rusty,
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
-	},
-/area/f13/caves)
 "qiW" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -32623,12 +32172,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qkD" = (
-/obj/machinery/light/small{
-	pixel_x = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "qkL" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33317,10 +32860,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
-"qDY" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "qEe" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -33455,9 +32994,9 @@
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
 	dir = 4;
+	icon_state = "tube-burned";
 	light_color = "#BC8F8F";
-	name = "bar light";
-	icon_state = "tube-burned"
+	name = "bar light"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/freezer/blood{
@@ -33488,9 +33027,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qHY" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "qIh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -33786,16 +33322,6 @@
 /obj/structure/flora/twig3,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qOe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "qOg" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/outside/gravel{
@@ -34244,12 +33770,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
-"qYV" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
 "qZa" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -34303,15 +33823,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/wasteland)
-"raq" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "raA" = (
 /obj/structure/junk/drawer,
 /obj/effect/decal/cleanable/dirt,
@@ -34584,10 +34095,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"rhw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "rhz" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -34812,8 +34319,8 @@
 /area/f13/wasteland)
 "rms" = (
 /obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -30;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -35027,12 +34534,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"rqs" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/caves)
 "rqJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -35043,13 +34544,6 @@
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"rqS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "rra" = (
 /obj/structure/campfire/barrel{
 	pixel_x = 15;
@@ -35148,12 +34642,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"rtc" = (
-/obj/structure/sign/poster/prewar/poster68,
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
-	},
-/area/f13/caves)
 "rtl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -35770,20 +35258,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
-"rIN" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/computer/terminal{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "rIX" = (
 /obj/structure/reagent_dispensers/compostbin,
 /obj/effect/decal/cleanable/dirt,
@@ -36098,16 +35572,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"rRD" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1";
-	pixel_y = -4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "rRY" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -36221,19 +35685,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"rUf" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "rUC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -37212,8 +36663,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -37502,20 +36953,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/building)
-"sAS" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"sAV" = (
-/obj/item/gun/ballistic/automatic/sportcarbine,
-/obj/item/gun/ballistic/automatic/sportcarbine,
-/obj/item/gun/ballistic/automatic/sportcarbine,
-/obj/structure/shelf_wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "sAX" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -37768,11 +37205,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sGN" = (
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
-	},
-/area/f13/caves)
 "sHo" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt,
@@ -38019,8 +37451,8 @@
 	pixel_y = 5
 	},
 /obj/structure/junk/small/bed2{
-	pixel_y = 4;
-	layer = 1
+	layer = 1;
+	pixel_y = 4
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -38108,14 +37540,6 @@
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"sQq" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "sRf" = (
 /obj/item/reagent_containers/glass/beaker/waterbottle/empty,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -38287,8 +37711,8 @@
 	pixel_y = 5
 	},
 /obj/structure/junk/small/bed2{
-	pixel_y = 4;
-	layer = 1
+	layer = 1;
+	pixel_y = 4
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -38358,16 +37782,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"sZZ" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "cardboardbunker"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tab" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/table/reinforced{
@@ -38844,8 +38258,8 @@
 	color = "#9c9c9c";
 	mutmod = 0;
 	name = "ancient fertile soil";
-	yieldmod = 1.3;
-	pixel_y = 10
+	pixel_y = 10;
+	yieldmod = 1.3
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
@@ -39001,10 +38415,6 @@
 /obj/structure/girder/displaced,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tqQ" = (
-/obj/machinery/msgterminal/brotherhood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tqW" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -39127,8 +38537,8 @@
 	name = "bar light"
 	},
 /obj/structure/ladder/unbreakable{
-	id = "mango";
-	height = 1
+	height = 1;
+	id = "mango"
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
@@ -39773,20 +39183,6 @@
 "tIN" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
-"tJg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tJh" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -39940,18 +39336,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village/tunnel_diner)
-"tOB" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/mfc,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "tOQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -39987,10 +39371,6 @@
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"tQL" = (
-/obj/machinery/workbench/forge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tQO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -40012,13 +39392,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tQV" = (
-/obj/structure/shelf_wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "tQZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40063,13 +39436,6 @@
 	name = "stagnant water"
 	},
 /area/f13/building)
-"tTs" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4";
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tTv" = (
 /obj/structure/chair/folding{
 	dir = 4
@@ -40168,13 +39534,6 @@
 /obj/item/stack/sheet/mineral/wood/twenty,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"tWx" = (
-/obj/machinery/light/floor,
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "tWE" = (
 /obj/structure/campfire/stove{
 	pixel_y = 10
@@ -40581,17 +39940,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"ueG" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 33
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "ueP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -40617,8 +39965,8 @@
 	pixel_y = 9
 	},
 /obj/item/lighter{
-	pixel_y = -4;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = -4
 	},
 /obj/item/melee/onehanded/knife/cosmicdirty{
 	pixel_x = 7
@@ -40675,21 +40023,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"ugG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
 "ugO" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/rock/pile/largejungle{
@@ -41609,16 +40942,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"uFl" = (
-/obj/structure/kitchenspike_frame{
-	desc = "A robust, thick metal frame used to hold power armor upright during maintenance.";
-	name = "Power Armor Frame"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "uFu" = (
 /obj/structure/sink/well{
 	pixel_y = -5
@@ -41659,13 +40982,6 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/village)
-"uGO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "uGZ" = (
 /obj/structure/fence{
 	dir = 8
@@ -41840,17 +41156,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
-"uMr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs{
-	icon_state = "gibup1"
-	},
-/obj/effect/decal/remains/robot,
-/obj/effect/overlay/junk/oldpipes/end,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
-	},
-/area/f13/caves)
 "uMH" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_y = 10
@@ -41994,19 +41299,19 @@
 	color = "#363636"
 	},
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/effect/overlay/junk/sink{
-	pixel_y = 23;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
 	dir = 8;
-	pixel_y = 28;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 28
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -42291,8 +41596,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -43085,14 +42390,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vrM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/structure/frame/machine,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "vsj" = (
 /obj/structure/stone_tile/slab,
 /turf/open/indestructible/ground/outside/gravel{
@@ -43343,19 +42640,6 @@
 /obj/structure/fence,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"vyj" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 5
-	},
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 31
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "vyD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/cabinet/anchored{
@@ -43434,13 +42718,6 @@
 /obj/structure/butter_churn,
 /turf/open/floor/wood_common,
 /area/f13/village)
-"vzj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#d9cdb9";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/caves)
 "vzl" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/reinforced,
@@ -43660,10 +42937,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"vFe" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/r_wall,
-/area/f13/caves)
 "vFj" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43989,8 +43262,8 @@
 /obj/effect/decal/cleanable/flour,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -44022,9 +43295,9 @@
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
 	dir = 4;
+	icon_state = "tube-burned";
 	light_color = "#BC8F8F";
-	name = "bar light";
-	icon_state = "tube-burned"
+	name = "bar light"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -44432,13 +43705,6 @@
 /obj/structure/flora/grass/wasteland,
 /turf/closed/wall/f13/ruins,
 /area/f13/village/overpass_lower)
-"vZX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "wao" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44666,9 +43932,9 @@
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
 	dir = 4;
+	icon_state = "tube-burned";
 	light_color = "#BC8F8F";
-	name = "bar light";
-	icon_state = "tube-burned"
+	name = "bar light"
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -44701,15 +43967,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"wgv" = (
-/obj/machinery/light,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "wgw" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
@@ -44804,12 +44061,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wjS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "wkj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
@@ -44867,13 +44118,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
-"wlf" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Knight's Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "wlg" = (
 /obj/structure/junk/arcade,
 /turf/open/indestructible/ground/outside/dirt,
@@ -45201,18 +44445,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
-"wuj" = (
-/obj/structure/table/wood/junk,
-/obj/structure/decoration/smokeold{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"wus" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "wuz" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building)
@@ -45293,12 +44525,12 @@
 	color = "#363636"
 	},
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/effect/overlay/junk/sink{
-	pixel_y = 23;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
@@ -45784,16 +45016,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"wFR" = (
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "wGb" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -46557,13 +45779,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/village)
-"xbG" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "xbR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -46805,8 +46020,8 @@
 	},
 /obj/structure/mirror{
 	dir = 8;
-	pixel_y = 23;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 23
 	},
 /turf/open/floor/wood_common,
 /area/f13/village)
@@ -46841,16 +46056,6 @@
 /obj/effect/landmark/start/f13/villager,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"xjt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe,
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess2"
-	},
-/area/f13/caves)
 "xjx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -47160,20 +46365,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"xrw" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/chem_pile,
-/obj/structure/glowshroom,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelrusty"
-	},
-/area/f13/caves)
-"xrx" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "xrP" = (
 /obj/structure/decoration/rag{
 	layer = 4.3
@@ -47482,8 +46673,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -47564,9 +46755,6 @@
 	name = "stagnant water"
 	},
 /area/f13/building)
-"xAl" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "xAs" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -47648,8 +46836,8 @@
 /area/f13/building)
 "xCL" = (
 /obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -30;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -48164,8 +47352,8 @@
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 8;
-	light_color = "#e8eaff";
-	icon_state = "tube-burned"
+	icon_state = "tube-burned";
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -48326,8 +47514,8 @@
 /area/f13/building)
 "xVI" = (
 /obj/effect/overlay/junk/toilet{
-	pixel_y = 12;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 12
 	},
 /obj/structure/sink{
 	pixel_x = -7;
@@ -48441,15 +47629,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/building)
-"xZJ" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "xZL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -109786,16 +108965,16 @@ tRd
 tRd
 tRd
 tRd
+eWw
+tRd
+eWw
 tRd
 tRd
+eWw
+tRd
+eWw
 tRd
 tRd
-tRd
-tRd
-mCc
-mCc
-mCc
-mCc
 tRd
 tRd
 tRd
@@ -110044,17 +109223,17 @@ tRd
 tRd
 tRd
 tRd
-tRd
-mCc
-mCc
-mCc
-mCc
-mCc
+eWw
 tRd
 tRd
-mCc
-mCc
 tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
 tRd
 tRd
 tRd
@@ -110300,24 +109479,24 @@ tRd
 tRd
 tRd
 tRd
-mCc
-mCc
-mCc
-mCc
-mCc
 tRd
-sGN
 tRd
-dsc
-sGN
-sGN
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+eWw
+tRd
+eWw
+tRd
+eWw
+eWw
+eWw
 tRd
 tRd
 tRd
@@ -110553,29 +109732,29 @@ tRd
 tRd
 tRd
 tRd
-mCc
-mCc
-mCc
-mCc
 tRd
 tRd
 tRd
 tRd
 tRd
 tRd
-sGN
-czJ
-xAl
-xAl
-sGN
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+eWw
+eWw
+tRd
+tRd
+eWw
+eWw
 tRd
 tRd
 tRd
 tRd
 tRd
-tRd
-mCc
-mCc
 tRd
 tRd
 tRd
@@ -110810,34 +109989,34 @@ tRd
 tRd
 tRd
 tRd
-mCc
 tRd
 tRd
-tRd
-tRd
-tRd
-tRd
-tRd
-tRd
-tRd
-sGN
-hkh
-bHc
-qkD
-sGN
-tRd
-tRd
-tRd
-tRd
-tRd
-tRd
-tRd
-mCc
-mCc
 tRd
 tRd
 tRd
 eWw
+tRd
+tRd
+eWw
+eWw
+tRd
+eWw
+eWw
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+eWw
+eWw
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -111066,35 +110245,35 @@ tRd
 tRd
 tRd
 tRd
-mCc
-mCc
 tRd
 tRd
 tRd
-sGN
-sGN
-sGN
-sGN
-vFe
-jwr
-sGN
-sGN
-sGN
-wlf
-sGN
-jwr
-sGN
-jwr
-rtc
-sGN
-jwr
-sGN
-jwr
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
 eWw
+tRd
+tRd
+tRd
+eWw
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
 tRd
 eWw
 tRd
@@ -111323,36 +110502,36 @@ tRd
 tRd
 tRd
 tRd
-mCc
 tRd
 tRd
 tRd
-tRd
-sGN
-kwq
-dcy
-xrx
-pMt
-iZj
-kwq
-jwr
-fBQ
-xAl
-fPt
-sGN
-pIC
-lqV
-aBk
-kLj
-lqV
-xjt
-jwr
-mCc
 tRd
 tRd
 tRd
 tRd
 eWw
+eWw
+eWw
+tRd
+tRd
+eWw
+eWw
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -111579,33 +110758,33 @@ tRd
 tRd
 eWw
 tRd
-mCc
-mCc
 tRd
 tRd
 tRd
 tRd
-jwr
-tWx
-xAl
-aBk
-xAl
-sAS
-qDY
-jwr
-tqQ
-sAS
-wuj
-jwr
-tQL
-aBk
-kLj
-vZX
-sQq
-aEu
 tRd
-mCc
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+eWw
+tRd
+eWw
+eWw
+tRd
+tRd
+tRd
+eWw
+eWw
+eWw
+tRd
+tRd
+eWw
+eWw
 tRd
 tRd
 tRd
@@ -111836,33 +111015,33 @@ tRd
 tRd
 eWw
 tRd
-mCc
-jwr
-jwr
-sGN
-sGN
-jwr
-jwr
-kwq
-kwq
-aBk
-xAl
-xAl
-kwq
-jwr
-sAS
-xAl
-sQq
-jwr
-xAl
-ceE
-rhw
-aBk
-xAl
-wgv
-jwr
-mCc
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+eWw
+tRd
+eWw
+tRd
+tRd
+eWw
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -112093,33 +111272,33 @@ tRd
 tRd
 tRd
 tRd
-mCc
-jwr
-sZZ
-aBk
-xAl
-czb
-jwr
-jwr
-sGN
-jwr
-puk
-jwr
-jwr
-jwr
-sGN
-jYS
-jwr
-sGN
-eJn
-xZJ
-xZJ
-ieH
-aBk
-xAl
-jwr
-mCc
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+eWw
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -112350,33 +111529,33 @@ tRd
 tRd
 tRd
 tRd
-mCc
-sGN
-jDx
-xAl
-jDx
-jDx
-cvd
-wFR
-xAl
-wus
-xAl
-rqs
-sGN
-dVz
-dVz
-xAl
-qiT
-sGN
-sGN
-sGN
-sQq
-sQq
-sGN
-dVz
 tRd
-mCc
-mCc
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+eWw
+tRd
+eWw
+eWw
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -112607,32 +111786,32 @@ tRd
 tRd
 tRd
 tRd
-mCc
-jwr
-jDx
-jDx
-raq
-raq
-ugG
-aBk
-aBk
-aBk
-xAl
-xAl
-jYS
-dVz
-mSK
-jCs
-xAl
-sGN
-kNu
-avt
-sGN
-wjS
-xbG
 tRd
-jwr
-mCc
+tRd
+tRd
+eWw
+eWw
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -112864,37 +112043,37 @@ tRd
 tRd
 tRd
 tRd
-mCc
-sGN
-jDx
-xAl
-rIN
-gLX
-bGA
-gem
-nEI
-aBk
-ipG
-rqs
 tRd
 tRd
-mSK
-xAl
-mSK
-mSK
-ueG
-wjS
-xAl
-xAl
-jAY
+tRd
+eWw
 tRd
 tRd
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -113121,37 +112300,37 @@ tRd
 tRd
 tRd
 tRd
-mCc
-sGN
-iVK
-aBk
-uGO
-aBk
-jwr
-qiT
-fcG
-nAW
-sGN
-tRd
-tRd
-jwr
-aQE
-puk
-aQE
-aQE
-eEG
-jwr
-jwr
-qYV
-jwr
-jwr
-jwr
-jwr
 tRd
 tRd
 tRd
 tRd
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 eWw
 tRd
@@ -113378,37 +112557,37 @@ tRd
 tRd
 tRd
 tRd
-mCc
-jwr
-sGN
-iwK
-bGA
-bGA
-jwr
-sGN
-xrw
-vrM
-uMr
 tRd
-sGN
-sGN
-bBY
-bBY
-qOe
-vzj
-oaf
-jwr
-axh
-pYi
-axh
-qHY
-tJg
-jwr
-sGN
-qiT
-sGN
 tRd
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 eWw
@@ -113635,37 +112814,37 @@ tRd
 tRd
 tRd
 tRd
-mCc
-mCc
 tRd
 tRd
 tRd
 tRd
 tRd
-sGN
-gei
-rqS
-gis
-sGN
-sGN
-rUf
-bBY
-vzj
-hii
-bBY
-ohc
-jwr
-qHY
-wjS
-qHY
-aBk
-aBk
-puk
-otF
-mIV
-sGN
 tRd
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+eWw
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 eWw
@@ -113890,39 +113069,39 @@ tRd
 tRd
 tRd
 tRd
-tRd
-tRd
-mCc
-mCc
+eWw
 tRd
 tRd
 tRd
 tRd
 tRd
-sGN
-sGN
-sGN
-sGN
-sGN
-sGN
-tOB
-vzj
-bBY
-bBY
-oQa
-uFl
-jwr
-jur
-ksp
-cqw
-buh
-aBk
-jwr
-nlg
-mUP
-sGN
 tRd
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -114150,36 +113329,36 @@ tRd
 tRd
 tRd
 tRd
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-mCc
-sGN
-sGN
-sAV
-tQV
-tQV
-tQV
-jwr
-jwr
-vyj
-xAl
-bFx
-rRD
-tTs
-jwr
-sGN
-sGN
-sGN
 tRd
-mCc
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
+tRd
 tRd
 tRd
 tRd
@@ -114419,19 +113598,19 @@ qnn
 qnn
 qnn
 qnn
-sGN
-sGN
-sGN
-sGN
-sGN
-sGN
-jwr
-jwr
-jwr
-jwr
-jwr
-jwr
-jwr
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
+qnn
 qnn
 qnn
 qnn


### PR DESCRIPTION
## About The Pull Request
re-adds bos spawns to redwater, moves bunker to dungeons.dm

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
