### PR TITLE
Adds Firing Range to RedRiver

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -562,9 +562,12 @@
 	},
 /area/f13/wasteland)
 "apl" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building)
 "apD" = (
 /turf/open/indestructible/ground/outside/road{
@@ -606,13 +609,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "aqm" = (
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aqP" = (
 /obj/structure/disposalpipe/broken{
@@ -821,8 +819,13 @@
 	},
 /area/f13/wasteland)
 "azQ" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/structure/closet/crate/trashcart,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalleft"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -1842,6 +1845,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
+"bdV" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "bdX" = (
 /obj/structure/mirror{
 	pixel_x = -25
@@ -3464,6 +3473,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cbn" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
+"cbr" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ccg" = (
 /obj/structure/nest/gecko,
 /obj/structure/flora/rock/pile/largejungle,
@@ -3692,13 +3714,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"chO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "ciB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rock/pile/largejungle{
@@ -3743,12 +3758,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"cjc" = (
-/mob/living/simple_animal/hostile/renegade/soldier,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "cji" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13{
@@ -3808,12 +3817,8 @@
 	},
 /area/f13/wasteland)
 "cln" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
+/obj/structure/decoration/clock,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "clB" = (
 /obj/structure/rack/shelf_metal,
@@ -3935,13 +3940,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/building/abandoned)
-"col" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "coq" = (
 /obj/structure/car,
 /obj/effect/decal/cleanable/dirt,
@@ -4297,16 +4295,9 @@
 	},
 /area/f13/building/abandoned)
 "cyo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/marking{
-	icon_state = "singlehorizontal"
-	},
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontalleft"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
+/obj/item/target,
+/obj/item/target/vaultie2,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "cyw" = (
 /obj/item/clothing/glasses/legiongoggles{
@@ -4533,13 +4524,6 @@
 	icon_state = "tealwhrustychess"
 	},
 /area/f13/building/abandoned)
-"cHg" = (
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "cHh" = (
 /obj/machinery/light{
 	dir = 4
@@ -5196,17 +5180,6 @@
 "cVO" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
-"cWe" = (
-/obj/structure/closet/fridge,
-/obj/item/export/bottle/rum,
-/obj/item/export/bottle/vodka,
-/obj/item/export/bottle/absinthe,
-/obj/item/reagent_containers/food/snacks/burrito,
-/obj/item/reagent_containers/food/snacks/candy,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "cWs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5345,9 +5318,8 @@
 	},
 /area/f13/building)
 "daF" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/turf/closed/wall/f13/store,
+/obj/item/broken_bottle,
+/turf/open/floor/carpet,
 /area/f13/building)
 "daQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5648,7 +5620,9 @@
 /area/f13/building)
 "dlC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -6135,17 +6109,16 @@
 	},
 /area/f13/wasteland)
 "dBE" = (
-/obj/machinery/light/lampost{
-	dir = 1;
-	pixel_x = -32
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerborder"
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
 	},
-/area/f13/wasteland/city)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "dBV" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/dark,
@@ -6354,13 +6327,6 @@
 	icon_state = "bench_center"
 	},
 /obj/effect/spawner/lootdrop/raiderloot,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/building)
-"dGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/grill,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -6919,10 +6885,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
-"dUt" = (
-/obj/item/broken_bottle,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dUF" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/structure/curtain,
@@ -7334,10 +7296,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
-/area/f13/wasteland)
-"ehE" = (
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ehG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7844,11 +7802,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
-"evX" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ewn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
@@ -8098,14 +8051,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"eDN" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/wasteland)
 "eEr" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -9042,6 +8987,17 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
+"fiF" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "fiL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -9854,6 +9810,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"fEL" = (
+/obj/item/broken_bottle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fEU" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/f13{
@@ -10221,6 +10181,14 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"fQv" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "fQx" = (
 /obj/machinery/light{
 	dir = 4
@@ -11220,6 +11188,11 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city)
+"gwI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gwK" = (
 /obj/structure/flora/tree/thick_tree,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11945,14 +11918,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland/city)
-"gRc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "gRn" = (
 /turf/closed/mineral/random/low_chance{
 	mineralAmt = 6;
@@ -12817,10 +12782,6 @@
 /obj/structure/nest/mirelurk,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
-"hyi" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/wasteland)
 "hyp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13427,6 +13388,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hSi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hSk" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel{
@@ -13653,13 +13621,6 @@
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/water,
 /area/f13/building/abandoned)
-"hXY" = (
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
-	},
-/area/f13/wasteland)
 "hYa" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -13668,6 +13629,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"hYd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire/prelit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "hYe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14227,13 +14195,13 @@
 	},
 /area/f13/wasteland/city)
 "ipL" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/fence/corner{
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "ipV" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/brick,
@@ -15345,12 +15313,6 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/building/abandoned)
-"iWv" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "iWH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15465,8 +15427,13 @@
 	},
 /area/f13/building)
 "jbi" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -15800,6 +15767,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jkk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/anchored,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "jko" = (
 /obj/structure/simple_door/metal/store{
 	name = "Warren Police Department"
@@ -15958,8 +15934,10 @@
 	},
 /area/f13/wasteland)
 "joe" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/structure/car/rubbish3,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -16166,12 +16144,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water/running{
 	color = " A6635D"
-	},
-/area/f13/wasteland)
-"jvn" = (
-/obj/item/broken_bottle,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "jvp" = (
@@ -17523,6 +17495,10 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
+"kir" = (
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kiu" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -17687,13 +17663,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building/abandoned)
-"knQ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "knY" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -18279,6 +18248,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"kFU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kFV" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 27
@@ -18514,6 +18490,13 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
+"kNB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kOc" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -18606,11 +18589,12 @@
 	},
 /area/f13/building/abandoned)
 "kQh" = (
-/obj/structure/bonfire/dense,
+/obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+	dir = 4;
+	icon_state = "outerborder"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "kQq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -18658,9 +18642,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
-"kRh" = (
-/obj/item/broken_bottle,
-/turf/open/floor/carpet,
+"kQV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "kRj" = (
 /obj/structure/window/fulltile/store,
@@ -19423,10 +19411,13 @@
 	},
 /area/f13/wasteland/city)
 "llp" = (
-/obj/structure/simple_door/metal/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "llC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19623,10 +19614,6 @@
 /obj/structure/flora/burnedtree5,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"lsv" = (
-/obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "lsy" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
@@ -20336,10 +20323,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/abandoned)
-"lQd" = (
-/obj/structure/sign/poster/contraband/revolver,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "lQm" = (
 /obj/structure/railing{
 	dir = 10
@@ -21329,13 +21312,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"mur" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "muz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -21421,15 +21397,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building/abandoned)
-"mwK" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "mwN" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21687,6 +21654,10 @@
 /obj/structure/flora/tree_log,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"mEi" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "mEP" = (
 /obj/structure/wreck/trash/two_tire,
 /obj/effect/decal/cleanable/dirt,
@@ -21694,10 +21665,6 @@
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontaltopborderbottom1"
 	},
-/area/f13/wasteland)
-"mFc" = (
-/obj/effect/spawner/lootdrop/cig_packs,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mFk" = (
 /obj/structure/lattice/catwalk,
@@ -21770,17 +21737,22 @@
 /turf/open/indestructible/ground/outside/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mGM" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "mGN" = (
 /obj/structure/flora/grass/coyote/twentyseven,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"mHc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire/prelit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "mHi" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -21956,10 +21928,6 @@
 	color = " A6635D"
 	},
 /area/f13/wasteland/city)
-"mNM" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "mOi" = (
 /obj/structure/fence{
 	dir = 4
@@ -22926,10 +22894,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"nrG" = (
-/obj/item/target,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "nrM" = (
 /obj/structure/fence{
 	dir = 4
@@ -23306,6 +23270,10 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nEC" = (
+/obj/structure/decoration/cctv,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "nEI" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -23628,10 +23596,11 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "nOf" = (
-/obj/item/target,
-/obj/item/target/vaultie2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/bonfire/dense,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "nOC" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/tree/jungle{
@@ -23660,8 +23629,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "nPB" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/structure/car/rubbish2,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -23996,10 +23970,6 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
-"obX" = (
-/obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "obY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -24581,17 +24551,6 @@
 /obj/structure/flora/grass/coyote/twentyfour,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"osn" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/obj/structure/barricade/wooden/planks{
-	icon_state = "board-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "osp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25865,6 +25824,14 @@
 	name = "bathroom tiles"
 	},
 /area/f13/building/abandoned)
+"pdZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "pen" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -26168,14 +26135,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
-"pok" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "pol" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
@@ -26311,6 +26270,15 @@
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
 	name = "concrete wall"
+	},
+/area/f13/building)
+"psp" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "psA" = (
@@ -26469,14 +26437,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/city)
-"pwL" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "pxh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -26744,11 +26704,13 @@
 "pDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/white/line,
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
 	},
 /obj/effect/spawner/lootdrop/cig_packs,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -26905,7 +26867,13 @@
 /turf/closed/indestructible/wood,
 /area/f13/building/abandoned)
 "pHs" = (
-/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalleft"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -27486,13 +27454,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
-"pZJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "pZK" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27636,6 +27597,10 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"qbX" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "qcl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27945,14 +27910,6 @@
 /obj/effect/gluttony,
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
-"qoN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
-	},
-/area/f13/wasteland/city)
 "qoP" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -28282,9 +28239,11 @@
 	},
 /area/f13/wasteland)
 "qyR" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/effect/decal/cleanable/oil{
 	pixel_x = 15
+	},
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -29679,12 +29638,6 @@
 /obj/item/crafting/fuse,
 /turf/open/floor/plating/rust,
 /area/f13/building)
-"rue" = (
-/mob/living/simple_animal/hostile/renegade/grunt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "ruh" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -30606,16 +30559,6 @@
 	icon_state = "outerborder"
 	},
 /area/f13/caves)
-"rWr" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "rWw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -30924,6 +30867,11 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"sgt" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "sgB" = (
 /obj/structure/flora/grass/coyote/one,
 /obj/structure/flora/grass/coyote/one,
@@ -31019,13 +30967,14 @@
 	},
 /area/f13/building/abandoned)
 "sip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/structure/closet/anchored,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
 	},
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "siv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31103,16 +31052,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
-"skG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/flag_texas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "skM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -31212,6 +31151,14 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"slW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "slZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -31746,9 +31693,18 @@
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
 "sCK" = (
-/obj/structure/decoration/cctv,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalleft"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "sDc" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31830,6 +31786,11 @@
 	dir = 4
 	},
 /area/f13/wasteland)
+"sGD" = (
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sGH" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/cig_packs,
@@ -32279,15 +32240,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sUb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "sUc" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/f13/outside/road{
@@ -32416,6 +32368,10 @@
 "sXK" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
+"sXT" = (
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "sYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32555,6 +32511,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"tbI" = (
+/obj/item/broken_bottle,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "tbP" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -32574,6 +32536,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"tbZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "tct" = (
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
@@ -32798,6 +32769,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
+"thC" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "thD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33788,6 +33763,10 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
+"tNi" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tNp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -34445,6 +34424,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
+"udT" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "udV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35172,10 +35156,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"uyf" = (
-/obj/structure/billboard/ritas,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "uyG" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/road{
@@ -35516,9 +35496,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/abandoned)
 "uJR" = (
-/obj/structure/sign/poster/contraband/tools,
+/obj/structure/sign/flag_texas,
 /turf/closed/wall/f13/store,
-/area/f13/building)
+/area/f13/wasteland)
 "uJU" = (
 /obj/structure/sign/poster/contraband/have_a_puff,
 /turf/closed/wall/rust,
@@ -35850,6 +35830,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"uVE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/flag_texas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "uVX" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -37019,6 +37009,13 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
+"vKW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vLt" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
@@ -37188,10 +37185,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/building/abandoned)
-"vRq" = (
-/obj/structure/decoration/clock,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "vRr" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -37234,6 +37227,12 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
+"vSw" = (
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vSR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -37350,6 +37349,12 @@
 "vWx" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"vWH" = (
+/obj/item/target/vaultie,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "vWI" = (
 /obj/structure/statue/wood/headstonewood{
 	pixel_y = 2
@@ -38011,11 +38016,20 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"wrK" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "wsC" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/structure/wreck/trash/one_tire{
 	pixel_x = 6;
 	pixel_y = -16
+	},
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -38077,9 +38091,11 @@
 	},
 /area/f13/wasteland)
 "wuJ" = (
-/obj/effect/turf_decal/trimline/white/line,
 /obj/effect/decal/waste{
 	icon_state = "goo9"
+	},
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -38587,12 +38603,6 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/radiation)
-"wJM" = (
-/obj/item/target/vaultie,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "wJX" = (
 /obj/structure/ladder,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38735,6 +38745,17 @@
 	},
 /turf/open/water,
 /area/f13/building/abandoned)
+"wNP" = (
+/obj/structure/closet/fridge,
+/obj/item/export/bottle/rum,
+/obj/item/export/bottle/vodka,
+/obj/item/export/bottle/absinthe,
+/obj/item/reagent_containers/food/snacks/burrito,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "wOb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39722,6 +39743,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building)
+"xuN" = (
+/obj/item/target,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xvd" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -40591,6 +40616,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city)
+"xUu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "xUB" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -55787,7 +55819,7 @@ qwS
 qwS
 qwS
 qwS
-hyi
+uJR
 ele
 uSf
 uSf
@@ -56050,10 +56082,10 @@ uSf
 rqj
 cEA
 uSf
-apl
+udT
 rdI
 tBA
-llp
+sGD
 oph
 oph
 oph
@@ -56305,10 +56337,10 @@ eLd
 oph
 lgf
 gLM
-kRh
+daF
 xOQ
 tBA
-evX
+gwI
 tBA
 uSf
 oph
@@ -56552,7 +56584,7 @@ oph
 oph
 uvV
 pZm
-nOf
+cyo
 gOB
 gOB
 stW
@@ -56563,8 +56595,8 @@ gpG
 uPy
 iHv
 oes
-vRq
-dUt
+cln
+fEL
 oaw
 tBA
 uSf
@@ -57073,9 +57105,9 @@ stW
 tiN
 oph
 jrO
-ehE
+kir
 uSf
-lsv
+sXT
 uSf
 uSf
 sGH
@@ -57085,10 +57117,10 @@ lMP
 wxt
 wxt
 uSf
-cWe
+wNP
 qCb
 vyJ
-ipL
+slW
 bJF
 fQd
 mva
@@ -57331,13 +57363,13 @@ frr
 oph
 jrO
 oph
-kQh
+nOf
 iyC
 hKR
 aZh
 xHT
-pZJ
-col
+vKW
+hSi
 bZc
 qCb
 qCb
@@ -57347,7 +57379,7 @@ dZs
 jpO
 ndZ
 dZs
-cjc
+vSw
 mva
 uSf
 oph
@@ -57599,7 +57631,7 @@ uSf
 wxt
 qCb
 agt
-pwL
+apl
 dZs
 heB
 dZs
@@ -57850,7 +57882,7 @@ xuF
 iyC
 gXJ
 qCb
-pwL
+apl
 qCb
 qCb
 qWC
@@ -58097,11 +58129,11 @@ oph
 oph
 oph
 dBx
-wJM
+vWH
 oph
 oph
 pBD
-chO
+kNB
 aNe
 iyC
 iyC
@@ -58119,7 +58151,7 @@ qCb
 ndZ
 dZs
 ndZ
-sUb
+tbZ
 lMP
 oph
 tSK
@@ -58360,7 +58392,7 @@ uIM
 eLd
 oph
 aNe
-dGp
+xUu
 qWv
 uSf
 vtu
@@ -58369,12 +58401,12 @@ kLQ
 uSf
 wxt
 qCb
-sCK
+nEC
 rwh
 uSf
 qCb
 pMr
-knQ
+kFU
 lCs
 qCb
 uSf
@@ -58612,7 +58644,7 @@ oph
 oph
 nMe
 wdJ
-nrG
+xuN
 oph
 eLd
 oph
@@ -58875,22 +58907,22 @@ tFq
 uSf
 aZh
 uSf
-lQd
+qbX
 uSf
 uSf
-obX
+wrK
 uSf
 uSf
 qLB
 wsL
 gWt
 wxt
-uJR
+thC
 qCb
 sln
-pok
+fQv
 leS
-sip
+jkk
 uSf
 oph
 tfn
@@ -59134,13 +59166,13 @@ qAQ
 wxt
 wxt
 wxt
-cln
+kQV
 cks
 bqF
 wxt
 wxt
 yja
-mur
+cbn
 dlZ
 uSf
 uSf
@@ -59398,7 +59430,7 @@ qCb
 qCb
 qCb
 qCb
-iWv
+cbr
 uSf
 oMa
 nPB
@@ -59646,10 +59678,10 @@ oph
 uSf
 nNi
 wxt
-mwK
+psp
 cks
 gPC
-pwL
+apl
 wxt
 rsY
 wxt
@@ -59658,9 +59690,9 @@ cks
 aFi
 uSf
 rCb
-pHs
+llp
 oMa
-pHs
+llp
 rCb
 out
 oph
@@ -59904,20 +59936,20 @@ uSf
 uSf
 uSf
 uSf
-mNM
+mEi
 ssw
-osn
+fiF
 lgf
-rWr
+sip
 gxl
-skG
+uVE
 jSn
-daF
+sgt
 lMP
 prn
 aKy
 xTO
-rue
+bdV
 oMa
 out
 oph
@@ -60164,10 +60196,10 @@ oph
 eGO
 oMa
 fqV
-pHs
+llp
 osB
-aqm
-mHc
+dBE
+hYd
 jbi
 elF
 wsC
@@ -60421,11 +60453,11 @@ oph
 eGO
 oMa
 oMa
-pHs
+llp
 oMa
 pDh
 oMa
-pHs
+llp
 oMa
 qyR
 quh
@@ -60934,7 +60966,7 @@ oph
 oph
 eGO
 jnT
-pHs
+llp
 pVV
 oMa
 gVU
@@ -60946,7 +60978,7 @@ dlC
 fqV
 joe
 oMa
-pHs
+llp
 out
 oph
 oph
@@ -61191,7 +61223,7 @@ oph
 tiN
 eGO
 oMa
-gRc
+sCK
 bsV
 oMa
 oMa
@@ -61199,7 +61231,7 @@ oMa
 qct
 oMa
 iUq
-cHg
+pHs
 oMa
 wuJ
 oMa
@@ -61420,7 +61452,7 @@ lrT
 nGN
 xVg
 nGN
-cyo
+wlX
 nGN
 vvV
 nGN
@@ -61717,7 +61749,7 @@ out
 ihy
 oph
 oph
-uyf
+tNi
 oph
 oph
 oph
@@ -61970,7 +62002,7 @@ wTK
 oMa
 oMa
 oMa
-jvn
+tbI
 oph
 oph
 oph
@@ -62227,7 +62259,7 @@ hmH
 oMa
 oMa
 oMa
-hXY
+kQh
 kgF
 kgF
 kgF
@@ -62299,7 +62331,7 @@ dOc
 dXu
 jdn
 wuc
-qoN
+pdZ
 ajY
 mXC
 mXC
@@ -63580,7 +63612,7 @@ mJQ
 hZR
 hZR
 hZR
-dBE
+mGM
 dXu
 jdn
 nIi
@@ -65811,7 +65843,7 @@ oph
 oph
 tiN
 oph
-mFc
+aqm
 oph
 oph
 oph
@@ -66840,7 +66872,7 @@ oph
 oph
 oph
 tfn
-mFc
+aqm
 oph
 oph
 nZZ
@@ -67863,7 +67895,7 @@ hwJ
 hNF
 duP
 cQC
-eDN
+ipL
 rdE
 kCV
 mup

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -275,9 +275,6 @@
 	},
 /area/f13/wasteland)
 "agt" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "carshop"
-	},
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
@@ -562,13 +559,10 @@
 	},
 /area/f13/wasteland)
 "apl" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "apD" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
@@ -609,9 +603,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "aqm" = (
-/obj/effect/spawner/lootdrop/cig_packs,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aqH" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "aqP" = (
 /obj/structure/disposalpipe/broken{
 	dir = 8
@@ -730,6 +732,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
+"avc" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "avK" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/book/bible,
@@ -771,6 +778,17 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland/city)
+"axu" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "axC" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt{
@@ -1483,6 +1501,18 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/city)
+"aRK" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "aRT" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -1845,12 +1875,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
-"bdV" = (
-/mob/living/simple_animal/hostile/renegade/grunt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "bdX" = (
 /obj/structure/mirror{
 	pixel_x = -25
@@ -2572,6 +2596,14 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"bxY" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "bya" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13{
@@ -2968,6 +3000,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bLr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bMz" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
@@ -3306,6 +3346,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bWP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/obj/structure/bed/mattress,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "bWS" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -3316,6 +3366,19 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/abandoned)
+"bXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalleft"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "bXu" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -3472,19 +3535,6 @@
 	termtag = "Business"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"cbn" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
-"cbr" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
 /area/f13/building)
 "ccg" = (
 /obj/structure/nest/gecko,
@@ -3817,9 +3867,13 @@
 	},
 /area/f13/wasteland)
 "cln" = (
-/obj/structure/decoration/clock,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "clB" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -3856,6 +3910,15 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/city)
+"cmm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/anchored,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "cmo" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13,
@@ -4295,10 +4358,15 @@
 	},
 /area/f13/building/abandoned)
 "cyo" = (
-/obj/item/target,
-/obj/item/target/vaultie2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/flag_texas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "cyw" = (
 /obj/item/clothing/glasses/legiongoggles{
 	pixel_y = -6
@@ -5304,6 +5372,11 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland)
+"cZA" = (
+/obj/item/target,
+/obj/item/target/vaultie2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "dab" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/spacevine,
@@ -5318,9 +5391,16 @@
 	},
 /area/f13/building)
 "daF" = (
-/obj/item/broken_bottle,
-/turf/open/floor/carpet,
-/area/f13/building)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "daQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/comfy/purple{
@@ -6093,6 +6173,12 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
 /area/f13/wasteland)
+"dAg" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "dBj" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top"
@@ -6109,9 +6195,6 @@
 	},
 /area/f13/wasteland)
 "dBE" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/decal/marking{
 	icon_state = "singlehorizontal"
 	},
@@ -6822,6 +6905,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"dRS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dRZ" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -7221,6 +7316,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
+"eec" = (
+/obj/structure/bonfire/dense,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "eew" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -7427,6 +7528,10 @@
 "ekY" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/engie,
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -8464,6 +8569,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"eRe" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "eRC" = (
 /obj/structure/fence{
 	dir = 4
@@ -8987,17 +9098,6 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/wasteland)
-"fiF" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/obj/structure/barricade/wooden/planks{
-	icon_state = "board-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "fiL" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -9810,10 +9910,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fEL" = (
-/obj/item/broken_bottle,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fEU" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/f13{
@@ -9953,6 +10049,14 @@
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
+"fJd" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 1;
+	pixel_x = -2
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -10005,6 +10109,11 @@
 /obj/item/weldingtool/mini,
 /turf/open/floor/plasteel/neutral,
 /area/f13/building/abandoned)
+"fKR" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/epipak,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "fKW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/corner{
@@ -10181,14 +10290,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
-"fQv" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "fQx" = (
 /obj/machinery/light{
 	dir = 4
@@ -10661,6 +10762,9 @@
 "gfS" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -11188,11 +11292,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city)
-"gwI" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gwK" = (
 /obj/structure/flora/tree/thick_tree,
 /turf/open/indestructible/ground/outside/dirt,
@@ -11467,7 +11566,7 @@
 /area/f13/wasteland)
 "gEd" = (
 /obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/f13/store,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "gEj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11947,6 +12046,10 @@
 "gRE" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/savannah,
+/area/f13/wasteland)
+"gRM" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gRS" = (
 /obj/machinery/light{
@@ -12467,6 +12570,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned)
+"hkw" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "hkX" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/decal/cleanable/dirt,
@@ -12834,6 +12946,12 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/building)
+"hAx" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hAC" = (
 /obj/structure/tires/five{
 	pixel_x = -19;
@@ -13388,13 +13506,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hSi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hSk" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel{
@@ -13629,13 +13740,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
-"hYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire/prelit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "hYe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14195,13 +14299,9 @@
 	},
 /area/f13/wasteland/city)
 "ipL" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "ipV" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/brick,
@@ -14350,6 +14450,12 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
+	},
+/area/f13/building)
+"iuH" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
 "ivl" = (
@@ -14851,11 +14957,21 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
 	dir = 4;
-	termtag = "Business"
+	termtag = "Business";
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /obj/structure/curtain{
 	color = "#e09634";
 	pixel_y = 32
+	},
+/obj/item/export/bottle/absinthe{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_y = 3;
+	pixel_x = 1
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
@@ -14964,6 +15080,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
+"iKr" = (
+/obj/item/target/vaultie,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "iKC" = (
@@ -15199,6 +15321,13 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plating/rust,
+/area/f13/building)
+"iSs" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "iSE" = (
 /obj/structure/chair/booth,
@@ -15767,15 +15896,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"jkk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/structure/closet/anchored,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "jko" = (
 /obj/structure/simple_door/metal/store{
 	name = "Warren Police Department"
@@ -16994,6 +17114,10 @@
 /obj/structure/flora/tallgrass5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"jQv" = (
+/obj/item/broken_bottle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jQH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17494,10 +17618,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
-/area/f13/wasteland)
-"kir" = (
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kiu" = (
 /turf/open/indestructible/ground/outside/road{
@@ -18248,13 +18368,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"kFU" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "kFV" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 27
@@ -18490,13 +18603,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topright,
 /area/f13/wasteland)
-"kNB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "kOc" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /obj/effect/decal/cleanable/dirt,
@@ -18589,12 +18695,12 @@
 	},
 /area/f13/building/abandoned)
 "kQh" = (
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kQq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -18642,14 +18748,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
-"kQV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "kRj" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/spacevine,
@@ -19089,6 +19187,8 @@
 /area/f13/building)
 "leS" = (
 /obj/structure/rack/shelf_metal,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
 	},
@@ -19411,12 +19511,8 @@
 	},
 /area/f13/wasteland/city)
 "llp" = (
-/obj/effect/decal/marking{
-	icon_state = "singlehorizontal"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "llC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20394,6 +20490,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"lRr" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lRI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -20798,6 +20899,16 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
+"mdu" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "mdA" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -20895,6 +21006,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
+	},
+/area/f13/wasteland)
+"mgO" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
 "mgT" = (
@@ -21196,6 +21314,10 @@
 /obj/structure/flora/tallgrass5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mqP" = (
+/obj/structure/decoration/cctv,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "mqV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -21654,10 +21776,6 @@
 /obj/structure/flora/tree_log,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"mEi" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "mEP" = (
 /obj/structure/wreck/trash/two_tire,
 /obj/effect/decal/cleanable/dirt,
@@ -21737,18 +21855,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"mGM" = (
-/obj/machinery/light/lampost{
-	dir = 1;
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerborder"
-	},
-/area/f13/wasteland/city)
 "mGN" = (
 /obj/structure/flora/grass/coyote/twentyseven,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23271,9 +23377,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nEC" = (
-/obj/structure/decoration/cctv,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nEI" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -23596,9 +23702,9 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "nOf" = (
-/obj/structure/bonfire/dense,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "nOC" = (
@@ -24572,6 +24678,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"osU" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "osV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/armylootbasic,
@@ -24793,6 +24903,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
 /area/f13/wasteland)
+"oBD" = (
+/obj/item/broken_bottle,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "oBH" = (
 /obj/structure/fence{
 	dir = 1
@@ -24882,6 +24998,10 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
+/area/f13/building)
+"oDd" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "oDf" = (
 /obj/structure/chair/office/dark,
@@ -25824,14 +25944,6 @@
 	name = "bathroom tiles"
 	},
 /area/f13/building/abandoned)
-"pdZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
-	},
-/area/f13/wasteland/city)
 "pen" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -26028,6 +26140,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"pjF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/janitorialcart,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "pki" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2top"
@@ -26270,15 +26391,6 @@
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
 	name = "concrete wall"
-	},
-/area/f13/building)
-"psp" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
 	},
 /area/f13/building)
 "psA" = (
@@ -27597,10 +27709,6 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
-"qbX" = (
-/obj/structure/sign/poster/contraband/revolver,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "qcl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28002,6 +28110,9 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"qsc" = (
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "qsf" = (
 /obj/effect/overlay/junk/sink{
 	dir = 1
@@ -28889,6 +29000,10 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"qVU" = (
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "qWv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30867,11 +30982,6 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
-"sgt" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "sgB" = (
 /obj/structure/flora/grass/coyote/one,
 /obj/structure/flora/grass/coyote/one,
@@ -30967,14 +31077,12 @@
 	},
 /area/f13/building/abandoned)
 "sip" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
 	},
-/turf/closed/wall/f13/store,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
 /area/f13/building)
 "siv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31151,14 +31259,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"slW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "slZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -31693,18 +31793,9 @@
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
 "sCK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/decal/marking{
-	icon_state = "singlehorizontal"
-	},
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontalleft"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "sDc" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31786,14 +31877,9 @@
 	dir = 4
 	},
 /area/f13/wasteland)
-"sGD" = (
-/obj/structure/simple_door/metal/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sGH" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/cig_packs,
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sGV" = (
@@ -32270,6 +32356,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sUW" = (
+/obj/structure/bed/mattress{
+	pixel_x = -9
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sVa" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -32368,10 +32462,6 @@
 "sXK" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
-"sXT" = (
-/obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "sYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -32511,12 +32601,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"tbI" = (
-/obj/item/broken_bottle,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
 "tbP" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -32536,15 +32620,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"tbZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "tct" = (
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
@@ -32769,10 +32844,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
-"thC" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "thD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33062,6 +33133,10 @@
 	icon_state = "stagestairs"
 	},
 /area/f13/building/abandoned)
+"tqq" = (
+/obj/item/target,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tqw" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/f13/wood,
@@ -33763,10 +33838,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"tNi" = (
-/obj/structure/billboard/ritas,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "tNp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -34424,11 +34495,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
-"udT" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "udV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34613,6 +34679,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/city)
+"uja" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "ujz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -34868,6 +34941,14 @@
 /obj/structure/junk/drawer,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"uqm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "uqr" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -35496,9 +35577,9 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/abandoned)
 "uJR" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/wasteland)
+/obj/item/broken_bottle,
+/turf/open/floor/carpet,
+/area/f13/building)
 "uJU" = (
 /obj/structure/sign/poster/contraband/have_a_puff,
 /turf/closed/wall/rust,
@@ -35620,7 +35701,12 @@
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
+"uPD" = (
+/obj/structure/decoration/clock,
+/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "uPS" = (
 /obj/structure/fence{
@@ -35830,16 +35916,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"uVE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/flag_texas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "uVX" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -35933,6 +36009,13 @@
 	icon_state = "redchess"
 	},
 /area/f13/building/abandoned)
+"uYN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire/prelit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "uYP" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -36366,6 +36449,10 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/city)
+"vnw" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "vnx" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/glass{
@@ -36587,6 +36674,11 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/building)
+"vuD" = (
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vuG" = (
 /obj/structure/rack,
@@ -37009,13 +37101,6 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
-"vKW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vLt" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
@@ -37164,6 +37249,16 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city)
+"vQx" = (
+/obj/structure/closet/fridge,
+/obj/item/export/bottle/rum,
+/obj/item/export/bottle/vodka,
+/obj/item/export/bottle/absinthe,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "vQM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37227,12 +37322,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
-"vSw" = (
-/mob/living/simple_animal/hostile/renegade/soldier,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "vSR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -37349,12 +37438,6 @@
 "vWx" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
-"vWH" = (
-/obj/item/target/vaultie,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "vWI" = (
 /obj/structure/statue/wood/headstonewood{
 	pixel_y = 2
@@ -38016,10 +38099,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"wrK" = (
-/obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "wsC" = (
 /obj/structure/wreck/trash/one_tire{
 	pixel_x = 6;
@@ -38393,6 +38472,12 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
+"wEq" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "wEx" = (
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/outside/road{
@@ -38645,6 +38730,7 @@
 "wLN" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
+/obj/machinery/light/small,
 /turf/open/floor/carpet,
 /area/f13/building)
 "wMe" = (
@@ -38745,17 +38831,6 @@
 	},
 /turf/open/water,
 /area/f13/building/abandoned)
-"wNP" = (
-/obj/structure/closet/fridge,
-/obj/item/export/bottle/rum,
-/obj/item/export/bottle/vodka,
-/obj/item/export/bottle/absinthe,
-/obj/item/reagent_containers/food/snacks/burrito,
-/obj/item/reagent_containers/food/snacks/candy,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "wOb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39125,6 +39200,21 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/city)
+"xbd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
+"xbf" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/wasteland)
 "xbg" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
@@ -39743,10 +39833,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building)
-"xuN" = (
-/obj/item/target,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xvd" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -40117,6 +40203,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
+"xGV" = (
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xHb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -40616,13 +40706,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city)
-"xUu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/building)
 "xUB" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -40798,6 +40881,10 @@
 /obj/structure/flora/burnedbush5,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"xZU" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xZX" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40813,6 +40900,18 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"yaJ" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "ybl" = (
 /obj/structure/flora/tallgrass8,
 /turf/open/indestructible/ground/outside/dirt,
@@ -55819,7 +55918,7 @@ qwS
 qwS
 qwS
 qwS
-uJR
+vnw
 ele
 uSf
 uSf
@@ -56081,11 +56180,11 @@ oph
 uSf
 rqj
 cEA
-uSf
-udT
+qsc
+fJd
 rdI
 tBA
-sGD
+vuD
 oph
 oph
 oph
@@ -56337,10 +56436,10 @@ eLd
 oph
 lgf
 gLM
-daF
+uJR
 xOQ
 tBA
-gwI
+avc
 tBA
 uSf
 oph
@@ -56351,7 +56450,7 @@ oph
 oph
 oph
 oph
-oph
+hAx
 oph
 tiN
 tiN
@@ -56583,8 +56682,8 @@ oph
 oph
 oph
 uvV
-pZm
-cyo
+llp
+cZA
 gOB
 gOB
 stW
@@ -56595,12 +56694,12 @@ gpG
 uPy
 iHv
 oes
-cln
-fEL
+uPD
+jQv
 oaw
-tBA
+xZU
 uSf
-whc
+oph
 tfn
 lOC
 tiN
@@ -56840,7 +56939,7 @@ oph
 oph
 oph
 uvV
-xGa
+pZm
 pZm
 gOB
 oni
@@ -57105,22 +57204,22 @@ stW
 tiN
 oph
 jrO
-kir
+nEC
 uSf
-sXT
+qVU
 uSf
 uSf
 sGH
 tBA
 xHT
 lMP
-wxt
+uqm
 wxt
 uSf
-wNP
+vQx
 qCb
 vyJ
-slW
+pjF
 bJF
 fQd
 mva
@@ -57363,13 +57462,13 @@ frr
 oph
 jrO
 oph
-nOf
+eec
 iyC
 hKR
 aZh
 xHT
-vKW
-hSi
+dRS
+kQh
 bZc
 qCb
 qCb
@@ -57379,7 +57478,7 @@ dZs
 jpO
 ndZ
 dZs
-vSw
+nOf
 mva
 uSf
 oph
@@ -57631,10 +57730,10 @@ uSf
 wxt
 qCb
 agt
-apl
+sip
 dZs
 heB
-dZs
+sUW
 dZs
 dZs
 mhZ
@@ -57875,16 +57974,16 @@ dBx
 klB
 tiN
 frr
-eLd
+fKR
 gEj
 aNe
 xuF
 iyC
 gXJ
 qCb
-apl
+yaJ
 qCb
-qCb
+wEq
 qWC
 qwv
 aZh
@@ -58129,11 +58228,11 @@ oph
 oph
 oph
 dBx
-vWH
+iKr
 oph
 oph
 pBD
-kNB
+aqm
 aNe
 iyC
 iyC
@@ -58151,7 +58250,7 @@ qCb
 ndZ
 dZs
 ndZ
-tbZ
+bWP
 lMP
 oph
 tSK
@@ -58392,21 +58491,21 @@ uIM
 eLd
 oph
 aNe
-xUu
+xbd
 qWv
 uSf
 vtu
 kLQ
-kLQ
+iuH
 uSf
 wxt
 qCb
-nEC
+mqP
 rwh
 uSf
 qCb
 pMr
-kFU
+iSs
 lCs
 qCb
 uSf
@@ -58644,9 +58743,9 @@ oph
 oph
 nMe
 wdJ
-xuN
+tqq
 oph
-eLd
+lRr
 oph
 hAv
 dGm
@@ -58907,22 +59006,22 @@ tFq
 uSf
 aZh
 uSf
-qbX
+oDd
 uSf
 uSf
-wrK
+ipL
 uSf
 uSf
 qLB
 wsL
 gWt
 wxt
-thC
+sCK
 qCb
 sln
-fQv
+bxY
 leS
-jkk
+cmm
 uSf
 oph
 tfn
@@ -59166,13 +59265,13 @@ qAQ
 wxt
 wxt
 wxt
-kQV
+bLr
 cks
 bqF
 wxt
 wxt
 yja
-cbn
+uja
 dlZ
 uSf
 uSf
@@ -59430,7 +59529,7 @@ qCb
 qCb
 qCb
 qCb
-cbr
+eRe
 uSf
 oMa
 nPB
@@ -59678,10 +59777,10 @@ oph
 uSf
 nNi
 wxt
-psp
+hkw
 cks
 gPC
-apl
+sip
 wxt
 rsY
 wxt
@@ -59690,9 +59789,9 @@ cks
 aFi
 uSf
 rCb
-llp
+dBE
 oMa
-llp
+dBE
 rCb
 out
 oph
@@ -59936,20 +60035,20 @@ uSf
 uSf
 uSf
 uSf
-mEi
+osU
 ssw
-fiF
+axu
 lgf
-sip
+mdu
 gxl
-uVE
+cyo
 jSn
-sgt
+aqH
 lMP
 prn
 aKy
 xTO
-bdV
+dAg
 oMa
 out
 oph
@@ -60196,10 +60295,10 @@ oph
 eGO
 oMa
 fqV
-llp
-osB
 dBE
-hYd
+osB
+daF
+uYN
 jbi
 elF
 wsC
@@ -60453,11 +60552,11 @@ oph
 eGO
 oMa
 oMa
-llp
+dBE
 oMa
 pDh
 oMa
-llp
+dBE
 oMa
 qyR
 quh
@@ -60966,7 +61065,7 @@ oph
 oph
 eGO
 jnT
-llp
+dBE
 pVV
 oMa
 gVU
@@ -60978,7 +61077,7 @@ dlC
 fqV
 joe
 oMa
-llp
+dBE
 out
 oph
 oph
@@ -61223,7 +61322,7 @@ oph
 tiN
 eGO
 oMa
-sCK
+bXq
 bsV
 oMa
 oMa
@@ -61749,7 +61848,7 @@ out
 ihy
 oph
 oph
-tNi
+gRM
 oph
 oph
 oph
@@ -62002,7 +62101,7 @@ wTK
 oMa
 oMa
 oMa
-tbI
+oBD
 oph
 oph
 oph
@@ -62259,7 +62358,7 @@ hmH
 oMa
 oMa
 oMa
-kQh
+mgO
 kgF
 kgF
 kgF
@@ -62331,7 +62430,7 @@ dOc
 dXu
 jdn
 wuc
-pdZ
+cln
 ajY
 mXC
 mXC
@@ -63612,7 +63711,7 @@ mJQ
 hZR
 hZR
 hZR
-mGM
+aRK
 dXu
 jdn
 nIi
@@ -65843,7 +65942,7 @@ oph
 oph
 tiN
 oph
-aqm
+xGV
 oph
 oph
 oph
@@ -66872,7 +66971,7 @@ oph
 oph
 oph
 tfn
-aqm
+xGV
 oph
 oph
 nZZ
@@ -67895,7 +67994,7 @@ hwJ
 hNF
 duP
 cQC
-ipL
+xbf
 rdE
 kCV
 mup
@@ -83720,7 +83819,7 @@ fBL
 oph
 oph
 oph
-oph
+cRF
 oph
 tfn
 oph
@@ -84491,7 +84590,7 @@ lmY
 oph
 oph
 oph
-tiN
+apl
 oph
 tfn
 oph

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -308,16 +308,6 @@
 	dir = 4
 	},
 /area/f13/building/abandoned)
-"ahz" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "ahE" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/outside/road{
@@ -572,9 +562,10 @@
 	},
 /area/f13/wasteland)
 "apl" = (
-/obj/item/target,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "apD" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
@@ -615,10 +606,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "aqm" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/closed/wall/f13/store,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "aqP" = (
 /obj/structure/disposalpipe/broken{
@@ -688,13 +682,6 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/city)
-"atm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "att" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -1493,15 +1480,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/city)
-"aRS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	pixel_x = -16
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "aRT" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -1810,12 +1788,6 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
-"bcM" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "bcS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2041,12 +2013,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2"
-	},
-/area/f13/wasteland)
-"bjX" = (
-/obj/item/broken_bottle,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "bjY" = (
@@ -3460,17 +3426,6 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
-"cab" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore"
-	},
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "cam" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -3665,10 +3620,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"cgk" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "cgr" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3741,6 +3692,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"chO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ciB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/rock/pile/largejungle{
@@ -3785,6 +3743,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"cjc" = (
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cji" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/f13{
@@ -3844,11 +3808,13 @@
 	},
 /area/f13/wasteland)
 "cln" = (
-/obj/item/target/vaultie,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "clB" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -3908,14 +3874,6 @@
 	},
 /turf/open/water,
 /area/f13/building/abandoned)
-"cmV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "cmX" = (
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
@@ -3977,6 +3935,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/building/abandoned)
+"col" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "coq" = (
 /obj/structure/car,
 /obj/effect/decal/cleanable/dirt,
@@ -4568,6 +4533,13 @@
 	icon_state = "tealwhrustychess"
 	},
 /area/f13/building/abandoned)
+"cHg" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "cHh" = (
 /obj/machinery/light{
 	dir = 4
@@ -5224,6 +5196,17 @@
 "cVO" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
+"cWe" = (
+/obj/structure/closet/fridge,
+/obj/item/export/bottle/rum,
+/obj/item/export/bottle/vodka,
+/obj/item/export/bottle/absinthe,
+/obj/item/reagent_containers/food/snacks/burrito,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "cWs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5362,9 +5345,9 @@
 	},
 /area/f13/building)
 "daF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/floor/f13/wood,
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "daQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6141,10 +6124,6 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland)
-"dBs" = (
-/obj/item/broken_bottle,
-/turf/open/floor/carpet,
-/area/f13/building)
 "dBx" = (
 /obj/structure/fence{
 	dir = 8;
@@ -6156,10 +6135,17 @@
 	},
 /area/f13/wasteland)
 "dBE" = (
-/obj/structure/simple_door/metal/store,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "dBV" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/dark,
@@ -6368,6 +6354,13 @@
 	icon_state = "bench_center"
 	},
 /obj/effect/spawner/lootdrop/raiderloot,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
+"dGp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/grill,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
 	},
@@ -6926,6 +6919,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"dUt" = (
+/obj/item/broken_bottle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dUF" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/structure/curtain,
@@ -7337,6 +7334,10 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2"
 	},
+/area/f13/wasteland)
+"ehE" = (
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ehG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7843,6 +7844,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"evX" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ewn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
@@ -8057,13 +8063,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned)
-"eDa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/grill,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/building)
 "eDb" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -8083,10 +8082,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"eDm" = (
-/obj/structure/sign/poster/contraband/revolver,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "eDs" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/outside/road{
@@ -8103,6 +8098,14 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"eDN" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/wasteland)
 "eEr" = (
 /obj/structure/railing/wood{
 	dir = 8;
@@ -11942,6 +11945,14 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland/city)
+"gRc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "gRn" = (
 /turf/closed/mineral/random/low_chance{
 	mineralAmt = 6;
@@ -12806,6 +12817,10 @@
 /obj/structure/nest/mirelurk,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"hyi" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "hyp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13638,6 +13653,13 @@
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/water,
 /area/f13/building/abandoned)
+"hXY" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "hYa" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -13788,12 +13810,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/building/abandoned)
-"idQ" = (
-/obj/structure/bonfire/dense,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/building)
 "idT" = (
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
@@ -14211,8 +14227,8 @@
 	},
 /area/f13/wasteland/city)
 "ipL" = (
-/obj/machinery/light/broken{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
@@ -14988,12 +15004,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"iKH" = (
-/mob/living/simple_animal/hostile/renegade/soldier,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "iLx" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
@@ -15335,6 +15345,12 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/building/abandoned)
+"iWv" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "iWH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16150,6 +16166,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water/running{
 	color = " A6635D"
+	},
+/area/f13/wasteland)
+"jvn" = (
+/obj/item/broken_bottle,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
 "jvp" = (
@@ -17328,10 +17350,6 @@
 	icon_state = "redsolid"
 	},
 /area/f13/building/abandoned)
-"jZK" = (
-/obj/structure/billboard/ritas,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jZU" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -17669,18 +17687,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building/abandoned)
-"kno" = (
-/obj/machinery/light/lampost{
-	dir = 1;
-	pixel_x = -32
-	},
+"knQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerborder"
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/wasteland/city)
+/area/f13/building)
 "knY" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -18593,9 +18606,11 @@
 	},
 /area/f13/building/abandoned)
 "kQh" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/wasteland)
+/obj/structure/bonfire/dense,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "kQq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -18643,6 +18658,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
+"kRh" = (
+/obj/item/broken_bottle,
+/turf/open/floor/carpet,
+/area/f13/building)
 "kRj" = (
 /obj/structure/window/fulltile/store,
 /obj/structure/spacevine,
@@ -19404,8 +19423,9 @@
 	},
 /area/f13/wasteland/city)
 "llp" = (
-/obj/structure/decoration/clock,
-/turf/closed/wall/f13/store,
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "llC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19603,6 +19623,10 @@
 /obj/structure/flora/burnedtree5,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"lsv" = (
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "lsy" = (
 /obj/structure/fence/wooden{
 	pixel_x = -18
@@ -20312,6 +20336,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/abandoned)
+"lQd" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "lQm" = (
 /obj/structure/railing{
 	dir = 10
@@ -21301,6 +21329,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mur" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "muz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -21386,6 +21421,15 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building/abandoned)
+"mwK" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "mwN" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21651,6 +21695,10 @@
 	icon_state = "horizontaltopborderbottom1"
 	},
 /area/f13/wasteland)
+"mFc" = (
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mFk" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -21726,6 +21774,13 @@
 /obj/structure/flora/grass/coyote/twentyseven,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"mHc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire/prelit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "mHi" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -21804,11 +21859,6 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
-"mKi" = (
-/obj/structure/sign/flag_texas,
-/obj/structure/sign/flag_arkansas,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "mKu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -21866,14 +21916,6 @@
 "mMb" = (
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
-"mMn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "mMo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -21914,6 +21956,10 @@
 	color = " A6635D"
 	},
 /area/f13/wasteland/city)
+"mNM" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "mOi" = (
 /obj/structure/fence{
 	dir = 4
@@ -22049,13 +22095,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building/abandoned)
-"mRl" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/renegade,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "mRx" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -22887,6 +22926,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"nrG" = (
+/obj/item/target,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nrM" = (
 /obj/structure/fence{
 	dir = 4
@@ -23263,15 +23306,6 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"nEl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
-/obj/structure/closet/anchored,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "nEI" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -23594,17 +23628,10 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "nOf" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
-"nOg" = (
-/obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/item/target,
+/obj/item/target/vaultie2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "nOC" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/tree/jungle{
@@ -23969,6 +23996,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
+"obX" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "obY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -24550,6 +24581,17 @@
 /obj/structure/flora/grass/coyote/twentyfour,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"osn" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "osp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24958,11 +25000,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"oEL" = (
-/obj/item/target,
-/obj/item/target/vaultie2,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "oEQ" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/ruins,
@@ -26131,6 +26168,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"pok" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "pol" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
@@ -26301,14 +26346,6 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/city)
-"ptg" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "ptu" = (
 /obj/machinery/light/small,
 /obj/structure/railing/wood{
@@ -26432,6 +26469,14 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/city)
+"pwL" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "pxh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -27296,17 +27341,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/city)
-"pVg" = (
-/obj/structure/closet/fridge,
-/obj/item/export/bottle/rum,
-/obj/item/export/bottle/vodka,
-/obj/item/export/bottle/absinthe,
-/obj/item/reagent_containers/food/snacks/burrito,
-/obj/item/reagent_containers/food/snacks/candy,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/building)
 "pVu" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -27452,6 +27486,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"pZJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pZK" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27811,13 +27852,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qkU" = (
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "qkX" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -27911,6 +27945,14 @@
 /obj/effect/gluttony,
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
+"qoN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "qoP" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood,
@@ -29637,6 +29679,12 @@
 /obj/item/crafting/fuse,
 /turf/open/floor/plating/rust,
 /area/f13/building)
+"rue" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "ruh" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -30558,6 +30606,16 @@
 	icon_state = "outerborder"
 	},
 /area/f13/caves)
+"rWr" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "rWw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -30658,13 +30716,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
-"saW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bonfire/prelit,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "sbc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
@@ -30969,12 +31020,13 @@
 /area/f13/building/abandoned)
 "sip" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/stop,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/anchored,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
 	},
-/area/f13/wasteland/city)
+/area/f13/building)
 "siv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31051,6 +31103,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
+"skG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/flag_texas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "skM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -31359,8 +31421,8 @@
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
 	},
-/obj/structure/barricade/wooden/planks{
-	icon_state = "board-2"
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
 	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
@@ -31606,12 +31668,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland)
-"sAN" = (
-/mob/living/simple_animal/hostile/renegade/grunt,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland)
 "sBa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31690,9 +31746,8 @@
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
 "sCK" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
+/obj/structure/decoration/cctv,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "sDc" = (
 /obj/structure/closet/cabinet,
@@ -32224,6 +32279,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sUb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "sUc" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/f13/outside/road{
@@ -32254,10 +32318,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sUX" = (
-/obj/structure/decoration/cctv,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "sVa" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -33204,10 +33264,6 @@
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
-"txj" = (
-/obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "txx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -33310,15 +33366,6 @@
 	},
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
-"tAX" = (
-/obj/effect/turf_decal/trimline/white/line,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
 /area/f13/wasteland)
 "tAZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -33747,10 +33794,6 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
-"tNu" = (
-/obj/structure/sign/flag_texas,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "tNy" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -34059,14 +34102,6 @@
 /obj/structure/dresser,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
-"tVe" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
-/area/f13/wasteland)
 "tVB" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -35137,6 +35172,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"uyf" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uyG" = (
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/outside/road{
@@ -35477,11 +35516,8 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/abandoned)
 "uJR" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/bomb/tier2,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/f13/store,
 /area/f13/building)
 "uJU" = (
 /obj/structure/sign/poster/contraband/have_a_puff,
@@ -36154,15 +36190,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"vhB" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/building)
 "vhJ" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -36196,13 +36223,6 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
-/area/f13/building)
-"viU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor3"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "vjm" = (
 /obj/item/kirbyplants,
@@ -36406,13 +36426,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"voQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "voZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -37175,6 +37188,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
 /area/f13/building/abandoned)
+"vRq" = (
+/obj/structure/decoration/clock,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "vRr" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -38276,16 +38293,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wBt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/flag_texas,
-/obj/structure/decoration/rag{
-	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
-	icon_state = "skulls";
-	name = "skulls"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "wBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38580,6 +38587,12 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/radiation)
+"wJM" = (
+/obj/item/target/vaultie,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wJX" = (
 /obj/structure/ladder,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38680,10 +38693,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"wNn" = (
-/obj/item/broken_bottle,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "wNq" = (
 /turf/open/floor/plating/rust,
@@ -39199,10 +39208,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"xeB" = (
-/mob/living/simple_animal/hostile/renegade/doc,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xeW" = (
 /obj/structure/fluff/railing{
 	dir = 4
@@ -39297,13 +39302,6 @@
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plasteel/darkbrown/side,
 /area/f13/building/abandoned)
-"xiS" = (
-/obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder"
-	},
-/area/f13/wasteland)
 "xiV" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -55782,14 +55780,14 @@ oph
 lmY
 yaf
 qwS
-aqm
 qwS
 qwS
 qwS
 qwS
 qwS
 qwS
-kQh
+qwS
+hyi
 ele
 uSf
 uSf
@@ -56052,10 +56050,10 @@ uSf
 rqj
 cEA
 uSf
-sCK
+apl
 rdI
 tBA
-dBE
+llp
 oph
 oph
 oph
@@ -56307,10 +56305,10 @@ eLd
 oph
 lgf
 gLM
-dBs
+kRh
 xOQ
 tBA
-daF
+evX
 tBA
 uSf
 oph
@@ -56554,7 +56552,7 @@ oph
 oph
 uvV
 pZm
-oEL
+nOf
 gOB
 gOB
 stW
@@ -56565,8 +56563,8 @@ gpG
 uPy
 iHv
 oes
-llp
-wNn
+vRq
+dUt
 oaw
 tBA
 uSf
@@ -57075,9 +57073,9 @@ stW
 tiN
 oph
 jrO
-xeB
+ehE
 uSf
-nOg
+lsv
 uSf
 uSf
 sGH
@@ -57087,10 +57085,10 @@ lMP
 wxt
 wxt
 uSf
-pVg
+cWe
 qCb
 vyJ
-ptg
+ipL
 bJF
 fQd
 mva
@@ -57333,13 +57331,13 @@ frr
 oph
 jrO
 oph
-idQ
+kQh
 iyC
 hKR
 aZh
 xHT
-voQ
-viU
+pZJ
+col
 bZc
 qCb
 qCb
@@ -57349,7 +57347,7 @@ dZs
 jpO
 ndZ
 dZs
-iKH
+cjc
 mva
 uSf
 oph
@@ -57601,7 +57599,7 @@ uSf
 wxt
 qCb
 agt
-nOf
+pwL
 dZs
 heB
 dZs
@@ -57852,7 +57850,7 @@ xuF
 iyC
 gXJ
 qCb
-nOf
+pwL
 qCb
 qCb
 qWC
@@ -58099,11 +58097,11 @@ oph
 oph
 oph
 dBx
-cln
+wJM
 oph
 oph
 pBD
-atm
+chO
 aNe
 iyC
 iyC
@@ -58121,7 +58119,7 @@ qCb
 ndZ
 dZs
 ndZ
-aRS
+sUb
 lMP
 oph
 tSK
@@ -58362,7 +58360,7 @@ uIM
 eLd
 oph
 aNe
-eDa
+dGp
 qWv
 uSf
 vtu
@@ -58371,12 +58369,12 @@ kLQ
 uSf
 wxt
 qCb
-sUX
+sCK
 rwh
 uSf
 qCb
 pMr
-mRl
+knQ
 lCs
 qCb
 uSf
@@ -58614,7 +58612,7 @@ oph
 oph
 nMe
 wdJ
-apl
+nrG
 oph
 eLd
 oph
@@ -58877,22 +58875,22 @@ tFq
 uSf
 aZh
 uSf
-eDm
+lQd
 uSf
 uSf
-txj
+obX
 uSf
 uSf
 qLB
 wsL
 gWt
 wxt
-cgk
+uJR
 qCb
 sln
-ipL
+pok
 leS
-nEl
+sip
 uSf
 oph
 tfn
@@ -59136,13 +59134,13 @@ qAQ
 wxt
 wxt
 wxt
-cmV
+cln
 cks
 bqF
 wxt
 wxt
 yja
-uJR
+mur
 dlZ
 uSf
 uSf
@@ -59400,7 +59398,7 @@ qCb
 qCb
 qCb
 qCb
-bcM
+iWv
 uSf
 oMa
 nPB
@@ -59648,10 +59646,10 @@ oph
 uSf
 nNi
 wxt
-vhB
+mwK
 cks
 gPC
-nOf
+pwL
 wxt
 rsY
 wxt
@@ -59906,20 +59904,20 @@ uSf
 uSf
 uSf
 uSf
-tNu
-cab
+mNM
 ssw
+osn
 lgf
-ahz
+rWr
 gxl
-wBt
+skG
 jSn
-mKi
+daF
 lMP
 prn
 aKy
 xTO
-sAN
+rue
 oMa
 out
 oph
@@ -60168,8 +60166,8 @@ oMa
 fqV
 pHs
 osB
-tAX
-saW
+aqm
+mHc
 jbi
 elF
 wsC
@@ -61193,7 +61191,7 @@ oph
 tiN
 eGO
 oMa
-mMn
+gRc
 bsV
 oMa
 oMa
@@ -61201,7 +61199,7 @@ oMa
 qct
 oMa
 iUq
-qkU
+cHg
 oMa
 wuJ
 oMa
@@ -61719,7 +61717,7 @@ out
 ihy
 oph
 oph
-jZK
+uyf
 oph
 oph
 oph
@@ -61972,7 +61970,7 @@ wTK
 oMa
 oMa
 oMa
-bjX
+jvn
 oph
 oph
 oph
@@ -62229,7 +62227,7 @@ hmH
 oMa
 oMa
 oMa
-xiS
+hXY
 kgF
 kgF
 kgF
@@ -62301,7 +62299,7 @@ dOc
 dXu
 jdn
 wuc
-sip
+qoN
 ajY
 mXC
 mXC
@@ -63582,7 +63580,7 @@ mJQ
 hZR
 hZR
 hZR
-kno
+dBE
 dXu
 jdn
 nIi
@@ -65813,7 +65811,7 @@ oph
 oph
 tiN
 oph
-oph
+mFc
 oph
 oph
 oph
@@ -66842,7 +66840,7 @@ oph
 oph
 oph
 tfn
-oph
+mFc
 oph
 oph
 nZZ
@@ -67865,7 +67863,7 @@ hwJ
 hNF
 duP
 cQC
-tVe
+eDN
 rdE
 kCV
 mup

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -28,7 +28,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "aaA" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright2"
@@ -135,6 +135,14 @@
 	dir = 4
 	},
 /area/f13/wasteland)
+"adM" = (
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 15
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "aek" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -267,12 +275,14 @@
 	},
 /area/f13/wasteland)
 "agt" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/poddoor/shutters{
+	id = "carshop"
 	},
-/area/f13/building/abandoned)
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "agw" = (
 /obj/structure/chair/sofa/right{
 	dir = 8;
@@ -298,6 +308,16 @@
 	dir = 4
 	},
 /area/f13/building/abandoned)
+"ahz" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "ahE" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/outside/road{
@@ -538,7 +558,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "apa" = (
 /turf/open/floor/carpet/purple,
 /area/f13/building/abandoned)
@@ -550,6 +570,10 @@
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 8
 	},
+/area/f13/wasteland)
+"apl" = (
+/obj/item/target,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "apD" = (
 /turf/open/indestructible/ground/outside/road{
@@ -590,6 +614,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
+"aqm" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "aqP" = (
 /obj/structure/disposalpipe/broken{
 	dir = 8
@@ -658,6 +688,13 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/city)
+"atm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "att" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -794,6 +831,13 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
+"azQ" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/closet/crate/trashcart,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "azT" = (
@@ -992,7 +1036,7 @@
 "aDN" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/closed/wall/f13/wood/house,
-/area/f13/building/abandoned)
+/area/f13/building)
 "aEf" = (
 /obj/structure/window/fulltile/house,
 /obj/effect/decal/cleanable/dirt,
@@ -1026,6 +1070,23 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"aFi" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"aFl" = (
+/obj/effect/overlay/junk/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "aFw" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1115,6 +1176,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"aHm" = (
+/obj/structure/simple_door/metal/dirtystore,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "aHn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -1212,7 +1282,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "aKV" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -1310,9 +1380,10 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "aNe" = (
-/obj/structure/flora/grass/coyote/twentynine,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "aNG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -1422,6 +1493,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/city)
+"aRS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "aRT" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -1448,6 +1528,17 @@
 	icon_state = "graveldirtedge"
 	},
 /area/f13/wasteland)
+"aSS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "aSW" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/car/rubbish3,
@@ -1657,6 +1748,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"baM" = (
+/obj/structure/junk/micro,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "bbj" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -1713,6 +1810,12 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"bcM" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bcS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1767,6 +1870,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
+"bdX" = (
+/obj/structure/mirror{
+	pixel_x = -25
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "beb" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -1789,11 +1905,14 @@
 	},
 /area/f13/building/abandoned)
 "bfd" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence/corner{
+	dir = 4
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "bfs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkbrown,
@@ -1924,6 +2043,12 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland)
+"bjX" = (
+/obj/item/broken_bottle,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "bjY" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2039,7 +2164,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "boe" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -2157,6 +2282,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/building/abandoned)
+"bqF" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "bqV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2210,16 +2341,11 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "bsV" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "btk" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -38;
@@ -2808,6 +2934,12 @@
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
+"bJF" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "bJZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2946,6 +3078,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bPQ" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
+	},
+/obj/structure/fence/end,
+/turf/open/indestructible/ground/outside/water/running{
+	color = " A6635D"
+	},
+/area/f13/wasteland)
 "bPU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair2{
@@ -2971,14 +3112,13 @@
 	},
 /area/f13/wasteland)
 "bQa" = (
-/obj/structure/simple_door/metal/dirtystore,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bQe" = (
 /obj/effect/decal/cleanable/blood/gibs/human/down,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -3187,21 +3327,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bWL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 27
-	},
-/obj/structure/mirror{
-	pixel_y = 34
-	},
-/obj/item/lock_construct,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bWS" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -3331,6 +3460,17 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"cab" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cam" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -3359,6 +3499,15 @@
 	dir = 1;
 	icon_state = "dirt"
 	},
+/area/f13/building)
+"cbh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ccg" = (
 /obj/structure/nest/gecko,
@@ -3516,6 +3665,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"cgk" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "cgr" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3665,12 +3818,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"cks" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ckM" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland/city)
+"clc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/ghoul/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cle" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/outside/road{
@@ -3678,15 +3844,11 @@
 	},
 /area/f13/wasteland)
 "cln" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
-/obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/target/vaultie,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "clB" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -3746,6 +3908,14 @@
 	},
 /turf/open/water,
 /area/f13/building/abandoned)
+"cmV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "cmX" = (
 /obj/structure/simple_door/wood,
 /turf/open/indestructible/ground/outside/desert,
@@ -3994,17 +4164,22 @@
 	},
 /area/f13/wasteland)
 "ctE" = (
-/obj/structure/flora/grass/coyote/ten,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"ctH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
+"ctH" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/tool_box,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "ctM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -4332,6 +4507,10 @@
 /obj/structure/closet/crate/large,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland)
+"cEA" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/turf/open/floor/carpet,
+/area/f13/building)
 "cEI" = (
 /obj/structure/chair/folding,
 /obj/effect/decal/cleanable/dirt,
@@ -4627,6 +4806,11 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/city)
+"cOB" = (
+/obj/structure/decoration/clock/old/active,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "cOS" = (
 /obj/structure/bed/dogbed,
 /obj/item/reagent_containers/food/snacks/deadmouse,
@@ -5144,6 +5328,13 @@
 	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
+"cYQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "cYU" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -5169,6 +5360,11 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
+/area/f13/building)
+"daF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "daQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5202,6 +5398,16 @@
 /obj/item/stack/ore/slag,
 /turf/open/water,
 /area/f13/building/abandoned)
+"dbx" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dcm" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/plating/f13/outside/road{
@@ -5342,13 +5548,13 @@
 	},
 /area/f13/wasteland)
 "dhQ" = (
-/obj/structure/simple_door/metal/barred,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "dij" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/ruins,
@@ -5459,21 +5665,24 @@
 /area/f13/building)
 "dlC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "dlP" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
+/area/f13/building)
+"dlZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
 /area/f13/building)
 "dme" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5845,11 +6054,18 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "dxH" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
