### PR TITLE
Fixes weather not working, like, at all

### DIFF
--- a/code/__DEFINES/weather.dm
+++ b/code/__DEFINES/weather.dm
@@ -1,0 +1,37 @@
+/// Z levels that are more or less above ground and can see the sky
+/// For telling players about the weather
+#define ABOVE_GROUND_Z_LEVELS list(4, 5, 6, 7, 8)
+
+/// Minimum time between weathers
+#define WEATHER_WAIT_MIN 30 MINUTES
+/// Maximum time between weathers
+#define WEATHER_WAIT_MAX 45 MINUTES
+
+/// Weather tags!
+
+#define WEATHER_HEAT "heat_wave"
+#define WEATHER_COLD "cold_snap"
+#define WEATHER_SNOW "snow_storm"
+#define WEATHER_RAIN "normal_ass_rain"
+#define WEATHER_ACID "acid_rain"
+#define WEATHER_SAND "sand_storm"
+#define WEATHER_RADS "RADSTORM"
+#define WEATHER_ALL_AREAS "all_of_em"
+
+/// All weather tags
+#define WEATHER_ALL WEATHER_HEAT,\
+	WEATHER_COLD,\
+	WEATHER_SNOW,\
+	WEATHER_RAIN,\
+	WEATHER_ACID,\
+	WEATHER_SAND,\
+	WEATHER_RADS
+
+/// All weather tags,
+#define WEATHER_ALL_MINUS_HEAT WEATHER_COLD,\
+	WEATHER_SNOW,\
+	WEATHER_RAIN,\
+	WEATHER_ACID,\
+	WEATHER_SAND,\
+	WEATHER_RADS
+

--- a/code/controllers/subsystem/processing/weather.dm
+++ b/code/controllers/subsystem/processing/weather.dm
@@ -9,40 +9,36 @@ PROCESSING_SUBSYSTEM_DEF(weather)
 	flags = SS_BACKGROUND
 	wait = 10
 	runlevels = RUNLEVEL_GAME
-	var/list/eligible_zlevels = list()
-	var/list/next_hit_by_zlevel = list() //Used by barometers to know when the next storm is coming
-	var/weather_on_start = FALSE
+	var/list/eligible_zlevels = ABOVE_GROUND_Z_LEVELS // 4 through 8, its 4 through 8, fuck you its 4 through 8
+	var/list/weather_rolls = list()
+	var/next_hit_by_zlevel //Used by barometers to know when the next storm is coming
+	/// Was a random weather queued?
+	var/weather_queued = FALSE
+	/// What weather is currently running?
+	var/datum/weather/current_weather
 
 /datum/controller/subsystem/processing/weather/fire()
-	. = ..()		//Active weather is handled by . = ..() processing subsystem base fire().
+	. = ..() //Active weather is handled by . = ..() processing subsystem base fire().
 
-	// start random weather on relevant levels
-	for(var/z in eligible_zlevels)
-		var/possible_weather = eligible_zlevels[z]
-		var/datum/weather/W = pickweight(possible_weather)
-		if(weather_on_start)
-			run_weather(W, list(text2num(z)), initial(W.weather_duration_upper))
-		eligible_zlevels -= z
-		var/randTime = rand(15000, 18000)
-		addtimer(CALLBACK(src, .proc/make_eligible, z, possible_weather), randTime + initial(W.weather_duration_upper), TIMER_UNIQUE) //Around 25-30 minutes between weathers
-		next_hit_by_zlevel["[z]"] = world.time + randTime + initial(W.telegraph_duration)
-	if(!weather_on_start)
-		weather_on_start = TRUE
+	// start random weather on relevant levels - the SAME weather on all those Zs!
+	if(weather_queued || !LAZYLEN(weather_rolls))
+		return FALSE
+	var/datum/weather/W = pickweight(weather_rolls)
+	var/randTime = rand(WEATHER_WAIT_MIN, WEATHER_WAIT_MAX)
+	addtimer(CALLBACK(src, .proc/run_weather, W), randTime + initial(W.weather_duration_upper), TIMER_UNIQUE) //Around 25-30 minutes between weathers
+	next_hit_by_zlevel = world.time + randTime + initial(W.telegraph_duration)
+	weather_queued = TRUE // weather'll set this to FALSE when it ends
 
 /datum/controller/subsystem/processing/weather/Initialize(start_timeofday)
 	for(var/V in subtypesof(/datum/weather))
 		var/datum/weather/W = V
 		var/probability = initial(W.probability)
