### PR TITLE
Reworks ambient sound effects

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -6,9 +6,10 @@
 #define CHANNEL_JUKEBOX_START 1016 //The gap between this and CHANNEL_JUKEBOX determines the amount of free jukebox channels. This currently allows 6 jukebox channels to exist.
 #define CHANNEL_JUSTICAR_ARK 1015
 #define CHANNEL_HEARTBEAT 1014 //sound channel for heartbeats
-#define CHANNEL_AMBIENCE 1013
-#define CHANNEL_BUZZ 1012
-#define CHANNEL_BICYCLE 1011
+#define CHANNEL_AMBIENT_MUSIC 1013
+#define CHANNEL_AMBIENT_SOUND 1012
+#define CHANNEL_AMBIENT_LOOP 1011
+#define CHANNEL_BICYCLE 1010
 
 ///Default range of a sound.
 #define SOUND_RANGE 17
@@ -81,67 +82,175 @@
 #define SOUND_AREA_ICEMOON SOUND_ENVIRONMENT_CAVE
 #define SOUND_AREA_WOODFLOOR SOUND_ENVIRONMENT_CITY
 
+/// Ambience defines
+#define AMBIENCE_COOLDOWN 3 SECONDS
+#define AMB_MIN_VOLUME "min"
+#define AMB_MAX_VOLUME "max"
+#define SOUND_LOOP_VOL_RANGE(min,max) list(AMB_MIN_VOLUME = min, AMB_MAX_VOLUME = max)
+
+#define SL_FILE_PATH "sound_path"
+#define SL_FILE_LENGTH "sound_length"
+#define SOUND_LOOP_ENTRY(file, length, chance) list(SL_FILE_PATH = file, SL_FILE_LENGTH = length) = chance
+#define AREA_MUSIC(file, length) list(SL_FILE_PATH = file, SL_FILE_LENGTH = length)
+#define AREA_SOUND(file, length) list(SL_FILE_PATH = file, SL_FILE_LENGTH = length)
+
 
 //Ambience types
 
-#define GENERIC list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg',\
-								'sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg',\
-								'sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg',\
-								'sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg',\
-								'sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg',\
-								'sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg','sound/ambience/ambigen15.ogg')
+#define GENERIC list(\
+	AREA_SOUND('sound/ambience/ambigen1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen5.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen6.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen7.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen8.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen9.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen10.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen11.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen12.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen14.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambigen15.ogg', 10 SECONDS))
 
-#define HOLY list('sound/ambience/ambicha1.ogg','sound/ambience/ambicha2.ogg','sound/ambience/ambicha3.ogg',\
-										'sound/ambience/ambicha4.ogg', 'sound/ambience/ambiholy.ogg', 'sound/ambience/ambiholy2.ogg',\
-										'sound/ambience/ambiholy3.ogg')
+#define HOLY list(\
+	AREA_SOUND('sound/ambience/ambicha1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambicha2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambicha3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambicha4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiholy.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiholy2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiholy3.ogg', 10 SECONDS))
 
-#define HIGHSEC list('sound/ambience/ambidanger.ogg', 'sound/ambience/ambidanger2.ogg')
+#define HIGHSEC list(\
+	AREA_SOUND('sound/ambience/ambidanger.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger2.ogg', 10 SECONDS))
 
-#define RUINS list('sound/ambience/ambimine.ogg', 'sound/ambience/ambicave.ogg', 'sound/ambience/ambiruin.ogg',\
-									'sound/ambience/ambiruin2.ogg',  'sound/ambience/ambiruin3.ogg',  'sound/ambience/ambiruin4.ogg',\
-									'sound/ambience/ambiruin5.ogg',  'sound/ambience/ambiruin6.ogg',  'sound/ambience/ambiruin7.ogg',\
-									'sound/ambience/ambidanger.ogg', 'sound/ambience/ambidanger2.ogg', 'sound/ambience/ambitech3.ogg',\
-									'sound/ambience/ambimystery.ogg', 'sound/ambience/ambimaint1.ogg')
+#define RUINS list(\
+	AREA_SOUND('sound/ambience/ambimine.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambicave.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin5.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin6.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin7.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimystery.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint1.ogg', 10 SECONDS))
 
-#define ENGINEERING list('sound/ambience/ambisin1.ogg','sound/ambience/ambisin2.ogg','sound/ambience/ambisin3.ogg','sound/ambience/ambisin4.ogg',\
-										'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambitech3.ogg')
+#define ENGINEERING list(\
+	AREA_SOUND('sound/ambience/ambisin1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambisin2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambisin3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambisin4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiatmos.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiatmos2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech3.ogg', 10 SECONDS))
 
-#define MINING list('sound/ambience/ambimine.ogg', 'sound/ambience/ambicave.ogg', 'sound/ambience/ambiruin.ogg',\
-											'sound/ambience/ambiruin2.ogg',  'sound/ambience/ambiruin3.ogg',  'sound/ambience/ambiruin4.ogg',\
-											'sound/ambience/ambiruin5.ogg',  'sound/ambience/ambiruin6.ogg',  'sound/ambience/ambiruin7.ogg',\
-											'sound/ambience/ambidanger.ogg', 'sound/ambience/ambidanger2.ogg', 'sound/ambience/ambimaint1.ogg', 'sound/ambience/ambilava.ogg')
+#define MINING list(\
+	AREA_SOUND('sound/ambience/ambimine.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambicave.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin5.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin6.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin7.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambilava.ogg', 10 SECONDS))
 
-#define MEDICAL list('sound/ambience/ambinice.ogg')
+#define MEDICAL list(\
+	AREA_SOUND('sound/ambience/ambinice.ogg', 10 SECONDS))
 
-#define SPOOKY list('sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg','sound/ambience/ambiruin7.ogg','sound/ambience/ambiruin6.ogg',\
-										'sound/ambience/ambiodd.ogg', 'sound/ambience/ambimystery.ogg')
+#define SPOOKY list(\
+	AREA_SOUND('sound/ambience/ambimo1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimo2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin7.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin6.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiodd.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimystery.ogg', 10 SECONDS))
 
-#define SPACE list('sound/ambience/ambispace.ogg', 'sound/ambience/ambispace2.ogg', 'sound/ambience/ambiatmos.ogg')
+#define SPACE list(\
+	AREA_SOUND('sound/ambience/ambispace.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambispace2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiatmos.ogg', 10 SECONDS))
 
-#define MAINTENANCE list('sound/ambience/ambimaint1.ogg', 'sound/ambience/ambimaint2.ogg', 'sound/ambience/ambimaint3.ogg', 'sound/ambience/ambimaint4.ogg',\
-											'sound/ambience/ambimaint5.ogg', 'sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg', 'sound/ambience/ambitech2.ogg' )
+#define MAINTENANCE list(\
+	AREA_SOUND('sound/ambience/ambimaint1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint5.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/voice/lowHiss2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/voice/lowHiss3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/voice/lowHiss4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech2.ogg', 10 SECONDS))
 
-#define AWAY_MISSION list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiruin.ogg',\
-									'sound/ambience/ambiruin2.ogg',  'sound/ambience/ambiruin3.ogg',  'sound/ambience/ambiruin4.ogg',\
-									'sound/ambience/ambiruin5.ogg',  'sound/ambience/ambiruin6.ogg',  'sound/ambience/ambiruin7.ogg',\
-									'sound/ambience/ambidanger.ogg', 'sound/ambience/ambidanger2.ogg', 'sound/ambience/ambimaint.ogg',\
-									'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg', 'sound/ambience/ambiodd.ogg')
+#define AWAY_MISSION list(\
+	AREA_SOUND('sound/ambience/ambitech.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambitech2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin4.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin5.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin6.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiruin7.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambidanger2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambimaint.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiatmos.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiatmos2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambiodd.ogg', 10 SECONDS))
 
-#define REEBE list('sound/ambience/ambireebe1.ogg', 'sound/ambience/ambireebe2.ogg', 'sound/ambience/ambireebe3.ogg')
+#define REEBE list(\
+	AREA_SOUND('sound/ambience/ambireebe1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambireebe2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/ambience/ambireebe3.ogg', 10 SECONDS))
 
 
 
-#define CREEPY_SOUNDS list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/heart_beat.ogg', 'sound/effects/screech.ogg',\
-	'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
-	'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
-	'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
-	'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
+#define CREEPY_SOUNDS list(\
+	AREA_SOUND('sound/effects/ghost.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/effects/ghost2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/effects/heart_beat.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/effects/screech.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/behind_you1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/behind_you2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/far_noise.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/growl1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/growl2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/growl3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/im_here1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/im_here2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/i_see_you1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/i_see_you2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/look_up1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/look_up2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/over_here1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/over_here2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/over_here3.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/turn_around1.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/turn_around2.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/veryfar_noise.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/hallucinations/wail.ogg', 10 SECONDS))
 
 //fortuna addition. wasteland ambient music goes here.
-#define WASTELAND_AMBIENCE list('sound/f13ambience/music/ccc_doesntworkforfree_ambience.ogg','sound/f13ambience/music/hailcaesar_ambience.ogg',\
-	'sound/f13ambience/music/invisible_ghosts_ambience.ogg',\
-	'sound/f13ambience/music/mole_miners_ambience.ogg',\
-	'sound/f13ambience/music/portaltothepast_ambience.ogg','sound/f13ambience/music/wind_and_the_reeds_ambience.ogg')
+#define WASTELAND_AMBIENCE list(\
+	AREA_SOUND('sound/f13ambience/music/ccc_doesntworkforfree_ambience.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/hailcaesar_ambience.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/invisible_ghosts_ambience.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/mole_miners_ambience.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/portaltothepast_ambience.ogg', 10 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/wind_and_the_reeds_ambience.ogg', 10 SECONDS))
 
 /// Sound properties! bunch of defines~
 /// Mostly for gunfire~

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -245,12 +245,12 @@
 
 //fortuna addition. wasteland ambient music goes here.
 #define WASTELAND_AMBIENCE list(\
-	AREA_SOUND('sound/f13ambience/music/ccc_doesntworkforfree_ambience.ogg', 10 SECONDS),\
-	AREA_SOUND('sound/f13ambience/music/hailcaesar_ambience.ogg', 10 SECONDS),\
-	AREA_SOUND('sound/f13ambience/music/invisible_ghosts_ambience.ogg', 10 SECONDS),\
-	AREA_SOUND('sound/f13ambience/music/mole_miners_ambience.ogg', 10 SECONDS),\
-	AREA_SOUND('sound/f13ambience/music/portaltothepast_ambience.ogg', 10 SECONDS),\
-	AREA_SOUND('sound/f13ambience/music/wind_and_the_reeds_ambience.ogg', 10 SECONDS))
+	AREA_SOUND('sound/f13ambience/music/ccc_doesntworkforfree_ambience.ogg', 94 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/hailcaesar_ambience.ogg', 103 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/invisible_ghosts_ambience.ogg', 122 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/mole_miners_ambience.ogg', 74 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/portaltothepast_ambience.ogg', 100 SECONDS),\
+	AREA_SOUND('sound/f13ambience/music/wind_and_the_reeds_ambience.ogg', 72 SECONDS))
 
 /// Sound properties! bunch of defines~
 /// Mostly for gunfire~

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -654,6 +654,30 @@ SUBSYSTEM_DEF(timer)
 		return null
 	return timer.timeToRun - (timer.flags & TIMER_CLIENT_TIME ? REALTIMEOFDAY : world.time)
 
+/**
+ * Set the wait time on a timer, mostly just useful for 
+ *
+ * Arguments:
+ * * id a timerid or a /datum/timedevent
+ * * wait a new time to set the timer
+ */
+/proc/set_timer_wait(id, wait = 0, datum/controller/subsystem/timer/timer_subsystem)
+	if (!id)
+		return null
+	if (id == TIMER_ID_NULL)
+		CRASH("Tried to get timeleft of a null timerid. Use TIMER_STOPPABLE flag")
+	if (istype(id, /datum/timedevent))
+		var/datum/timedevent/timer = id
+		timer.wait = wait
+		return timer.wait
+	timer_subsystem = timer_subsystem || SStimer
+	//id is string
+	var/datum/timedevent/timer = timer_subsystem.timer_id_dict[id]
+	if(!timer)
+		return null
+	timer.wait = wait
+	return timer.wait
+
 #undef BUCKET_LEN
 #undef BUCKET_POS
 #undef TIMER_MAX

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -1,50 +1,53 @@
 /*
-	output_atoms	(list of atoms)			The destination(s) for the sounds
-
-	mid_sounds		(list or soundfile)		Since this can be either a list or a single soundfile you can have random sounds. May contain further lists but must contain a soundfile at the end.
-	mid_length		(num)					The length to wait between playing mid_sounds
-
-	start_sound		(soundfile)				Played before starting the mid_sounds loop
-	start_length	(num)					How long to wait before starting the main loop after playing start_sound
-
-	end_sound		(soundfile)				The sound played after the main loop has concluded
-
-	chance			(num)					Chance per loop to play a mid_sound
-	volume			(num)					Sound output volume
-	max_loops		(num)					The max amount of loops to run for.
-	direct			(bool)					If true plays directly to provided atoms instead of from them
+	output_atoms	(list of atoms)		The destination(s) for the sounds
+	mid_sounds		(list or soundfile)	Sound to play over and over -- if its a list, use this format: list(SOUND_LOOP_ENTRY('sound/file.ogg', length_in_deciseconds, chance_weight), SOUND_LOOP_ENTRY('sound/file.ogg', length_in_deciseconds, chance_weight))
+	mid_length		(num)				The length to wait between playing mid_sounds -- only used if mid_sounds is NOT a list!
+	loop_delay		(num)				Delay between attempts to play a sound. if 0, it tries to play immediately after the sound ends
+	start_sound		(soundfile)			Played before starting the mid_sounds loop
+	start_length	(num)				How long to wait before starting the main loop after playing start_sound
+	end_sound		(soundfile)			The sound played after the main loop has concluded
+	chance			(num)				Chance per loop to play a mid_sound
+	volume			(num or list)		Sound output volume
+	max_loops		(num)				The max amount of loops to run for.
+	direct			(bool)				If true plays directly to provided atoms instead of from them
 */
 /datum/looping_sound
