### PR TITLE
Fix alacritous compost recipe

### DIFF
--- a/code/modules/fallout/reagents/other_reagents.dm
+++ b/code/modules/fallout/reagents/other_reagents.dm
@@ -68,16 +68,16 @@
 // Saltpetre Tribal Edition
 /datum/reagent/alacritous_compost
 	name = "alacritous compost"
-	description = "A strange mixture of compost, ashes and pungajuice. This potent mixture will hasten the plant's harvest while increasing the yield."
+	description = "A strange mixture of compost, ashes and pink pulque. This potent mixture will hasten the plant's harvest while increasing the yield."
 	reagent_state = "LIQUID"
-	color = "#4CB529"
-	taste_description = "cool, salty rot"
+	color = "#ECACEC"
+	taste_description = "cool, semisweet rot"
 
 //Making Saltpetre Tribal Edition
 /datum/chemical_reaction/alacritous_compost
 	id = /datum/reagent/alacritous_compost
 	results = list(/datum/reagent/alacritous_compost = 3)
-	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/ethanol/pungajuice = 1, /datum/reagent/compost = 1)
+	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/ethanol/pinkpulque = 1, /datum/reagent/compost = 1)
 	mix_message = "The compost starts smelling like manure"
 
 // If added to tray


### PR DESCRIPTION
## About The Pull Request
Punga juice is now unobtainable. Let's switch from requiring punga juice to prickly pear pink pulque instead. That way there's a reason to cultivate prickly pear fruit for that pleasant American Southwest flavor and the most nourishing compost can be a soothing pink color instead of radioactive green.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Fixed alacritous compost recipe. Punga juice -> pink pulque
/:cl:
