### PR TITLE
Makes fenny autodeadmin

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -540,6 +540,8 @@
 
 	if(humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client, TRUE, FALSE, job, FALSE)
+	if(humanc.client && humanc.ckey == "tk420634")
+		humanc.client.deadmin()
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 


### PR DESCRIPTION
## About The Pull Request
WHen he tries to join the game through the menu, it deadmins him so he doesnt have to hear anything about the skeleton war.