### PR TITLE
burrows now have less health when covered

### DIFF
--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -107,8 +107,9 @@
 		new /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid(src.loc)
 		if(istype(user))
 			to_chat(user, span_warning("You find something while covering the hole!"))
-			src.obj_integrity == 100
+			src.obj_integrity = 100
 	do_seal(itempath, cover_state, timer)
+
 
 /obj/structure/nest/proc/do_seal(itempath, cover_state, timer)
 	SEND_SIGNAL(src, COMSIG_SPAWNER_COVERED)

--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -107,6 +107,7 @@
 		new /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid(src.loc)
 		if(istype(user))
 			to_chat(user, span_warning("You find something while covering the hole!"))
+			src.obj_integrity == 100
 	do_seal(itempath, cover_state, timer)
 
 /obj/structure/nest/proc/do_seal(itempath, cover_state, timer)


### PR DESCRIPTION
## About The Pull Request
when you get loot from burrows after covering it, it also sets the burrow's obj_integrity to 100. technically if you don't finish breaking the burrow and it opens and someone re-covers it later, it'll get more hp back, but like, what the fuck ever? lmao

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
