### PR TITLE
Makes the Outcast Breastplate actually light armor.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -197,7 +197,7 @@ datum/crafting_recipe/steelbib/heavy
 
 /datum/crafting_recipe/bosoutcastlight
 	name = "knight armor"
-	result = /obj/item/clothing/suit/armor/medium/combat/brotherhood/light
+	result = /obj/item/clothing/suit/armor/light/duster/bos/outcast
 	reqs = list(/obj/item/stack/sheet/leather = 3,
 				/obj/item/weaponcrafting/string = 2,
 				/obj/item/stack/crafting/metalparts = 5)

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -1236,6 +1236,14 @@
 	item_state = "elder"
 	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_ENV_T2, ARMOR_MODIFIER_UP_DT_T1)
 
+/obj/item/clothing/suit/armor/light/duster/bos/outcast
+	name = "outcast's breastplate"
+	desc = "A generic light piece of armor for the Southern Brotherhood Outcasts. In their hasty retreat, there was little time to delegate supplies; and so, a frock of kevlar, polypropylene, and alloy was woven. Obviously, does not protect your arms or legs- but it does its job fine, otherwise."
+	icon_state = "brotherhood_armor_light"
+	item_state = "brotherhood_armor_light"
+	body_parts_covered = CHEST|GROIN
+	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_DOWN_MELEE_T1, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_DT_T1)
+
 /obj/item/clothing/suit/armor/light/duster/town
 	name = "town trenchcoat"
 	desc = "A non-descript black trenchcoat."
@@ -2130,18 +2138,7 @@
 	icon_state = "brotherhood_armor_knight"
 	item_state = "brotherhood_armor_knight"
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_DOWN_ENV_T1, ARMOR_MODIFIER_UP_DT_T1, ARMOR_MODIFIER_DOWN_BULLET_T1)
-
-/obj/item/clothing/suit/armor/medium/combat/brotherhood/light
-	name = "outcast's breastplate"
-	desc = "A generic light piece of armor for the Southern Brotherhood Outcasts. In their hasty retreat, there was little time to delegate supplies; and so, a frock of kevlar, polypropylene, and alloy was woven. Obviously, does not protect your arms or legs- but it does its job fine, otherwise."
-	icon_state = "brotherhood_armor_light"
-	item_state = "brotherhood_armor_light"
-	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor = ARMOR_VALUE_LIGHT
-	body_parts_covered = CHEST|GROIN
-	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T1, ARMOR_MODIFIER_DOWN_MELEE_T1, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_DT_T1)
-
+	armor_tokens = list(ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_DOWN_ENV_T1, ARMOR_MODIFIER_UP_DT_T1)
 
 /obj/item/clothing/suit/armor/medium/combat/brotherhood/senior
 	name = "brotherhood senior knight armor"

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -1037,7 +1037,7 @@ Initiate
 /datum/outfit/loadout/initiatek
 	name = "Knight-Aspirant"
 	belt = 			/obj/item/storage/belt/utility
-	suit = 			/obj/item/clothing/suit/armor/medium/combat/brotherhood/light
+	suit = 			/obj/item/clothing/suit/armor/light/duster/bos/outcast
 	head = 			/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/wattz=1,


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Reworks the Brotherhood Outcast Breastplate added in #912 to actually be proper light armor instead of the previous implementation which caused it to incur the medium armor slowdown.

Reverts a change in #912 that lowered the brotherhood combat armor's values as it looks like it was an accidental change that wasn't logged.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changed the Outcast Breastplate parent object to be the BOS Scribe duster instead of combat armor.
balance: rebalanced something
fix: Hopefully fixed the Breastplate incurring the medium armor slowdown.
revert: Reverted line 2133 in code/modules/clothing/suits/arfsuits.dm from pr #912 because the change wasn't logged and doesn't initially appear to be intentional.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
