### PR TITLE
Adds gear harness recipe for leather straps

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -331,6 +331,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 	merge_type = /obj/item/stack/sheet/leatherstrips
 
 GLOBAL_LIST_INIT(leatherstrips_recipes, list (
+	new/datum/stack_recipe("gear harness", /obj/item/clothing/under/misc/gear_harness, 2, time = 40),
 	new/datum/stack_recipe("slave labor outfit", /obj/item/clothing/suit/armor/outfit/slavelabor, 2, time = 50), 
 	new/datum/stack_recipe("jabroni outfit", /obj/item/clothing/under/jabroni, 4, time = 80),
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2, time = 40), 


### PR DESCRIPTION
Adds gear harnesses to the list of items craftable with leather straps in hands. Part-time and/or forced nudity enthusiasts rejoice.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added gear harness recipe for leather straps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
