### PR TITLE
Phobia Overhaul

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -148,6 +148,12 @@
 #define TRAIT_SIXTHSENSE		"sixthsense"
 #define TRAIT_DISSECTED			"dissected"
 #define TRAIT_FEARLESS			"fearless"
+#define TRAIT_SPIDERPHOBIA		"spiderphobia"
+#define TRAIT_BONERPHOBIA		"skelephobia"
+#define TRAIT_MASKPHOBIA		"maskphobia"
+#define TRAIT_DOCTORPHOBIA		"doctorphobia"
+#define TRAIT_EYEPHOBIA			"eyephobia"
+#define TRAIT_CATPHOBIA			"catphobia"
 #define TRAIT_UNSTABLE			"unstable"
 #define TRAIT_PARALYSIS_L_ARM	"para-l-arm" //These are used for brain-based paralysis, where replacing the limb won't fix it
 #define TRAIT_PARALYSIS_R_ARM	"para-r-arm"

--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -12,12 +12,28 @@ SUBSYSTEM_DEF(traumas)
 
 /datum/controller/subsystem/traumas/Initialize()
 	//phobia types is to pull from randomly for brain traumas, e.g. conspiracies is for special assignment only
-	phobia_types = list("spiders", "space", "security", "greytide", "lizards",
-						"skeletons", "snakes", "robots", "doctors", "authority", "the supernatural",
-						"aliens", "strangers", "birds", "falling", "anime", "cats","eye"
+	phobia_types = list("spiders",
+						"space",
+						"security",
+						"greytide",
+						"lizards",
+						"skeletons",
+						"snakes",
+						"robots",
+						"doctors",
+						"authority",
+						"the supernatural",
+						"aliens",
+						"strangers",
+						"birds",
+						"falling",
+						"anime",
+						"cats",
+						"eye"
 						)
 
-	phobia_words = list("spiders"   = strings(PHOBIA_FILE, "spiders"),
+	phobia_words = list(
+						"spiders"   = strings(PHOBIA_FILE, "spiders"),
 						"space"     = strings(PHOBIA_FILE, "space"),
 						"security"  = strings(PHOBIA_FILE, "security"),
 						"greytide"  = strings(PHOBIA_FILE, "greytide"),
@@ -38,25 +54,81 @@ SUBSYSTEM_DEF(traumas)
 						"eye" = strings(PHOBIA_FILE, "eye")
 						)
 
-	phobia_mobs = list("spiders"  = typecacheof(list(/mob/living/simple_animal/hostile/poison/giant_spider)),
-		"security" = typecacheof(list(/mob/living/simple_animal/bot/secbot, /mob/living/simple_animal/bot/ed209)),
-		"lizards"  = typecacheof(list(/mob/living/simple_animal/hostile/lizard)),
-		"skeletons" = typecacheof(list(/mob/living/simple_animal/hostile/skeleton)),
-		"snakes"   = typecacheof(list(/mob/living/simple_animal/hostile/retaliate/poison/snake)),
-		"robots"   = typecacheof(list(/mob/living/silicon/robot, /mob/living/silicon/ai,
-		/mob/living/simple_animal/drone, /mob/living/simple_animal/bot, /mob/living/simple_animal/hostile/swarmer)),
-		"doctors"   = typecacheof(list(/mob/living/simple_animal/bot/medbot)),
-		"the supernatural"   = typecacheof(list(/mob/living/simple_animal/hostile/construct,
-		/mob/living/simple_animal/hostile/clockwork, /mob/living/simple_animal/drone/cogscarab,
-		/mob/living/simple_animal/revenant, /mob/living/simple_animal/shade)),
-		"aliens"   = typecacheof(list(/mob/living/carbon/alien, /mob/living/simple_animal/slime)),
-		"conspiracies" = typecacheof(list(/mob/living/simple_animal/bot/secbot, /mob/living/simple_animal/bot/ed209, /mob/living/simple_animal/drone,
-		/mob/living/simple_animal/pet/penguin)),
-		"birds" = typecacheof(list(/mob/living/simple_animal/parrot, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-		/mob/living/simple_animal/pet/penguin)),
-		"anime" = typecacheof(list(/mob/living/simple_animal/hostile/guardian)),
-		"cats"= typecacheof(list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/pet/cat, /mob/living/simple_animal/hostile/cat_butcherer)),
-		"eye" = typecacheof(list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher, /mob/living/simple_animal/hostile/carp/eyeball))
+	phobia_mobs = list(
+		"spiders"  = typecacheof(list(
+			/mob/living/simple_animal/hostile/poison/giant_spider)
+			),
+
+		"security" = typecacheof(list(
+			/mob/living/simple_animal/bot/secbot,
+			/mob/living/simple_animal/bot/ed209)
+			),
+
+		"lizards"  = typecacheof(list(
+			/mob/living/simple_animal/hostile/lizard)
+			),
+
+		"skeletons" = typecacheof(list(
+			/mob/living/simple_animal/hostile/skeleton)
+			),
+
+		"snakes"   = typecacheof(list(
+			/mob/living/simple_animal/hostile/retaliate/poison/snake)
+			),
+
+		"robots"   = typecacheof(list(
+			/mob/living/silicon/robot,
+			/mob/living/silicon/ai,
+			/mob/living/simple_animal/drone,
+			/mob/living/simple_animal/bot,
+			/mob/living/simple_animal/hostile/swarmer)
+			),
+
+		"doctors"   = typecacheof(list(
+			/mob/living/simple_animal/bot/medbot)
+			),
+
+		"the supernatural"   = typecacheof(list(
+			/mob/living/simple_animal/hostile/construct,
+			/mob/living/simple_animal/hostile/clockwork,
+			/mob/living/simple_animal/drone/cogscarab,
+			/mob/living/simple_animal/revenant,
+			/mob/living/simple_animal/shade)
+			),
+
+		"aliens"   = typecacheof(list(
+			/mob/living/carbon/alien,
+			/mob/living/simple_animal/slime)
+			),
+
+		"conspiracies" = typecacheof(list(
+			/mob/living/simple_animal/bot/secbot,
+			/mob/living/simple_animal/bot/ed209,
+			/mob/living/simple_animal/drone,
+			/mob/living/simple_animal/pet/penguin)
+			),
+
+		"birds" = typecacheof(list(
+			/mob/living/simple_animal/parrot,
+			/mob/living/simple_animal/chick,
+			/mob/living/simple_animal/chicken,
+			/mob/living/simple_animal/pet/penguin)
+			),
+
+		"anime" = typecacheof(list(
+			/mob/living/simple_animal/hostile/guardian)
+			),
+
+		"cats"= typecacheof(list(
+			/mob/living/simple_animal/mouse,
+			/mob/living/simple_animal/pet/cat,
+			/mob/living/simple_animal/hostile/cat_butcherer)
+			),
+
+		"eye" = typecacheof(list(
+			/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,
+			/mob/living/simple_animal/hostile/carp/eyeball)
+			)
 		)
 
 
@@ -64,109 +136,307 @@ SUBSYSTEM_DEF(traumas)
 
 					"spiders"   = typecacheof(list(/obj/structure/spider)),
 
-					"security"  = typecacheof(list(/obj/item/clothing/under/rank/security/officer, /obj/item/clothing/under/rank/security/warden,
-						/obj/item/clothing/under/rank/security/head_of_security, /obj/item/clothing/under/rank/security/detective,
-						/obj/item/melee/baton, /obj/item/gun/energy/taser, /obj/item/restraints/handcuffs,
-						/obj/machinery/door/airlock/security, /obj/effect/hallucination/simple/securitron)),
+					"security"  = typecacheof(list(
+						/obj/item/clothing/under/rank/security/officer,
+						/obj/item/clothing/under/rank/security/warden,
+						/obj/item/clothing/under/rank/security/head_of_security,
+						/obj/item/clothing/under/rank/security/detective,
+						/obj/item/melee/baton,
+						/obj/item/gun/energy/taser,
+						/obj/item/restraints/handcuffs,
+						/obj/machinery/door/airlock/security,
+						/obj/effect/hallucination/simple/securitron)
+						),
 
-					"greytide"  = typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/cattleprod,
-						/obj/item/twohanded/spear, /obj/item/clothing/mask/gas)),
+					"greytide"  = typecacheof(list(
+						/obj/item/clothing/under/color/grey,
+						/obj/item/melee/baton/cattleprod,
+						/obj/item/twohanded/spear,
+						/obj/item/clothing/mask/gas)
+						),
 
