### PR TITLE
Changes the Follower Administrators Science Loadout

### DIFF
--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -123,7 +123,9 @@ Administrator
 /datum/outfit/loadout/research_specialist
 	name =	"Research Specialist"
 	backpack_contents = list(
-		/obj/item/circuitboard/machine/ore_redemption = 1,
+		/obj/item/disk/medical/defib_heal = 1,
+		/obj/item/disk/medical/defib_shock = 1,
+		/obj/item/disk/medical/defib_speed = 1,
 		/obj/item/blueprint/research = 1,
 	)
 


### PR DESCRIPTION
Since mining is borked, I replaced it with stuff to put more pressure on the concept of 'decisions decisions'. These disks aren't obtainable otherwise.