### PR TITLE
Common Negative Quirk Rebalance (take 1)

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -447,7 +447,7 @@
 
 // Roundstart trait system
 
-#define MAX_QUIRKS 4 //The maximum amount of quirks one character can have at roundstart
+#define MAX_QUIRKS 6 //The maximum amount of quirks one character can have at roundstart
 
 #define MAX_REVIVE_FIRE_DAMAGE 180
 #define MAX_REVIVE_BRUTE_DAMAGE 180

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -51,8 +51,8 @@
 
 /datum/mood_event/depression
 	description = span_warning("I feel sad for no particular reason.")
-	mood_change = -9
-	timeout = 2 MINUTES
+	mood_change = -15
+	timeout = 60 MINUTES
 
 /datum/mood_event/shameful_suicide //suicide_acts that return SHAME, like sord
 	description = span_boldwarning("I can't even end it all!")
@@ -118,7 +118,7 @@
 
 /datum/mood_event/family_heirloom_missing
 	description = span_warning("I'm missing my family heirloom...")
-	mood_change = -4
+	mood_change = -12
 
 /datum/mood_event/healsbadman
 	description = span_warning("I feel a lot better, but wow that was disgusting.")

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -52,8 +52,8 @@
 
 /datum/mood_event/jolly
 	description = span_nicegreen("I feel happy for no particular reason.")
-	mood_change = 6
-	timeout = 2 MINUTES
+	mood_change = 15
+	timeout = 60 MINUTES
 
 /datum/mood_event/focused
 	description = span_nicegreen("I have a goal, and I will reach it, whatever it takes!") //Used for syndies, nukeops etc so they can focus on their goals

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -27,7 +27,7 @@
 	mood_quirk = TRUE
 
 /datum/quirk/depression/on_process()
-	if(prob(0.05))
+	if(prob(0.15))
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
 
 /datum/quirk/family_heirloom

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1504,7 +1504,7 @@ Records disabled until a use for them is found
 	return
 
 /datum/preferences/proc/GetQuirkBalance()
-	var/bal = CONFIG_GET(number/quirk_points)
+	var/bal = 5
 	for(var/V in all_quirks)
 		var/datum/quirk/T = SSquirks.quirks[V]
 		bal -= initial(T.value)


### PR DESCRIPTION
Increases the chance for depression to trigger from 5 to 15 and last for much longer.

Makes the moodlet for Depression & losing your Family Heirloom much more serious (may need balancing.)

Makes being jolly give you a lot more happiness for a lot longer.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