-					"lizards"   = typecacheof(list(/obj/item/toy/plush/lizardplushie, /obj/item/reagent_containers/food/snacks/kebab/tail,
-						/obj/item/organ/tail/lizard, /obj/item/reagent_containers/food/drinks/bottle/lizardwine)),
+					"lizards"   = typecacheof(list(
+						/obj/item/toy/plush/lizardplushie,
+						/obj/item/reagent_containers/food/snacks/kebab/tail,
+						/obj/item/organ/tail/lizard,
+						/obj/item/reagent_containers/food/drinks/bottle/lizardwine)
+						),
 
-					"skeletons" = typecacheof(list(/obj/item/organ/tongue/bone, /obj/item/clothing/suit/armor/light/tribal/bone/cool, /obj/item/stack/sheet/bone,
+					"skeletons" = typecacheof(list(
+						/obj/item/organ/tongue/bone,
+						/obj/item/clothing/suit/armor/light/tribal/bone/cool,
+						/obj/item/stack/sheet/bone,
 						/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
-						/obj/effect/decal/remains/human)),
-					"conspiracies" = typecacheof(list(/obj/item/clothing/under/rank/captain, /obj/item/clothing/under/rank/security/head_of_security,
-						/obj/item/clothing/under/rank/engineering/chief_engineer, /obj/item/clothing/under/rank/medical/chief_medical_officer,
-						/obj/item/clothing/under/rank/civilian/head_of_personnel, /obj/item/clothing/under/rank/rnd/research_director,
-						/obj/item/clothing/under/rank/security/head_of_security/grey, /obj/item/clothing/under/rank/security/head_of_security/alt,
-						/obj/item/clothing/under/rank/rnd/research_director/alt, /obj/item/clothing/under/rank/rnd/research_director/turtleneck,
-						/obj/item/clothing/under/rank/captain/parade, /obj/item/clothing/under/rank/security/head_of_security/parade, /obj/item/clothing/under/rank/security/head_of_security/parade/female,
-						/obj/item/clothing/head/helmet/abductor, /obj/item/clothing/suit/armor/abductor/vest, /obj/item/abductor/baton,
-						/obj/item/storage/belt/utility/abductor, /obj/item/gun/energy/alien, /obj/item/abductor/silencer,
-						/obj/item/abductor/gizmo, /obj/item/clothing/under/rank/centcom/officer,
-						/obj/item/clothing/suit/space/hardsuit/ert, /obj/item/clothing/suit/space/hardsuit/ert/sec,
-						/obj/item/clothing/suit/space/hardsuit/ert/engi, /obj/item/clothing/suit/space/hardsuit/ert/med,
-						/obj/item/clothing/suit/space/hardsuit/deathsquad, /obj/item/clothing/head/helmet/space/hardsuit/deathsquad,
-						/obj/machinery/door/airlock/centcom)),
-					"robots"   = typecacheof(list(/obj/machinery/computer/upload, /obj/item/aiModule/, /obj/machinery/recharge_station,
-						/obj/item/aicard, /obj/item/deactivated_swarmer, /obj/effect/mob_spawn/swarmer)),
+						/obj/effect/decal/remains/human)
+						),
 