+"dxJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dxK" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -5925,17 +6141,25 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland)
+"dBs" = (
+/obj/item/broken_bottle,
+/turf/open/floor/carpet,
+/area/f13/building)
 "dBx" = (
-/obj/structure/decoration/clock/old/active,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"dBE" = (
+/obj/structure/simple_door/metal/store,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dBV" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/dark,
@@ -6067,6 +6291,16 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
+"dEY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fence{
+	max_integrity = 500;
+	name = "reinforced fence"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "dEZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/corp/right{
@@ -6128,6 +6362,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"dGm" = (
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench_center"
+	},
+/obj/effect/spawner/lootdrop/raiderloot,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "dGF" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -6394,6 +6638,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city)
+"dNs" = (
+/obj/structure/obstacle/barbedwire/end{
+	dir = 1;
+	pixel_x = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dNx" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6529,13 +6782,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dQd" = (
-/obj/structure/table,
-/obj/item/phone,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/waste{
+	icon_state = "goo9"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dQi" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/desert,
@@ -6656,6 +6907,16 @@
 	icon_state = "cafeteria"
 	},
 /area/f13/building/abandoned)
+"dUi" = (
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "dUo" = (
 /obj/structure/obstacle/old_locked_door,
 /obj/structure/barricade/wooden/planks{
@@ -6695,12 +6956,11 @@
 	},
 /area/f13/building/abandoned)
 "dVl" = (
-/mob/living/simple_animal/hostile/renegade/defender,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "catwalk"
+/obj/item/target,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "dVq" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = -3
@@ -6793,19 +7053,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "dXS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/tree/jungle{
-	color = "#d9b51c"
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/building/abandoned)
 "dXW" = (
-/obj/structure/junk/micro,
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "dXZ" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -7201,10 +7465,31 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city)
+"ekY" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/engie,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"ele" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/flag_arkansas,
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "els" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"elF" = (
+/obj/structure/wreck/car,
+/obj/effect/decal/waste{
+	icon_state = "goo9"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "elO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7217,6 +7502,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/city)
+"emg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/guncase{
+	anchored = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "emr" = (
 /obj/effect/decal/cleanable/glass{
 	pixel_x = 12
@@ -7302,14 +7597,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/abandoned)
 "eom" = (
-/obj/effect/overlay/junk/toilet{
-	pixel_y = 12
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag{
+	pixel_x = -14
 	},
-/obj/item/key,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "eoK" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -7508,6 +7802,11 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/city)
+"euI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building/abandoned)
 "euP" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt,
@@ -7604,13 +7903,14 @@
 	},
 /area/f13/building/abandoned)
 "exD" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "exI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing{
@@ -7757,6 +8057,13 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned)
+"eDa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/grill,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "eDb" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -7776,6 +8083,10 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"eDm" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "eDs" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/outside/road{
@@ -7895,12 +8206,14 @@
 	},
 /area/f13/wasteland)
 "eGO" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/bomb/tier1,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "eGY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -8008,14 +8321,9 @@
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland)
 "eLd" = (
-/obj/structure/obstacle/barbedwire/end{
-	dir = 1;
-	pixel_x = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "eLh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -8144,7 +8452,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "ePp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8473,6 +8781,11 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
+"faK" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/closed/wall/rust,
+/area/f13/city)
 "fba" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -8600,6 +8913,13 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"fft" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ffz" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -8795,7 +9115,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "fkY" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -9044,6 +9364,14 @@
 	color = "#e4e4e4"
 	},
 /area/f13/building/abandoned)
+"fqV" = (
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 15
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "frh" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -9493,11 +9821,11 @@
 	},
 /area/f13/building)
 "fEp" = (
-/obj/structure/closet,
+/obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "fEq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9724,6 +10052,12 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"fLo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "fMm" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /obj/effect/decal/cleanable/dirt,
@@ -9853,6 +10187,15 @@
 /obj/item/reagent_containers/food/snacks/salad/edensalad,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
+"fQd" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/spawner/lootdrop/wastelootgood,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "fQj" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -9904,7 +10247,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "fRl" = (
 /obj/structure/railing/wood{
 	dir = 1;
@@ -10075,6 +10418,10 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city)
+"fWF" = (
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fWP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -10142,6 +10489,12 @@
 "fYE" = (
 /obj/effect/spawner/lootdrop/f13/medical,
 /turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/building)
+"fZx" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "fZA" = (
 /obj/structure/fence/corner{
@@ -10335,22 +10688,11 @@
 	},
 /area/f13/building)
 "gfS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 27
-	},
-/obj/structure/mirror{
-	pixel_y = 34
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "gge" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -10687,6 +11029,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"gpG" = (
+/obj/structure/flora/tallgrass7,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gqk" = (
 /obj/structure/barricade/tentclothcorner{
 	dir = 1
@@ -10787,6 +11138,7 @@
 /obj/structure/filingcabinet{
 	pixel_x = 11
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned)
 "gtx" = (
@@ -10907,11 +11259,13 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
 "gxl" = (
-/obj/structure/obstacle/jammed_door,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowdestroyed"
 	},
-/area/f13/building/abandoned)
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "gxv" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -11135,6 +11489,10 @@
 	icon_state = "dirtfull_dark"
 	},
 /area/f13/wasteland)
+"gEd" = (
+/obj/structure/sign/poster/contraband/pinup_funk,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "gEj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11311,6 +11669,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gJi" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "gJA" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/road{
@@ -11349,6 +11713,16 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building/abandoned)
+"gKy" = (
+/obj/structure/flora/tallgrass7,
+/obj/structure/fence{
+	max_integrity = 500;
+	name = "reinforced fence"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "gKS" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/savannah,
@@ -11391,15 +11765,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gLM" = (
-/obj/structure/bed/mattress/pregame,
-/obj/effect/decal/remains{
-	icon_state = "remains"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/turf/open/floor/carpet,
+/area/f13/building)
 "gMf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul,
@@ -11407,6 +11777,10 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building/abandoned)
+"gMq" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gMF" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -11505,6 +11879,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gPC" = (
+/obj/effect/spawner/lootdrop/waste_loot_poor,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "gPG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -11755,6 +12135,12 @@
 /obj/effect/decal/cleanable/blood/gibs/human/down,
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned)
+"gWt" = (
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "gWD" = (
 /obj/structure/window/fulltile/house,
 /obj/effect/decal/cleanable/dirt,
@@ -11802,12 +12188,11 @@
 	},
 /area/f13/wasteland)
 "gXJ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "yellowrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "gYk" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_east_north"
@@ -11925,12 +12310,14 @@
 	},
 /area/f13/building/abandoned)
 "heB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ghoul/soldier,
+/obj/effect/spawner/lootdrop/armylootbasic,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "heC" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -12193,7 +12580,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "hpP" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#d9b51c"
@@ -12463,6 +12850,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"hAv" = (
+/obj/structure/chair/stool{
+	icon_state = "bench"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "hAC" = (
 /obj/structure/tires/five{
 	pixel_x = -19;
@@ -12470,8 +12865,18 @@
 	},
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
+"hAG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "hAH" = (
 /obj/item/crafting/coffee_pot,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"hAV" = (
+/obj/structure/flora/grass/coyote/twentyseven,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hBd" = (
@@ -12750,23 +13155,43 @@
 /obj/structure/table/wood/junk,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hKR" = (
+/obj/effect/turf_decal/delivery/white{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/structure/closet/abductor{
+	desc = "A secure metal pod for storing protectrons.";
+	name = "pulowski preservation shelter";
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/effect/decal/remains/human,
+/obj/item/clothing/shoes/laceup,
+/obj/effect/spawner/lootdrop/coin,
+/obj/effect/spawner/lootdrop/cig_packs,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/obj/item/clothing/under/croptop,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "hLb" = (
 /obj/structure/car/rubbish3,
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hLo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/overlay/junk/toilet{
+	dir = 1
 	},
-/area/f13/building/abandoned)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "hLx" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = -4;
@@ -13056,13 +13481,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hTu" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "hTz" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/dirt,
@@ -13365,6 +13788,12 @@
 	icon_state = "redmark"
 	},
 /area/f13/building/abandoned)
+"idQ" = (
+/obj/structure/bonfire/dense,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/building)
 "idT" = (
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
 /obj/item/reagent_containers/food/snacks/f13/canned/dog,
@@ -13495,6 +13924,10 @@
 "ihr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/savannah,
+/area/f13/wasteland)
+"ihy" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ihU" = (
 /obj/structure/spirit_board{
@@ -13777,6 +14210,14 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/city)
+"ipL" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "ipV" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/brick,
@@ -13883,14 +14324,14 @@
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
 "itz" = (
-/obj/effect/overlay/junk/toilet{
-	dir = 1
+/obj/structure/fence{
+	max_integrity = 500;
+	name = "reinforced fence"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "iua" = (
 /obj/effect/decal/waste{
 	pixel_x = -4;
@@ -14059,6 +14500,11 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/city)
+"iyC" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "iyJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
@@ -14084,6 +14530,17 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"izC" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "izO" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
 /area/f13/building/abandoned)
@@ -14407,16 +14864,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "iHv" = (
-/obj/effect/overlay/junk/toilet{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Business"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/curtain{
+	color = "#e09634";
+	pixel_y = 32
 	},
-/area/f13/building/abandoned)
+/turf/open/floor/carpet,
+/area/f13/building)
 "iHL" = (
 /obj/structure/destructible/tribal_torch,
 /obj/effect/turf_decal/weather/dirt{
@@ -14529,10 +14987,23 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
+"iKH" = (
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "iLx" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"iLT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "iMi" = (
 /obj/structure/sign/poster/contraband/tools,
 /obj/effect/decal/cleanable/dirt,
@@ -14566,6 +15037,17 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/abandoned)
+"iNU" = (
+/obj/structure/decoration/clock/old/active,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building)
 "iNY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14816,6 +15298,13 @@
 	color = "#d7d7d7"
 	},
 /area/f13/building/abandoned)
+"iUq" = (
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "iUs" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 8
@@ -14959,6 +15448,13 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"jbi" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "jbl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -14972,6 +15468,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"jbz" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "jbL" = (
 /obj/effect/decal/waste{
 	pixel_x = 18;
@@ -15244,6 +15749,7 @@
 "jiS" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
@@ -15359,7 +15865,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "jmM" = (
 /obj/structure/car/rubbish2,
 /obj/effect/decal/cleanable/dirt,
@@ -15429,6 +15935,19 @@
 /obj/structure/decoration/clock/old,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
+"jnT" = (
+/obj/structure/wreck/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"joe" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "joy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -15474,6 +15993,14 @@
 /obj/item/storage/crayons,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"jpO" = (
+/obj/item/flashlight/seclite,
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jqA" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -15485,6 +16012,20 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"jrk" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "jrv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15500,6 +16041,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"jrG" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/reagent_containers/hypospray/medipen/psycho,
+/obj/item/reagent_containers/hypospray/medipen/psycho,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jrL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/fence/wooden,
@@ -15508,15 +16059,10 @@
 	},
 /area/f13/wasteland/city)
 "jrO" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jsh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/missing_gloves{
@@ -15788,17 +16334,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jyl" = (
-/obj/structure/table,
-/obj/item/trash/f13/mre{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -6
-	},
+/obj/machinery/vending/nukacolavend,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "jyz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
@@ -16099,20 +16640,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jHg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/building/abandoned)
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "jHl" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -16432,18 +16963,11 @@
 	},
 /area/f13/building)
 "jPs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/building/abandoned)
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "jPF" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -16517,12 +17041,17 @@
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
 "jSn" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "ruinswindow"
 	},
-/area/f13/building/abandoned)
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "jSs" = (
 /obj/item/seeds/xander,
 /obj/item/seeds/poppy,
@@ -16658,15 +17187,16 @@
 	},
 /area/f13/wasteland)
 "jWg" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowleft"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/nest/ghoul,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "jWm" = (
 /turf/closed/wall/f13/sunset/brick_small_light,
 /area/f13/building/abandoned)
@@ -16798,6 +17328,10 @@
 	icon_state = "redsolid"
 	},
 /area/f13/building/abandoned)
+"jZK" = (
+/obj/structure/billboard/ritas,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jZU" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -17041,12 +17575,11 @@
 	},
 /area/f13/wasteland)
 "klB" = (
-/obj/structure/bed/mattress/pregame,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "klE" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
@@ -17136,6 +17669,18 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building/abandoned)
+"kno" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "knY" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -17344,6 +17889,12 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"kvr" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "kvx" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/old{
@@ -17352,16 +17903,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "kvz" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "kvA" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -17439,6 +17985,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"kxk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "kxn" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -17499,6 +18052,10 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2right"
 	},
+/area/f13/wasteland/city)
+"kzx" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city)
 "kzG" = (
 /turf/closed/wall/rust,
@@ -17839,19 +18396,19 @@
 	},
 /area/f13/wasteland)
 "kIJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/area/f13/building/abandoned)
+/obj/structure/curtain{
+	color = "#e09634";
+	pixel_y = 32
+	},
+/obj/item/broken_bottle,
+/turf/open/floor/carpet,
+/area/f13/building)
 "kJc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/cornersnew,
@@ -18035,6 +18592,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"kQh" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "kQq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/simple_door/metal/ventilation,
@@ -18048,14 +18609,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kQw" = (
-/obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "kQF" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/clock/old,
@@ -18127,7 +18691,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "kSI" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright3"
@@ -18369,11 +18933,13 @@
 	},
 /area/f13/building/abandoned)
 "laV" = (
-/mob/living/simple_animal/hostile/ghoul/soldier,
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "laX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/chair,
@@ -18514,12 +19080,22 @@
 	icon_state = "graveldirtedge"
 	},
 /area/f13/building)
+"leS" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "leX" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/structure/bed/mattress/pregame,
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "lfa" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah,
@@ -18559,6 +19135,19 @@
 	icon_state = "redchess"
 	},
 /area/f13/building/abandoned)
+"lgc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"lgf" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "lgh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -18603,11 +19192,14 @@
 	},
 /area/f13/building)
 "lgz" = (
-/obj/structure/bed/mattress/pregame,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "lgU" = (
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /turf/open/indestructible/ground/outside/road{
@@ -18765,17 +19357,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ljG" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	doc_content_1 = "INCIDENT REPORT: Recovered approx. $10,000USD worth of illegal stimulants from pharmacist. Moved into evidence storage.";
-	doc_title_1 = "Recovered Stimulants"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "lky" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -18817,6 +19403,10 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/city)
+"llp" = (
+/obj/structure/decoration/clock,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "llC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18904,6 +19494,15 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
 	dir = 1
+	},
+/area/f13/wasteland)
+"lnu" = (
+/obj/structure/fence/corner{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
 "loa" = (
@@ -19231,7 +19830,7 @@
 	desc = "A terrible fate to befall anyone. The screams are genuine."
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building/abandoned)
+/area/f13/building)
 "lCg" = (
 /obj/structure/curtain{
 	color = "#ffc0cb"
@@ -19256,6 +19855,15 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"lCs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/ammo/military,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "lCt" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19533,18 +20141,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lMP" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/decoration/rag{
+	pixel_x = -14
 	},
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
-	},
-/area/f13/building/abandoned)
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "lMW" = (
 /obj/structure/car/rubbish1,
 /obj/effect/decal/cleanable/dirt,
@@ -19660,6 +20261,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"lOC" = (
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lOH" = (
 /obj/structure/flora/grass/coyote/sixteen,
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -19767,6 +20372,17 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city)
+"lRj" = (
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "lRI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -20059,14 +20675,15 @@
 	},
 /area/f13/building/abandoned)
 "mar" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/overlay/junk/toilet{
+	dir = 8
 	},
-/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mau" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -20115,16 +20732,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase{
-	anchored = 1
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mcg" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -20148,14 +20761,12 @@
 	},
 /area/f13/building/abandoned)
 "mdf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mdl" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -20315,6 +20926,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
+"mhZ" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/crafting/coffee_pot,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "mid" = (
 /obj/structure/fluff/hedge/opaque,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20350,6 +20970,13 @@
 	},
 /turf/open/floor/f13{
 	icon_state = "dark"
+	},
+/area/f13/building)
+"mje" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "mjz" = (
@@ -20594,6 +21221,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
+"mrS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 27
+	},
+/obj/structure/mirror{
+	pixel_y = 34
+	},
+/obj/item/lock_construct,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "msj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -20674,17 +21317,13 @@
 	},
 /area/f13/wasteland/city)
 "mva" = (
-/obj/item/clothing/under/rank/security/detective/brown,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/suit/det_suit/forensicsblue,
-/obj/structure/closet{
-	anchored = 1
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "yellowrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mvk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20882,13 +21521,20 @@
 	},
 /area/f13/wasteland)
 "mAE" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/pill_bottle/chem_tin/mentats,
-/obj/item/storage/pill_bottle/chem_tin/mentats,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/overlay/junk/mirror{
+	pixel_x = 26;
+	pixel_y = -4
 	},
-/area/f13/building/abandoned)
+/obj/effect/overlay/junk/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "mAF" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/decoration/rag{
@@ -20958,7 +21604,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mBP" = (
 /obj/structure/campfire/barrel,
 /obj/item/stack/sheet/mineral/wood,
@@ -21158,6 +21804,11 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"mKi" = (
+/obj/structure/sign/flag_texas,
+/obj/structure/sign/flag_arkansas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "mKu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
@@ -21215,6 +21866,14 @@
 "mMb" = (
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
+"mMn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "mMo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -21263,11 +21922,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mOx" = (
-/obj/structure/simple_door/metal/barred,
+/obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mOM" = (
 /obj/structure/flora/burnedbush1,
 /turf/open/indestructible/ground/outside/desert,
@@ -21279,7 +21938,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mPo" = (
 /obj/structure/fence{
 	dir = 4;
@@ -21390,6 +22049,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building/abandoned)
+"mRl" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "mRx" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -21419,6 +22085,15 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"mSc" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "mSq" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife,
@@ -21562,13 +22237,14 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "mXT" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/closed/wall/f13/store,
-/area/f13/building/abandoned)
+/area/f13/building)
 "mXV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/waste{
@@ -21699,6 +22375,15 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"ndh" = (
+/obj/effect/overlay/junk/toilet{
+	pixel_y = 12
+	},
+/obj/item/key,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ndq" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13/wood,
@@ -22048,6 +22733,18 @@
 /obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
+/area/f13/building)
+"nnm" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	doc_content_1 = "INCIDENT REPORT: Recovered approx. $10,000USD worth of illegal stimulants from pharmacist. Moved into evidence storage.";
+	doc_title_1 = "Recovered Stimulants"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/building)
 "nns" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -22566,6 +23263,15 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"nEl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/structure/closet/anchored,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "nEI" = (
 /obj/structure/railing/wood{
 	dir = 4;
@@ -22590,6 +23296,10 @@
 	color = "#818181";
 	icon_state = "floorrustysolid"
 	},
+/area/f13/building/abandoned)
+"nEQ" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/carpet/red,
 /area/f13/building/abandoned)
 "nEW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22796,6 +23506,16 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/city)
+"nMe" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "nMi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22824,6 +23544,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"nNi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "nNl" = (
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22866,6 +23593,18 @@
 /obj/structure/table/wood/fancy/monochrome,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
+"nOf" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
+"nOg" = (
+/obj/structure/sign/poster/contraband/red_rum,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "nOC" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/flora/tree/jungle{
@@ -22894,12 +23633,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "nPB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "nQq" = (
 /obj/structure/statue/sandstone/gravestone{
 	desc = "The inscription reads: This land is so peaceful. All these flowers...";
@@ -23310,15 +24049,8 @@
 	},
 /area/f13/wasteland/city)
 "oes" = (
-/obj/effect/overlay/junk/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building/abandoned)
+/turf/open/floor/carpet,
+/area/f13/building)
 "oey" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -23398,6 +24130,12 @@
 	dir = 4;
 	icon_state = "outerborder"
 	},
+/area/f13/wasteland)
+"ogf" = (
+/obj/structure/mirror{
+	pixel_x = -27
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ogk" = (
 /obj/machinery/light/small/broken{
@@ -23671,6 +24409,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building/abandoned)
+"oni" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "onm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -23857,12 +24600,14 @@
 	},
 /area/f13/wasteland)
 "out" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "ouG" = (
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
@@ -23908,16 +24653,16 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city)
 "oxc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/structure/closet/crate/bin/trashbin,
+/obj/machinery/light/broken{
+	dir = 4;
+	pixel_y = -16
 	},
-/area/f13/building/abandoned)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oxk" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -23944,6 +24689,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"oyb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "oyc" = (
 /obj/structure/flora/tree/jungle{
 	color = "#d9b51c"
@@ -24114,6 +24867,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"oDa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building)
 "oDf" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -24190,6 +24958,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"oEL" = (
+/obj/item/target,
+/obj/item/target/vaultie2,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "oEQ" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/ruins,
@@ -24359,13 +25132,12 @@
 	},
 /area/f13/wasteland/city)
 "oJH" = (
+/obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "oJQ" = (
 /obj/structure/flora/grass/coyote/eight,
 /turf/open/indestructible/ground/outside/dirt,
@@ -24407,13 +25179,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "oLJ" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "oMa" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -24507,7 +25279,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "oOC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -24793,6 +25565,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/water,
 /area/f13/city)
+"oXD" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/water,
+/area/f13/city)
 "oXI" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
@@ -24840,14 +25616,14 @@
 	},
 /area/f13/building/abandoned)
 "oZd" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "oZg" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain{
@@ -24863,14 +25639,14 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "oZo" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "oZt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
@@ -24911,13 +25687,10 @@
 	},
 /area/f13/building/abandoned)
 "paY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "pba" = (
 /obj/structure/closet/crate/bin{
 	pixel_y = 10
@@ -24971,16 +25744,14 @@
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/wasteland)
 "pcl" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "pcq" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -25031,6 +25802,12 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned)
+"pde" = (
+/obj/structure/obstacle/jammed_door,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pdh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/outside/road{
@@ -25075,6 +25852,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
+"peR" = (
+/obj/item/target,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "peZ" = (
 /turf/open/floor/plating/f13/outside/road{
 	dir = 8;
@@ -25135,6 +25918,14 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"phq" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "phr" = (
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
@@ -25238,6 +26029,15 @@
 	icon_state = "verticalrightborderleft2top"
 	},
 /area/f13/wasteland)
+"pko" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pkw" = (
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -25355,6 +26155,14 @@
 	dir = 6
 	},
 /area/f13/wasteland)
+"poz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "poA" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -25423,6 +26231,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/building/abandoned)
+"prn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner"
+	},
+/area/f13/wasteland)
 "pro" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25487,6 +26301,14 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
 /area/f13/city)
+"ptg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "ptu" = (
 /obj/machinery/light/small,
 /obj/structure/railing/wood{
@@ -25833,6 +26655,11 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"pBD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pCj" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -25853,6 +26680,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/city)
+"pCG" = (
+/obj/effect/spawner/lootdrop/ammo/military,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/waste_loot_poor,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pCS" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -25861,12 +26697,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pDh" = (
-/obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
 	},
-/area/f13/building/abandoned)
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "pDp" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -26019,16 +26860,11 @@
 /turf/closed/indestructible/wood,
 /area/f13/building/abandoned)
 "pHs" = (
-/obj/structure/chair{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "pHA" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -26160,6 +26996,14 @@
 	dir = 8
 	},
 /area/f13/wasteland)
+"pMr" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "pMA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26225,8 +27069,13 @@
 /obj/structure/curtain{
 	color = "#363636"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"pNL" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "pOa" = (
 /obj/item/paper/crumpled,
 /obj/structure/table/wood,
@@ -26387,12 +27236,15 @@
 	},
 /area/f13/building)
 "pSB" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/building/abandoned)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "pSW" = (
 /obj/machinery/light/lampost,
 /turf/open/floor/plating/f13/outside/road{
@@ -26444,6 +27296,17 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/city)
+"pVg" = (
+/obj/structure/closet/fridge,
+/obj/item/export/bottle/rum,
+/obj/item/export/bottle/vodka,
+/obj/item/export/bottle/absinthe,
+/obj/item/reagent_containers/food/snacks/burrito,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "pVu" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -26732,6 +27595,12 @@
 	icon_state = "verticalinnermain2"
 	},
 /area/f13/wasteland)
+"qcl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qcp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26752,6 +27621,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"qda" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/bomb/tier1,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qdc" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -26935,6 +27811,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qkU" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "qkX" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -27110,6 +27993,16 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
+"qrQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 15
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "qsf" = (
 /obj/effect/overlay/junk/sink{
 	dir = 1
@@ -27264,21 +28157,15 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building/abandoned)
-"qwS" = (
-/obj/effect/overlay/junk/mirror{
-	pixel_x = 26;
-	pixel_y = -4
-	},
-/obj/effect/overlay/junk/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
+"qwv" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "yellowrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
+"qwS" = (
+/turf/closed/wall/f13/store,
+/area/f13/wasteland)
 "qxn" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -27352,6 +28239,15 @@
 	icon_state = "outerturn"
 	},
 /area/f13/wasteland)
+"qyR" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 15
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "qzh" = (
 /obj/structure/flora/grass/coyote/one,
 /obj/structure/flora/small_bush,
@@ -27406,6 +28302,14 @@
 	icon_state = "cafeteria"
 	},
 /area/f13/building/abandoned)
+"qzV" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "qAg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/topright,
@@ -27438,6 +28342,13 @@
 	icon_state = "damaged2"
 	},
 /area/f13/building/abandoned)
+"qAQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/bigredvend,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "qCb" = (
 /turf/open/floor/f13{
 	icon_state = "yellowrustychess"
@@ -27530,6 +28441,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
+"qGr" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "qHa" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -27648,16 +28563,11 @@
 	},
 /area/f13/wasteland)
 "qLB" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/machinery/light/broken{
-	dir = 4;
-	pixel_y = -16
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "yellowrustyfull"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "qLT" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/building)
@@ -27943,6 +28853,7 @@
 "qUu" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
 /turf/open/floor/f13{
 	icon_state = "grass2"
 	},
@@ -27977,6 +28888,23 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"qWv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
+"qWC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "qWL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -28260,18 +29188,10 @@
 	},
 /area/f13/wasteland)
 "rdI" = (
-/obj/structure/mirror{
-	pixel_x = -25
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/burger/baconburger,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "reA" = (
 /obj/effect/decal/waste{
 	icon_state = "goo13"
@@ -28300,6 +29220,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"rfv" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "rgu" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -28404,16 +29334,13 @@
 	},
 /area/f13/wasteland/city)
 "rjP" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "rjQ" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -28603,6 +29530,10 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"rqj" = (
+/obj/structure/bookcase,
+/turf/open/floor/carpet,
+/area/f13/building)
 "rqv" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -38;
@@ -28661,6 +29592,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"rsY" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/spawner/lootdrop/stock_parts,
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"rtd" = (
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rtl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28755,14 +29710,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/abandoned)
 "rvQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/obstacle/barbedwire/end,
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "rwf" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -28785,6 +29741,14 @@
 	name = "bathroom tiles"
 	},
 /area/f13/building/abandoned)
+"rwF" = (
+/obj/structure/table,
+/obj/item/phone,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rwH" = (
 /obj/structure/chair/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -28956,6 +29920,13 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland)
+"rBB" = (
+/obj/structure/bed/mattress/pregame,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rBO" = (
 /obj/machinery/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -28967,6 +29938,14 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/water,
 /area/f13/building/abandoned)
+"rCb" = (
+/obj/effect/decal/waste{
+	icon_state = "goo9"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "rCd" = (
 /obj/structure/fluff/hedge/opaque,
 /obj/structure/fluff/hedge/opaque,
@@ -28985,12 +29964,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "rCB" = (
-/obj/structure/car/rubbish1{
-	pixel_x = -38;
-	pixel_y = -5
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 27
+	},
+/obj/structure/mirror{
+	pixel_y = 34
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "rCE" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -29057,6 +30046,13 @@
 /obj/item/newspaper,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"rFk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluerustychess"
+	},
+/area/f13/building)
 "rFn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/outside/road{
@@ -29138,6 +30134,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
+"rJv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/lootshelf/cans,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "rJZ" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -29250,13 +30255,16 @@
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/wasteland)
 "rNh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "rNu" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -29276,12 +30284,9 @@
 	},
 /area/f13/building)
 "rOj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/item/target/clown,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "rOB" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/blood/old,
@@ -29364,6 +30369,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned)
+"rQm" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "grass2"
+	},
+/area/f13/wasteland)
 "rQt" = (
 /turf/open/indestructible/ground/outside/roaddirt{
 	icon_state = "innercornermisc"
@@ -29420,6 +30431,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/abandoned)
+"rSk" = (
+/obj/structure/wreck/car/bike,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rSs" = (
 /obj/structure/fence{
 	dir = 4
@@ -29643,6 +30658,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
+"saW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bonfire/prelit,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "sbc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
@@ -29714,19 +30736,14 @@
 	},
 /area/f13/building)
 "scq" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "scD" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
@@ -29774,6 +30791,14 @@
 	icon_state = "verticalrightborderleft2"
 	},
 /area/f13/wasteland)
+"seM" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sfi" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -29943,10 +30968,13 @@
 	},
 /area/f13/building/abandoned)
 "sip" = (
-/obj/structure/decoration/clock/old/active,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
-/area/f13/building/abandoned)
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland/city)
 "siv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30052,6 +31080,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/building/abandoned)
+"sln" = (
+/obj/effect/spawner/lootdrop/f13/traitbooks/low,
+/obj/effect/spawner/lootdrop/waste_loot_poor,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "slu" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/f13{
@@ -30140,15 +31176,11 @@
 	},
 /area/f13/building/abandoned)
 "smo" = (
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/f13/police/officer,
-/obj/item/clothing/under/f13/police/officer,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "smP" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -30215,12 +31247,14 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/building/abandoned)
 "sqe" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/obstacle/barbedwire/end,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "sqh" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -30311,16 +31345,27 @@
 	dir = 9
 	},
 /area/f13/wasteland)
-"ssw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+"ssr" = (
+/obj/structure/fence{
+	max_integrity = 500;
+	name = "reinforced fence"
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"ssw" = (
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "ssK" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -30546,9 +31591,26 @@
 	icon_state = "horizontalbottombordertop3"
 	},
 /area/f13/wasteland)
+"sAr" = (
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sAM" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
+/area/f13/wasteland)
+"sAN" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "sBa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30562,6 +31624,10 @@
 /obj/structure/chair/folding,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/building/abandoned)
+"sBl" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "sBw" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/twenty,
@@ -30589,15 +31655,11 @@
 /turf/closed/wall/mineral/brick,
 /area/f13/building/abandoned)
 "sBJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase{
-	anchored = 1
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/area/f13/wasteland)
 "sBY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30613,12 +31675,25 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"sCs" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sCI" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland)
+"sCK" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sDc" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30668,6 +31743,14 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"sEP" = (
+/obj/effect/spawner/lootdrop/wastelootgood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "sET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30692,6 +31775,11 @@
 	dir = 4
 	},
 /area/f13/wasteland)
+"sGH" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sGV" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -31166,6 +32254,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sUX" = (
+/obj/structure/decoration/cctv,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "sVa" = (
 /obj/structure/lattice/catwalk,
 /mob/living/simple_animal/hostile/trog/sporecarrier,
@@ -31340,7 +32432,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "sZV" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -31776,6 +32868,12 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/city)
+"tli" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluerustychess"
+	},
+/area/f13/building)
 "tlk" = (
 /obj/structure/flora/grass/wasteland,
 /obj/structure/nest/ghoul,
@@ -31821,13 +32919,18 @@
 /area/f13/building/abandoned)
 "tnv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/building/abandoned)
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building)
 "tnz" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -32030,6 +33133,15 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"tuu" = (
+/obj/structure/fence/corner{
+	max_integrity = 500
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "tuC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/tank,
@@ -32092,6 +33204,10 @@
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/floor/plasteel,
 /area/f13/building/abandoned)
+"txj" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "txx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -32147,6 +33263,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tzk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/guncase{
+	anchored = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "tzt" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -32183,6 +33310,15 @@
 	},
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
+"tAX" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/wasteland)
 "tAZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -32276,15 +33412,34 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "tCA" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/tires/five{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/tires/five{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/area/f13/building/abandoned)
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = 15;
+	pixel_y = -7
+	},
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = 15;
+	pixel_y = -7
+	},
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "tCD" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/carpet,
@@ -32512,6 +33667,11 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"tJO" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tJR" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -32587,6 +33747,10 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
+"tNu" = (
+/obj/structure/sign/flag_texas,
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "tNy" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -32869,14 +34033,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "tUs" = (
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "tUR" = (
 /obj/structure/mirror/magic{
 	pixel_x = -5
@@ -32895,6 +34059,14 @@
 /obj/structure/dresser,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
+"tVe" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/wasteland)
 "tVB" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowright"
@@ -32961,7 +34133,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "tXl" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_north"
@@ -33269,7 +34441,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "ueQ" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -33404,12 +34576,18 @@
 	},
 /area/f13/wasteland)
 "uiY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/area/f13/building/abandoned)
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building)
 "uiZ" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33505,6 +34683,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ukT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ule" = (
 /obj/structure/chair/bench,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -33609,14 +34797,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "uon" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/remains{
+	icon_state = "remains"
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "uoL" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
@@ -33776,13 +34966,18 @@
 	},
 /area/f13/building)
 "uud" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/decoration/rag{
+	desc = "Writing in your own blood seems like a bad idea.";
+	icon_state = "blood_pic_1";
+	layer = 4.3;
+	name = "old dried blood";
+	pixel_x = 17;
+	pixel_y = 30
 	},
-/area/f13/building/abandoned)
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "uuo" = (
 /obj/structure/wreck/car/bike,
 /turf/open/indestructible/ground/outside/savannah,
@@ -33879,6 +35074,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"uwQ" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "uwY" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks{
@@ -33945,6 +35148,12 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building/abandoned)
+"uyP" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "uyY" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -34234,6 +35443,11 @@
 	color = " A6635D"
 	},
 /area/f13/caves)
+"uIM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uIO" = (
 /turf/open/indestructible/ground/outside/roaddirt{
 	dir = 8;
@@ -34263,11 +35477,12 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building/abandoned)
 "uJR" = (
-/obj/structure/closet/crate/bin/trashbin,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "yellowrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "uJU" = (
 /obj/structure/sign/poster/contraband/have_a_puff,
 /turf/closed/wall/rust,
@@ -34385,6 +35600,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/building/abandoned)
+"uPy" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "uPS" = (
 /obj/structure/fence{
 	dir = 4
@@ -34529,6 +35750,32 @@
 /obj/structure/railing,
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/f13/building/abandoned)
+"uTE" = (
+/obj/structure/tires/five{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/structure/tires/five{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/structure/tires/five{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "uTM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -34907,6 +36154,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"vhB" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
 "vhJ" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -34940,6 +36196,13 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/building)
+"viU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vjm" = (
 /obj/item/kirbyplants,
@@ -35143,6 +36406,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"voQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "voZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -35176,6 +36446,15 @@
 	dir = 9
 	},
 /area/f13/wasteland)
+"vpU" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "vqd" = (
 /obj/structure/table_frame,
 /obj/item/shard,
@@ -35263,12 +36542,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "vtu" = (
-/obj/machinery/vending/nukacolavend,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/sink/greyscale{
+	dir = 8;
+	pixel_x = -14
 	},
-/area/f13/building/abandoned)
+/obj/structure/mirror{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluerustychess"
+	},
+/area/f13/building)
 "vtG" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft1"
@@ -35309,7 +36593,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "vvR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13vaultrusted,
@@ -35332,7 +36616,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "vxN" = (
 /obj/structure/bedsheetbin,
 /turf/open/floor/carpet,
@@ -35356,6 +36640,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city)
+"vyJ" = (
+/obj/effect/spawner/lootdrop/ammo/military,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "vzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35667,7 +36959,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "vJK" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -36218,6 +37510,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wcU" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/indestructible/ground/outside/water/running{
+	color = " A6635D"
+	},
+/area/f13/wasteland)
 "wdb" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -36311,6 +37609,12 @@
 /obj/structure/nest/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"wfC" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "wfE" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/box/cups,
@@ -36382,7 +37686,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "whc" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#d9b51c"
@@ -36598,6 +37902,15 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/building/abandoned)
+"wnU" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks{
+	icon_state = "board-2"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building)
 "woA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -36645,6 +37958,15 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland)
+"wpQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "wpS" = (
 /obj/structure/flora/grass/coyote/one,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36673,12 +37995,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "wsC" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = 6;
+	pixel_y = -16
 	},
-/area/f13/building/abandoned)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"wsL" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "wsW" = (
 /obj/structure/railing{
 	dir = 10
@@ -36726,6 +38057,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland)
+"wuJ" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/decal/waste{
+	icon_state = "goo9"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "wvl" = (
@@ -36794,6 +38134,13 @@
 "wxt" = (
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
+	},
+/area/f13/building)
+"wxD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "wxH" = (
@@ -36929,6 +38276,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wBt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/flag_texas,
+/obj/structure/decoration/rag{
+	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
+	icon_state = "skulls";
+	name = "skulls"
+	},
+/turf/closed/wall/f13/store,
+/area/f13/building)
 "wBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37263,14 +38620,10 @@
 /turf/closed/wall/mineral/brick,
 /area/f13/building/abandoned)
 "wLN" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building/abandoned)
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
+/turf/open/floor/carpet,
+/area/f13/building)
 "wMe" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13/wood,