-		var/target_trait = initial(W.target_trait)
-
 		// any weather with a probability set may occur at random
 		if (probability)
-			for(var/z in SSmapping.levels_by_trait(target_trait))
-				LAZYINITLIST(eligible_zlevels["[z]"])
-				eligible_zlevels["[z]"][W] = probability
+			weather_rolls[W] = probability
 	return ..()
 
-/datum/controller/subsystem/processing/weather/proc/run_weather(datum/weather/weather_datum_type, z_levels, duration)
+/datum/controller/subsystem/processing/weather/proc/run_weather(datum/weather/weather_datum_type, duration)
 	if (istext(weather_datum_type))
 		for (var/V in subtypesof(/datum/weather))
 			var/datum/weather/W = V
@@ -51,29 +47,26 @@ PROCESSING_SUBSYSTEM_DEF(weather)
 				break
 	if (!ispath(weather_datum_type, /datum/weather))
 		CRASH("run_weather called with invalid weather_datum_type: [weather_datum_type || "null"]")
-
-	if (isnull(z_levels))
+/* 	if (isnull(z_levels))
 		z_levels = SSmapping.levels_by_trait(initial(weather_datum_type.target_trait))
 	else if (isnum(z_levels))
 		z_levels = list(z_levels)
 	else if (!islist(z_levels))
 		CRASH("run_weather called with invalid z_levels: [z_levels || "null"]")
-
 	if(duration && !isnum(duration))
-		CRASH("run_weather called with invalid duration: [duration || "null"]")
+		CRASH("run_weather called with invalid duration: [duration || "null"]") */
+	current_weather = new weather_datum_type(eligible_zlevels, duration)
 
-	var/datum/weather/W = new weather_datum_type(z_levels, duration)
-	W.telegraph()
+/datum/controller/subsystem/processing/weather/proc/end_weather(z, possible_weather)
+	next_hit_by_zlevel = null
+	weather_queued = FALSE
+	current_weather = null
 
-/datum/controller/subsystem/processing/weather/proc/make_eligible(z, possible_weather)
-	eligible_zlevels[z] = possible_weather
-	next_hit_by_zlevel["[z]"] = null
-
-/datum/controller/subsystem/processing/weather/proc/get_weather(z, area/active_area)
+/datum/controller/subsystem/processing/weather/proc/get_weather(area/active_area)
 	var/datum/weather/A
 	for(var/V in processing)
 		var/datum/weather/W = V
-		if((z in W.impacted_z_levels) && is_path_in_list(active_area.type, W.area_types))
+		if((W.tag_weather in active_area.weather_tags))
 			A = W
 			break
 	return A

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -54,6 +54,8 @@
 	var/protect_indoors = TRUE
 	/// Areas to be affected by the weather, calculated when the weather begins
 	var/list/impacted_areas = list()
+	/// Is the weather particularly dangerous?
+	var/is_dangerous = TRUE // most are tbh
 
 	/// Areas that are protected and excluded from the affected areas.
 	var/list/protected_areas = list()
@@ -181,13 +183,15 @@
  * Removes weather from processing completely
  *
  */
-/datum/weather/proc/end()
+/datum/weather/proc/end(forced)
 	if(stage == END_STAGE)
 		return 1
 	stage = END_STAGE
-	SSweather.end_weather()
 	STOP_PROCESSING(SSweather, src)
 	update_areas()
+	SSweather.end_weather(TRUE, TRUE, FALSE)
+	if(forced)
+		alert_players(end_message, end_sound)
 	qdel(src)
 
 /datum/weather/process()
@@ -251,8 +255,8 @@
 			if(WIND_DOWN_STAGE)
 				N.icon_state = end_overlay
 			if(END_STAGE)
-				N.color = initial(N.color)
-				N.icon_state = initial(N.icon_state)
-				N.icon = initial(N.icon)
+				N.color = null
+				N.icon_state = ""
+				N.icon = 'icons/turf/areas.dmi'
 				N.layer = AREA_LAYER //Just default back to normal area stuff since I assume setting a var is faster than initial
 				N.set_opacity(FALSE)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -48,15 +48,17 @@
 
 	/// Types of area(s) to affect
 	var/area_types = list(/area/space)
+	/// Pulls a list of areas that are set as valid to have this weather, and uses that! see [code\__DEFINES\weather.dm] for details~
+	var/tag_weather
 	/// TRUE value protects areas with outdoors marked as false, regardless of area type
