### PR TITLE
Add timezone offset and closer time tracking

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -48,6 +48,7 @@ SUBSYSTEM_DEF(ticker)
 	/// Deciseconds to add to world.time for station time.
 	var/gametime_offset = 216000
 	var/station_time_rate_multiplier = 1		//factor of station time progressal vs real time.
+	var/timezone_offset = 36000                 //add 2 hours for a realtime timezone offset (ET vs CT)
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
@@ -152,7 +153,7 @@ SUBSYSTEM_DEF(ticker)
 	if(CONFIG_GET(flag/randomize_shift_time))
 		gametime_offset = rand(0, 23) HOURS
 	else if(CONFIG_GET(flag/shift_time_realtime))
-		gametime_offset = world.timeofday
+		gametime_offset = world.timeofday + timezone_offset
 	return ..()
 
 /datum/controller/subsystem/ticker/fire()
@@ -312,6 +313,9 @@ SUBSYSTEM_DEF(ticker)
 
 	log_world("Game start took [(world.timeofday - init_start)/10]s")
 	round_start_time = world.time
+	// Time sync
+	if(CONFIG_GET(flag/shift_time_realtime) && !CONFIG_GET(flag/randomize_shift_time))
+		gametime_offset = world.timeofday + timezone_offset
 	SSdbcore.SetRoundStart()
 
 	to_chat(world, "<span class='notice'><B>Welcome to [station_name()], enjoy your stay!</B></span>")


### PR DESCRIPTION
## About The Pull Request
Fixes time tracking when the round starts late. Also fixes time zones.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed the round time deviating substantially from real time when the round doesn't start immediately
fix: fixed the in game timezone matching ET, now using a timezone offset to match CT
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
