### PR TITLE
Naughty Time Roleplay Quirks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -132,6 +132,8 @@
 #define TRAIT_HOLY				"holy"
 #define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"
+#define TRAIT_IN_HEAT			"ERP Receptive"
+#define TRAIT_HEAT_DETECT		"ERP Seeking"
 #define TRAIT_NOCRITDAMAGE		"no_crit"
 #define TRAIT_NOSLIPWATER		"noslip_water"
 #define TRAIT_NOSLIPALL			"noslip_all"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -319,14 +319,14 @@
 
 /datum/quirk/in_heat
 	name = "ERP Receptive"
-	desc = "Your character, for whatever reason, is PASSIVELY seeking out attention from those who match your OOC Prefences."
+	desc = "Your character, for whatever reason, is PASSIVELY seeking out attention from those who match your OOC Prefences. Remember to set your OOC notes!"
 	value = 0
 	mob_trait = TRAIT_IN_HEAT
 
 
 /datum/quirk/heat
 	name = "ERP Seeking"
-	desc = "Your character, for whatever reason, is ACTIVELY seeking out attention from those who match your OOC Preferences."
+	desc = "Your character, for whatever reason, is ACTIVELY seeking out attention from those who match your OOC Preferences. Remember to check peoples OOC notes!"
 	value = 0
 	mob_trait = TRAIT_HEAT_DETECT
 

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -316,3 +316,17 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		H.remove_language(/datum/language/tribal)
+
+/datum/quirk/in_heat
+	name = "ERP Receptive"
+	desc = "Your character, for whatever reason, is PASSIVELY seeking out attention from those who match your OOC Prefences."
+	value = 0
+	mob_trait = TRAIT_IN_HEAT
+
+
+/datum/quirk/heat
+	name = "ERP Seeking"
+	desc = "Your character, for whatever reason, is ACTIVELY seeking out attention from those who match your OOC Preferences."
+	value = 0
+	mob_trait = TRAIT_HEAT_DETECT
+

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -453,6 +453,10 @@
 	if (!isnull(trait_exam))
 		. += trait_exam
 
+	if(HAS_TRAIT(src, TRAIT_IN_HEAT) && (HAS_TRAIT(user, TRAIT_HEAT_DETECT) || src == user))
+		. += ""
+		. += "<span class='love'>[t_He] [t_is] looking for [gender == MALE ? "a good time, you should check their OOC Notes" : "a good time, you should check their OOC Notes"].</span>"
+
 	var/traitstring = get_trait_string()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
Yeah, it's just splurts in heat but worded down to be more straight forward and less.  Idk.  Raunchy.

Scalable with a few other concepts as well, definitely going to use it as a springboard.

For those who I know will be concerned about rampant horni, what this does is basically totally ignorable if you choose not to take either of the free neutral quirks.  It's totally obfuscated to those without them.  It just streamlines the process of two players looking for specific interactions to be able to know what they're about a bit swifter.

Credit to whoever over at splurt made it, only had to modify it a bit, also didn't port all of its features but we couldn't even use ALL of them anyway so who gives a shnart.

![9fdc334e75c03d27a4322830af21dd5a](https://user-images.githubusercontent.com/13924177/200190696-d2a8ad78-59dd-4d1e-89d7-63954f03b5cd.png)


## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