-	var/protect_indoors = FALSE
+	var/protect_indoors = TRUE
 	/// Areas to be affected by the weather, calculated when the weather begins
 	var/list/impacted_areas = list()
 
 	/// Areas that are protected and excluded from the affected areas.
 	var/list/protected_areas = list()
-	/// The list of z-levels that this weather is actively affecting
-	var/impacted_z_levels
+	/// The list of z-levels that can reasonably see the weather coming and get messages about it
+	var/list/impacted_z_levels = ABOVE_GROUND_Z_LEVELS
 
 	/// Since it's above everything else, this is the layer used by default. TURF_LAYER is below mobs and walls if you need to use that. 
 	var/overlay_layer = AREA_LAYER 
@@ -87,6 +89,12 @@
 /datum/weather/New(z_levels)
 	..()
 	impacted_z_levels = z_levels
+	telegraph()
+
+/datum/weather/Destroy(force, ...)
+	. = ..()
+	if(SSweather.current_weather == src)
+		SSweather.end_weather()
 
 /**
  * Telegraphs the beginning of the weather on the impacted z levels
@@ -96,34 +104,34 @@
  *
  */
 /datum/weather/proc/telegraph()
-	if(stage == STARTUP_STAGE)
+	if(stage == STARTUP_STAGE || !tag_weather)
+		end()
 		return
-	stage = STARTUP_STAGE
-	var/list/affectareas = list()
-	for(var/area_type in area_types)
-		for(var/V in get_areas(area_type))
+	if(tag_weather == WEATHER_ALL_AREAS) // pretty much just for the floor is lava, which works in theory
+		var/list/affectareas = list()
+		for(var/V in get_areas(/area))
 			var/area/A = V
 			affectareas |= A
 			if(A.sub_areas)
 				affectareas |= A.sub_areas
-	for(var/V in protected_areas)
-		affectareas -= get_areas(V)
-	for(var/V in affectareas)
-		var/area/A = V
-		if(protect_indoors && !A.outdoors)
-			continue
-		if(A.z in impacted_z_levels)
-			impacted_areas |= A
+		for(var/V in protected_areas)
+			affectareas -= get_areas(V)
+		for(var/V in affectareas)
+			var/area/A = V
+			if(protect_indoors && !A.outdoors)
+				continue
+			if(A.z in impacted_z_levels)
+				impacted_areas |= A
+	else if(LAZYLEN(GLOB.area_weather_list[tag_weather]))
+		impacted_areas |= GLOB.area_weather_list[tag_weather]
+	if(!LAZYLEN(impacted_areas))
+		end()
+		return
+	stage = STARTUP_STAGE
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
-	START_PROCESSING(SSweather, src)			//The reason this doesn't start and stop at main stage is because processing list is also used to see active running weathers (for example, you wouldn't want two ash storms starting at once.)
+	START_PROCESSING(SSweather, src) //The reason this doesn't start and stop at main stage is because processing list is also used to see active running weathers (for example, you wouldn't want two ash storms starting at once.)
 	update_areas()
-	for(var/M in GLOB.player_list)
-		var/turf/mob_turf = get_turf(M)
-		if(mob_turf && (mob_turf.z in impacted_z_levels))
-			if(telegraph_message)
-				to_chat(M, telegraph_message)
-			if(telegraph_sound)
-				SEND_SOUND(M, sound(telegraph_sound))
+	alert_players(telegraph_message, telegraph_sound)
 	addtimer(CALLBACK(src, .proc/start), telegraph_duration)
 
 /**
@@ -138,13 +146,7 @@
 		return
 	stage = MAIN_STAGE
 	update_areas()
-	for(var/M in GLOB.player_list)
-		var/turf/mob_turf = get_turf(M)
-		if(mob_turf && (mob_turf.z in impacted_z_levels))
-			if(weather_message)
-				to_chat(M, weather_message)
-			if(weather_sound)
-				SEND_SOUND(M, sound(weather_sound))
+	alert_players(weather_message, weather_sound)
 	addtimer(CALLBACK(src, .proc/wind_down), weather_duration)
 
 /**
@@ -159,15 +161,19 @@
 		return
 	stage = WIND_DOWN_STAGE
 	update_areas()
+	alert_players(end_message, end_sound)
+	addtimer(CALLBACK(src, .proc/end), end_duration)
+
+/datum/weather/proc/alert_players(message, sound_play)
+	if(!message && !sound_play)
+		return FALSE
 	for(var/M in GLOB.player_list)
 		var/turf/mob_turf = get_turf(M)
 		if(mob_turf && (mob_turf.z in impacted_z_levels))
-			if(end_message)
-				to_chat(M, end_message)
+			if(message)
+				to_chat(M, message)
 			if(end_sound)
-				SEND_SOUND(M, sound(end_sound))
-	addtimer(CALLBACK(src, .proc/end), end_duration)
-
+				SEND_SOUND(M, sound(sound_play))
 /**
  * Fully ends the weather
  *
@@ -179,8 +185,10 @@
 	if(stage == END_STAGE)
 		return 1
 	stage = END_STAGE
+	SSweather.end_weather()
 	STOP_PROCESSING(SSweather, src)
 	update_areas()
+	qdel(src)
 
 /datum/weather/process()
 	if(aesthetic || (stage != MAIN_STAGE))
@@ -201,9 +209,9 @@
  *
  */
 /datum/weather/proc/can_weather_act(mob/living/L)