-					"doctors"   = typecacheof(list(/obj/item/clothing/under/rank/medical/doctor, /obj/item/clothing/under/rank/medical/chemist,
-						/obj/item/clothing/under/rank/medical/doctor/nurse, /obj/item/clothing/under/rank/medical/chief_medical_officer,
-						/obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill/, /obj/item/reagent_containers/hypospray,
-						/obj/item/storage/firstaid, /obj/item/storage/pill_bottle, /obj/item/healthanalyzer,
-						/obj/structure/sign/departments/medbay, /obj/machinery/door/airlock/medical, /obj/machinery/sleeper,
-						/obj/machinery/dna_scannernew, /obj/machinery/atmospherics/components/unary/cryo_cell, /obj/item/surgical_drapes,
-						/obj/item/retractor, /obj/item/hemostat, /obj/item/cautery, /obj/item/surgicaldrill, /obj/item/scalpel, /obj/item/circular_saw,
-						/obj/item/clothing/suit/bio_suit/plaguedoctorsuit, /obj/item/clothing/head/plaguedoctorhat, /obj/item/clothing/mask/gas/plaguedoctor)),
+					"conspiracies" = typecacheof(list(
+						/obj/item/clothing/under/rank/captain,
+						/obj/item/clothing/under/rank/security/head_of_security,
+						/obj/item/clothing/under/rank/engineering/chief_engineer,
+						/obj/item/clothing/under/rank/medical/chief_medical_officer,
+						/obj/item/clothing/under/rank/civilian/head_of_personnel,
+						/obj/item/clothing/under/rank/rnd/research_director,
+						/obj/item/clothing/under/rank/security/head_of_security/grey,
+						/obj/item/clothing/under/rank/security/head_of_security/alt,
+						/obj/item/clothing/under/rank/rnd/research_director/alt,
+						/obj/item/clothing/under/rank/rnd/research_director/turtleneck,
+						/obj/item/clothing/under/rank/captain/parade,
+						/obj/item/clothing/under/rank/security/head_of_security/parade,
+						/obj/item/clothing/under/rank/security/head_of_security/parade/female,
+						/obj/item/clothing/head/helmet/abductor,
+						/obj/item/clothing/suit/armor/abductor/vest,
+						/obj/item/abductor/baton,
+						/obj/item/storage/belt/utility/abductor,
+						/obj/item/gun/energy/alien,
+						/obj/item/abductor/silencer,
+						/obj/item/abductor/gizmo,
+						/obj/item/clothing/under/rank/centcom/officer,
+						/obj/item/clothing/suit/space/hardsuit/ert,
+						/obj/item/clothing/suit/space/hardsuit/ert/sec,
+						/obj/item/clothing/suit/space/hardsuit/ert/engi,
+						/obj/item/clothing/suit/space/hardsuit/ert/med,
+						/obj/item/clothing/suit/space/hardsuit/deathsquad,
+						/obj/item/clothing/head/helmet/space/hardsuit/deathsquad,
+						/obj/machinery/door/airlock/centcom)
+						),
 
