### PR TITLE
Nerf decorative rag durability

### DIFF
--- a/code/modules/fallout/obj/decor.dm
+++ b/code/modules/fallout/obj/decor.dm
@@ -10,6 +10,7 @@
 	icon = 'icons/fallout/objects/decals.dmi'
 	icon_state = "rag" //skulls, skin
 	layer = 3.2
+	max_integrity = 25
 
 /obj/structure/decoration/sign //Signs.
 	name = "sign"

--- a/code/modules/farming/farming_structures.dm
+++ b/code/modules/farming/farming_structures.dm
@@ -139,8 +139,8 @@
 	user.show_message(span_notice("You start weaving \the [W.name] through the loom.."), MSG_VISUAL)
 	if(W.use_tool(src, user, W.pull_effort))
 		if(W.amount >= FABRIC_PER_SHEET)
-			new W.loom_result(drop_location())
-			W.use(FABRIC_PER_SHEET)
+			new W.loom_result(drop_location(), round(W.amount / FABRIC_PER_SHEET))
+			W.use(W.amount - W.amount % FABRIC_PER_SHEET)
 			user.show_message(span_notice("You weave \the [W.name] into a workable fabric."), MSG_VISUAL)
 	return TRUE
 

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -34,10 +34,13 @@
 
 /obj/item/grown/cotton/attack_self(mob/user)
 	user.show_message(span_notice("You pull some [cotton_name] out of the [name]!"), MSG_VISUAL)
-	var/seed_modifier = 0
-	if(seed)
-		seed_modifier = round(seed.potency / 25)
-	new cotton_type(user.loc, 1 + seed_modifier)
+	var/cottonAmt = 1 + round(seed.potency / 25) // The cotton we're holding
+	for(var/obj/item/grown/cotton/C in user.loc) // The cotton on the floor
+		if(C.cotton_type != cotton_type)
+			continue
+		cottonAmt += 1 + round(C.seed.potency / 25)
+		qdel(C)
+	new cotton_type(user.drop_location(), cottonAmt)
 	qdel(src)
 
 //reinforced mutated variant


### PR DESCRIPTION
## About The Pull Request
As it stands, decorative tattered rags are exactly as durable as solid steel doors. Bringing them down to the integrity level level of a standard glass window will ensure that a good swipe or two with a decent melee weapon will tear them down like the ruined scraps of cloth they are. Reclaimed raider buildings will be that much easier to clean up and renovate.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Reduced decorative rag integrity from 300 to 25
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
