### PR TITLE
Jet Inhalant Mood fixed to not be permanent to people

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -19,7 +19,7 @@
 
 /datum/mood_event/jet_euphoria
 	description = span_nicegreen("I feel like i'm flying...")
-	mood_change = 25 //god DAMN does jet feel good
+	mood_change = 25
 	timeout = 15 MINUTES
 
 /datum/mood_event/overdose

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -19,7 +19,8 @@
 
 /datum/mood_event/jet_euphoria
 	description = span_nicegreen("I feel like i'm flying...")
-	mood_change = 80 //god DAMN does jet feel good
+	mood_change = 25 //god DAMN does jet feel good
+	timeout = 15 MINUTES
 
 /datum/mood_event/overdose
 	mood_change = -8


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This is a simple change to Jet Inhalant mood so it isn't permanent.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Modified settings to the Jet Inhalant mood.
balance: No longer permanent buff from jet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
