### PR TITLE
More Emotes Take 2

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -2,6 +2,7 @@
 	key = "blush"
 	key_third_person = "blushes"
 	message = "blushes."
+	message_param = "blushes at %t."
 	sound = 'sound/f13effects/sunsetsounds/blush.ogg' //Sunset Edit - TK
 
 /datum/emote/living/blush/run_emote(mob/user, params)
@@ -20,6 +21,7 @@
 	key = "burp"
 	key_third_person = "burps"
 	message = "burps."
+	message_param = "burps from the %t."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/f13effects/sunsetsounds/lilburp.ogg' //Sunset Edit - TK
 
@@ -27,19 +29,22 @@
 	key = "choke"
 	key_third_person = "chokes"
 	message = "chokes!"
+	message_param = "chokes on the %t."
 	emote_type = EMOTE_AUDIBLE
-	sound = 'sound/f13effects/sunsetsounds/choke.ogg' //Sunset Edit - TK
+	// sound = 'sound/f13effects/sunsetsounds/choke.ogg' Turned off due to upset tummies
 
 /datum/emote/living/cross
 	key = "cross"
 	key_third_person = "crosses"
 	message = "crosses their arms."
+	message_param = "crosses their arms at %t."
 	restraint_check = TRUE
 
 /datum/emote/living/chuckle
 	key = "chuckle"
 	key_third_person = "chuckles"
 	message = "chuckles."
+	message_param = "chuckles at %t."
 	emote_type = EMOTE_AUDIBLE
 
 
@@ -69,6 +74,7 @@
 	key = "cough"
 	key_third_person = "coughs"
 	message = "coughs!"
+	message_param = "coughs from the %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/cough/can_run_emote(mob/user, status_check = TRUE , intentional)
@@ -89,6 +95,36 @@
 	key = "dance"
 	key_third_person = "dances"
 	message = "dances around happily."
+	message_param = "dances %t."
+	restraint_check = TRUE
+
+/datum/emote/hearthand
+	key = "hearthand"
+	key_third_person = "hearthands"
+	message = "makes a heart with their hands."
+	message_param = "makes a heart with their hands at %t."
+	restraint_check = TRUE
+
+/datum/emote/ok
+	key = "ok"
+	key_third_person = "oks"
+	message = "makes an okay sign with their hand."
+	message_param = "makes an okay sign with their hand at %t."
+	restraint_check = TRUE
+
+
+/datum/emote/thumbup
+	key = "thumbsup"
+	key_third_person = "thumbsups"
+	message = "makes a thumbs up sign with their hand."
+	message_param = "makes a thumbs up sign with their hand at %t."
+	restraint_check = TRUE
+
+/datum/emote/thumbdown
+	key = "thumbsdown"
+	key_third_person = "thumbsdowns"
+	message = "makes a thumbs down sign with their hand."
+	message_param = "makes a thumbs down sign with their hand at %t."
 	restraint_check = TRUE
 
 /datum/emote/living/deathgasp
@@ -122,11 +158,13 @@
 	key = "drool"
 	key_third_person = "drools"
 	message = "drools."
+	message_param = "drools at %t."
 
 /datum/emote/living/faint
 	key = "faint"
 	key_third_person = "faints"
 	message = "faints."
+	message_param = "faints from %t."
 
 /datum/emote/living/faint/run_emote(mob/user, params)
 	. = ..()
@@ -168,11 +206,13 @@
 	key = "frown"
 	key_third_person = "frowns"
 	message = "frowns."
+	message_param = "frowns at %t."
 
 /datum/emote/living/gag
 	key = "gag"
 	key_third_person = "gags"
 	message = "gags."
+	message_param = "gags from %t."
 	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/effects/gag.ogg'
 	sound_volume = 100
@@ -181,6 +221,7 @@
 	key = "gasp"
 	key_third_person = "gasps"
 	message = "gasps!"
+	message_param = "gasps at %t."
 	emote_type = EMOTE_AUDIBLE
 	stat_allowed = UNCONSCIOUS
 
@@ -197,6 +238,7 @@
 	key = "giggle"
 	key_third_person = "giggles"
 	message = "giggles."
+	message_param = "giggles at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/giggle/get_sound(mob/living/M)
@@ -219,16 +261,19 @@
 	key = "grin"
 	key_third_person = "grins"
 	message = "grins."
+	message_param = "grins at %t."
 
 /datum/emote/living/groan
 	key = "groan"
 	key_third_person = "groans"
 	message = "groans!"
