### PR TITLE
Fixes 14mm Improvised Bag not having a sprite

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -509,8 +509,10 @@
 
 /obj/item/ammo_box/m14mm/improvised
 	name = "bag with reloaded 14mm bullets"
+	icon_state = "improvshotbag"
 	max_ammo = 20
 	ammo_type = /obj/item/ammo_casing/p14mm/improvised
+	multiple_sprites = 3
 
 //Misc.
 /obj/item/ammo_box/m473


### PR DESCRIPTION
## About The Pull Request
The 14mm improvised bag had no sprite. Now it does.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed the lack of a sprite on a bag.
/:cl: