### PR TITLE
Vendor Pricing and content pass

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -41,7 +41,7 @@
 #define PRICE_REALLY_CHEAP		5    // low end ammo.
 #define PRICE_PRETTY_CHEAP		8    // -
 #define PRICE_CHEAP				10   //  Normal ammo?
-#define PRICE_ALMOST_CHEAP		15   // cosmetic clothing
+#define PRICE_ALMOST_CHEAP		15   // cosmetic clothing, discounted healing items.
 #define PRICE_BELOW_NORMAL		17   // -
 #define PRICE_NORMAL			20   // Useful clothing.
 #define PRICE_ABOVE_NORMAL		25   // low end healing items

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -467,8 +467,8 @@
 	throw_range = 7
 	var/empty = FALSE
 	item_state = "firstaid"
-	custom_price = PRICE_ABOVE_NORMAL
-	custom_premium_price = PRICE_EXPENSIVE
+	custom_price = PRICE_REALLY_EXPENSIVE
+	custom_premium_price = PRICE_REALLY_EXPENSIVE
 
 /obj/item/storage/hypospraykit/ComponentInitialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -13,6 +13,7 @@
 	resistance_flags = ACID_PROOF
 	reagent_flags = OPENCONTAINER
 	slot_flags = ITEM_SLOT_BELT
+	custom_price = PRICE_ABOVE_EXPENSIVE
 	var/ignore_flags = 0
 	var/infinite = FALSE
 

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -25,11 +25,6 @@
 					/obj/item/reagent_containers/glass/bottle/morphine = 4,
 					/obj/item/reagent_containers/glass/bottle/toxin = 3,
 					/obj/item/reagent_containers/syringe/antiviral = 6,
-					/obj/item/storage/hypospraykit/fire = 2,
-					/obj/item/storage/hypospraykit/toxin = 2,
-					/obj/item/storage/hypospraykit/o2 = 2,
-					/obj/item/storage/hypospraykit/brute = 2,
-					/obj/item/reagent_containers/glass/bottle/vial/small = 5,
 					/obj/item/storage/briefcase/medical = 2,
 					/obj/item/stack/sticky_tape/surgical = 3,
 					/obj/item/healthanalyzer/wound = 4,
@@ -54,7 +49,7 @@
 	armor = ARMOR_VALUE_HEAVY
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
-	default_price = PRICE_ALMOST_CHEAP
+	default_price = PRICE_ABOVE_NORMAL
 	extra_price = PRICE_ABOVE_NORMAL
 	payment_department = ACCOUNT_MED
 	cost_multiplier_per_dept = list(ACCOUNT_MED = 0)
@@ -100,7 +95,6 @@
 					/obj/item/storage/pill_bottle/chem_tin/radx = 2,
 					/obj/item/reagent_containers/hypospray/medipen/stimpak/epipak = 3,
 					/obj/item/storage/belt/medical = 3,
-					/obj/item/wrench/medical = 1,
 					/obj/item/storage/belt/medolier = 2)
 	force_free = TRUE
 
@@ -170,5 +164,5 @@
 					/obj/item/reagent_containers/glass/bottle/toxin = 3,
 					/obj/item/reagent_containers/glass/bottle/methamphetamine = 1,
 					/obj/item/reagent_containers/glass/bottle/crank = 1)
-	default_price = PRICE_FREE
-	custom_premium_price = PRICE_ALMOST_EXPENSIVE
+	default_price = PRICE_ALMOST_CHEAP
+	extra_price = PRICE_ALMOST_EXPENSIVE


### PR DESCRIPTION
## About The Pull Request
Removes hyposprays from medical vendors. Also tweaks prices on some medical items

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Normal medical vendors no longer contain hypo sprays
tweak: Hyposprays now have a default vendor price of 120 caps
tweak: Hypospray kits now have a default vendor price of 240 caps
tweak: Redwaters medical vendor now costs caps as opposed to being completely free, Though it's still cheaper then normal vendors for most items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