-	var/list/atom/output_atoms
-	var/mid_sounds
+	var/list/atom/output_atoms = list()
+	var/list/mid_sounds
 	var/mid_length
+	var/loop_delay = 0
 	var/start_sound
 	var/start_length
 	var/end_sound
 	var/chance
 	var/volume = 100
 	var/vary = FALSE
+	/// Makes direct sounds emulate coming from other directions
+	var/vary_direction = FALSE
 	var/max_loops
 	var/direct
 	var/extra_range = 0
 	var/falloff
+	var/channel
 
 	var/timerid
 	var/init_timerid
 
-/datum/looping_sound/New(list/_output_atoms=list(), start_immediately=FALSE, _direct=FALSE)
+/datum/looping_sound/New(list/_output_atoms=list(), start_immediately=FALSE, _direct)
 	if(!mid_sounds)
 		WARNING("A looping sound datum was created without sounds to play.")
 		return
 
-	output_atoms = _output_atoms
-	direct = _direct
+	if(LAZYLEN(_output_atoms))
+		output_atoms |= _output_atoms
+	if(_direct)
+		direct = _direct
 
 	if(start_immediately)
 		start()
 
 /datum/looping_sound/Destroy()
-	stop()
+	stop(kill = TRUE)
 	output_atoms = null
 	return ..()
 
@@ -55,44 +58,78 @@
 		return
 	on_start()
 
-/datum/looping_sound/proc/stop(atom/remove_thing)
+/datum/looping_sound/proc/stop(atom/remove_thing, kill = FALSE)
+	on_stop()
 	if(remove_thing)
 		output_atoms -= remove_thing
+	if(LAZYLEN(output_atoms) && !kill)
+		return // If people're still listening, dont kill it yet
 	if(init_timerid)
 		deltimer(init_timerid)
 		init_timerid = null
 	if(!timerid)
 		return
-	on_stop()
 	deltimer(timerid)
 	timerid = null
 
 /datum/looping_sound/proc/sound_loop(starttime)
-	if(max_loops && world.time >= starttime + mid_length * max_loops)
-		stop()
+	if(max_loops && world.time >= starttime + ((mid_length + loop_delay) * max_loops))
+		stop(kill = TRUE)
 		return
-	if(!chance || prob(chance))
-		play(get_sound(starttime))
-	if(!timerid)
-		timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
-
-/datum/looping_sound/proc/play(soundfile)
 	var/list/atoms_cache = output_atoms
-	var/sound/S = sound(soundfile)
+	if(!LAZYLEN(atoms_cache))
+		return // If a datum sound_loops and nobodys around to hear it, does it make a sound? no
+	if(!chance || prob(chance))
+		var/sound_play = get_sound(starttime)
+		if(!sound_play) // someone didnt set it up right~
+			stop(kill = TRUE)
+			return
+		if(isfile(sound_play))
+			sound_play = list(sound_play, mid_length)
+		play(sound_play)
+		mid_length = sound_play[SL_FILE_LENGTH]
+	if(!timerid)
+		timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length + loop_delay, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
+	else
+		set_timer_wait(timerid, mid_length + loop_delay)
+
+/// takes in list('sound/file.ogg', mid_length) and plays the file and ques up another in mid_length deciseconds
+/datum/looping_sound/proc/play(list/sound_list)
+	var/list/atoms_cache = output_atoms
+	if(!LAZYLEN(atoms_cache))
+		return
+	var/sound/S = sound(sound_list[SL_FILE_PATH])
 	if(direct)
-		S.channel = SSsounds.random_available_channel()
+		if(channel)
+			S.channel = channel
+		else
+			S.channel = SSsounds.random_available_channel()
+		if(vary_direction)
+			S.x = rand(-10, 10)
+			S.z = rand(-10, 10)
+	if(islist(volume))
+		S.volume = rand(volume[AMB_MIN_VOLUME], volume[AMB_MAX_VOLUME])
+	else
 		S.volume = volume
 	for(var/i in 1 to atoms_cache.len)
 		var/atom/thing = atoms_cache[i]
 		if(direct)
 			SEND_SOUND(thing, S)
 		else
-			playsound(thing, S, volume, vary, extra_range, falloff)
+			playsound(thing, S, S.volume, vary, extra_range, falloff)
 
+/// Converts SOUND_LOOP_ENTRY('sound/file.ogg', length, weight) to list('sound/file.ogg', length) and returns that
 /datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
-	. = _mid_sounds || mid_sounds
-	while(!isfile(.) && !isnull(.))
-		. = pickweight(.)
+	var/list/sound_list
+	if(_mid_sounds)
+		sound_list = _mid_sounds
+	else
+		sound_list = mid_sounds
+	if(sound_list)
+		if(!islist(sound_list))
+			sound_list = list(SOUND_LOOP_ENTRY(sound_list, mid_length, 10))
+	if(LAZYLEN(sound_list))
+		return pickweight(sound_list)
 
 /datum/looping_sound/proc/on_start()
 	var/start_wait = 0

--- a/code/datums/looping_sounds/ambient_sounds.dm
+++ b/code/datums/looping_sounds/ambient_sounds.dm
@@ -1,0 +1,37 @@
+/datum/looping_sound/ambient
+	/// Chance every 'mid_length' time to play an ambient sound
+	chance = 1
+	vary = TRUE
+	vary_direction = TRUE
+	/// adds in varied volumes, use this format plz: volume = SOUND_LOOP_VOL_RANGE(min, max)
+	volume = SOUND_LOOP_VOL_RANGE(10, 50)
+	/// Plays the sound directly to the player, cus ambient sounds dont have a real source tile
+	direct = TRUE
+	/// Here used as time between rolls for sounds happening
+	loop_delay = 5 SECONDS
+
+// random bullshit used for testing
+/datum/looping_sound/ambient/debug
+	chance = 25 // might be kinda low for ambience
+	vary = TRUE
+	volume = SOUND_LOOP_VOL_RANGE(10, 50)
+	direct = TRUE
+	vary_direction = TRUE
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/misc/sadtrombone.ogg', 3.5 SECONDS, 1), 
+		SOUND_LOOP_ENTRY('sound/machines/microwave/microwave-mid2.ogg', 1 SECONDS, 1),
+		SOUND_LOOP_ENTRY('sound/machines/sm/supermatter1.ogg', 1 SECONDS, 1),
+		SOUND_LOOP_ENTRY('sound/items/geiger/ext3.ogg', 0.2 SECONDS, 1)
+		)
+/datum/looping_sound/ambient/debug2
+	chance = 100
+	vary = TRUE
+	volume = SOUND_LOOP_VOL_RANGE(10, 50)
+	direct = TRUE
+	loop_delay = 0
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/f13weapons/american180.ogg', 0.2 SECONDS, 1), 
+		SOUND_LOOP_ENTRY('sound/f13weapons/boltfire.ogg', 1.7 SECONDS, 1), 
+		SOUND_LOOP_ENTRY('sound/f13weapons/laser_rifle.ogg', 2.2 SECONDS, 1), 
+		SOUND_LOOP_ENTRY('sound/f13weapons/magnum_fire.ogg', 2.4 SECONDS, 1)
+		)

--- a/code/datums/looping_sounds/item_sounds.dm
+++ b/code/datums/looping_sounds/item_sounds.dm
@@ -4,10 +4,30 @@
 
 /datum/looping_sound/geiger
 	mid_sounds = list(
-		list('sound/items/geiger/low1.ogg'=1, 'sound/items/geiger/low2.ogg'=1, 'sound/items/geiger/low3.ogg'=1, 'sound/items/geiger/low4.ogg'=1),
-		list('sound/items/geiger/med1.ogg'=1, 'sound/items/geiger/med2.ogg'=1, 'sound/items/geiger/med3.ogg'=1, 'sound/items/geiger/med4.ogg'=1),
-		list('sound/items/geiger/high1.ogg'=1, 'sound/items/geiger/high2.ogg'=1, 'sound/items/geiger/high3.ogg'=1, 'sound/items/geiger/high4.ogg'=1),
-		list('sound/items/geiger/ext1.ogg'=1, 'sound/items/geiger/ext2.ogg'=1, 'sound/items/geiger/ext3.ogg'=1, 'sound/items/geiger/ext4.ogg'=1)
+		list(
+			SOUND_LOOP_ENTRY('sound/items/geiger/low1.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/low2.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/low3.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/low4.ogg', 2, 1)
+			),
+		list(
+			SOUND_LOOP_ENTRY('sound/items/geiger/med1.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/med2.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/med3.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/med4.ogg', 2, 1)
+			),
+		list(
+			SOUND_LOOP_ENTRY('sound/items/geiger/high1.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/high2.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/high3.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/high4.ogg', 2, 1)
+			),
+		list(
+			SOUND_LOOP_ENTRY('sound/items/geiger/ext1.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/ext2.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/ext3.ogg', 2, 1),
+			SOUND_LOOP_ENTRY('sound/items/geiger/ext4.ogg', 2, 1)
+			)
 		)
 	mid_length = 2
 	volume = 25
@@ -28,7 +48,7 @@
 			return null
 	return ..(starttime, mid_sounds[danger])
 
-/datum/looping_sound/geiger/stop()
+/datum/looping_sound/geiger/stop(atom/remove_thing, kill = FALSE)
 	. = ..()
 	last_radiation = 0
 

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -1,7 +1,11 @@
 /datum/looping_sound/showering
 	start_sound = 'sound/machines/shower/shower_start.ogg'
 	start_length = 2
-	mid_sounds = list('sound/machines/shower/shower_mid1.ogg'=1,'sound/machines/shower/shower_mid2.ogg'=1,'sound/machines/shower/shower_mid3.ogg'=1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/shower/shower_mid1.ogg', 10, 1),
+		SOUND_LOOP_ENTRY('sound/machines/shower/shower_mid2.ogg', 10, 1),
+		SOUND_LOOP_ENTRY('sound/machines/shower/shower_mid3.ogg', 10, 1)
+		)
 	mid_length = 10
 	end_sound = 'sound/machines/shower/shower_end.ogg'
 	volume = 10
@@ -9,7 +13,11 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/supermatter
-	mid_sounds = list('sound/machines/sm/supermatter1.ogg'=1,'sound/machines/sm/supermatter2.ogg'=1,'sound/machines/sm/supermatter3.ogg'=1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/sm/supermatter1.ogg', 10, 1),
+		SOUND_LOOP_ENTRY('sound/machines/sm/supermatter2.ogg', 10, 1),
+		SOUND_LOOP_ENTRY('sound/machines/sm/supermatter3.ogg', 10, 1)
+		)
 	mid_length = 10
 	volume = 1
 
@@ -18,7 +26,11 @@
 /datum/looping_sound/generator
 	start_sound = 'sound/machines/generator/generator_start.ogg'
 	start_length = 4
-	mid_sounds = list('sound/machines/generator/generator_mid1.ogg'=1, 'sound/machines/generator/generator_mid2.ogg'=1, 'sound/machines/generator/generator_mid3.ogg'=1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/generator/generator_mid1.ogg', 4, 1), 
+		SOUND_LOOP_ENTRY('sound/machines/generator/generator_mid2.ogg', 4, 1), 
+		SOUND_LOOP_ENTRY('sound/machines/generator/generator_mid3.ogg', 4, 1)
+		)
 	mid_length = 4
 	end_sound = 'sound/machines/generator/generator_end.ogg'
 	volume = 40
@@ -29,7 +41,10 @@
 /datum/looping_sound/deep_fryer
 	start_sound = 'sound/machines/fryer/deep_fryer_immerse.ogg' //my immersions
 	start_length = 10
-	mid_sounds = list('sound/machines/fryer/deep_fryer_1.ogg' = 1, 'sound/machines/fryer/deep_fryer_2.ogg' = 1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/fryer/deep_fryer_1.ogg', 2, 1), 
+		SOUND_LOOP_ENTRY('sound/machines/fryer/deep_fryer_2.ogg', 2, 1)
+		)
 	mid_length = 2
 	end_sound = 'sound/machines/fryer/deep_fryer_emerge.ogg'
 	volume = 5
@@ -39,7 +54,10 @@
 /datum/looping_sound/microwave
 	start_sound = 'sound/machines/microwave/microwave-start.ogg'
 	start_length = 10
-	mid_sounds = list('sound/machines/microwave/microwave-mid1.ogg'=10, 'sound/machines/microwave/microwave-mid2.ogg'=1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/microwave/microwave-mid1.ogg', 10, 10), 
+		SOUND_LOOP_ENTRY('sound/machines/microwave/microwave-mid2.ogg', 10, 1)
+		)
 	mid_length = 10
 	end_sound = 'sound/machines/microwave/microwave-end.ogg'
 	volume = 90
@@ -48,7 +66,25 @@
 
 /datum/looping_sound/grill
 	mid_length = 2
-	mid_sounds = list('sound/machines/fryer/deep_fryer_1.ogg' = 1, 'sound/machines/fryer/deep_fryer_2.ogg' = 1)
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/fryer/deep_fryer_1.ogg', 10, 1), 
+		SOUND_LOOP_ENTRY('sound/machines/fryer/deep_fryer_2.ogg', 10, 1)
+		)
 	volume = 10
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/datum/looping_sound/debug_area_ambiance
+	start_sound = 'sound/machines/microwave/microwave-start.ogg'
+	start_length = 10
+	mid_sounds = list(
+		SOUND_LOOP_ENTRY('sound/machines/microwave/microwave-mid1.ogg', 10, 10), 
+		SOUND_LOOP_ENTRY('sound/machines/microwave/microwave-mid2.ogg', 10, 1)
+		)
+	mid_length = 10
+	end_sound = 'sound/machines/microwave/microwave-end.ogg'
+	volume = 90
+	channel = CHANNEL_AMBIENT_LOOP
+	direct = TRUE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/datums/looping_sounds/weather.dm
+++ b/code/datums/looping_sounds/weather.dm
@@ -1,8 +1,8 @@
 /datum/looping_sound/active_outside_ashstorm
 	mid_sounds = list(
-		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
-		'sound/weather/ashstorm/outside/active_mid1.ogg'=1,
-		'sound/weather/ashstorm/outside/active_mid1.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/active_mid1.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/active_mid1.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/active_mid1.ogg', 80, 1)
 		)
 	mid_length = 80
 	start_sound = 'sound/weather/ashstorm/outside/active_start.ogg'
@@ -12,9 +12,9 @@
 
 /datum/looping_sound/active_inside_ashstorm
 	mid_sounds = list(
-		'sound/weather/ashstorm/inside/active_mid1.ogg'=1,
-		'sound/weather/ashstorm/inside/active_mid2.ogg'=1,
-		'sound/weather/ashstorm/inside/active_mid3.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/active_mid1.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/active_mid2.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/active_mid3.ogg', 80, 1)
 		)
 	mid_length = 80
 	start_sound = 'sound/weather/ashstorm/inside/active_start.ogg'
@@ -24,9 +24,9 @@
 
 /datum/looping_sound/weak_outside_ashstorm
 	mid_sounds = list(
-		'sound/weather/ashstorm/outside/weak_mid1.ogg'=1,
-		'sound/weather/ashstorm/outside/weak_mid2.ogg'=1,
-		'sound/weather/ashstorm/outside/weak_mid3.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/weak_mid1.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/weak_mid2.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/outside/weak_mid3.ogg', 80, 1)
 		)
 	mid_length = 80
 	start_sound = 'sound/weather/ashstorm/outside/weak_start.ogg'
@@ -36,9 +36,9 @@
 
 /datum/looping_sound/weak_inside_ashstorm
 	mid_sounds = list(
-		'sound/weather/ashstorm/inside/weak_mid1.ogg'=1,
-		'sound/weather/ashstorm/inside/weak_mid2.ogg'=1,
-		'sound/weather/ashstorm/inside/weak_mid3.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/weak_mid1.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/weak_mid2.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/ashstorm/inside/weak_mid3.ogg', 80, 1)
 		)
 	mid_length = 80
 	start_sound = 'sound/weather/ashstorm/inside/weak_start.ogg'
@@ -49,9 +49,9 @@
 //credit: soundjay.com
 /datum/looping_sound/rain_sounds
 	mid_sounds = list(
-		'sound/weather/rain/outdoors/rain-01.ogg'=1,
-		'sound/weather/rain/outdoors/rain-02.ogg'=1,
-		'sound/weather/rain/outdoors/rain-03.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/rain/outdoors/rain-01.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/rain/outdoors/rain-02.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/rain/outdoors/rain-03.ogg', 80, 1)
 		)
 	mid_length = 80
 	volume = 50
@@ -59,9 +59,9 @@
 //credit: soundjay.com
 /datum/looping_sound/indoor_rain_sounds
 	mid_sounds = list(
-		'sound/weather/rain/indoors/rain-01.ogg'=1,
-		'sound/weather/rain/indoors/rain-02.ogg'=1,
-		'sound/weather/rain/indoors/rain-03.ogg'=1
+		SOUND_LOOP_ENTRY('sound/weather/rain/indoors/rain-01.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/rain/indoors/rain-02.ogg', 80, 1),
+		SOUND_LOOP_ENTRY('sound/weather/rain/indoors/rain-03.ogg', 80, 1)
 		)
 	mid_length = 80
 	volume = 25

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -904,7 +904,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/detectives_office
 	name = "Detective's Office"
 	icon_state = "detective"
-	ambientsounds = list('sound/ambience/ambidet1.ogg','sound/ambience/ambidet2.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/ambidet1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambidet2.ogg', 10 SECONDS))
 
 /area/security/detectives_office/private_investigators_office
 	name = "Private Investigator's Office"
@@ -1292,7 +1294,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	//Turret_protected
 
 /area/ai_monitored/turret_protected
-	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/ambimalf.ogg', 10 SECONDS), 
+		AREA_SOUND('sound/ambience/ambitech.ogg', 10 SECONDS), 
+		AREA_SOUND('sound/ambience/ambitech2.ogg', 10 SECONDS), 
+		AREA_SOUND('sound/ambience/ambiatmos.ogg', 10 SECONDS), 
+		AREA_SOUND('sound/ambience/ambiatmos2.ogg', 10 SECONDS))
 
 /area/ai_monitored/turret_protected/ai_upload
 	name = "AI Upload Chamber"
@@ -1356,8 +1363,15 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/tcommsat
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "For safety reasons, warping here is disallowed; the radio and bluespace noise could cause catastrophic results."
-	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg', 'sound/ambience/ambitech.ogg',\
-											'sound/ambience/ambitech2.ogg', 'sound/ambience/ambitech3.ogg', 'sound/ambience/ambimystery.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/ambisin2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambigen10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambitech.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambitech2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambitech3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambimystery.ogg', 10 SECONDS))
 
 /area/tcommsat/entrance
 	name = "Telecomms Teleporter"
@@ -1412,7 +1426,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters/lounge/jazz
 	name = "Jazz Lounge"
 	icon_state = "yellow"
-	ambientsounds = list('sound/ambience/ambidet1.ogg','sound/ambience/ambidet2.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/ambidet1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambidet2.ogg', 10 SECONDS))
 	nightshift_public_area = NIGHTSHIFT_AREA_RECREATION
 
 
@@ -1632,7 +1648,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	power_equip = FALSE
 	outdoors = TRUE
 	lightswitch = FALSE //no. just no
-	ambientsounds = list('sound/f13ambience/wasteland.ogg', 'sound/f13ambience/sewer.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/wasteland.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/sewer.ogg', 10 SECONDS))
 	flags_1 = NONE //>desert >>has destroyed robo dirt on it
 
 /area/f13/sunny_dale
@@ -1698,7 +1716,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/f13/underground/enclave_base
 	name = "Enclave Base"
 	icon_state = "enclave_base"
-	ambientsounds = list('sound/f13ambience/enclave_vault.ogg')
+	ambientsounds = list(AREA_SOUND('sound/f13ambience/enclave_vault.ogg', 10 SECONDS))
 
 /area/f13/den
 	name = "Den"
@@ -1708,19 +1726,19 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Overseer's Office"
 	icon_state = "overseer_office"
 	requires_power = TRUE
-	ambientsounds = list('sound/f13ambience/vaulttec_vault.ogg')
+	ambientsounds = list(AREA_SOUND('sound/f13ambience/vaulttec_vault.ogg', 10 SECONDS))
 
 /area/f13/underground/vault_atrium_upper
 	name = "Vault Atrium Upper"
 	icon_state = "vault_atrium_upper"
 	requires_power = TRUE
-	ambientsounds = list('sound/f13ambience/vaulttec_vault.ogg')
+	ambientsounds = list(AREA_SOUND('sound/f13ambience/vaulttec_vault.ogg', 10 SECONDS))
 
 /area/f13/underground/vault_atrium_Lower
 	name = "Vault Atrium Lower"
 	icon_state = "vault_atrium_upper"
 	requires_power = TRUE
-	ambientsounds = list('sound/f13ambience/vaulttec_vault.ogg')
+	ambientsounds = list(AREA_SOUND('sound/f13ambience/vaulttec_vault.ogg', 10 SECONDS))
 
 /area/shuttle/vault_elevator
 	name = "Vault Elevator"
@@ -1753,7 +1771,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/shuttle/vault113_elevator
 	name = "Vault 113 Elevator"
 
-	ambientsounds = list('sound/f13ambience/vaulttec_vault.ogg')
+	ambientsounds = list(AREA_SOUND('sound/f13ambience/vaulttec_vault.ogg', 10 SECONDS))
 
 /area/shuttle/mining_elevator
 	name = "Mining Elevator"

--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -16,7 +16,13 @@ Unused icons for new areas are "awaycontent1" ~ "awaycontent30"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	ambientsounds = list('sound/ambience/shore.ogg', 'sound/ambience/seag1.ogg','sound/ambience/seag2.ogg','sound/ambience/seag2.ogg','sound/ambience/ambiodd.ogg','sound/ambience/ambinice.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/shore.ogg', 10 SECONDS), 
+		AREA_SOUND('sound/ambience/seag1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/seag2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/seag2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambiodd.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambinice.ogg', 10 SECONDS))
 
 /area/awaymission/errorroom
 	name = "Super Secret Room"

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -65,7 +65,7 @@
 
 /area/ruin/space/has_grav/powered/aesthetic
 	name = "Aesthetic"
-	ambientsounds = list('sound/ambience/ambivapor1.ogg')
+	ambientsounds = list(AREA_SOUND('sound/ambience/ambivapor1.ogg', 10 SECONDS))
 
 
 //Ruin of Hotel
@@ -517,14 +517,14 @@
 	name = "Abandoned Teleporter"
 	icon_state = "teleporter"
 	music = "signal"
-	ambientsounds = list('sound/ambience/ambimalf.ogg')
+	ambientsounds = list(AREA_SOUND('sound/ambience/ambimalf.ogg', 10 SECONDS))
 
 //OLD AI SAT
 
 /area/ruin/space/old_ai_sat/ai
 	name = "AI Chamber"
 	icon_state = "ai"
-	ambientsounds = list('sound/ambience/ambimalf.ogg')
+	ambientsounds = list(AREA_SOUND('sound/ambience/ambimalf.ogg', 10 SECONDS))
 
 /area/ruin/space/old_ai_sat/main
 	name = "Wreck"

--- a/code/modules/awaymissions/mission_code/moonoutpost19.dm
+++ b/code/modules/awaymissions/mission_code/moonoutpost19.dm
@@ -24,7 +24,7 @@
 	power_equip = FALSE
 	power_light = FALSE
 	poweralm = FALSE
-	ambientsounds = list('sound/ambience/ambimine.ogg')
+	ambientsounds = list(AREA_SOUND('sound/ambience/ambimine.ogg', 10 SECONDS))
 	icon_state = "awaycontent5"
 
 /area/awaymission/moonoutpost19/hive

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -43,8 +43,10 @@
 		///////////////
 		//SOUND STUFF//
 		///////////////
-	var/ambience_playing= null
-	var/played			= 0
+	/// minimum time between an area will play its on-enter sound, if it plays at all
+	COOLDOWN_DECLARE(area_sound_effect_cooldown)
+	/// minimum time between an area will play its on-enter music
+	COOLDOWN_DECLARE(area_music_cooldown)
 		////////////
 		//SECURITY//
 		////////////

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -176,8 +176,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, Toggle_Soundscape)()
 		to_chat(usr, "You will now hear ambient sounds.")
 	else
 		to_chat(usr, "You will no longer hear ambient sounds.")
-		usr.stop_sound_channel(CHANNEL_AMBIENCE)
-		usr.stop_sound_channel(CHANNEL_BUZZ)
+		SEND_SOUND(usr, sound(null))
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ambience", "[usr.client.prefs.toggles & SOUND_AMBIENCE ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 /datum/verbs/menu/Settings/Sound/Toggle_Soundscape/Get_checked(client/C)
 	return C.prefs.toggles & SOUND_AMBIENCE
@@ -193,8 +192,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings/Sound, toggle_ship_ambience)()
 		to_chat(usr, "You will now hear wasteland ambience.")
 	else
 		to_chat(usr, "You will no longer hear wasteland ambience.")
-		usr.stop_sound_channel(CHANNEL_BUZZ)
-		usr.client.ambience_playing = 0
+		SEND_SOUND(usr, sound(null))
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Wasteland Ambience", "[usr.client.prefs.toggles & SOUND_SHIP_AMBIENCE ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, I bet you read this comment expecting to see the same thing :^)
 /datum/verbs/menu/Settings/Sound/toggle_ship_ambience/Get_checked(client/C)
 	return C.prefs.toggles & SOUND_SHIP_AMBIENCE

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -1,12 +1,6 @@
 //Fallout 13 specific areas directory
 
 /area
-	var/open_space = 0
-	var/list/ambientmusic = list('sound/misc/null.ogg')
-//	var/ambience_area =  list('sound/f13ambience/wasteland.ogg')
-	ambientsounds = list('sound/misc/null.ogg')
-	var/environment = -1
-	var/grow_chance = 100
 
 /area/f13
 	name = "error"
@@ -18,13 +12,23 @@
 
 //Ambigen sound tips for ambientsounds: 1 - 2 : outside the ruined buildings, 3 - 9 : inside the wasteland buildings, 10 - 14 : vaults and bunkers specific, 15-19 : caves
 
+
 /area/f13/wasteland
 	name = "Wasteland"
 	icon_state = "wasteland"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
 	ambientmusic = WASTELAND_AMBIENCE
-	ambientsounds = list('sound/f13ambience/swampsounds.ogg','sound/f13ambience/battle_1.ogg','sound/f13ambience/battle_2.ogg','sound/f13ambience/battle_3.ogg', \
-	'sound/f13ambience/rattlesnake_1.ogg','sound/f13ambience/rattlesnake_2.ogg','sound/f13ambience/rattlesnake_3.ogg','sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/swampsounds.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -105,10 +109,19 @@
 /area/f13/forest
 	name = "Forest"
 	icon_state = "forest"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
 //	ambientmusic = list('sound/f13music/fo2_wasteland.ogg','sound/f13music/fo2_chapel.ogg','sound/f13music/fo2_world.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg','sound/f13ambience/bird_5.ogg','sound/f13ambience/bird_6.ogg','sound/f13ambience/bird_7.ogg','sound/f13ambience/bird_8.ogg', \
-	'sound/f13ambience/rattlesnake_1.ogg','sound/f13ambience/rattlesnake_2.ogg','sound/f13ambience/rattlesnake_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_8.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_3.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -118,10 +131,16 @@
 /area/f13/ruins
 	name = "Ruins"
 	icon_state = "ruins"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
 //	ambientmusic = list('sound/f13music/fo2_ruins.ogg','sound/f13music/fo2_necropolis.ogg','sound/f13music/fo2_raider.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg','sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/rattlesnake_1.ogg','sound/f13ambience/rattlesnake_2.ogg','sound/f13ambience/rattlesnake_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_3.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -131,20 +150,32 @@
 /area/f13/shack
 	name = "Shack"
 	icon_state = "shack"
-//	ambience_area =  list('sound/f13ambience/shack.ogg')
 //	ambientmusic = list('sound/f13music/fo2_ruins.ogg','sound/f13music/fo2_city.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg', \
-	'sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg','sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS))
 	environment = 2
 	grow_chance = 5
 
 /area/f13/building
 	name = "Building"
 	icon_state = "building"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_ruins.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg', \
-	'sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg','sound/f13ambience/ambigen_9.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS))
 	environment = 2
 	grow_chance = 5
 