@@ -37323,15 +38676,15 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/building/abandoned)
 "wNm" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/reagent_containers/hypospray/medipen/psycho,
-/obj/item/reagent_containers/hypospray/medipen/psycho,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
+"wNn" = (
+/obj/item/broken_bottle,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wNq" = (
 /turf/open/floor/plating/rust,
 /area/f13/building/abandoned)
@@ -37361,7 +38714,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "wND" = (
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/indestructible/ground/outside/dirt,
@@ -37490,6 +38843,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"wTK" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "wTU" = (
 /obj/structure/barricade/wooden/planks,
 /obj/structure/decoration/rag{
@@ -37555,12 +38914,16 @@
 /area/f13/building/abandoned)
 "wVA" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/trash/f13/mre{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -6
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "wVF" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/rust,
@@ -37836,6 +39199,10 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"xeB" = (
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xeW" = (
 /obj/structure/fluff/railing{
 	dir = 4
@@ -37914,10 +39281,29 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/building/abandoned)
+"xin" = (
+/obj/item/clothing/under/rank/security/detective/brown,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/suit/det_suit/forensicsblue,
+/obj/structure/closet{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "xix" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plasteel/darkbrown/side,
 /area/f13/building/abandoned)
+"xiS" = (
+/obj/structure/bus_door,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "xiV" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -38056,6 +39442,16 @@
 /obj/item/reagent_containers/food/snacks/herby_cheese,
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/abandoned)
+"xnp" = (
+/obj/item/clothing/shoes/combat,
+/obj/structure/closet,
+/obj/item/clothing/head/f13/police/officer,
+/obj/item/clothing/under/f13/police/officer,
+/obj/effect/spawner/lootdrop/f13/weapon/revolver44variants,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "xnq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/prewar/poster71{
@@ -38152,7 +39548,7 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "xoS" = (
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland/city)
@@ -38322,6 +39718,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"xuF" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/building)
 "xvd" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -38540,7 +39942,7 @@
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "xCX" = (
 /obj/structure/flora/timber,
 /turf/open/indestructible/ground/outside/desert,
@@ -38719,6 +40121,12 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city)
+"xHT" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xIt" = (
 /obj/structure/closet/crate/wicker,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -38869,6 +40277,15 @@
 	},
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"xME" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "xMP" = (
 /obj/structure/fence{
 	dir = 4
@@ -38956,6 +40373,10 @@
 /turf/open/floor/f13{
 	icon_state = "dark"
 	},
+/area/f13/building)
+"xOQ" = (
+/obj/structure/obstacle/old_locked_door,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "xPf" = (
 /obj/structure/decoration/rag{
@@ -39134,6 +40555,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xTH" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/waste_loot_poor,
+/mob/living/simple_animal/hostile/renegade,
+/obj/effect/decal/cleanable/semen,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluerustychess"
+	},
+/area/f13/building)
 "xTO" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -39410,14 +40844,12 @@
 	},
 /area/f13/building/abandoned)
 "ydL" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building/abandoned)
+/area/f13/building)
 "yet" = (
 /obj/structure/nest/raider/ranged,
 /obj/effect/decal/cleanable/dirt,
@@ -39603,6 +41035,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
+"yja" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building)
 "yjz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41604,7 +43043,7 @@ cfu
 bft
 xGc
 flw
-eWO
+bPQ
 euo
 qEd
 euo
@@ -52828,7 +54267,7 @@ egf
 oph
 oph
 oph
-oph
+dQd
 cNS
 tfn
 tfn
@@ -53320,6 +54759,9 @@ oph
 oph
 oph
 oph
+oph
+oph
+oph
 tiN
 oph
 tiN
@@ -53340,9 +54782,6 @@ oph
 oph
 oph
 oph
-oph
-oph
-tiN
 oph
 tiN
 lmY
@@ -53572,6 +55011,9 @@ oph
 oph
 oph
 oph
+oph
+oph
+oph
 tiN
 oph
 oph
@@ -53593,9 +55035,6 @@ oph
 oph
 oph
 lmY
-oph
-oph
-oph
 oph
 oph
 oph
@@ -53829,6 +55268,9 @@ oph
 oph
 oph
 oph
+oph
+oph
+oph
 qaz
 oph
 lmY
@@ -53841,10 +55283,7 @@ sgM
 sgM
 oph
 oph
-oph
-oph
-oph
-oph
+rSk
 oph
 oph
 oph
@@ -54085,6 +55524,9 @@ oph
 oph
 oph
 oph
+oph
+oph
+oph
 whc
 tfn
 oph
@@ -54112,9 +55554,6 @@ tiN
 oph
 oph
 afz
-oph
-oph
-oph
 gEj
 tiN
 oph
@@ -54341,22 +55780,25 @@ oph
 oph
 oph
 lmY
-oph
-oph
-oph
-oph
-oph
-wEK
-wEK
-tiN
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-gEj
+yaf
+qwS
+aqm
+qwS
+qwS
+qwS
+qwS
+qwS
+qwS
+kQh
+ele
+uSf
+uSf
+uSf
+uSf
+wnU
+uSf
+uSf
+rwh
 tiN
 oph
 oph
@@ -54369,9 +55811,6 @@ oph
 oph
 oph
 egf
-tfn
-tfn
-oph
 oph
 rCS
 oph
@@ -54571,13 +56010,6 @@ tfn
 oph
 oph
 oph
-tiN
-oph
-oph
-oph
-oph
-oph
-oph
 wEK
 oph
 oph
@@ -54605,15 +56037,25 @@ lmY
 lmY
 tiN
 oph
+yaf
+uvV
+rOj
+pZm
+pZm
+pZm
+bQa
+lmY
+tiN
+eLd
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
+uSf
+rqj
+cEA
+uSf
+sCK
+rdI
+tBA
+dBE
 oph
 oph
 oph
@@ -54625,9 +56067,6 @@ oph
 oph
 oph
 tfn
-tfn
-oph
-oph
 tfn
 oph
 oph
@@ -54826,13 +56265,6 @@ oph
 oph
 tfn
 oph
-tiN
-tiN
-oph
-oph
-tiN
-yaf
-oph
 oph
 oph
 tiN
@@ -54863,14 +56295,24 @@ oph
 oph
 oph
 oph
+uvV
+pNL
+xGa
+xGa
+xGa
+klB
+frr
+frr
+eLd
 oph
-oph
-oph
-oph
-oph
-tiN
-oph
-oph
+lgf
+gLM
+dBs
+xOQ
+tBA
+daF
+tBA
+uSf
 oph
 whc
 tiN
@@ -54883,9 +56325,6 @@ oph
 oph
 tiN
 tiN
-oph
-oph
-oph
 oph
 tfn
 oph
@@ -55082,31 +56521,24 @@ oph
 afz
 oph
 oph
-tiN
-tiN
-oph
-egf
-oph
-oph
-oph
 oph
 lWL
 lWL
 lWL
 bgP
 ciB
-cdc
-cdc
-cdc
-cdc
-cdc
+uSf
+uSf
+uSf
+uSf
+uSf
 liR
-ecn
-ecn
-ecn
-ecn
-ecn
-fwb
+gVD
+gVD
+gVD
+gVD
+gVD
+bvs
 kcD
 kcD
 iAW
@@ -55119,18 +56551,28 @@ oph
 oph
 oph
 oph
-tfn
+oph
+uvV
+pZm
+oEL
+gOB
+gOB
+stW
 oph
 oph
-oph
-oph
-oph
-tiN
-tiN
-oph
+tJO
+gpG
+uPy
+iHv
+oes
+llp
+wNn
+oaw
+tBA
+uSf
 whc
 tfn
-oph
+lOC
 tiN
 oph
 tfn
@@ -55139,9 +56581,6 @@ oph
 oph
 oph
 tfn
-oph
-oph
-oph
 oph
 tfn
 lmY
@@ -55339,31 +56778,24 @@ afz
 wEK
 oph
 tiN
-tiN
 oph
-oph
-tiN
-oph
-oph
-oph
-oph
+jPs
+uSf
+uSf
+uSf
+uSf
+aZh
+sCs
 mXT
-cdc
-cdc
-cdc
-cdc
-vRd
-paY
-gXJ
-sqe
-cdc
-ecn
-ecn
-ecn
-fwb
-fwb
-ecn
-fwb
+mca
+uSf
+gVD
+gVD
+gVD
+bvs
+bvs
+gVD
+bvs
 cRv
 tbe
 iAW
@@ -55376,30 +56808,37 @@ oph
 gEj
 oph
 oph
+oph
+uvV
+xGa
+pZm
+gOB
+oni
+klB
+qcl
+frr
+eLd
 tiN
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-tiN
-oph
-oph
-oph
-oph
-oph
-tSK
-oph
-oph
-ddh
-afz
+gfS
+kIJ
+wLN
+gEd
+fWF
+tBA
+cbh
+uSf
+aZh
+uSf
+uSf
+uSf
+uSf
+uSf
+aZh
+uSf
+uSf
+aZh
+uSf
 lmY
-oph
-oph
-oph
 tfn
 oph
 oph
@@ -55596,31 +57035,24 @@ tiN
 oph
 oph
 tiN
-tiN
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-mXT
+jPs
+jrG
+phq
+qda
+uSf
+ljG
+dZs
+dZs
 wNm
 oLJ
-eGO
-cdc
+gVD
+mrS
 fEp
-pbk
-pbk
+srk
+rCB
 leX
-oJH
-ecn
-bWL
-lgz
-hLo
-gfS
-gLM
-ecn
+gVD
 ggm
 tev
 wjo
@@ -55634,29 +57066,36 @@ tiN
 oph
 tiN
 oph
-oph
-oph
-oph
-oph
-whc
-oph
+uvV
+pZm
+pZm
+dVl
+pZm
+stW
 tiN
 oph
+jrO
+xeB
+uSf
+nOg
+uSf
+uSf
+sGH
+tBA
+xHT
+lMP
+wxt
+wxt
+uSf
+pVg
+qCb
+vyJ
+ptg
+bJF
+fQd
+mva
+uSf
 oph
-oph
-oph
-oph
-oph
-oph
-cNS
-lmY
-oph
-egf
-afz
-oph
-oph
-oph
-wEK
 wEK
 oph
 oph
@@ -55854,33 +57293,26 @@ tiN
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-whc
-oph
-cdc
-pbk
-pbk
-pbk
-cdc
-jrO
-pbk
-mva
-pbk
-cln
-ecn
-eom
-lsO
+uSf
+dZs
+dZs
+dZs
+uSf
+dUi
+dZs
+xin
+dZs
+xnp
+gVD
+ndh
+dzC
+srk
+ndZ
 hLo
-uqT
-iHv
-fwb
-ecn
-ecn
-oxc
+bvs
+gVD
+gVD
+rNh
 oph
 oph
 oph
@@ -55891,28 +57323,35 @@ oph
 oph
 tiN
 oph
+qel
+ssr
+ssr
+ssr
+jbz
+klB
+frr
 oph
+jrO
 oph
-oph
-tiN
-whc
-tiN
-tiN
-oph
-oph
-tfn
-oph
-oph
-oph
-oph
-tSK
-oph
-oph
-wEK
-wEK
-oph
-oph
-oph
+idQ
+iyC
+hKR
+aZh
+xHT
+voQ
+viU
+bZc
+qCb
+qCb
+agt
+qCb
+dZs
+jpO
+ndZ
+dZs
+iKH
+mva
+uSf
 oph
 oph
 oph
@@ -56111,33 +57550,26 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-cdc
-mAE
-pbk
-pbk
-cdc
+uSf
+seM
+dZs
+dZs
+uSf
+rtd
+ydL
+kvz
+ndZ
+sAr
+gVD
+fft
 scq
-jSn
+srk
 laV
-uqT
-bsV
-ecn
-wsC
+uwQ
+gVD
+bdX
+ndZ
 kQw
-hLo
-dhQ
-hTu
-ecn
-rdI
-uqT
-dlC
 tiN
 oph
 oph
@@ -56149,27 +57581,34 @@ oph
 oph
 oph
 oph
-tiN
-tiN
-tiN
 oph
 oph
 oph
-oph
-tfn
-oph
-oph
-yaf
+dBx
+peR
 oph
 oph
+bWL
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
+aNe
+hAG
+hAG
+kxk
+uSf
+uSf
+uSf
+uSf
+wxt
+qCb
+agt
+nOf
+dZs
+heB
+dZs
+dZs
+dZs
+mhZ
+uSf
 oph
 tfn
 oph
@@ -56367,34 +57806,27 @@ oph
 oph
 tiN
 oph
-wOL
-lmY
 oph
-oph
-oph
-whc
-oph
-oph
-cdc
-bfd
+uSf
+fZx
+sqe
+dNs
+uSf
+lRj
+qzV
+gJi
+dZs
 rvQ
-eLd
-cdc
+gVD
+dzC
 rjP
 exD
-uJR
-pbk
+ndZ
+dZs
 smo
-ecn
-lsO
+ndZ
+aFl
 rNh
-mdf
-uqT
-pbk
-mOx
-uqT
-itz
-oxc
 oph
 oph
 oph
@@ -56404,30 +57836,37 @@ oph
 tiN
 oph
 oph
+oph
+oph
+oph
+oph
+oph
+dBx
+klB
+tiN
+frr
+eLd
 gEj
-oph
-tfn
-oph
-oph
-oph
-tfn
-tfn
-oph
-tiN
-oph
-tiN
-yaf
-egf
-oph
-oph
-oph
-tiN
-oph
-oph
+aNe
+xuF
+iyC
+gXJ
+qCb
+nOf
+qCb
+qCb
+qWC
+qwv
+aZh
+uud
+dZs
+adM
+dZs
+dZs
+ndZ
+ctH
+uSf
 lmY
-oph
-oph
-oph
 tSK
 tiN
 oph
@@ -56624,34 +58063,27 @@ oph
 oph
 tiN
 afz
-tiN
-tiN
 oph
-wEK
-whc
-whc
-oph
-oph
-vRd
-aCL
-vRd
-gxl
-cdc
-cdc
-vRd
-cdc
-agt
-cdc
-fwb
-lsO
-ssw
-pbk
-jSn
-lsO
-hTu
-rNh
-klB
-ecn
+aZh
+rwh
+aZh
+pde
+uSf
+uSf
+aZh
+uSf
+oJH
+uSf
+bvs
+dzC
+ukT
+dZs
+ydL
+dzC
+uwQ
+rjP
+rBB
+gVD
 oph
 oph
 whc
@@ -56661,30 +58093,37 @@ oph
 oph
 oph
 oph
-tiN
-oph
-tfn
-tfn
 oph
 oph
 oph
 oph
-tiN
+oph
+dBx
+cln
 oph
 oph
-tiN
+pBD
+atm
+aNe
+iyC
+iyC
+uSf
+uSf
+tli
+uSf
+aZh
+wxt
+mSc
+aZh
+iXB
+qCb
+qCb
+ndZ
+dZs
+ndZ
+aRS
+lMP
 oph
-wEK
-oph
-tiN
-oph
-tiN
-tiN
-oph
-oph
-oph
-oph
-tiN
 tSK
 oph
 oph
@@ -56882,33 +58321,26 @@ tiN
 egf
 oph
 oph
-oph
-oph
-qaz
-tiN
-oph
-yaf
-oph
-vRd
-pcl
+aZh
+izC
+baM
+ndZ
+uSf
+vpU
+oZd
+dZs
+dZs
 dXW
-uqT
-cdc
+gVD
+pko
 oZo
 tUs
-pbk
-pbk
-out
-ecn
+tzk
+emg
+bvs
+gVD
 tnv
-uon
-wLN
-mca
-sBJ
-fwb
-ecn
-kIJ
-lMP
+uiY
 oph
 tiN
 oph
@@ -56919,28 +58351,35 @@ oph
 tiN
 oph
 oph
-oph
-tiN
-gEj
-whc
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-dXS
-oph
-oph
-oph
 tiN
 tiN
 oph
 oph
+dBx
+klB
+frr
+uIM
+eLd
 oph
-oph
-oph
+aNe
+eDa
+qWv
+uSf
+vtu
+kLQ
+kLQ
+uSf
+wxt
+qCb
+sUX
+rwh
+uSf
+qCb
+pMr
+mRl
+lCs
+qCb
+uSf
 oph
 oph
 oph
@@ -57139,30 +58578,23 @@ tiN
 oph
 oph
 oph
-tiN
-oph
-oph
-aNe
-oph
-yaf
-oph
-vRd
-ctH
-uqT
-pbk
-slu
-jxv
-pbk
-uqT
-pbk
-uqT
-agt
-uqT
-oZd
-jHg
-jPs
-ecn
-fwb
+aZh
+oyb
+ndZ
+dZs
+mOx
+dxJ
+dZs
+ndZ
+dZs
+ndZ
+oJH
+ndZ
+pcl
+oDa
+gkh
+gVD
+bvs
 lKj
 fAb
 hRF
@@ -57175,30 +58607,37 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-gEj
-tiN
-oph
-oph
 egf
 oph
 oph
 oph
-tiN
 oph
+nMe
+wdJ
+apl
 oph
-afz
+eLd
 oph
-oph
+hAv
+dGm
+rfv
+eom
+rFk
+kLQ
+xTH
+uSf
+wxt
+qCb
+wxt
+rJv
+uSf
+qCb
+sEP
+dZs
+pCG
+qCb
+kxk
 tfn
-tiN
-tfn
-tfn
-oph
-oph
 oph
 oph
 tpt
@@ -57395,31 +58834,24 @@ oph
 oph
 rCS
 oph
-tiN
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-vRd
-lsO
-jcq
-heB
-oxc
-poO
-pbk
-pbk
+aZh
+dzC
+hTu
+clc
+rNh
+poz
+dZs
+dZs
+wxD
+ndZ
+bvs
+dzC
+cYQ
+aHm
+iLT
 pSB
-uqT
-fwb
-lsO
-rOj
-bQa
-nPB
-tCA
-ecn
+gVD
 fJi
 oph
 oph
@@ -57433,28 +58865,35 @@ ddh
 tiN
 tiN
 oph
-tiN
-tfn
-wis
-oph
-oph
-oph
-wEK
-oph
-oph
-oph
-oph
-oph
-oph
-tfn
-oph
-oph
 oph
 tiN
 oph
 oph
-oph
-oph
+qel
+mup
+tFq
+tFq
+tFq
+uSf
+aZh
+uSf
+eDm
+uSf
+uSf
+txj
+uSf
+uSf
+qLB
+wsL
+gWt
+wxt
+cgk
+qCb
+sln
+ipL
+leS
+nEl
+uSf
 oph
 tfn
 afz
@@ -57653,30 +59092,23 @@ tiN
 tfn
 oph
 oph
-tiN
-oph
-oph
-oph
+aZh
+ndZ
+nnm
 ctE
-oph
-oph
-vRd
-uqT
+rNh
+wVA
+uon
+ndZ
+wpQ
 ljG
-uud
+gVD
 oxc
 jyl
-pHs
-uqT
+rNh
+mAE
 mar
-fEp
-ecn
-qLB
-vtu
-oxc
-qwS
-oes
-ecn
+gVD
 fJi
 wlA
 rWg
@@ -57689,29 +59121,36 @@ whc
 oph
 tiN
 oph
-oph
+tSK
+tfn
 tiN
 oph
 oph
 oph
+whc
 oph
 tiN
 oph
-oph
-oph
-oph
-oph
-tiN
-oph
-oph
-oph
-oph
-tiN
-oph
-oph
-oph
-oph
-oph
+uSf
+qAQ
+wxt
+wxt
+wxt
+cmV
+cks
+bqF
+wxt
+wxt
+yja
+uJR
+dlZ
+uSf
+uSf
+uSf
+uSf
+aZh
+uSf
+uSf
 oph
 tiN
 egf
@@ -57909,31 +59348,24 @@ oph
 oph
 oph
 tiN
-lSf
-oph
-oph
-oph
-oph
-oph
-tiN
 yaf
-vRd
-uqT
+aZh
+ndZ
+dbx
+rwF
+rNh
+bvs
+iNU
+lgc
 jWg
-dQd
-oxc
-fwb
-dBx
+jWg
+gVD
+gVD
+gVD
+bvs
 uiY
-kvz
-kvz
-ecn
-ecn
-ecn
-fwb
-lMP
-lMP
-kIJ
+uiY
+tnv
 mWP
 uLW
 oph
@@ -57951,24 +59383,31 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-tfn
-oph
-oph
 tiN
-tiN
+lZN
 oph
 oph
 oph
-oph
+uSf
+ekY
+qCb
+qCb
+uyP
+qCb
+gWt
+qCb
+qCb
+qCb
+qCb
+qCb
+bcM
+uSf
+oMa
+nPB
+oMa
+dlC
+msr
+out
 oph
 oph
 oph
@@ -57996,10 +59435,10 @@ tlD
 tlD
 uJq
 ygK
-tlD
+faK
 tUp
-dbe
-lfe
+oXD
+rQm
 jiS
 qUu
 fbH
@@ -58166,19 +59605,12 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
 iwK
-sip
-pDh
-ydL
-wVA
-lMP
+cOB
+mje
+lgz
+dhQ
+uiY
 mvt
 hlV
 gBg
@@ -58204,13 +59636,6 @@ oph
 oph
 oph
 oph
-afz
-afz
-oph
-tiN
-oph
-afz
-afz
 oph
 oph
 oph
@@ -58220,12 +59645,26 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-afz
-oph
+uSf
+nNi
+wxt
+vhB
+cks
+gPC
+nOf
+wxt
+rsY
+wxt
+aSS
+cks
+aFi
+uSf
+rCb
+pHs
+oMa
+pHs
+rCb
+out
 oph
 oph
 oph
@@ -58260,7 +59699,7 @@ mGp
 fOr
 fzH
 fbH
-glq
+sBl
 ecn
 gtu
 wmP
@@ -58424,18 +59863,11 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-fwb
-fwb
-ecn
-ecn
-lMP
+bvs
+bvs
+gVD
+gVD
+uiY
 qZY
 ddJ
 gjA
@@ -58463,27 +59895,34 @@ oph
 oph
 oph
 oph
-oph
 tfn
-tfn
+tSK
+tiN
 oph
 oph
 oph
 oph
+uSf
+uSf
+uSf
+uSf
+tNu
+cab
+ssw
+lgf
+ahz
+gxl
+wBt
+jSn
+mKi
+lMP
+prn
+aKy
+xTO
+sAN
+oMa
+out
 oph
-tfn
-tfn
-oph
-oph
-tfn
-nTJ
-oph
-oph
-oph
-oph
-oph
-oph
-tfn
 oph
 oph
 oph
@@ -58521,7 +59960,7 @@ glq
 ecn
 gKt
 glm
-jTL
+nEQ
 jTL
 jTL
 eGt
@@ -58681,13 +60120,6 @@ afz
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-tiN
-oph
-oph
 tiN
 tiN
 oph
@@ -58717,22 +60149,10 @@ oph
 oph
 oph
 oph
-tiN
 oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-tfn
-tfn
-oph
-tfn
-oph
-afz
 oph
 oph
 oph
@@ -58740,20 +60160,39 @@ oph
 oph
 oph
 tiN
+oph
+oph
+oph
+eGO
+oMa
+fqV
+pHs
+osB
+tAX
+saW
+jbi
+elF
+wsC
+pXU
+gMq
+pyr
+oMa
+oMa
+out
+oph
 tiN
-tiN
-vsM
+eFz
 aDN
-vsM
-vsM
-vsM
-cdc
-cdc
-cdc
-cdc
-cdc
-cdc
-cdc
+eFz
+eFz
+eFz
+uSf
+uSf
+uSf
+uSf
+uSf
+uSf
+uSf
 oph
 oph
 oph
@@ -58780,7 +60219,7 @@ aMY
 fOO
 aMY
 rum
-fOO
+euI
 fOO
 rum
 ecn
@@ -58941,13 +60380,6 @@ oph
 oph
 oph
 oph
-tiN
-oph
-oph
-oph
-oph
-oph
-oph
 oph
 oph
 oph
@@ -58974,43 +60406,50 @@ tQG
 tQG
 cQC
 oph
+sgM
 oph
-tiN
-wEK
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-tfn
-oph
-tfn
-oph
-oph
-oph
-tfn
-oph
-oph
-oph
-oph
-tiN
 gEj
 oph
 oph
-vsM
+oph
+oph
+oph
+tfn
+oph
+oph
+tiN
+afz
+oph
+eGO
+oMa
+oMa
+pHs
+oMa
+pDh
+oMa
+pHs
+oMa
+qyR
+quh
+buc
+cpw
+oMa
+oMa
+out
+oph
+oph
+eFz
 aoL
-jcq
-jcq
+hTu
+hTu
 xoG
 ePl
 xCy
 tXj
 mXL
 vJA
-hUl
-cdc
+mdf
+uSf
 oph
 oph
 oph
@@ -59040,9 +60479,9 @@ ccx
 dOT
 cXa
 jTL
-ecn
+dXS
 gMW
-gMW
+qGr
 gMW
 uGR
 maU
@@ -59194,13 +60633,6 @@ oph
 oph
 oph
 oph
-oph
-tfn
-tfn
-oph
-oph
-oph
-tfn
 tfn
 oph
 oph
@@ -59233,41 +60665,48 @@ vGR
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-tfn
-oph
-oph
-oph
-tfn
-oph
-oph
-oph
-tfn
-wEK
-wEK
-oph
-wEK
-gEj
-rCS
 tiN
 oph
-gvq
+oph
+oph
+oph
+oph
+tSK
+oph
+oph
+oph
+oph
+oph
+eGO
+oMa
+oMa
+oMa
+sBJ
+pVV
+oMa
+oMa
+oMa
+oMa
+oMa
+oMa
+oMa
+oMa
+oMa
+out
+oph
+oph
+xMn
 iKC
-pbk
+dZs
 iKC
-jcq
+hTu
 ePl
-hiX
+fLo
 whb
-hUl
-hFc
-hiX
-cdc
+mdf
+paY
+fLo
+uSf
 oph
 oph
 oph
@@ -59301,7 +60740,7 @@ ecn
 gMW
 gMW
 gMW
-uGR
+kzx
 jNR
 fmm
 ida
@@ -59451,13 +60890,6 @@ oph
 oph
 oph
 oph
-oph
-oph
-tfn
-oph
-tfn
-tfn
-oph
 tfn
 oph
 tfn
@@ -59489,42 +60921,49 @@ oMa
 cQC
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-tfn
 tiN
-vsk
+oph
+oph
+oph
+oph
+oph
+oph
 tfn
 oph
 oph
 oph
 oph
 oph
+eGO
+jnT
+pHs
+pVV
+oMa
+gVU
+oMa
+oMa
+oMa
+oMa
+dlC
+fqV
+joe
+oMa
+pHs
+out
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-gvq
+xMn
 fRj
 oOn
 vxf
-pbk
+dZs
 ePl
-hUl
+mdf
 aAN
-hFc
+paY
 kSt
 vuG
-cdc
+uSf
 oph
 oph
 oph
@@ -59708,13 +61147,6 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
 tfn
 tfn
 oph
@@ -59746,42 +61178,49 @@ mmC
 vGR
 tiN
 oph
-oph
-oph
+tiN
 tiN
 oph
-tfn
-tSK
-oph
-tfn
-tfn
-tfn
-oph
-oph
-oph
 oph
 oph
 oph
 tfn
+tfn
+tiN
 oph
+wEK
 oph
+tiN
+eGO
+oMa
+mMn
+bsV
+oMa
+oMa
+oMa
+qct
+oMa
+iUq
+qkU
+oMa
+wuJ
+oMa
+azQ
+out
 tfn
 oph
-oph
-oph
-oph
-vsM
+eFz
 sZN
-nZG
-uqT
-uqT
+kvr
+ndZ
+ndZ
 aKL
-hiX
-hiX
+fLo
+fLo
 fkR
-hiX
+fLo
 ues
-cdc
+uSf
 oph
 oph
 oph
@@ -59965,13 +61404,6 @@ oph
 oph
 oph
 tfn
-oph
-oph
-oph
-oph
-oph
-oph
-oph
 jyh
 tiN
 oph
@@ -60004,41 +61436,48 @@ vGR
 tiN
 oph
 oph
-oph
 tiN
+oph
+oph
+oph
 oph
 tfn
 oph
-tfn
-oph
 tiN
-tfn
+oph
 oph
 oph
 tiN
-whc
+bfd
+gKy
+itz
+gKy
+itz
+dEY
+xME
+uTE
+tCA
+qrQ
+lnu
+itz
+itz
+itz
+itz
+tuu
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-vsM
+eFz
 aav
 mPg
 mPg
 mPg
-cdc
+uSf
 mBN
 bnX
 jmB
 wNB
 dxE
-cdc
+uSf
 oph
 oph
 oph
@@ -60227,13 +61666,6 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
 tiN
 oph
 oph
@@ -60259,19 +61691,14 @@ lHJ
 wiQ
 cQC
 oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
+hAV
 oph
 oph
 tiN
 oph
 oph
 oph
+gEj
 oph
 oph
 oph
@@ -60283,19 +61710,31 @@ oph
 oph
 oph
 oph
+gEj
+eGO
+jrk
+wfC
+oMa
+out
+ihy
 oph
-vsM
-vsM
-vsM
+oph
+jZK
+oph
+oph
+oph
+eFz
+eFz
+eFz
 hpJ
-vsM
-cdc
-cdc
-cdc
-cdc
-cdc
-cdc
-cdc
+eFz
+uSf
+uSf
+uSf
+uSf
+uSf
+uSf
+uSf
 oph
 oph
 oph
@@ -60479,13 +61918,6 @@ oph
 oph
 oph
 oph
-oph
-oph
-oph
-oph
-oph
-rCB
-oph
 tiN
 oph
 hSN
@@ -60516,20 +61948,6 @@ lHJ
 mmC
 art
 tiN
-tiN
-tiN
-tiN
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
-oph
 oph
 oph
 oph
@@ -60538,6 +61956,27 @@ oph
 oph
 oph
 tiN
+oph
+tiN
+tiN
+tiN
+tiN
+oph
+oph
+oph
+oph
+oph
+oph
+oph
+wTK
+oMa
+oMa
+oMa
+bjX
+oph
+oph
+oph
+oph
 oph
 oph
 oph
@@ -60741,13 +62180,6 @@ kgF
 kgF
 kgF
 kgF
-kgF
-jdL
-kgF
-kgF
-kgF
-kgF
-kgF
 jdL
 kgF
 kgF
@@ -60776,6 +62208,16 @@ jdL
 kgF
 kgF
 jdL
+kgF
+jdL
+jdL
+jdL
+jdL
+kgF
+jdL
+kgF
+kgF
+jdL
 jdL
 kgF
 jdL
@@ -60783,19 +62225,16 @@ jdL
 kgF
 kgF
 kgF
+hmH
+oMa
+oMa
+oMa
+xiS
 kgF
 kgF
 kgF
 kgF
 kgF
-kgF
-kgF
-kgF
-kgF
-kgF
-kgF
-kgF
-jdL
 kgF
 oVr
 kgF
@@ -60862,7 +62301,7 @@ dOc
 dXu
 jdn
 wuc
-nNq
+sip
 ajY
 mXC
 mXC
@@ -61044,9 +62483,9 @@ oUn
 oUn
 oUn
 oUn
-oUn
-oUn
-oUn
+oMa
+oMa
+oMa
 oUn
 oUn
 oUn
@@ -62143,7 +63582,7 @@ mJQ
 hZR
 hZR
 hZR
-qnQ
+kno
 dXu
 jdn
 nIi
@@ -63966,7 +65405,7 @@ euo
 euo
 euo
 euo
-euo
+wcU
 euo
 euo
 euo
@@ -66426,7 +67865,7 @@ hwJ
 hNF
 duP
 cQC
-pje
+tVe
 rdE
 kCV
 mup
@@ -68733,7 +70172,7 @@ oph
 hyW
 cMt
 voZ
-nAu
+jHg
 aCs
 tcA
 udV
@@ -75489,7 +76928,7 @@ rYb
 gVD
 aqh
 iAX
-dVl
+jSg
 osp
 jSg
 pyl
@@ -76204,7 +77643,7 @@ oph
 oph
 oph
 oph
-oph
+ogf
 lmY
 tiN
 tiN


### PR DESCRIPTION
## About The Pull Request
This PR adds a firing range just south of the police station in RedRiver, presently occupied by everyone's favorite Renegades! Yayyy. 

Loot is comprised entirely of ballistics, most in the hobo-low tiers, with one low-mid and one mid spawn - in addition to a .44 variant spawn.

![firing range](https://user-images.githubusercontent.com/110785567/198862598-9e36d280-df28-4073-8868-c27b29e34ec2.PNG)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds Firing Range to Red River.
tweak: Also fixes a blank tile in one of the nearby dungeons ;)


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
