### PR TITLE
Gives Vaulties a customizable ID.

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1095,7 +1095,7 @@ Raider
 	uniform = /obj/item/clothing/under/f13/vault
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/fingerless
-	id = /obj/item/card/id/dogtag/vaultiecard
+	id = /obj/item/card/id/selfassign
 	suit = /obj/item/clothing/suit/suspenders
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,


### PR DESCRIPTION
## About The Pull Request
Replaces the ID for the Vaultie Wasteland role to a customizable ID.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changed the Vaultie ID.
/:cl:

