### PR TITLE
Fixes heavy-duty sheath and twin sheath; adds knife bandolier

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -126,6 +126,17 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_BELTS
 
+/datum/crafting_recipe/bandolierknife
+	name = "Knife Bandolier"
+	result = /obj/item/storage/belt/sabre/knife
+	reqs = list(/obj/item/stack/sheet/metal = 1,
+				/obj/item/stack/sheet/leather = 3,
+				/obj/item/stack/crafting/metalparts = 2)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_CLOTHING
+	subcategory = CAT_BELTS
+
 /datum/crafting_recipe/twinsheath
 	name = "Twin Sheath"
 	result = /obj/item/storage/belt/sword/twin

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -628,7 +628,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	content_overlays = TRUE
 	onmob_overlays = TRUE
-	slot_flags = ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_BELT
 	fitting_swords = list(/obj/item/melee/smith/machete,
 	/obj/item/melee/smith/machete/reforged,
 	/obj/item/melee/smith/wakizashi,
@@ -645,6 +645,26 @@
 	/obj/item/melee/transforming/energy/axe/protonaxe,
 	/obj/item/melee/powered/ripper)
 	starting_sword = null
+
+/obj/item/storage/belt/sabre/knife
+	name = "knife bandolier"
+	desc = "A bandolier lined with loops, perfect for slipping in a few small blades."
+	icon_state = "bandolier"
+	item_state = "bandolier"
+	w_class = WEIGHT_CLASS_BULKY
+	content_overlays = TRUE
+	onmob_overlays = TRUE
+	slot_flags = ITEM_SLOT_NECK
+	starting_sword = null
+
+/obj/item/storage/belt/sabre/knife/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = STORAGE_BELT_HOLSTER_MAX_ITEMS
+	STR.max_w_class = STORAGE_BELT_HOLSTER_MAX_SIZE
+	STR.max_combined_w_class = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
+	STR.can_hold = GLOB.knifebelt_allowed
+	STR.quickdraw = TRUE
 
 /obj/item/storage/belt/sabre/rapier
 	name = "rapier sheath"
@@ -669,7 +689,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	content_overlays = TRUE
 	onmob_overlays = TRUE
-	slot_flags = ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_BELT
 	var/list/fitting_swords = list(/obj/item/melee/smith/sword, /obj/item/melee/baton/stunsword)
 
 // Instead of half-assed broken weaboo stuff lets have something that works.

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -605,10 +605,10 @@
 /obj/item/storage/belt/sabre/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = STORAGE_BELT_HOLSTER_MAX_ITEMS
-	STR.max_w_class = STORAGE_BELT_HOLSTER_MAX_SIZE
-	STR.max_combined_w_class = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
-	STR.can_hold = GLOB.knifebelt_allowed
+	STR.max_items = 1
+	STR.max_w_class = WEIGHT_CLASS_BULKY
+	STR.max_combined_w_class = 4
+	STR.can_hold = typecacheof(fitting_swords)
 	STR.quickdraw = TRUE
 
 /obj/item/storage/belt/sabre/examine(mob/user)
@@ -685,6 +685,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 2
 	STR.max_w_class = WEIGHT_CLASS_BULKY + WEIGHT_CLASS_NORMAL //katana and waki.
+	STR.max_volume = 7
 	STR.can_hold = typecacheof(fitting_swords)
 	STR.quickdraw = TRUE
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Allows heavy-duty sheath to actually fit and take the items listed in fitting_swords. Adjusts the volume of the twin sheath so that it can fit its respective swords. Both items now fit on the belt slot. New knife bandolier that fits on neck and can hold knifebelt_allowed items.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixes heavy-duty sheath and twin sheath
add: adds knife bandolier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
