### PR TITLE
dragonfire katana buffs

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -29,7 +29,7 @@
 
 /obj/item/melee/onehanded/dragonfire //unique. big damage. can parry.
 	name = "Dragonfire Katana"
-	desc = "A sword that crackles with an unknown power source. It's warm in your hands, cutting and cauterizing flesh like butter- and yet, the geiger counter remains silent. Seems to be well suited for parrying. <br> <span class='phobia'>The sky above the clouds, a rainbow that fate has devoured- I gave up hope!</span>"
+	desc = "A sword that crackles with an unknown power source. It's warm in your hands, cutting and cauterizing flesh like butter- and yet, the geiger counter remains silent. The blade seems to guide you to block, twist, and dodge.. <br> <span class='phobia'>The sky above the clouds, a rainbow that fate has devoured- I gave up hope!</span>"
 //	icon_state = "DFkatana" HAHA THE INHAND SPRITES DON'T EXIST
 //	item_state = "DFkatana"
 	icon_state = "temporalkatana"
@@ -50,10 +50,7 @@
 	armor = ARMOR_VALUE_GENERIC_ITEM
 	resistance_flags = FIRE_PROOF
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
-	item_flags = ITEM_CAN_PARRY
-	parry_time_active = 15 //decent window
-	parry_time_spindown = 0
-	parry_time_perfect = 2
+//	item_flags = ITEM_CAN_PARRY does nothing from what i can tell arghhhggh todo: fix
 
 /obj/item/melee/onehanded/dragonfire/attack(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -29,7 +29,7 @@
 
 /obj/item/melee/onehanded/dragonfire //unique. big damage. can parry.
 	name = "Dragonfire Katana"
-	desc = "A sword that crackles with an unknown power source. It's warm in your hands, cutting and cauterizing flesh like butter- and yet, the geiger counter remains silent. <br> <span class='phobia'>The sky above the clouds, a rainbow that fate has devoured- I gave up hope!</span>"
+	desc = "A sword that crackles with an unknown power source. It's warm in your hands, cutting and cauterizing flesh like butter- and yet, the geiger counter remains silent. Seems to be well suited for parrying. <br> <span class='phobia'>The sky above the clouds, a rainbow that fate has devoured- I gave up hope!</span>"
 //	icon_state = "DFkatana" HAHA THE INHAND SPRITES DON'T EXIST
 //	item_state = "DFkatana"
 	icon_state = "temporalkatana"
@@ -38,7 +38,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 65
+	force = 55
 	throwforce = 10
 	block_chance = 20
 	armour_penetration = 0.40

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -27,7 +27,7 @@
 ////////////		-block, 34-39 damage
 
 
-/obj/item/melee/onehanded/dragonfire //unique
+/obj/item/melee/onehanded/dragonfire //unique. big damage. can parry.
 	name = "Dragonfire Katana"
 	desc = "A sword that crackles with an unknown power source. It's warm in your hands, cutting and cauterizing flesh like butter- and yet, the geiger counter remains silent. <br> <span class='phobia'>The sky above the clouds, a rainbow that fate has devoured- I gave up hope!</span>"
 //	icon_state = "DFkatana" HAHA THE INHAND SPRITES DON'T EXIST
@@ -38,8 +38,9 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 50
+	force = 65
 	throwforce = 10
+	block_chance = 20
 	armour_penetration = 0.40
 	w_class = WEIGHT_CLASS_BULKY
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -49,6 +50,10 @@
 	armor = ARMOR_VALUE_GENERIC_ITEM
 	resistance_flags = FIRE_PROOF
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	item_flags = ITEM_CAN_PARRY
+	parry_time_active = 15 //decent window
+	parry_time_spindown = 0
+	parry_time_perfect = 2
 
 /obj/item/melee/onehanded/dragonfire/attack(mob/living/M, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
dragonfire katana: damage up by 15 for parity with high tier melee weps, can now parry.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: aye
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