+	message_param = "groans at %t."
 
 /datum/emote/living/grimace
 	key = "grimace"
 	key_third_person = "grimaces"
 	message = "grimaces."
+	message_param = "grimaces at %t."
 
 /datum/emote/living/jump
 	key = "jump"
@@ -257,6 +302,7 @@
 	key = "laugh"
 	key_third_person = "laughs"
 	message = "laughs."
+	message_param = "laughs about %t."
 
 /datum/emote/living/audible/laugh/get_sound(mob/living/user)
 	. = ..()
@@ -271,6 +317,7 @@
 	key = "chitter"
 	key_third_person = "chitters"
 	message = "chitters."
+	message_param = "chitters at %t."
 
 /datum/emote/living/audible/chitter/get_sound(mob/living/user)
 	. = ..()
@@ -321,36 +368,42 @@
 	key = "pout"
 	key_third_person = "pouts"
 	message = "pouts."
+	message_param = "pouts at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/scream
 	key = "scream"
 	key_third_person = "screams"
 	message = "screams."
+	message_param = "screams at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/scowl
 	key = "scowl"
 	key_third_person = "scowls"
 	message = "scowls."
+	message_param = "scowls at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shake
 	key = "shake"
 	key_third_person = "shakes"
 	message = "shakes their head."
+	message_param = "shakes their head at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/shiver
 	key = "shiver"
 	key_third_person = "shiver"
 	message = "shivers."
+	message_param = "shivers from the %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sigh
 	key = "sigh"
 	key_third_person = "sighs"
 	message = "sighs."
+	message_param = "sighs about %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sigh/get_sound(mob/living/M)
@@ -366,21 +419,25 @@
 	key = "sit"
 	key_third_person = "sits"
 	message = "sits down."
+	message_param = "sits down on %t."
 
 /datum/emote/living/smile
 	key = "smile"
 	key_third_person = "smiles"
 	message = "smiles."
+	message_param = "smiles at %t."
 
 /datum/emote/living/smirk
 	key = "smirk"
 	key_third_person = "smirks"
 	message = "smirks."
+	message_param = "smirks at %t."
 
 /datum/emote/living/sneeze
 	key = "sneeze"
 	key_third_person = "sneezes"
 	message = "sneezes."
+	message_param = "sneezes from %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/sneeze/get_sound(mob/living/M)
@@ -397,11 +454,13 @@
 	key = "smug"
 	key_third_person = "smugs"
 	message = "grins smugly."
+	message_param = "smugly grins at %t."
 
 /datum/emote/living/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
 	message = "sniffs."
+	message_param = "sniffs at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/snore
@@ -431,6 +490,7 @@
 	key = "stretch"
 	key_third_person = "stretches"
 	message = "stretches their arms."
+	message_param = "stretches their %t."
 
 /datum/emote/living/sulk
 	key = "sulk"
@@ -466,6 +526,7 @@
 	key = "tremble"
 	key_third_person = "trembles"
 	message = "trembles in fear!"
+	message_param = "trembles in fear at %t."
 
 /datum/emote/living/twitch
 	key = "twitch"
@@ -480,11 +541,13 @@
 	key = "wave"
 	key_third_person = "waves"
 	message = "waves."
+	message_param = "waves at %t."
 
 /datum/emote/living/whimper
 	key = "whimper"
 	key_third_person = "whimpers"
 	message = "whimpers."
+
 
 /datum/emote/living/whimper/get_sound(mob/living/M)
 	. = ..()
@@ -499,11 +562,12 @@
 	key = "wsmile"
 	key_third_person = "wsmiles"
 	message = "smiles weakly."
-
+	message_param = "weakly smiles at %t."
 /datum/emote/living/yawn
 	key = "yawn"
 	key_third_person = "yawns"
 	message = "yawns."
+	message_param = "yawns at %t."
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/custom


### PR DESCRIPTION
Adds emote parameters to
*blush
*burp
*choke
*cross
*chuckle
*cough
*drool
*frown
*gasps
*grins
*giggle
*groan
*grimace
*laugh
*chitter
*pout
*scowl
*shake
*shiver
*sigh
*sit
*smile
*sneeze
*smug
*sniff
*stretch
*tremble
*wave
*wsmile
*yawn
*slap

These are the the system that *kiss uses to target what you're blowing a kiss at. Try them out, saves a few seconds of time from writing out the emote long hand, mostly just quality of life.

Also muted choking for now due to upset tummy complaints from some players.  Understandable, I suppose.

Adds Emotes, with params
*hearthand, you make a heart with your hands.
*ok, you make an okay sign.
*thumbsup & *thumbsdown, self explanatory.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