-					"authority"   = typecacheof(list(/obj/item/clothing/under/rank/captain,  /obj/item/clothing/under/rank/civilian/head_of_personnel,
-						/obj/item/clothing/under/rank/security/head_of_security, /obj/item/clothing/under/rank/rnd/research_director,
-						/obj/item/clothing/under/rank/medical/chief_medical_officer, /obj/item/clothing/under/rank/engineering/chief_engineer,
-						/obj/item/clothing/under/rank/centcom/officer, /obj/item/clothing/under/rank/centcom/commander,
-						/obj/item/melee/classic_baton/telescopic, /obj/item/card/id/silver, /obj/item/card/id/gold,
-						/obj/item/card/id/captains_spare, /obj/item/card/id/centcom, /obj/machinery/door/airlock/command)),
+					"robots"   = typecacheof(list(
+						/obj/machinery/computer/upload,
+						/obj/item/aiModule/, /obj/machinery/recharge_station,
+						/obj/item/aicard,
+						/obj/item/deactivated_swarmer,
+						/obj/effect/mob_spawn/swarmer)
+						),
 
-					"the supernatural"  = typecacheof(list(/obj/structure/destructible/cult, /obj/item/tome,
-						/obj/item/melee/cultblade, /obj/item/cult_bastard, /obj/item/restraints/legcuffs/bola/cult,
-						/obj/item/clothing/suit/cultrobes, /obj/item/clothing/suit/space/hardsuit/cult,
-						/obj/item/clothing/suit/hooded/cultrobes, /obj/item/clothing/head/hooded/cult_hoodie, /obj/effect/rune,
-						/obj/item/stack/sheet/runed_metal, /obj/machinery/door/airlock/cult, /obj/singularity/narsie,
+					"doctors"   = typecacheof(list(
+						/obj/item/clothing/under/rank/medical/doctor,
+						/obj/item/clothing/under/rank/medical/chemist,
+						/obj/item/clothing/under/rank/medical/doctor/nurse,
+						/obj/item/clothing/under/rank/medical/chief_medical_officer,
+						/obj/item/reagent_containers/syringe,
+						/obj/item/reagent_containers/pill/,
+						/obj/item/reagent_containers/hypospray,
+						/obj/item/storage/firstaid,
+						/obj/item/storage/pill_bottle,
+						/obj/item/healthanalyzer,
+						/obj/structure/sign/departments/medbay,
+						/obj/machinery/door/airlock/medical,
+						/obj/machinery/sleeper,
+						/obj/machinery/dna_scannernew,
+						/obj/machinery/atmospherics/components/unary/cryo_cell,
+						/obj/item/surgical_drapes,
+						/obj/item/retractor,
+						/obj/item/hemostat,
+						/obj/item/cautery,
+						/obj/item/surgicaldrill,
+						/obj/item/scalpel,
+						/obj/item/circular_saw,
+						/obj/item/clothing/suit/bio_suit/plaguedoctorsuit,
+						/obj/item/clothing/head/plaguedoctorhat,
+						/obj/item/clothing/mask/gas/plaguedoctor)
+						),
+
+					"authority"   = typecacheof(list(
+						/obj/item/clothing/under/rank/captain,
+						/obj/item/clothing/under/rank/civilian/head_of_personnel,
+						/obj/item/clothing/under/rank/security/head_of_security,
+						/obj/item/clothing/under/rank/rnd/research_director,
+						/obj/item/clothing/under/rank/medical/chief_medical_officer,
+						/obj/item/clothing/under/rank/engineering/chief_engineer,
+						/obj/item/clothing/under/rank/centcom/officer,
+						/obj/item/clothing/under/rank/centcom/commander,
+						/obj/item/melee/classic_baton/telescopic,
+						/obj/item/card/id/silver,
+						/obj/item/card/id/gold,
+						/obj/item/card/id/captains_spare,
+						/obj/item/card/id/centcom,
+						/obj/machinery/door/airlock/command)
+						),
+
+					"the supernatural"  = typecacheof(list(
+						/obj/structure/destructible/cult,
+						/obj/item/tome,
+						/obj/item/melee/cultblade,
+						/obj/item/cult_bastard,
+						/obj/item/restraints/legcuffs/bola/cult,
+						/obj/item/clothing/suit/cultrobes,
+						/obj/item/clothing/suit/space/hardsuit/cult,
+						/obj/item/clothing/suit/hooded/cultrobes,
+						/obj/item/clothing/head/hooded/cult_hoodie,
+						/obj/effect/rune,
+						/obj/item/stack/sheet/runed_metal,
+						/obj/machinery/door/airlock/cult,
+						/obj/singularity/narsie,
 						/obj/item/soulstone,
-						/obj/structure/destructible/clockwork, /obj/item/clockwork, /obj/item/clothing/suit/armor/clockwork,
-						/obj/item/clothing/glasses/judicial_visor, /obj/effect/clockwork/sigil/, /obj/item/stack/tile/brass,
+						/obj/structure/destructible/clockwork,
+						/obj/item/clockwork,
+						/obj/item/clothing/suit/armor/clockwork,
+						/obj/item/clothing/glasses/judicial_visor,
+						/obj/effect/clockwork/sigil/,
+						/obj/item/stack/tile/brass,
 						/obj/machinery/door/airlock/clockwork,
-						/obj/item/clothing/suit/wizrobe, /obj/item/clothing/head/wizard, /obj/item/spellbook, /obj/item/staff,
-						/obj/item/clothing/suit/space/hardsuit/shielded/wizard, /obj/item/clothing/suit/space/hardsuit/wizard,
-						/obj/item/gun/magic/staff, /obj/item/gun/magic/wand,
-						/obj/item/nullrod, /obj/item/clothing/under/rank/civilian/chaplain)),
+						/obj/item/clothing/suit/wizrobe,
+						/obj/item/clothing/head/wizard,
+						/obj/item/spellbook,
+						/obj/item/staff,
+						/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+						/obj/item/clothing/suit/space/hardsuit/wizard,
+						/obj/item/gun/magic/staff,
+						/obj/item/gun/magic/wand,
+						/obj/item/nullrod,
+						/obj/item/clothing/under/rank/civilian/chaplain)
+						),
 
-					"aliens"   = typecacheof(list(/obj/item/clothing/mask/facehugger, /obj/item/organ/body_egg/alien_embryo,
-						/obj/structure/alien, /obj/item/toy/toy_xeno,
-						/obj/item/clothing/suit/armor/abductor, /obj/item/abductor, /obj/item/gun/energy/alien,
-						/obj/item/abductor/baton, /obj/item/radio/headset/abductor, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
-						/obj/item/retractor/alien, /obj/item/circular_saw/alien, /obj/item/surgicaldrill/alien, /obj/item/cautery/alien,
-						/obj/item/clothing/head/helmet/abductor, /obj/structure/bed/abductor, /obj/structure/table_frame/abductor,
-						/obj/structure/table/abductor, /obj/structure/table/optable/abductor, /obj/structure/closet/abductor, /obj/item/organ/heart/gland,
-						/obj/machinery/abductor, /obj/item/crowbar/abductor, /obj/item/screwdriver/abductor, /obj/item/weldingtool/abductor,
-						/obj/item/wirecutters/abductor, /obj/item/wrench/abductor, /obj/item/stack/sheet/mineral/abductor)),
+					"aliens"   = typecacheof(list(
+						/obj/item/clothing/mask/facehugger,
+						/obj/item/organ/body_egg/alien_embryo,
+						/obj/structure/alien,
+						/obj/item/toy/toy_xeno,
+						/obj/item/clothing/suit/armor/abductor,
+						/obj/item/abductor,
+						/obj/item/gun/energy/alien,
+						/obj/item/abductor/baton,
+						/obj/item/radio/headset/abductor,
+						/obj/item/scalpel/alien,
+						/obj/item/hemostat/alien,
+						/obj/item/retractor/alien,
+						/obj/item/circular_saw/alien,
+						/obj/item/surgicaldrill/alien,
+						/obj/item/cautery/alien,
+						/obj/item/clothing/head/helmet/abductor,
+						/obj/structure/bed/abductor,
+						/obj/structure/table_frame/abductor,
+						/obj/structure/table/abductor,
+						/obj/structure/table/optable/abductor,
+						/obj/structure/closet/abductor,
+						/obj/item/organ/heart/gland,
+						/obj/machinery/abductor,
+						/obj/item/crowbar/abductor,
+						/obj/item/screwdriver/abductor,
+						/obj/item/weldingtool/abductor,
+						/obj/item/wirecutters/abductor,
+						/obj/item/wrench/abductor,
+						/obj/item/stack/sheet/mineral/abductor)
+						),
 
-					"birds" = typecacheof(list(/obj/item/clothing/mask/gas/plaguedoctor, /obj/item/reagent_containers/food/snacks/cracker,
-						/obj/item/clothing/suit/chickensuit, /obj/item/clothing/head/chicken,
-						/obj/item/clothing/suit/toggle/owlwings, /obj/item/clothing/under/costume/owl, /obj/item/clothing/mask/gas/owl_mask,
-						/obj/item/clothing/under/costume/griffin, /obj/item/clothing/shoes/griffin, /obj/item/clothing/head/griffin,
-						/obj/item/clothing/head/helmet/space/freedom, /obj/item/clothing/suit/space/freedom)),
+					"birds" = typecacheof(list(
+						/obj/item/clothing/mask/gas/plaguedoctor,
+						/obj/item/reagent_containers/food/snacks/cracker,
+						/obj/item/clothing/suit/chickensuit,
+						/obj/item/clothing/head/chicken,
+						/obj/item/clothing/suit/toggle/owlwings,
+						/obj/item/clothing/under/costume/owl,
+						/obj/item/clothing/mask/gas/owl_mask,
+						/obj/item/clothing/under/costume/griffin,
+						/obj/item/clothing/shoes/griffin,
+						/obj/item/clothing/head/griffin,
+						/obj/item/clothing/head/helmet/space/freedom,
+						/obj/item/clothing/suit/space/freedom)
+						),
 
-					"anime" = typecacheof(list(/obj/item/clothing/under/costume/schoolgirl, /obj/item/katana, /obj/item/reagent_containers/food/snacks/sashimi, /obj/item/reagent_containers/food/snacks/chawanmushi,
-						/obj/item/reagent_containers/food/drinks/bottle/sake, /obj/item/throwing_star, /obj/item/clothing/head/kitty/genuine, /obj/item/clothing/suit/space/space_ninja,
-						/obj/item/clothing/mask/gas/space_ninja, /obj/item/clothing/shoes/space_ninja, /obj/item/clothing/gloves/space_ninja, /obj/item/vibro_weapon,
-						/obj/item/nullrod/scythe/vibro, /obj/item/energy_katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana, /obj/structure/window/paperframe, /obj/structure/mineral_door/paperframe)),
+					"anime" = typecacheof(list(
+						/obj/item/clothing/under/costume/schoolgirl,
+						/obj/item/katana,
+						/obj/item/reagent_containers/food/snacks/sashimi,
+						/obj/item/reagent_containers/food/snacks/chawanmushi,
+						/obj/item/reagent_containers/food/drinks/bottle/sake,
+						/obj/item/throwing_star,
+						/obj/item/clothing/head/kitty/genuine,
+						/obj/item/clothing/suit/space/space_ninja,
+						/obj/item/clothing/mask/gas/space_ninja,
+						/obj/item/clothing/shoes/space_ninja,
+						/obj/item/clothing/gloves/space_ninja,
+						/obj/item/vibro_weapon,
+						/obj/item/nullrod/scythe/vibro,
+						/obj/item/energy_katana,
+						/obj/item/toy/katana,
+						/obj/item/nullrod/claymore/katana,
+						/obj/structure/window/paperframe,
+						/obj/structure/mineral_door/paperframe)
+						),
 
-					"cats" = typecacheof(list(/obj/item/organ/ears/cat, /obj/item/organ/tail/cat, /obj/item/laser_pointer, /obj/item/toy/cattoy, /obj/item/clothing/head/kitty,
-						/obj/item/clothing/head/collectable/kitty, /obj/item/melee/chainofcommand/tailwhip/kitty, /obj/item/stack/sheet/animalhide/cat)),
+					"cats" = typecacheof(list(
+						/obj/item/organ/ears/cat,
+						/obj/item/organ/tail/cat,
+						/obj/item/laser_pointer,
+						/obj/item/toy/cattoy,
+						/obj/item/clothing/head/kitty,
+						/obj/item/clothing/head/collectable/kitty,
+						/obj/item/melee/chainofcommand/tailwhip/kitty,
+						/obj/item/stack/sheet/animalhide/cat)
+						),
 
-					"eye" = typecacheof(list(/obj/item/organ/eyes, /obj/item/reagent_containers/syringe))
+					"eye" = typecacheof(list(
+						/obj/item/organ/eyes,
+						/obj/item/reagent_containers/syringe)
+						)
 						)
 
-	phobia_turfs = list("space" = typecacheof(list(/turf/open/space, /turf/open/floor/holofloor/space, /turf/open/floor/fakespace)),
-						"the supernatural" = typecacheof(list(/turf/open/floor/clockwork, /turf/closed/wall/clockwork,
-						/turf/open/floor/plasteel/cult, /turf/closed/wall/mineral/cult)),
-						"aliens" = typecacheof(list(/turf/open/floor/plating/abductor, /turf/open/floor/plating/abductor2,
-						/turf/open/floor/mineral/abductor, /turf/closed/wall/mineral/abductor)),
-						"falling" = typecacheof(list(/turf/open/chasm, /turf/open/floor/fakepit)),
+	phobia_turfs = list("space" = typecacheof(list(
+						/turf/open/space,
+						/turf/open/floor/holofloor/space,
+						/turf/open/floor/fakespace)
+						),
+
+					"the supernatural" = typecacheof(list(
+						/turf/open/floor/clockwork,
+						/turf/closed/wall/clockwork,
+						/turf/open/floor/plasteel/cult,
+						/turf/closed/wall/mineral/cult)),
+					
+					"aliens" = typecacheof(list(
+						/turf/open/floor/plating/abductor,
+						/turf/open/floor/plating/abductor2,
+						/turf/open/floor/mineral/abductor,
+						/turf/closed/wall/mineral/abductor)
+						),
+
+						"falling" = typecacheof(list(
+							/turf/open/chasm,
+							/turf/open/floor/fakepit)),
 						)
 
-	phobia_species = list("lizards" = typecacheof(list(/datum/species/lizard)),
-						"skeletons" = typecacheof(list(/datum/species/skeleton, /datum/species/plasmaman)),
-						"conspiracies" = typecacheof(list(/datum/species/abductor, /datum/species/lizard, /datum/species/synth, /datum/species/corporate)),
-						"robots" = typecacheof(list(/datum/species/android, /datum/species/synth)),
-						"the supernatural" = typecacheof(list(/datum/species/golem/clockwork, /datum/species/golem/runic)),
-						"aliens" = typecacheof(list(/datum/species/abductor, /datum/species/jelly, /datum/species/pod, /datum/species/shadow)),
-						"anime" = typecacheof(list(/datum/species/human/felinid)),
-						"cats" = typecacheof(list(/datum/species/human/felinid)),
+	phobia_species = list("lizards" = typecacheof(list(
+							/datum/species/lizard)
+							),
+
+						"skeletons" = typecacheof(list(
+							/datum/species/skeleton,
+							/datum/species/plasmaman)
+							),
+
+						"conspiracies" = typecacheof(list(
+							/datum/species/abductor,
+							/datum/species/lizard,
+							/datum/species/synth,
+							/datum/species/corporate)
+							),
+
+						"robots" = typecacheof(list(
+							/datum/species/android,
+							/datum/species/synth)
+							),
+
+						"the supernatural" = typecacheof(list(
+							/datum/species/golem/clockwork,
+							/datum/species/golem/runic)
+							),
+
+						"aliens" = typecacheof(list(
+						/datum/species/abductor, 
+						/datum/species/jelly, 
+						/datum/species/pod, 
+						/datum/species/shadow)
+						),
+
+						"anime" = typecacheof(list(
+							/datum/species/human/felinid)
+							),
+
+						"cats" = typecacheof(list(
+							/datum/species/human/felinid)
+							),
 						)
 
 	return ..()

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -204,3 +204,11 @@
 /datum/brain_trauma/mild/phobia/conspiracies
 	phobia_type = "conspiracies"
 	random_gain = FALSE
+
+/datum/brain_trauma/mild/phobia/eye
+	phobia_type = "eye"
+	random_gain = FALSE
+
+/datum/brain_trauma/mild/phobia/cats
+	phobia_type = "cats"
+	random_gain = FALSE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	quirk_holder.become_mega_nearsighted(ROUNDSTART_TRAIT)
 
 /datum/quirk/nyctophobia
-	name = "Nyctophobia"
+	name = "Phobia - The Dark"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
 	value = -1
 	medical_record_text = "Patient demonstrates a fear of the dark."
@@ -220,7 +220,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 
 /datum/quirk/lightless
-	name = "Light Sensitivity"
+	name = "Phobia - Bright Light"
 	desc = "Bright lights irritate you. Your eyes start to water, your skin feels itchy against the photon radiation, and your hair gets dry and frizzy. Maybe it's a medical condition."
 	value = -1
 	gain_text = span_danger("The safety of light feels off...")
@@ -394,24 +394,126 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	mood_change = -5
 	timeout = 3 MINUTES
 
-/datum/quirk/phobia
-	name = "Phobia"
-	desc = "You've had a traumatic past, one that has scarred you for life, and cripples you when dealing with your greatest fears."
-	value = -1 // It can hardstun you. You can be a job that your phobia targets...
-	gain_text = span_danger("You begin to tremble as an immeasurable fear grips your mind.")
+/datum/quirk/spiderphobia
+	name = "Phobia - Spiders"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with spiders."
+	value = -2 
+	mob_trait = TRAIT_SPIDERPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of eight legged monsters grips your mind.")
 	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
 	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
-	var/datum/brain_trauma/mild/phobia/phobia
-	locked = TRUE
+	locked = FALSE
 
-/datum/quirk/phobia/post_add()
+/datum/quirk/spiderphobia/post_add()
+	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
-	phobia = new
-	H.gain_trauma(phobia, TRAUMA_RESILIENCE_ABSOLUTE)
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/spiders, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/quirk/phobia/remove()
+/datum/quirk/spiderphobia/remove()
+	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
-	H?.cure_trauma_type(phobia, TRAUMA_RESILIENCE_ABSOLUTE)
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/spiders, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/skelephobia
+	name = "Phobia - Skeletons"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with bones."
+	value = -1 
+	mob_trait = TRAIT_BONERPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of bones grips your mind.")
+	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
+	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
+	locked = FALSE
+
+/datum/quirk/skelephobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/skeletons, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/skelephobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/skeletons, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/maskphobia
+	name = "Phobia - Masked People"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with someone wearing a mask."
+	value = -2 
+	mob_trait = TRAIT_MASKPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of the unknown stranger grips your mind.")
+	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
+	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
+	locked = FALSE
+
+/datum/quirk/maskphobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/strangers, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/maskphobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/strangers, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/doctorphobia
+	name = "Phobia - Doctors"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with doctors."
+	value = -3 
+	mob_trait = TRAIT_DOCTORPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of the doctors grips your mind.")
+	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
+	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
+	locked = FALSE
+
+/datum/quirk/doctorphobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/doctors, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/maskphobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/doctors, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/catphobia
+	name = "Phobia - Cats"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with cats."
+	value = -1
+	mob_trait = TRAIT_CATPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of the feline menace grips your mind.")
+	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
+	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
+	locked = FALSE
+
+/datum/quirk/catphobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/cats, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/catphobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/cats, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/eyephobia
+	name = "Phobia - Eyes"
+	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with eyes."
+	value = -1
+	mob_trait = TRAIT_EYEPHOBIA
+	gain_text = span_danger("You begin to tremble as an immeasurable fear of your eyes being stabbed grips your mind.")
+	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
+	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
+	locked = FALSE
+
+/datum/quirk/eyephobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/mild/phobia/eye, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/eyephobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/eye, TRAUMA_RESILIENCE_ABSOLUTE)
+	
 
 /datum/quirk/mute
 	name = "Mute"

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -228,7 +228,7 @@
 "cats": [
 		"mew",
 		"nya",
-		"moew",
+		"meow",
 		"feline",
 		"cat",
 		"neko",


### PR DESCRIPTION
I hate phobias.

Now we have like 8 of them.

Phobias include negatives quirks suchs as

![88485cb42b777566dd087825d26fbfaf-png](https://user-images.githubusercontent.com/13924177/200395118-76e7e0e2-dfcf-43f6-a61b-f07a5fb7c21d.jpg)


Being afraid of spiders
Being afraid of skeletons
Being afraid of masked strangers
Being afraid of doctors
Being afraid of things happening to your eyes
Being afraid of cats

Also renames the light and dark 'phobias' to be in line with being afraid of them as well.

Also also unratfucks traumas.dm

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
