### PR TITLE
Fix falling freerunning check when falling 1 z-level

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You climb tables more quickly. Still trying to figure out how to jump off buildings safely tho..."
+	desc = "You're great at quick moves! You climb tables more quickly and land gracefully when falling from one floor up."
 	value = 1
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = span_notice("You feel lithe on your feet!")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -53,10 +53,10 @@
 	return ..()
 
 /mob/living/proc/ZImpactDamage(turf/T, levels)
-	if(levels <= 1 && HAS_TRAIT(src, TRAIT_FREERUNNING))
+	if(levels <= 2 && HAS_TRAIT(src, TRAIT_FREERUNNING)) //levels is incremented prior to damage proc and is always >= 2
 		visible_message(span_danger("[src] slams into [T], rolling as they land and keeping their pace!"),
 						span_userdanger("You slam into [T], rolling and keeping your momentum!"))
-		adjustBruteLoss((levels * 5))
+		adjustBruteLoss(5)
 	else
 		visible_message(span_danger("[src] crashes into [T] with a sickening noise!"),
 						span_userdanger("You crash into [T] with a sickening noise!"))


### PR DESCRIPTION
## About The Pull Request
Fixes fall damage calculations so freerunning is properly taken into account when falling from one floor up.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Fixed freerunning check when falling 1 z-level
/:cl:
