### PR TITLE
Prevents people having more than 6 positive quirks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3280,10 +3280,17 @@ Records disabled until a use for them is found
 	if(find_gear)
 		loadout_data["SAVE_[save_slot]"] -= list(find_gear)
 
-/datum/preferences/proc/reset_quirks()
+/datum/preferences/proc/reset_quirks(why)
 	all_quirks = list()
 	if(istype(parent))
-		to_chat(parent, span_warning("Your quirk balance was invalid, and has been reset! You'll need to set up your quirks again."))
+		switch(why)
+			if("balance")
+				to_chat(parent, span_userdanger("Your quirk balance was invalid! Your quirks have been reset, and you'll need to set up your quirks again."))
+			if("max")
+				to_chat(parent, span_userdanger("Your character had too many positive quirks, likely due to a bug! Your quirks have been reset, and you'll need to set up your quirks again."))
+			else
+				to_chat(parent, span_userdanger("Something went wrong! Your quirks have been reset, and you'll need to set up your quirks again."))
+
 
 #undef DEFAULT_SLOT_AMT
 #undef HANDS_SLOT_AMT

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -911,7 +911,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			to_chat(parent, span_warning("You're attempting to save your character a little too fast. Wait half a second, then try again."))
 		return 0
 	if(GetQuirkBalance() < 0)
-		reset_quirks()
+		reset_quirks("balance")
+	if(GetPositiveQuirkCount() >= MAX_QUIRKS)
+		reset_quirks("max")
 	savecharcooldown = world.time + PREF_SAVELOAD_COOLDOWN
 	var/savefile/S = new /savefile(path)
 	if(!S)


### PR DESCRIPTION
## About The Pull Request
If someone has more than 6 positive quirks saved and, say, someone makes another quirk positive, if it pushes them over 6, it resets the character's quirks when it loads.