### PR TITLE
Revolvers can eject empties with a click

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -126,7 +126,7 @@
 		bounce_away(FALSE, NONE)
 	. = ..()
 
-/obj/item/ammo_casing/proc/bounce_away(still_warm = FALSE, bounce_delay = 3, toss_direction)
+/obj/item/ammo_casing/proc/bounce_away(still_warm = FALSE, bounce_delay = 3, toss_direction, max_dist = 6, max_spread = 2)
 	update_icon()
 	SpinAnimation(10, 1)
 	var/matrix/M = matrix(transform)
@@ -135,7 +135,7 @@
 	pixel_x = rand(-12, 12)
 	pixel_y = rand(-12, 12)
 	if(toss_direction)
-		var/turf/ejected_case_destination = get_casing_destination(toss_direction)
+		var/turf/ejected_case_destination = get_casing_destination(toss_direction, max_dist, max_spread)
 		if(!isturf(ejected_case_destination))
 			return
 		throw_at(ejected_case_destination, 10, rand(1,3))
@@ -146,7 +146,7 @@
 	else if(this_turf_here && this_turf_here.bullet_bounce_sound)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, src, this_turf_here.bullet_bounce_sound, 60, 1), bounce_delay) //Soft / non-solid turfs that shouldn't make a sound when a shell casing is ejected over them.
 
-/obj/item/ammo_casing/proc/get_casing_destination(eject_direction)
+/obj/item/ammo_casing/proc/get_casing_destination(eject_direction, max_dist = 6, max_spread = 2)
 	if(!eject_direction)
 		return get_turf(src) // just throw it on the ground
-	return get_ranged_target_turf(src, eject_direction, rand(1,6), 2)
+	return get_ranged_target_turf(src, eject_direction, rand(1,max_dist), max_spread)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -80,13 +80,20 @@
 		insert_round(other_casing)
 		return TRUE
 
-	if(replace_spent_rounds)
+	for(var/i in 1 to length(stored_ammo)) // revolvers are tricky, try and stuff in a shell in an empty slot
+		var/obj/item/ammo_casing/bullet = stored_ammo[i]
+		if(!bullet || isnull(bullet))
+			insert_round(other_casing, i) // pop it in
+			return TRUE
+
+	if(replace_spent)
 		for(var/i in 1 to length(stored_ammo)) // mag is full, check for empties
 			var/obj/item/ammo_casing/bullet = stored_ammo[i]
-			if(isnull(bullet) || !bullet.BB || isnull(bullet.BB)) // Found a bullet, but its empty!)
-				eject_round(bullet, i) // pop it out
-				insert_round(other_casing, i) // pop it in
-				return TRUE
+			if(bullet.BB) // Found a bullet, but its empty!)
+				continue
+			eject_round(bullet, i) // pop it out
+			insert_round(other_casing, i) // pop it in
+			return TRUE
 	return FALSE
 
 /obj/item/ammo_box/proc/eject_round(obj/item/ammo_casing/casing_to_eject, index)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -360,5 +360,5 @@
 			if(GUN_EJECTOR_LEFT)
 				return turn(user.dir, -90)
 			if(GUN_EJECTOR_ANY)
-				return turn(user.dir, pick(-90, 90))
+				return turn(user.dir, pick(0, -90, 90, 180))
 	return angle2dir_cardinal(rand(0,360)) // something fucked up, just send a direction

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -170,7 +170,7 @@
 			ui.open()
 	else
 		if(!user.IsAdvancedToolUser() && !istype(src, /obj/machinery/chem_master/condimaster))
-			to_chat(user, span_warning("The legion has no use for drugs! Better to destroy it."))
+			to_chat(user, span_warning("You stare at a machine you'll never understand."))
 			return
 		if(!HAS_TRAIT(user, TRAIT_CHEMWHIZ) && !istype(src, /obj/machinery/chem_master/condimaster))
 			to_chat(user, span_warning("Try as you might, you have no clue how to work this thing."))


### PR DESCRIPTION
## About The Pull Request

when you click on a revolver, it dumps out the empty casings. click it again to empty the rest.

you can load empty casings into a revolver that isnt full of casings without it kicking out other casings. if the revolver is full, it'll still kick out an empty casing.

rewords a legion reference in chemmasters.