@@ -187,10 +218,20 @@
 /area/f13/farm
 	name = "Farm"
 	icon_state = "farm"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_village.ogg','sound/f13music/fo2_wasteland.ogg','sound/f13music/fo2_chapel.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg','sound/f13ambience/bird_5.ogg','sound/f13ambience/bird_6.ogg','sound/f13ambience/bird_7.ogg','sound/f13ambience/bird_8.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_8.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -200,10 +241,20 @@
 /area/f13/tribe
 	name = "Tribe"
 	icon_state = "tribe"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_village.ogg','sound/f13music/fo2_wasteland.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg','sound/f13ambience/bird_5.ogg','sound/f13ambience/bird_6.ogg','sound/f13ambience/bird_7.ogg','sound/f13ambience/bird_8.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_8.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -213,10 +264,16 @@
 /area/f13/village
 	name = "Village"
 	icon_state = "village"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_village.ogg','sound/f13music/fo2_wasteland.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 15
 	grow_chance = 5
@@ -224,10 +281,16 @@
 /area/f13/outpost
 	name = "Outpost"
 	icon_state = "outpost"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_outpost.ogg','sound/f13music/fo2_brotherhood.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/battle_1.ogg','sound/f13ambience/battle_2.ogg','sound/f13ambience/battle_3.ogg', \
-	'sound/f13ambience/bird_1.ogg','sound/f13ambience/bird_2.ogg','sound/f13ambience/bird_3.ogg','sound/f13ambience/bird_4.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/battle_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/bird_4.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 16
 	grow_chance = 5
@@ -235,10 +298,15 @@
 /area/f13/hub
 	name = "Hub"
 	icon_state = "hub"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_hub.ogg','sound/f13music/fo2_village.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/rattlesnake_1.ogg','sound/f13ambience/rattlesnake_2.ogg','sound/f13ambience/rattlesnake_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_3.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -248,10 +316,14 @@
 /area/f13/city
 	name = "City"
 	icon_state = "city"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_city.ogg','sound/f13music/fo2_hub.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -269,27 +341,38 @@
 /area/f13/citycaves
 	name = "City Caves"
 	icon_state = "citycaves"
-//	ambience_area =  list('sound/f13ambience/cave.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_city.ogg','sound/f13music/fo2_hub.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg','sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS))
 	environment = 8
 	grow_chance = 25
 
 /area/f13/chapel
 	name = "Chapel"
 	icon_state = "chapel"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_chapel.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/ambience/ambicha1.ogg','sound/ambience/ambicha2.ogg','sound/ambience/ambicha3.ogg','sound/ambience/ambicha4.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/ambicha1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambicha2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambicha3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/ambicha4.ogg', 10 SECONDS))
 	environment = 5
 	grow_chance = 5
 
 /area/f13/bar
 	name = "Bar"
 	icon_state = "bar"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_bar.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS))
 	environment = 2
 	grow_chance = 5
 
@@ -300,50 +383,82 @@
 /area/f13/casino
 	name = "Casino"
 	icon_state = "casino"
-//	ambience_area =  list('sound/f13ambience/warehouse.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_bar.ogg','sound/f13music/fo2_raiders.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg', \
-	'sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS))
 	environment = 6
 	grow_chance = 5
 
 /area/f13/clinic
 	name = "Clinic"
 	icon_state = "clinic"
-//	ambience_area =  list('sound/f13ambience/warehouse.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_necropolis.ogg','sound/f13music/fo2_ruins.ogg','sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_caves.ogg','sound/f13music/fo2_desert.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg','sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg', \
-	'sound/f13ambience/ambigen_5.ogg','sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg','sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_17.ogg','sound/f13ambience/ambigen_18.ogg','sound/f13ambience/ambigen_19.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_17.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_18.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_19.ogg', 10 SECONDS))
 	environment = 6
 	grow_chance = 5
 
 /area/f13/office
 	name = "Office"
 	icon_state = "office"
-//	ambience_area =  list('sound/f13ambience/warehouse.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_city.ogg','sound/f13music/fo2_ruins.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg', \
-	'sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS))
 	environment = 2
 	grow_chance = 5
 
 /area/f13/store
 	name = "Store"
 	icon_state = "store"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_bar.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg', \
-	'sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg','sound/f13ambience/ambigen_8.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS))
 	environment = 4
 	grow_chance = 5
 
 /area/f13/bunker
 	name = "Bunker"
 	icon_state = "bunker"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_vats.ogg','sound/f13music/fo2_outpost.ogg','sound/f13music/fo2_ruins.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg','sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg', \
-	'sound/f13ambience/ambigen_12.ogg','sound/f13ambience/ambigen_13.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS))
 	environment = 11
 	grow_chance = 5
 
@@ -360,9 +475,15 @@
 /area/f13/tunnel
 	name = "Tunnel"
 	icon_state = "tunnel"
-//	ambience_area =  list('sound/f13ambience/cave.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_caves.ogg','sound/f13music/fo2_vats.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_12.ogg','sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg','sound/f13effects/steam_short.ogg','sound/f13effects/steam_long.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_short.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_long.ogg', 10 SECONDS))
 	environment = 21
 	grow_chance = 25
 
@@ -401,55 +522,80 @@
 /area/f13/trainstation
 	name = "Tunnel"
 	icon_state = "tunnel"
-//	ambience_area =  list('sound/f13ambience/cave.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_caves.ogg','sound/f13music/fo2_vats.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_12.ogg','sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg','sound/f13effects/steam_short.ogg','sound/f13effects/steam_long.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_short.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_long.ogg', 10 SECONDS))
 	environment = 21
 	grow_chance = 25
 
 /area/f13/sewer
 	name = "Sewer"
 	icon_state = "sewer"
-//	ambience_area =  list('sound/f13ambience/sewer.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_caves.ogg','sound/f13music/fo2_desert.ogg','sound/f13music/fo2_vats.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_9.ogg','sound/f13effects/steam_short.ogg','sound/f13effects/steam_long.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_short.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_long.ogg', 10 SECONDS))
 	environment = 21
 	grow_chance = 50
 
 /area/f13/caves
 	name = "Caves"
 	icon_state = "caves"
-//	ambience_area =  list('sound/f13ambience/cave.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_caves.ogg','sound/f13music/fo2_desert.ogg','sound/f13music/fo2_necropolis.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg','sound/f13ambience/ambigen_17.ogg','sound/f13ambience/ambigen_18.ogg','sound/f13ambience/ambigen_19.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_17.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_18.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_19.ogg', 10 SECONDS))
 	environment = 8
 	grow_chance = 75
 
 /area/f13/subway
 	name = "Subway"
 	icon_state = "subway"
-//	ambience_area =  list('sound/f13ambience/cave.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_tunnels.ogg','sound/f13music/fo2_caves.ogg','sound/f13music/fo2_vats.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg','sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_12.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS))
 	environment = 21
 	grow_chance = 25
 
 /area/f13/secret
 	name = "Secret"
 	icon_state = "secret"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_chapel.ogg','sound/f13music/fo2_city.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/ambience/signal.ogg','sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg', \
-	'sound/f13ambience/ambigen_12.ogg','sound/f13ambience/ambigen_13.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS))
 	environment = 11
 	grow_chance = 0
 
 /area/f13/radiation
 	name = "Radiation"
 	icon_state = "radiation"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_wasteland.ogg','sound/f13music/fo2_desert.ogg','sound/f13music/fo2_world.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/rattlesnake_1.ogg','sound/f13ambience/rattlesnake_2.ogg','sound/f13ambience/rattlesnake_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/rattlesnake_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/rattlesnake_3.ogg', 10 SECONDS))
 	environment = 19
 	grow_chance = 5
 
@@ -458,10 +604,17 @@
 /area/f13/raiders
 	name = "Raiders"
 	icon_state = "raiders"
-//	ambience_area =  list('sound/f13ambience/wasteland.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_raider.ogg','sound/f13music/fo2_raiders.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_1.ogg','sound/f13ambience/ambigen_2.ogg','sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg', \
-	'sound/f13ambience/battle_1.ogg','sound/f13ambience/battle_2.ogg','sound/f13ambience/battle_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/battle_3.ogg', 10 SECONDS))
 	outdoors = 1
 	open_space = 1
 	blob_allowed = 0
@@ -471,10 +624,16 @@
 /area/f13/vault
 	name = "Vault"
 	icon_state = "vaulttec"
-//	ambience_area =  list('sound/f13ambience/vaulttec_vault.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_vats.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg','sound/f13ambience/ambigen_12.ogg', \
-	'sound/f13ambience/ambigen_13.ogg','sound/f13ambience/ambigen_14.ogg','sound/f13effects/steam_short.ogg','sound/f13effects/steam_long.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_14.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_short.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13effects/steam_long.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 6
 	grow_chance = 5
@@ -578,10 +737,14 @@
 /area/f13/brotherhood
 	name = "Brotherhood of Steel Bunker"//Brother Hood
 	icon_state = "brotherhood"
-//	ambience_area =  list('sound/f13ambience/enclave_vault.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_brotherhood.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg', \
-	'sound/f13ambience/ambigen_12.ogg','sound/f13ambience/ambigen_13.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 6
 	grow_chance = 5
@@ -645,10 +808,16 @@
 /area/f13/enclave
 	name = "Enclave Bunker"
 	icon_state = "enclave"
-//	ambience_area =  list('sound/f13ambience/enclave_vault.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_vats.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg','sound/f13ambience/ambigen_12.ogg', \
-	'sound/f13ambience/ambigen_13.ogg','sound/f13ambience/ambigen_14.ogg','sound/ambience/signal.ogg','sound/f13ambience/enclave_vault.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_14.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/enclave_vault.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 6
 	grow_chance = 5
@@ -656,10 +825,14 @@
 /area/f13/ahs
 	name = "Adepts of Hubology Studies"
 	icon_state = "ahs"
-//	ambience_area =  list('sound/f13ambience/enclave_vault.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_vats.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg','sound/f13ambience/ambigen_12.ogg', \
-	'sound/f13ambience/ambigen_13.ogg','sound/ambience/signal.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 5
 	grow_chance = 5
@@ -667,10 +840,19 @@
 /area/f13/ncr
 	name = "NCR Outpost"
 	icon_state = "ncr"
-//	ambience_area =  list('sound/f13ambience/warehouse.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_city.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_5.ogg','sound/f13ambience/ambigen_6.ogg','sound/f13ambience/ambigen_7.ogg', \
-	'sound/f13ambience/ambigen_8.ogg','sound/f13ambience/ambigen_9.ogg','sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg','sound/f13ambience/ambigen_12.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_5.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_6.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_7.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_8.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_9.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 4
 	grow_chance = 5
@@ -679,10 +861,16 @@
 /area/f13/legion
 	name = "Legion Fortress"
 	icon_state = "legion"
-//	ambience_area =  list('sound/f13ambience/building.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_hub.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_3.ogg','sound/f13ambience/ambigen_4.ogg','sound/f13ambience/ambigen_15.ogg','sound/f13ambience/ambigen_16.ogg', \
-	'sound/f13ambience/dog_distant_1.ogg','sound/f13ambience/dog_distant_2.ogg','sound/f13ambience/dog_distant_3.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_3.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_4.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_15.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_16.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_1.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_2.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/dog_distant_3.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 4
 	grow_chance = 5
@@ -690,10 +878,14 @@
 /area/f13/followers
 	name = "Followers of the Apocalypse Clinic"
 	icon_state = "followers"
-//	ambience_area =  list('sound/f13ambience/warehouse.ogg')
+
 //	ambientmusic = list('sound/f13music/fo2_vats.ogg','sound/f13music/fo2_outpost.ogg','sound/misc/null.ogg')
-	ambientsounds = list('sound/f13ambience/ambigen_10.ogg','sound/f13ambience/ambigen_11.ogg','sound/f13ambience/ambigen_12.ogg', \
-	'sound/f13ambience/ambigen_13.ogg','sound/ambience/signal.ogg')
+	ambientsounds = list(
+		AREA_SOUND('sound/f13ambience/ambigen_10.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_11.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_12.ogg', 10 SECONDS),
+		AREA_SOUND('sound/f13ambience/ambigen_13.ogg', 10 SECONDS),
+		AREA_SOUND('sound/ambience/signal.ogg', 10 SECONDS))
 	blob_allowed = 0
 	environment = 5
 	grow_chance = 5

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -661,6 +661,7 @@
 #include "code\datums\helper_datums\stack_end_detector.dm"
 #include "code\datums\helper_datums\teleport.dm"
 #include "code\datums\looping_sounds\_looping_sound.dm"
+#include "code\datums\looping_sounds\ambient_sounds.dm"
 #include "code\datums\looping_sounds\item_sounds.dm"
 #include "code\datums\looping_sounds\machinery_sounds.dm"
 #include "code\datums\looping_sounds\weather.dm"


### PR DESCRIPTION
## About The Pull Request

Adds in support for areas to use layerable sound loops as ambient effects! Doesn't actually add any, but that's where you come in!

TO MAKE A NEW AMBIENT SOUND LOOP:

Goto code\datums\looping_sounds\ambient_sounds.dm
make sure direct = TRUE
v- this is the most important part
mid_sounds = list(
		SOUND_LOOP_ENTRY('sound/file.ogg', num SECONDS, pick weight), 
		SOUND_LOOP_ENTRY('sound/file.ogg', num SECONDS, pick weight), 
		SOUND_LOOP_ENTRY('sound/file.ogg', num SECONDS, pick weight), 
		SOUND_LOOP_ENTRY('sound/file.ogg', num SECONDS, pick weight)
		)

Works best if you make an ambient loop be just a bunch of similar sounds, like animal noises, or machinery stuff, cus we can layer them all together in the area!

To assign ambient sound loops to an area, add it to a list of type paths on the ambience_area var.
ambience_area = list(/datum/looping_sound/ambient/something, /datum/looping_sound/ambient/some_other_thing)

Also fixes on-enter sound effects (different from sound loops, for some reason includes music and stuff like birds) to actually work. Fin fact, this game actually has ambient sounds, just that they were broken.