-	var/turf/mob_turf = get_turf(L)
+/* 	var/turf/mob_turf = get_turf(L)
 	if(mob_turf && !(mob_turf.z in impacted_z_levels))
-		return
+		return */
 	if(immunity_type in L.weather_immunities)
 		return
 	if(!(get_area(L) in impacted_areas))
@@ -243,8 +251,8 @@
 			if(WIND_DOWN_STAGE)
 				N.icon_state = end_overlay
 			if(END_STAGE)
-				N.color = null
-				N.icon_state = ""
-				N.icon = 'icons/turf/areas.dmi'
+				N.color = initial(N.color)
+				N.icon_state = initial(N.icon_state)
+				N.icon = initial(N.icon)
 				N.layer = AREA_LAYER //Just default back to normal area stuff since I assume setting a var is faster than initial
 				N.set_opacity(FALSE)

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -18,6 +18,7 @@
 	end_message = span_userdanger("The downpour gradually slows to a light shower. It should be safe outside now.")
 	end_sound = 'sound/ambience/acidrain_end.ogg'
 
+	tag_weather = WEATHER_ACID
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
 	target_trait = ZTRAIT_STATION
 	protect_indoors = TRUE

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -16,13 +16,20 @@
 	end_duration = 300
 	end_overlay = "light_ash"
 
-	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
+	area_types = list(
+		/area/f13/wasteland,
+		/area/f13/desert,
+		/area/f13/farm,
+		/area/f13/forest,
+		/area/f13/ruins
+		)
 	protect_indoors = TRUE
 	target_trait = ZTRAIT_ASHSTORM
+	tag_weather = WEATHER_SAND
 
 	immunity_type = "ash"
 
-	probability = 90
+	probability = 10
 
 	barometer_predictable = TRUE
 

--- a/code/datums/weather/weather_types/cold_wave.dm
+++ b/code/datums/weather/weather_types/cold_wave.dm
@@ -1,7 +1,7 @@
 /datum/weather/cold_wave
 	name = "cold wave"
 	desc = "Harsh cold wave will grip an entire area."
-	probability = 7
+	probability = 20
 
 	telegraph_message = span_notice("A chilling and unfamiliar breeze sweeps over the valley.")
 	telegraph_duration = 300
@@ -19,6 +19,7 @@
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
 	protected_areas = list(/area/shuttle)
 	target_trait = ZTRAIT_STATION
+	tag_weather = WEATHER_COLD
 
 	immunity_type = "snow"
 

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -14,6 +14,7 @@
 	end_message = span_danger("The ground cools and returns to its usual form.")
 	end_duration = 0
 
+	tag_weather = WEATHER_ALL_AREAS
 	area_types = list(/area)
 	protected_areas = list(/area/space)
 	target_trait = ZTRAIT_STATION

--- a/code/datums/weather/weather_types/heat_wave.dm
+++ b/code/datums/weather/weather_types/heat_wave.dm
@@ -1,7 +1,7 @@
 /datum/weather/heat_wave
 	name = "heat wave"
 	desc = "Harsh heat wave will grip an entire area."
-	probability = 7
+	probability = 0
 
 	telegraph_message = span_notice("The temperature outside starts to rise unfavorably.")
 	telegraph_duration = 300
@@ -16,6 +16,7 @@
 	end_duration = 100
 	end_message = span_notice("The heat outside seems to wane to a more bearable degree. You feel as though the outdoors may be viable once more.")
 
+	tag_weather = WEATHER_HEAT
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
 	protected_areas = list(/area/shuttle)
 	target_trait = ZTRAIT_STATION

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -1,7 +1,7 @@
 /datum/weather/rad_storm
 	name = "radiation storm"
 	desc = "A thunderstorm of intense radiation passes through the area dealing radiation damage to those who are unprotected."
-	probability = 6
+	probability = 3
 
 	telegraph_duration = 700
 	telegraph_message = span_userdanger("The skies slowly turn into a glowing green, distant distorted thunder can be heard as dark clouds approach.")
@@ -18,9 +18,21 @@
 	end_duration = 100
 	end_message = span_userdanger("The air seems to be cooling off again as the radiation storm passes, the sky returning to it's normal color.")
 
+	tag_weather = WEATHER_RADS
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
-	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
-	/area/ai_monitored/turret_protected/ai, /area/storage/emergency/starboard, /area/storage/emergency/port, /area/shuttle, /area/security/prison, /area/ruin, /area/space/nearstation, /area/icemoon)
+	protected_areas = list(
+		/area/maintenance,
+		/area/ai_monitored/turret_protected/ai_upload,
+		/area/ai_monitored/turret_protected/ai_upload_foyer,
+		/area/ai_monitored/turret_protected/ai,
+		/area/storage/emergency/starboard,
+		/area/storage/emergency/port,
+		/area/shuttle,
+		/area/security/prison,
+		/area/ruin,
+		/area/space/nearstation,
+		/area/icemoon
+		)
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = "rad"
@@ -32,9 +44,7 @@
 	status_alarm(TRUE)
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
-	var/resist = L.getarmor(null, "rad")
-	var/ratio = 1 - (min(resist, 100) / 100)
-	L.rad_act(radiation_intensity * ratio)
+	L.rad_act(rand(10,20))
 
 /datum/weather/rad_storm/end()
 	if(..())

--- a/code/datums/weather/weather_types/rain.dm
+++ b/code/datums/weather/weather_types/rain.dm
@@ -22,6 +22,7 @@
 	target_trait = ZTRAIT_STATION
 	protect_indoors = TRUE
 	immunity_type = "water"
+	is_dangerous = FALSE // thankfully our slimes dont mind water
 
 	barometer_predictable = TRUE
 

--- a/code/datums/weather/weather_types/rain.dm
+++ b/code/datums/weather/weather_types/rain.dm
@@ -16,6 +16,7 @@
 	end_duration = 250
 	end_message = "<span class='notice'><font size=2>You start to hear the last of the rain as the sky begins to clear up.</font></span>"
 	end_overlay = "rain_gathering"
+	tag_weather = WEATHER_RAIN
 	area_types = list(/area/f13/wasteland, /area/f13/desert, /area/f13/farm, /area/f13/forest, /area/f13/ruins)
 	protected_areas = list(/area/shuttle)
 	target_trait = ZTRAIT_STATION

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -1,7 +1,7 @@
 /datum/weather/snow_storm
 	name = "snow storm"
 	desc = "Harsh snowstorms roam the topside of this arctic planet, burying any area unfortunate enough to be in its path."
-	probability = 90
+	probability = 0
 
 	telegraph_message = span_warning("Drifting particles of snow begin to dust the surrounding area..")
 	telegraph_duration = 300
@@ -15,6 +15,7 @@
 	end_duration = 100
 	end_message = span_boldannounce("The snowfall dies down, it should be safe to go outside again.")
 
+	tag_weather = WEATHER_SNOW
 	area_types = list(/area)
 	protect_indoors = TRUE
 	target_trait = ZTRAIT_SNOWSTORM

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1652,11 +1652,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 		AREA_SOUND('sound/f13ambience/wasteland.ogg', 10 SECONDS),
 		AREA_SOUND('sound/f13ambience/sewers.ogg', 10 SECONDS))
 	flags_1 = NONE //>desert >>has destroyed robo dirt on it
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/sunny_dale
 	name = "Sunny Dale"
 	icon_state = "sunny_dale"
 	requires_power = TRUE
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/ncr_main
 	name = "NCR Mainbase"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -711,7 +711,7 @@ GENETICS SCANNER
 			if(ongoing_weather.aesthetic)
 				to_chat(user, span_warning("[src]'s barometer function says that the next storm will breeze on by."))
 		else
-			var/next_hit = SSweather.next_hit_by_zlevel["[T.z]"]
+			var/next_hit = SSweather.next_hit_by_zlevel
 			var/fixed = next_hit ? next_hit - world.time : -1
 			if(fixed < 0)
 				to_chat(user, span_warning("[src]'s barometer function was unable to trace any weather patterns."))

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -39,6 +39,7 @@
 	blob_allowed = 0
 	environment = 19
 	grow_chance = 45
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/wasteland/city
 	name = "City"
@@ -75,6 +76,8 @@
 		/datum/looping_sound/ambient/general,
 		/datum/looping_sound/ambient/woodcreak,
 		)
+	weather_tags = null
+	outdoors = FALSE
 
 /area/f13/building/abandoned
 	name = "Abandoned Building"
@@ -94,6 +97,7 @@
 		/datum/looping_sound/ambient/woodcreak,
 		/datum/looping_sound/ambient/building/hospital,
 		)
+	weather_tags = null
 
 /area/f13/building/church
 	name = "Church Building"
@@ -139,6 +143,7 @@
 		)
 	ambientmusic = null
 	grow_chance = 5
+	weather_tags = null
 
 /area/f13/caves
 	name = "Caves"
@@ -149,6 +154,7 @@
 		/datum/looping_sound/ambient/cave,
 		/datum/looping_sound/ambient/tunnel,
 	)
+	weather_tags = null
 
 /area/f13/tunnel
 	name = "Tunnel"
@@ -161,6 +167,8 @@
 		/datum/looping_sound/ambient/cave,
 		/datum/looping_sound/ambient/tunnel,
 	)
+	weather_tags = null
+
 /area/f13/bar
 	name = "Bar"
 	icon_state = "bar"
@@ -171,6 +179,7 @@
 		/datum/looping_sound/ambient/town,
 		/datum/looping_sound/ambient/woodcreak,
 	)
+	weather_tags = null
 
 ///////////////
 //C O Y O T E//
@@ -273,6 +282,7 @@
 	blob_allowed = 0
 	environment = 15
 	grow_chance = 75
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/ruins
 	name = "Ruins"
@@ -292,6 +302,7 @@
 	blob_allowed = 0
 	environment = 5
 	grow_chance = 5
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/shack
 	name = "Shack"
@@ -380,6 +391,7 @@
 	blob_allowed = 0
 	environment = 15
 	grow_chance = 50
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/tribe
 	name = "Tribe"
@@ -403,6 +415,7 @@
 	blob_allowed = 0
 	environment = 15
 	grow_chance = 5
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/village
 	name = "Village"
@@ -420,6 +433,7 @@
 	blob_allowed = 0
 	environment = 15
 	grow_chance = 5
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/outpost
 	name = "Outpost"
@@ -750,6 +764,7 @@
 	blob_allowed = 0
 	environment = 6
 	grow_chance = 5
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/vault
 	name = "Vault"
@@ -1004,6 +1019,7 @@
 	blob_allowed = 0
 	environment = 4
 	grow_chance = 5
+	weather_tags = list(WEATHER_ALL)
 
 /area/f13/followers
 	name = "Followers of the Apocalypse Clinic"
@@ -1023,3 +1039,4 @@
 /area/f13/wasteland/khans
 	name = "Great Khan Encampment"
 	icon_state = "tribe"
+	weather_tags = list(WEATHER_ALL)

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -133,6 +133,7 @@
 #include "code\__DEFINES\vote.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wall_dents.dm"
+#include "code\__DEFINES\weather.dm"
 #include "code\__DEFINES\wires.dm"
 #include "code\__DEFINES\wounds.dm"
 #include "code\__DEFINES\_flags\_flags.dm"


### PR DESCRIPTION
## About The Pull Request

Weather is now shared across all Z levels! No more wierdness where one map is having a sunny day and another is a raging shitstorm!

Weather is also a lot more configurable as to where it happens. Areas have a list of weather types that are allowed to affect them, so you can have some areas that are affected by just rain, some by just radstorms, or even have some weather effects even affect you inside areas that're otherwise protected! No more fuckery with area subtypes!

Weather warnings should be broadcast to all above-ground non-admeme Z levels. Now if a radstorm is coming, and you're not in the sewers, you'll know! No more surprise storms!

Also fixes radstorms doing fuck all. Seriously, it was checking rad resistance twice, and then delivering a tiny dose even before armor! I changed it to work properly, and still deal a tiny bit of radiation, about as much as before, but its actually *intended* now!

If a nasty weather is happening on the other end of a ladder, it'll warn you and pop up a little rotary menu to confirm that yes, you want to run out into the fuckscape out there.