### PR TITLE
Mobility Quirk Overhaul

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -287,6 +287,9 @@
 #define TRAIT_CYBERNETICIST_EXPERT	"Cyberneticist Expert" //Can augument people into robots directly
 #define TRAIT_MACHINE_SPIRITS	"machine_spirits" //for tribe unique functions.
 #define TRAIT_HARD_YARDS        "hard_yards" //trekking, removes slowdown on all tiles
+#define	TRAIT_SOFT_YARDS		"soft_yards" //lesser trekking
+#define	TRAIT_SLUG				"slow" //You're a little slow. On your feet, at least.
+#define	TRAIT_SLOWAF			"slower" //Damn boi how'd you even get here, you're slow as SHIT off road
 #define	TRAIT_LIFEGIVER			"lifegiver" //boosts HP by 10
 #define	TRAIT_LIFEGIVERPLUS		"lifegiverplus" //boosts HP by 20
 #define	TRAIT_FLIMSY			"flimsy" //lowers HP by 10

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -27,7 +27,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			list("Nearsighted - Corrected","Nearsighted - No Glasses", "Nearsighted - Trashed Vision"),
 			list("Melee - Big Leagues", "Melee - Little Leagues", "Melee - Gentle", "Melee - Wimpy"),
 			list("Fists of Steel","Fists of Iron","Fists of Noodle"),
-			list("Lifegiver", "Life Giver Plus", "Flimsy", "Very Flimsy")
+			list("Lifegiver", "Life Giver Plus", "Flimsy", "Very Flimsy"),
+			list("Mobility - Wasteland Trekker","Mobility - Wasteland Wanderer","Mobility - Wasteland Slug","Mobility - Wasteland Molasses")
 			)
 	return ..()
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -92,10 +92,12 @@
 		AM.forceMove(T)
 		if(isliving(AM))
 			var/mob/living/L = AM
-			L.DefaultCombatKnockdown(100)
-			L.adjustBruteLoss(30)
+			if(HAS_TRAIT(user, TRAIT_FREERUNNING))
+				L.adjustBruteLoss(10)
+			else
+				L.DefaultCombatKnockdown(100)
+				L.adjustBruteLoss(40)
 		falling_atoms -= AM
-
 
 	else
 		// send to oblivion

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -92,11 +92,8 @@
 		AM.forceMove(T)
 		if(isliving(AM))
 			var/mob/living/L = AM
-			if(HAS_TRAIT(user, TRAIT_FREERUNNING))
-				L.adjustBruteLoss(10)
-			else
-				L.DefaultCombatKnockdown(100)
-				L.adjustBruteLoss(40)
+			L.DefaultCombatKnockdown(100)
+			L.adjustBruteLoss(40)
 		falling_atoms -= AM
 
 	else

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -96,6 +96,7 @@
 			L.adjustBruteLoss(30)
 		falling_atoms -= AM
 
+
 	else
 		// send to oblivion
 		AM.visible_message(span_boldwarning("[AM] falls into [parent]!"), span_userdanger("[oblivion_message]"))

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -413,11 +413,20 @@ GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	locked = FALSE
 
 /datum/quirk/hard_yards
-	name = "Wasteland Trekker"
+	name = "Mobility - Wasteland Trekker"
 	desc = "You've spent a lot of time wandering the wastes, and for your hard work you out pace most folks when travelling across them."
 	value = 3
 	mob_trait = TRAIT_HARD_YARDS
 	gain_text = span_notice("Rain or shine, nothing slows you down.")
+	lose_text = span_danger("You walk with a less sure gait, the ground seeming less firm somehow.")
+	locked = FALSE
+
+/datum/quirk/soft_yards
+	name = "Mobility - Wasteland Wanderer"
+	desc = "You've spent some time in the wastes, and can move a bit better around them for it."
+	value = 2
+	mob_trait = TRAIT_SOFT_YARDS
+	gain_text = span_notice("Rain or shine only slow you down a little.")
 	lose_text = span_danger("You walk with a less sure gait, the ground seeming less firm somehow.")
 	locked = FALSE
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -607,3 +607,20 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	lose_text = span_danger("You feel like slapping the mess out of a Deathclaw!")
 	locked = FALSE
 
+/datum/quirk/slow
+	name = "Mobility - Wasteland Slug"
+	desc = "You've spent some time in the wastes, you don't get around great."
+	value = -1
+	mob_trait = TRAIT_SLUG
+	gain_text = span_notice("Rain or shine, you might get there eventually.")
+	lose_text = span_danger("Your gait feels a little more sure!")
+	locked = FALSE
+
+/datum/quirk/slower
+	name = "Mobility - Wasteland Molasses"
+	desc = "You don't get around well off road. Like. At all."
+	value = -2
+	mob_trait = TRAIT_SLOWAF
+	gain_text = span_notice("You feel like staying at home.")
+	lose_text = span_danger("Wow! You feel like you could run around the whole WORLD!")
+	locked = FALSE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -79,7 +79,7 @@
 	if(isalien(user))
 		adjusted_climb_time *= 0.25 //aliens are terrifyingly fast
 	if(HAS_TRAIT(user, TRAIT_FREERUNNING)) //do you have any idea how fast I am???
-		adjusted_climb_time *= 0.8
+		adjusted_climb_time *= 0.25
 	structureclimber = user
 	if(do_mob(user, user, adjusted_climb_time))
 		if(src.loc) //Checking if structure has been destroyed
@@ -87,7 +87,7 @@
 				user.visible_message(span_warning("[user] climbs onto [src]."), \
 									span_notice("You climb onto [src]."))
 				log_combat(user, src, "climbed onto")
-				if(climb_stun)
+				if(climb_stun && !HAS_TRAIT(user, TRAIT_FREERUNNING))
 					user.Stun(climb_stun)
 				. = 1
 			else

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -17,7 +17,7 @@
 			SSI = CONFIG_GET_ENTRY(number/movedelay/sprint_speed_increase)
 		. -= SSI.config_entry_value
 	if(m_intent == MOVE_INTENT_WALK && HAS_TRAIT(src, TRAIT_SPEEDY_STEP))
-		. -= 1.5
+		. -= 1.25
 
 /mob/living/carbon/human/slip(knockdown_amount, obj/O, lube)
 	if(HAS_TRAIT(src, TRAIT_NOSLIPALL))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -53,11 +53,15 @@
 	return ..()
 
 /mob/living/proc/ZImpactDamage(turf/T, levels)
-	visible_message(span_danger("[src] crashes into [T] with a sickening noise!"), \
-					span_userdanger("You crash into [T] with a sickening noise!"))
-	adjustBruteLoss((levels * 5) ** 1.5)
-	DefaultCombatKnockdown(levels * 50)
-
+	if(levels <= 1 && HAS_TRAIT(src, TRAIT_FREERUNNING))
+		visible_message(span_danger("[src] slams into [T], rolling as they land and keeping their pace!"),
+						span_userdanger("You slam into [T], rolling and keeping your momentum!"))
+		adjustBruteLoss((levels * 5))
+	else
+		visible_message(span_danger("[src] crashes into [T] with a sickening noise!"),
+						span_userdanger("You crash into [T] with a sickening noise!"))
+		adjustBruteLoss((levels * 5) ** 1.5)
+		DefaultCombatKnockdown(levels * 50)
 
 /mob/living/proc/OpenCraftingMenu()
 	return

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -60,10 +60,22 @@
 	add_movespeed_modifier((m_intent == MOVE_INTENT_WALK)? /datum/movespeed_modifier/config_walk_run/walk : /datum/movespeed_modifier/config_walk_run/run)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)
-	if(isopenturf(T) && !HAS_TRAIT(src, TRAIT_HARD_YARDS))
+	if(isopenturf(T))
+		if(HAS_TRAIT(src, TRAIT_HARD_YARDS))
+			remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
+			return
+		if(HAS_TRAIT(src, TRAIT_SOFT_YARDS))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 0.5))
+			return
+		if(HAS_TRAIT(src, TRAIT_SLUG))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 1.5))
+			return
+		if(HAS_TRAIT(src, TRAIT_SLOWAF))
+			add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = (T.slowdown * 2.5))
+			return
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown, multiplicative_slowdown = T.slowdown)
-	else
-		remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
+		return
+	remove_movespeed_modifier(/datum/movespeed_modifier/turf_slowdown)
 
 /mob/living/proc/update_special_speed(speed)//SPECIAL Integration
 	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/special_speed, multiplicative_slowdown = speed)


### PR DESCRIPTION
## About The Pull Request
Freerunning - Can now go over tables MUCH faster, and fall from one z level up FAIRLY safely.  Not more than that tho.  Go jump off the Followers roof and find out.

Hard Yards -> Mobility - Wasteland Trekker (Unchanged mechanically)

Remember that Hard Yards, and these derivatives only effect off-roading speed.

Added Positive Traits
Mobility - Wasteland Wanderer (Slower than Hard Yards, faster than normal)

Added Negative Traits
Mobility - Wasteland Slug (Slower than normal running, without hard yards)
Mobility - Wasteland Molasses (even SLOWER than slug when off roading)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
