### PR TITLE
Some changes + Loadout kits! (see description)

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -419,14 +419,18 @@ Contains:
 	item_state = "hardsuit0-inq"
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor/old
-	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats. Alas, this one looks pretty worn out and rusted."
-	slowdown = 0.8
+	desc = "Who you going to call? Definitely not vault-tec! Protects against abnormal oddities. Or so it says...such things don't really exist!"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor/old
 	charges = 12
+	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T2 * ARMOR_SLOWDOWN_GLOBAL_MULT
+	armor = ARMOR_VALUE_MEDIUM
+	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T4, ARMOR_MODIFIER_UP_LASER_T3, ARMOR_MODIFIER_UP_DT_T3)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor/old
-	desc = "A helmet worn by those who deal with paranormal threats for a living. Alas, this one looks pretty worn out and rusted."
+	desc = "The helmet plating of the inquisitor suit. Vault-tec has no time for 'ghosts'!"
 	charges = 12
+	armor = ARMOR_VALUE_MEDIUM
+	armor_tokens = list(ARMOR_MODIFIER_DOWN_BULLET_T4, ARMOR_MODIFIER_UP_LASER_T3, ARMOR_MODIFIER_UP_DT_T3)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/beserker
 	name = "champion's hardsuit"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1110,16 +1110,16 @@
 	name = "bubblegum chest"
 
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
-	new /obj/item/clothing/suit/space/hostile_environment(src)
-	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
+	new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor/old(src)
+	new /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor/old(src)
 	var/loot = rand(1,3)
 	switch(loot)
 		if(1)
-			new /obj/item/mayhem(src)
+			new /obj/item/reagent_containers/food/drinks/bottle/holywater(src)
 		if(2)
-			new /obj/item/guardiancreator(src)
+			new /obj/item/reagent_containers/glass/bottle/ichor/red(src)
 		if(3)
-			new /obj/item/guardiancreator(src)
+			new /obj/item/reagent_containers/glass/bottle/ichor/blue(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -85,6 +85,32 @@
 		else
 	..()
 
+/obj/item/card/id/selfassign/blue
+	icon_state = "holodogtag"
+	desc = "An advanced holographic dogtag that shows the duty of a BoS member. This one in particular is assigned to a Amethyst with a rank of Head Paladin. The sex is listed as female, the blood type is listed as A positive, A serial number is written of 253-331-173-22. The last line then reads: WCBOS-C CB-04 along with an insignia depicting wings, cogwheels and a sword."
+
+/obj/item/card/id/selfassign/blue/attack_self(mob/user)
+	var/input_name = null
+	var/target_occupation = null
+	if(isliving(user))
+		var/mob/living/living_user = user
+		if(alert(user, "Action", "Reprogrammable ID", "Show", "Forge") == "Forge")
+			input_name = stripped_input(user, "What name would you like to put on this card? Leave blank for your actual name.", "Reprogrammable ID", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), MAX_NAME_LEN)
+			input_name = reject_bad_name(input_name)
+			if(!input_name)
+				input_name = living_user.real_name
+			target_occupation = stripped_input(user, "What occupation would you like to put on this card?", "Reprogrammable ID", assignment ? assignment : "Wastelander", 60)
+			if(!target_occupation)
+				target_occupation = "Wastelander"
+				return
+			registered_name = input_name
+			assignment = target_occupation
+			update_label()
+			to_chat(user, span_notice("You successfully forge the ID card."))
+			return
+		else
+	..()
+
 /////////////////////
 ///Loadout Boxes///// See kits.dm, use this model for loadouts that have more than one item per character.
 /////////////////////
@@ -426,6 +452,16 @@
 // K
 // L
 
+/datum/gear/donator/kits/lifelessghoul
+	name = "Ancient Memories"
+	path = /obj/item/storage/box/large/custom_kit/lifelessghoul
+	ckeywhitelist = list("lifelessghoul")
+
+/obj/item/storage/box/large/custom_kit/lifelessghoul/PopulateContents()
+	new /obj/item/melee/smith/hammer(src)
+	new /obj/item/clothing/head/helmet/f13/legion/orator(src)
+	new /obj/item/flashlight/lantern(src)
+
 /datum/gear/donator/kits/lucine
 	name = "Earlong Travel Supplies"
 	path = /obj/item/storage/box/large/custom_kit/lucine
@@ -557,6 +593,16 @@
 /obj/item/storage/box/large/custom_kit/risingstarslash2/PopulateContents()
 	new /obj/item/book/granter/crafting_recipe/slimecookie(src)
 	new /obj/item/lighter/slime(src)
+
+/datum/gear/donator/kits/risingstarslash3
+	name = "Brotherhood Kit"
+	path = /obj/item/storage/box/large/custom_kit/risingstarslash3
+	ckeywhitelist = list("risingstarslash")
+
+/obj/item/storage/box/large/custom_kit/risingstarslash3/PopulateContents()
+	new /obj/item/lighter/gold (src)
+	new /obj/item/gun/ballistic/automatic/pistol/n99/crusader(src)
+	new /obj/item/card/id/selfassign/blue(src)
 
 /datum/gear/donator/kits/roachwitharoach
 	name = "Desert Kit"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -61,7 +61,7 @@
 
 /obj/item/card/id/selfassign/darknova
 	icon_state = "holodogtag"
-	desc = "An advanced holographic dogtag that shows the duty of a BoS member. This one in particular is assigned to a Nikolatz, J. S  with a rank of Knight. The sex is listed as male, the blood type is listed as O positive, A serial number is written of 242-355-179-22. The last line then reads: WCBOS CB-04 along with an insignia depicting wings, cogwheels and a sword."
+	desc = "An advanced holographic dogtag that shows the duty of a BoS member. This one in particular is assigned to a Nikolatz, J. S  with a rank of Knight. The sex is listed as male, the blood type is listed as O positive, A serial number is written of 242-355-179-22. The last line then reads: WCBOS-C CB-04 along with an insignia depicting wings, cogwheels and a sword."
 
 /obj/item/card/id/selfassign/darknova/attack_self(mob/user)
 	var/input_name = null


### PR DESCRIPTION
Changes up bubblegums loot. Replaces the heck suit with a fitting armor. Replaces the guardian creators with ichor. Replaces the mayhem in a bottle with holywater.

Said fitting armor also was adjusted to be medium armor with appropriate stats towards melee and ~~magic~~ energy lasers!

Loadout kit locked to lifeless ghoul.

Loadout kit locked to risingstar. (third one)