### PR TITLE
Hobogun changes

### DIFF
--- a/code/__DEFINES/ammo.dm
+++ b/code/__DEFINES/ammo.dm
@@ -38,6 +38,61 @@
 #define CALIBER_FOAM "foam darts"
 #define CALIBER_ANY "anything even remotely ammolike"
 
+/// Caliber POW levels
+/// for hobo guns scaling their explodiness to the casing fired
+/// Heavier rounds than the gun can handle? more chance to POW
+/// Lighter rounds? doesnt explode, shrimple as
+#define CASING_POWER_NONE 0
+#define CASING_POWER_LIGHT_PISTOL 1
+#define CASING_POWER_MEDIUM_PISTOL 2
+#define CASING_POWER_HEAVY_PISTOL 4
+#define CASING_POWER_HEAVIER_PISTOL 10
+#define CASING_POWER_LIGHT_RIFLE 4
+#define CASING_POWER_MEDIUM_RIFLE 8
+#define CASING_POWER_HEAVY_RIFLE 12
+#define CASING_POWER_SHOTGUN 5
+#define CASING_POWER_GRENADE 5
+
+/// Modifiers for different loads
+#define CASING_POWER_MOD_HANDLOAD 0.5
+#define CASING_POWER_MOD_SURPLUS 1
+#define CASING_POWER_MOD_MATCH 2
+
+#define ZIPGUN_AMMO_CALIBERS list(\
+	CALIBER_22LR,\
+	CALIBER_9MM,\
+	CALIBER_10MM,\
+	CALIBER_38,\
+	CALIBER_357,\
+	CALIBER_44,\
+	CALIBER_45LC,\
+	CALIBER_45ACP\
+	)
+
+#define AUTOPIPE_AMMO_CALIBERS list(\
+	CALIBER_22LR,\
+	CALIBER_9MM,\
+	CALIBER_10MM,\
+	CALIBER_38,\
+	CALIBER_357,\
+	CALIBER_45ACP\
+	)
+
+#define KNUCKLEGUN_AMMO_CALIBERS list(\
+	CALIBER_9MM,\
+	CALIBER_10MM,\
+	CALIBER_38,\
+	CALIBER_357,\
+	CALIBER_44,\
+	CALIBER_45ACP\
+	)
+
+/// this is an awful, awful idea
+#define SHOTGUNBAT_AMMO_CALIBERS list(\
+	CALIBER_SHOTGUN,\
+	CALIBER_50MG,\
+	)
+
 GLOBAL_LIST_INIT(pipe_rifle_valid_calibers, list(
 	CALIBER_22LR,
 	CALIBER_5MM,
@@ -53,23 +108,19 @@ GLOBAL_LIST_INIT(pipe_rifle_valid_calibers, list(
 	CALIBER_45ACP,
 	CALIBER_4570,
 	CALIBER_50MG,
+	CALIBER_40MM,
 	CALIBER_FOAM,
 	CALIBER_MUSKET_BALL,
 	CALIBER_SHOTGUN))
 
-GLOBAL_LIST_INIT(zipgun_valid_calibers, list(
-	CALIBER_22LR,
-	CALIBER_9MM,
-	CALIBER_10MM,
-	CALIBER_38,
-	CALIBER_45LC,
-	CALIBER_45ACP))
+GLOBAL_LIST_INIT(zipgun_valid_calibers, ZIPGUN_AMMO_CALIBERS)
 
 GLOBAL_LIST_INIT(hobo_gun_mag_fluff, list(
 	"prefix" = list("bullet","casing","cartridge","shell"),
 	"suffix" = list("chamber","holder","slot","hole","thing","pit"),
 	"postfix" = list("-thingy","-majig","...?"," assembly")
 ))
+
 #define MAGAZINE_CALIBER_CHANGE_STEP_0 0 // use screwdriver to get to step 1
 #define MAGAZINE_CALIBER_CHANGE_STEP_1 1 // used a screwdriver on it, ready for a metal part
 #define MAGAZINE_CALIBER_CHANGE_STEP_2 2 // used a metal part on it, ready for welding

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -22,6 +22,8 @@
 #define CLONELOSS		(1<<7)
 #define EMPLOSS			(1<<8)
 
+#define DAMAGES_LIST list(BRUTELOSS, FIRELOSS, TOXLOSS, OXYLOSS, RADIATIONLOSS, CLONELOSS, EMPLOSS)
+
 #define EFFECT_STUN		"stun"
 #define EFFECT_KNOCKDOWN		"knockdown"
 #define EFFECT_UNCONSCIOUS	"unconscious"

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -71,23 +71,23 @@
 			return getStaminaLoss()
 
 
-/mob/living/proc/apply_damages(brute = 0, burn = 0, tox = 0, oxy = 0, clone = 0, def_zone = null, blocked = FALSE, stamina = 0, brain = 0)
+/mob/living/proc/apply_damages(brute = 0, burn = 0, tox = 0, oxy = 0, clone = 0, def_zone = null, blocked = FALSE, stamina = 0, brain = 0, damagethreshold = 0)
 	if(blocked >= 100)
 		return 0
 	if(brute)
-		apply_damage(brute, BRUTE, def_zone, blocked)
+		apply_damage(brute, BRUTE, def_zone, blocked, damage_threshold = damagethreshold)
 	if(burn)
-		apply_damage(burn, BURN, def_zone, blocked)
+		apply_damage(burn, BURN, def_zone, blocked, damage_threshold = damagethreshold)
 	if(tox)
-		apply_damage(tox, TOX, def_zone, blocked)
+		apply_damage(tox, TOX, def_zone, blocked, damage_threshold = damagethreshold)
 	if(oxy)
-		apply_damage(oxy, OXY, def_zone, blocked)
+		apply_damage(oxy, OXY, def_zone, blocked, damage_threshold = damagethreshold)
 	if(clone)
-		apply_damage(clone, CLONE, def_zone, blocked)
+		apply_damage(clone, CLONE, def_zone, blocked, damage_threshold = damagethreshold)
 	if(stamina)
-		apply_damage(stamina, STAMINA, def_zone, blocked)
+		apply_damage(stamina, STAMINA, def_zone, blocked, damage_threshold = damagethreshold)
 	if(brain)
-		apply_damage(brain, BRAIN, def_zone, blocked)
+		apply_damage(brain, BRAIN, def_zone, blocked, damage_threshold = damagethreshold)
 	return 1
 
 /mob/living/proc/apply_effect(effect = 0,effecttype = EFFECT_STUN, blocked = FALSE, knockdown_stamoverride, knockdown_stammax)

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -26,6 +26,8 @@
 	var/heavy_metal = TRUE
 	var/harmful = TRUE //pacifism check for boolet, set to FALSE if bullet is non-lethal
 	var/is_pickable = TRUE
+	/// The power of the casing on the gun itself, mostly for hobo guns checking whats loaded for misfires
+	var/fire_power = CASING_POWER_NONE * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -7,6 +7,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER)
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/c10mm/improvised
 	name = "shoddy 10mm bullet casing"
@@ -16,6 +17,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c10mm/rubber
 	name = "A 10mm rubber bullet casing."
@@ -23,10 +25,12 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c10mm/incendiary
 	name = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c10mm/incendiary
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 // 9mm
 /obj/item/ammo_casing/c9mm
@@ -37,6 +41,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/c9mm/improvised
 	name = "homemade 9mm bullet casing"
@@ -45,6 +50,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c9mm/rubber
 	name = "9mm rubber bullet casing"
@@ -53,11 +59,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c9mm/incendiary
 	name = "9mm incendiary bullet casing"
 	desc = "A 9mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c9mm/incendiary
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 //14mm
 /obj/item/ammo_casing/p14mm
@@ -68,6 +76,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER)
+	fire_power = CASING_POWER_HEAVIER_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/p14mm/improvised
 	name = "shoddy 14mm bullet casing"
@@ -77,11 +86,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVIER_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/p14mm/contam
 	name = "14mm contaminated bullet casing"
 	desc = "A 14mm contaminated bullet casing."
 	projectile_type = /obj/item/projectile/bullet/mm14/contam
+	fire_power = CASING_POWER_HEAVIER_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /*
 /obj/item/ammo_casing/p14mm/uraniumtipped
@@ -100,16 +111,19 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a22/rubber
 	name = ".22lr rubber bullet casing"
 	desc = "A .22lr rubber bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c22/rubber
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a22/shock
 	name = ".22lr shock bullet casing"
 	desc = "A .22lr shock bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c22/shock
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 // BETA AMMO // Obsolete
 /obj/item/ammo_casing/testcasing

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -7,16 +7,19 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/a357/ricochet
 	name = ".357 ricochet bullet casing"
 	desc = "A .357 ricochet bullet casing."
 	projectile_type = /obj/item/projectile/bullet/a357/ricochet
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/a357/incendiary
 	name = ".357 incendiary bullet casing"
 	desc = "A .357 incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/a357/incendiary
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a357/improvised
 	name = "shoddy .357 bullet casing"
@@ -25,6 +28,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 
 // .38 special
@@ -36,6 +40,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c38/improvised
 	name = "shoddy .38 special bullet casing"
@@ -44,6 +49,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c38/rubber
 	name = ".38 special rubber bullet casing"
@@ -52,11 +58,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_SMALL_CASING + MATS_PISTOL_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c38/incendiary
 	name = ".38 special incendiary bullet casing"
 	desc = "A .38 special incendiary bullet casing. For when you want to be slightly less useless."
 	projectile_type = /obj/item/projectile/bullet/c38/incendiary
+	fire_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 // .44 magnum
 /obj/item/ammo_casing/m44
@@ -67,6 +75,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/m44/improvised
 	name = "shoddy .44 magnum bullet casing"
@@ -76,11 +85,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_HEAVY_CASING + MATS_PISTOL_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_HEAVY_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/m44/incendiary
 	name = ".44 magnum incendiary bullet casing"
 	desc = "A .44 magnum incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c45/incendiary
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 // .45-70 Gov't
 /obj/item/ammo_casing/c4570
@@ -91,6 +102,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/c4570/improvised
 	name = "shoddy .45-70 bullet casing"
@@ -100,11 +112,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c4570/explosive
 	name = ".45-70 explosive bullet casing"
 	desc = "A .45-70 explosive bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c4570/explosive
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/c4570/knockback
 	name = ".45-70 ultradense bullet casing"
@@ -113,6 +127,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 //.45 Long Colt bouncing
 /obj/item/ammo_casing/a45lc
@@ -123,6 +138,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a45lc/improvised
 	name = "shoddy .45 LC bullet casing"
@@ -132,4 +148,5 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_PISTOL * CASING_POWER_MOD_SURPLUS
 

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -8,6 +8,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER * MATS_AMMO_POWDER_MATCH_MULT)
+	fire_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a762/improvised
 	name = "shoddy .308 bullet casing"
@@ -16,6 +17,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a762/sport
 	name = ".308 bullet casing"
@@ -24,11 +26,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER)
+	fire_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/a762/microshrapnel
 	name = "7.62mm microshrapnel bullet casing"
 	desc = "Like shrapnel, but smaller, and thus more annoying."
 	projectile_type = /obj/item/projectile/bullet/a762/microshrapnel
+	fire_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_MATCH
 
 /*
 /obj/item/ammo_casing/a762/uraniumtipped
@@ -44,6 +48,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_MEDIUM_CASING + MATS_RIFLE_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 // 5.56mm
 /obj/item/ammo_casing/a556
@@ -54,6 +59,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER * MATS_AMMO_POWDER_MATCH_MULT)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a556/rubber
 	name = "5.56mm rubber bullet casing"
@@ -62,11 +68,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a556/microshrapnel
 	name = "5.56mm microshrapnel bullet casing"
 	desc = "Like shrapnel, but smaller, and thus more annoying."
 	projectile_type = /obj/item/projectile/bullet/a556/microshrapnel
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH
 
 /*
 /obj/item/ammo_casing/a556/uranium_tipped
@@ -82,6 +90,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/a556/improvised
 	name = "shoddy .223 bullet casing"
@@ -90,6 +99,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 //5mm
 
@@ -101,6 +111,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/m5mm/improvised
 	name = "shoddy 5mm bullet casing"
@@ -110,11 +121,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_SMALL_CASING + MATS_RIFLE_SMALL_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_SMALL_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/m5mm/shock
 	name = "5mm shock bullet casing"
 	desc = "A 5mm shock bullet casing."
 	projectile_type = /obj/item/projectile/bullet/m5mm/shock
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 // 40mm (Grenade Launcher)
 /obj/item/ammo_casing/a40mm
@@ -126,6 +139,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_GRENADE_CASING + MATS_GRENADE_BULLET,
 		/datum/material/blackpowder = MATS_GRENADE_POWDER)
+	fire_power = CASING_POWER_GRENADE * CASING_POWER_MOD_SURPLUS
 
 // 2mm EC
 /obj/item/ammo_casing/c2mm
@@ -136,8 +150,10 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_GAUSS_CASING + MATS_GAUSS_BULLET,
 		/datum/material/blackpowder = MATS_GAUSS_POWDER)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/c2mm/blender
 	name = "2mm gauss blender projectile casing"
 	desc = "A 2mm gauss projectile casing, \"Blender\" variant. Bounces off walls at hypersonic speeds."
 	projectile_type = /obj/item/projectile/bullet/c2mm/blender
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -10,6 +10,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_SHOTGUN_CASING + MATS_SHOTGUN_BULLET,
 		/datum/material/blackpowder = MATS_SHOTGUN_POWDER)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"
@@ -18,6 +19,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
 	variance = 18
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
@@ -29,6 +31,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_SHOTGUN_CASING + MATS_SHOTGUN_BULLET,
 		/datum/material/blackpowder = MATS_SHOTGUN_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
@@ -38,24 +41,28 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_SHOTGUN_CASING + MATS_SHOTGUN_BULLET,
 		/datum/material/blackpowder = MATS_SHOTGUN_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 obj/item/ammo_casing/shotgun/executioner
 	name = "executioner slug"
 	desc = "A 12 gauge lead slug purpose built to annihilate flesh on impact."
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug/executioner
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/pulverizer
 	name = "pulverizer slug"
 	desc = "A 12 gauge lead slug purpose built to annihilate bones on impact."
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug/pulverizer
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/shotgun/dragonsbreath
 	name = "dragonsbreath shell"
@@ -64,6 +71,7 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	pellets = 4
 	variance = 35
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
@@ -73,12 +81,14 @@ obj/item/ammo_casing/shotgun/executioner
 	custom_materials = list(
 		/datum/material/iron = MATS_SHOTGUN_CASING + MATS_SHOTGUN_BULLET,
 		/datum/material/blackpowder = MATS_SHOTGUN_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteorslug shell"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_meteorslug
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -87,12 +97,14 @@ obj/item/ammo_casing/shotgun/executioner
 	would have difficulty with."
 	icon_state = "pshell"
 	projectile_type = /obj/item/projectile/beam/pulse/shotgun
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
 	desc = "A high explosive breaching round for a 12 gauge shotgun."
 	icon_state = "heshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_frag12
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -104,6 +116,7 @@ obj/item/ammo_casing/shotgun/executioner
 	custom_materials = list(
 		/datum/material/iron = MATS_SHOTGUN_CASING + MATS_SHOTGUN_BULLET,
 		/datum/material/blackpowder = MATS_SHOTGUN_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
@@ -113,6 +126,7 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/ion/weak
 	pellets = 4
 	variance = 35
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/laserslug
 	name = "scatter laser shell"
@@ -121,12 +135,14 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 6
 	variance = 35
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
 	icon_state = "cshell"
 	projectile_type = null
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
@@ -134,6 +150,7 @@ obj/item/ammo_casing/shotgun/executioner
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/dart
 	var/reagent_amount = 30
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/dart/Initialize()
 	. = ..()
@@ -147,6 +164,7 @@ obj/item/ammo_casing/shotgun/executioner
 	desc = "A dart for use in shotguns. Uses technology similar to cryostasis beakers to keep internal reagents from reacting. Can be injected with up to 10 units of any chemical."
 	icon_state = "cnrshell"
 	reagent_amount = 10
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/dart/noreact/Initialize()
 	. = ..()
@@ -156,6 +174,7 @@ obj/item/ammo_casing/shotgun/executioner
 	desc = "A shotgun dart filled with an obscene amount of lethal reagents. God help whoever is shot with this."
 	projectile_type = /obj/item/projectile/bullet/dart/piercing
 	reagent_amount = 50
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize()
 	. = ..()
@@ -175,6 +194,7 @@ obj/item/ammo_casing/shotgun/executioner
 	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
 	variance = 25
 	custom_materials = list(/datum/material/iron=4000)
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/magnumshot
 	name = "12 gauge magnum buckshot shell"
@@ -183,6 +203,7 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/bullet/pellet/magnum_buckshot
 	pellets = 7
 	variance = 15
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/shotgun/trainshot
 	name = "12 gauge trainshot shell"
@@ -191,6 +212,7 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/bullet/pellet/trainshot
 	pellets = 3
 	variance = 15
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH
 
 // BETA STUFF // Obsolete
 /obj/item/ammo_casing/shotgun/buckshot/test
@@ -200,3 +222,4 @@ obj/item/ammo_casing/shotgun/executioner
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot/test
 	pellets = 6
 	variance = 18
+	fire_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_MATCH

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -8,7 +8,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER)
-
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_SURPLUS
 
 /obj/item/ammo_casing/c45/improvised
 	name = "shoddy .45 bullet casing"
@@ -18,11 +18,13 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c45/incendiary
 	name = ".45 incendiary bullet casing"
 	desc = "A .45 incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c45/incendiary
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/c45/rubber
 	name = ".45 rubber bullet casing"
@@ -31,4 +33,5 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_MEDIUM_PISTOL * CASING_POWER_MOD_HANDLOAD
 

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -9,6 +9,7 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_HEAVY_CASING + MATS_RIFLE_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_HEAVY_POWDER * MATS_AMMO_POWDER_MATCH_MULT)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a50MG/improvised
 	name = "shoddy .50MG bullet casing"
@@ -19,18 +20,21 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_HEAVY_CASING + MATS_RIFLE_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_HEAVY_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a50MG/incendiary
 	name = ".50 MG incendiary bullet casing"
 	desc = "A .50 MG incendiary bullet casing."
 	icon_state = "50in2"
 	projectile_type = /obj/item/projectile/bullet/a50MG/incendiary
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a50MG/explosive
 	name = ".50 MG explosive bullet casing"
 	desc = "Comes in 5 bullet racks...more then enough to kill anything that moves.."
 	icon_state = "50ex2"
 	projectile_type = /obj/item/projectile/bullet/a50MG/explosive
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a50MG/rubber
 	name = ".50 MG rubber bullet casing"
@@ -39,18 +43,21 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_RIFLE_HEAVY_CASING + MATS_RIFLE_HEAVY_BULLET,
 		/datum/material/blackpowder = MATS_RIFLE_HEAVY_POWDER * MATS_AMMO_POWDER_HANDLOAD_MULT)
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/a50MG/penetrator
 	name = ".50 MG penetrator bullet casing"
 	desc = "This titanium-reinforced highpower bullet will penetrate anything. Yes. Anything."
 	projectile_type = /obj/item/projectile/bullet/a50MG/penetrator
 	icon_state = "50ap2"
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/a50MG/contam
 	name = "12.7mm contaminated bullet casing"
 	desc = "A 12.7mm explosive round where the explosive has been replaced with a chemical smoke payload."
 	icon_state = "50ex2"
 	projectile_type = /obj/item/projectile/bullet/a50MG/contam
+	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 
 /*
 /obj/item/ammo_casing/a50MG/uraniumtipped

--- a/code/modules/projectiles/ammunition/caseless/ballistic.dm
+++ b/code/modules/projectiles/ammunition/caseless/ballistic.dm
@@ -7,14 +7,17 @@
 	custom_materials = list(
 		/datum/material/iron = MATS_PISTOL_MEDIUM_CASING + MATS_PISTOL_MEDIUM_BULLET,
 		/datum/material/blackpowder = MATS_PISTOL_MEDIUM_POWDER)
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/caseless/g11/rubber
 	name = "4.73mm polyurethane cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/rubber
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/caseless/g11/incendiary
 	name = "4.73mm tracer cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/incendiary
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /*
 /obj/item/ammo_casing/caseless/g11/uraniumtipped
@@ -25,16 +28,20 @@
 /obj/item/ammo_casing/caseless/g11/dumdum
 	name = "4.73mm flat-nose cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/dumdum
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/caseless/g11/explosive
 	name = "4.73mm explosive caseless cartridge"
 	desc = "An explosive 4.73 self-contained caseless rifle cartridge."
 	projectile_type = /obj/item/projectile/bullet/a473/explosive
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH
 
 /obj/item/ammo_casing/caseless/g11/shock
 	name = "4.73mm electro-static discharge cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/shock
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 
 /obj/item/ammo_casing/caseless/g11/hv
 	name = "4.73mm highvelocity cartridge"
 	projectile_type  = /obj/item/projectile/bullet/a473/hv
+	fire_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_MATCH

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -45,17 +45,12 @@
 	name = "Zip gun clip (9mm)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "zip"
-	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = list(CALIBER_9MM)
+	ammo_type = /obj/item/ammo_casing/c9mm/improvised
+	caliber = ZIPGUN_AMMO_CALIBERS
 	max_ammo = 5
 	multiple_sprites = 2
-	can_change_caliber = TRUE
 	custom_materials = list(/datum/material/iron = MATS_PISTOL_SPEEDLOADER)
 	w_class = WEIGHT_CLASS_TINY
-
-/obj/item/ammo_box/magazine/zipgun/Initialize()
-	. = ..()
-	valid_new_calibers = GLOB.zipgun_valid_calibers
 
 //9mm
 /obj/item/ammo_box/magazine/m9mm

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -32,7 +32,7 @@
 	name = "pipe rifle ammo belt (.357-ish)"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "autopipe_belt"
-	caliber = list(CALIBER_357, CALIBER_9MM, CALIBER_38)
+	caliber = AUTOPIPE_AMMO_CALIBERS
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 18
 	multiple_sprites = 2

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -59,7 +59,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder/improvised45
 	name = "improvised internal magazine .45"
 	ammo_type = /obj/item/ammo_casing/c45
-	caliber = list(CALIBER_45ACP)
+	caliber = KNUCKLEGUN_AMMO_CALIBERS
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/cylinder/improvised9mm
@@ -83,7 +83,7 @@
 /obj/item/ammo_box/magazine/internal/cylinder/improvised44
 	name = "improvised internal magazine .44"
 	ammo_type = /obj/item/ammo_casing/m44
-	caliber = list(CALIBER_44)
+	caliber = KNUCKLEGUN_AMMO_CALIBERS
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/cylinder/improvised762

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -55,6 +55,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/improvised
 	name = "improvised shotgun internal magazine"
+	caliber = SHOTGUNBAT_AMMO_CALIBERS
 	ammo_type = /obj/item/ammo_casing/shotgun/improvised
 	max_ammo = 1
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -163,7 +163,10 @@ ATTACHMENTS
 	var/gun_skill_check
 	/// What kind of temporary refire delay modifiers do we have?
 	var/cooldown_delay_mods
+	/// What kind of misfires can this thing do? Check out combat.dm for details
 	var/list/misfire_possibilities = list()
+	/// What power of cartridge does this gun prefer? Mostly used for hoboguns that explode
+	var/prefered_power
 	var/list/gun_sound_properties = list(
 		SP_VARY(FALSE),
 		SP_VOLUME(PISTOL_LIGHT_VOLUME),
@@ -1282,21 +1285,33 @@ ATTACHMENTS
 		return FALSE
 	if(!islist(misfire_possibilities))
 		return FALSE
+	if(prefered_power <= 0)
+		return FALSE
+	var/misfire_mod = 1
+	if(istype(chambered) && chambered.BB)
+		if(chambered.fire_power <= 0)
+			return FALSE
+		if(chambered.fire_power <= prefered_power)
+			return FALSE
+		if(chambered.fire_power > prefered_power)
+			misfire_mod = chambered.fire_power / prefered_power
+	else
+		return FALSE
 
 	for(var/gun_jank in misfire_possibilities)
-		if(!prob(misfire_possibilities[gun_jank][GUN_MF_CHANCE]))
+		if(!prob(misfire_mod * misfire_possibilities[gun_jank][GUN_MF_CHANCE]))
 			continue
 		switch(gun_jank)
 			if(GUN_MF_HURTS_YOU)
-				if(misfire_hurt_user(user))
+				if(misfire_hurt_user(user, misfire_mod))
 					. = TRUE
 					break
 			if(GUN_MF_DUMP)
-				if(misfire_dump_ammo(user))
+				if(misfire_dump_ammo(user, misfire_mod))
 					. = TRUE
 					break
 			if(GUN_MF_YEET)
-				if(misfire_yeet_gun(user))
+				if(misfire_yeet_gun(user, misfire_mod))
 					. = TRUE
 					break
 	if(prob(50)) // cus ur gun suxorz
@@ -1305,47 +1320,75 @@ ATTACHMENTS
 		do_sparks(3, FALSE, src)
 	return TRUE
 
-/obj/item/gun/proc/misfire_hurt_user(mob/living/user)
+/obj/item/gun/proc/misfire_hurt_user(mob/living/user, extra_hurt)
 	if(!user || !isliving(user))
 		return FALSE
+	
+	var/is_pow = extra_hurt > 1.5 ? TRUE : FALSE
+	extra_hurt = clamp(extra_hurt, 1, 2.5) // lets not literally kill whoever's using this thing
+
+	var/damage_divisor = 0
+	for(var/dmg in DAMAGES_LIST)
+		if(CHECK_BITFIELD(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE], dmg))
+			damage_divisor += 1
+	hurt_the_holder(user, extra_hurt, damage_divisor)
 
 	/// "The Shitgun misfires,"
 	var/what_happen_to_you = list()
 	var/what_happen_to_them = list()
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & BRUTELOSS)
-		user.adjustBruteLoss(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "slamming itself into you"
-		what_happen_to_them += "slamming itself into [user.p_them()]"
+		if(is_pow)
+			what_happen_to_you += "clobbering you into next week"
+			what_happen_to_them += "clobbering [user.p_them()] into next week"
+		else
+			what_happen_to_you += "slamming itself into you"
+			what_happen_to_them += "slamming itself into [user.p_them()]"
 		playsound(src, 'sound/weapons/genhit2.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & FIRELOSS)
-		user.adjustFireLoss(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "burning your flesh"
-		what_happen_to_them += "burning [user.p_their()] flesh"
+		if(is_pow)
+			what_happen_to_you += "searing you well done"
+			what_happen_to_them += "searing [user.p_them()] well done"
+		else
+			what_happen_to_you += "burning your flesh"
+			what_happen_to_them += "burning [user.p_their()] flesh"
 		playsound(src, 'sound/items/welder.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & TOXLOSS)
-		user.adjustToxLoss(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "blasting you with toxic fumes"
-		what_happen_to_them += "blasting [user.p_them()] with toxic fumes"
+		if(is_pow)
+			what_happen_to_you += "hosing you down with deadly grime"
+			what_happen_to_them += "hosing [user.p_them()]down with deadly grimt"
+		else
+			what_happen_to_you += "blasting you with toxic fumes"
+			what_happen_to_them += "blasting [user.p_them()] with toxic fumes"
 		playsound(src, 'sound/effects/zzzt.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & OXYLOSS)
-		user.adjustOxyLoss(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
 		what_happen_to_you += "knocking the wind out of you"
 		what_happen_to_them += "knocking the wind out of [user.p_them()]"
 		playsound(src, 'sound/weapons/genhit1.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & CLONELOSS)
-		user.adjustCloneLoss(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "damaging your genes"
-		what_happen_to_them += "damaging [user.p_their()] genes"
+		if(is_pow)
+			what_happen_to_you += "shredding your genetics"
+			what_happen_to_them += "shredding [user.p_their()] genetics"
+		else
+			what_happen_to_you += "damaging your genes"
+			what_happen_to_them += "damaging [user.p_their()] genes"
 		playsound(src, 'sound/weapons/ParticleBlaster.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & RADIATIONLOSS)
-		user.rad_act(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "zapping you with radiation"
-		what_happen_to_them += "zapping [user.p_them()] with radiation"
+		user.rad_act(extra_hurt * rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
+		if(is_pow)
+			what_happen_to_you += "just about guaranteeing you'll never have kids"
+			what_happen_to_them += "nuking [user.p_them()] in a sickly green glow"
+		else
+			what_happen_to_you += "zapping you with radiation"
+			what_happen_to_them += "zapping [user.p_them()] with radiation"
 		playsound(src, 'sound/weapons/resonator_blast.ogg', 50, 1)
 	if(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & EMPLOSS)
-		user.emp_act(rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
-		what_happen_to_you += "frying you with EMP"
-		what_happen_to_them += "frying [user.p_them()] with EMP"
+		user.emp_act(extra_hurt * rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]))
+		if(is_pow)
+			what_happen_to_you += "frying the daylights out of you with EMP"
+			what_happen_to_them += "frying [user.p_them()] with EMP"
+		else
+			what_happen_to_you += "frying you with EMP"
+			what_happen_to_them += "frying [user.p_them()] with EMP"
 		playsound(src, 'sound/weapons/ZapBang.ogg', 50, 1)
 	var/you_are_so_lucky = span_warning("[src] misfires, [english_list(what_happen_to_you)]!")
 	var/god_i_wish_i_was_them = span_alert("[user]'s [src] misfires, [english_list(what_happen_to_them)]!")
@@ -1358,14 +1401,34 @@ ATTACHMENTS
 	playsound(
 		user,
 		fire_sound,
-		gun_sound_properties[SOUND_PROPERTY_VOLUME] * 2,
+		gun_sound_properties[SOUND_PROPERTY_VOLUME] * extra_hurt * 2,
 		gun_sound_properties[SOUND_PROPERTY_VARY],
-		gun_sound_properties[SOUND_PROPERTY_NORMAL_RANGE] * 2,
+		gun_sound_properties[SOUND_PROPERTY_NORMAL_RANGE] * extra_hurt * 2,
 		ignore_walls = gun_sound_properties[SOUND_PROPERTY_IGNORE_WALLS],
-		distant_sound = gun_sound_properties[SOUND_PROPERTY_DISTANT_SOUND] * 2,
-		distant_range = gun_sound_properties[SOUND_PROPERTY_DISTANT_SOUND_RANGE] * 2
+		distant_sound = gun_sound_properties[SOUND_PROPERTY_DISTANT_SOUND] * extra_hurt * 2,
+		distant_range = gun_sound_properties[SOUND_PROPERTY_DISTANT_SOUND_RANGE] * extra_hurt * 2
 		)
 	return TRUE
+
+/obj/item/gun/proc/hurt_the_holder(mob/living/user, extra_hurt, dmg_divisor)
+	if(dmg_divisor <= 0)
+		dmg_divisor = 1
+	var/damage = rand(misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_LOW], misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_HIGH]) * extra_hurt
+	var/obj/item/bodypart/affecting = user.get_bodypart(ran_zone(user.get_active_hand()))
+	if(!affecting)
+		affecting = user.get_bodypart(BODY_ZONE_CHEST)
+	var/armor = user.run_armor_check(affecting, "melee")
+	var/dt = max(user.run_armor_check(affecting, "damage_threshold"), 0)
+	user.apply_damages(
+		misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & BRUTELOSS ? damage / dmg_divisor : 0,
+		misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & FIRELOSS ? damage / dmg_divisor : 0,
+		misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & TOXLOSS ? damage / dmg_divisor : 0,
+		misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & OXYLOSS ? damage / dmg_divisor : 0,
+		misfire_possibilities[GUN_MF_HURTS_YOU][GUN_MF_HURTS_YOU_DAMAGE_TYPE] & CLONELOSS ? damage / dmg_divisor : 0,
+		def_zone = affecting,
+		blocked = armor,
+		damagethreshold = dt
+	)
 
 GLOBAL_LIST_INIT(gun_yeet_words, list(
 	"prefix" = list(
@@ -1396,7 +1459,7 @@ GLOBAL_LIST_INIT(gun_yeet_words, list(
 	)
 ))
 
-/obj/item/gun/proc/misfire_dump_ammo(mob/user)
+/obj/item/gun/proc/misfire_dump_ammo(mob/user, dump_harder)
 	if(!user)
 		return FALSE
 	
@@ -1405,7 +1468,7 @@ GLOBAL_LIST_INIT(gun_yeet_words, list(
 	if(istype(src, /obj/item/gun/energy))
 		var/obj/item/gun/energy/zappergun = src
 		thing_2_yeet = zappergun.cell
-		if(zappergun.eject_cell(user, FALSE, FALSE))
+		if(!zappergun.eject_cell(user, FALSE, FALSE))
 			thing_2_yeet = null
 	else if(istype(src, /obj/item/gun/ballistic))
 		var/obj/item/gun/ballistic/gungun = src
@@ -1419,36 +1482,71 @@ GLOBAL_LIST_INIT(gun_yeet_words, list(
 	var/falls_or_flies = "falls"
 	if(prob(misfire_possibilities[GUN_MF_DUMP][GUN_MF_DUMP_THROW]))
 		falls_or_flies = "flies"
-		var/turf/throw_it_here = get_ranged_target_turf(get_turf(src), pick(GLOB.alldirs), rand(1,6), 3)
+		var/turf/throw_it_here = get_ranged_target_turf(get_turf(src), pick(GLOB.alldirs), rand(1,6) * dump_harder, 3 * dump_harder)
 		if(!isturf(throw_it_here))
 			return FALSE
-		thing_2_yeet.throw_at(throw_it_here, 10, rand(1,3))
+		thing_2_yeet.throw_at(throw_it_here, 10 * dump_harder, rand(1,3) * dump_harder)
 	user.visible_message(
 		span_alert("[user]'s [thing_2_yeet] [falls_or_flies] out of [user.p_their()] [src] like \a [pick(GLOB.gun_yeet_words["prefix"])] [pick(GLOB.gun_yeet_words["suffix"])]!")
 		)
 	playsound(src, "sound/f13weapons/garand_ping.ogg", 70, 1)
 	return TRUE
 
-/obj/item/gun/proc/misfire_yeet_gun(mob/user)
+/obj/item/gun/proc/misfire_yeet_gun(mob/user, throw_harder)
 	if(!user)
 		return FALSE
 	
 	user.dropItemToGround(src)
-	var/turf/throw_it_here = get_ranged_target_turf(get_turf(src), pick(GLOB.alldirs), rand(1,6), 3)
+	var/turf/throw_it_here = get_ranged_target_turf(get_turf(src), pick(GLOB.alldirs), rand(1,6) * throw_harder, 3 * throw_harder)
 	if(!isturf(throw_it_here))
 		return FALSE
-	src.throw_at(throw_it_here, 10, rand(1,3))
+	src.throw_at(throw_it_here, 10 * throw_harder, rand(1,3) * throw_harder)
 	user.visible_message(
 		span_alert("[user]'s [src] flies out of [user.p_their()] grip like \a [pick(GLOB.gun_yeet_words["prefix"])] [pick(GLOB.gun_yeet_words["suffix"])]!")
 		)
 	playsound(src, "sound/weapons/punchmiss.ogg", 100, 1)
 	return TRUE
 
+/obj/item/storage/backpack/debug_gun_hobo
+	name = "Bag of Gunstuff 4 hobos"
+	desc = "Cool shit for testing various guns!"
+
+/obj/item/storage/backpack/debug_gun_hobo/PopulateContents()
+	. = ..()
+	new /obj/item/screwdriver/abductor(src)
+	new /obj/item/crowbar/abductor(src)
+	new /obj/item/weldingtool/advanced(src)
+	new /obj/item/stack/crafting/metalparts/five(src)
+	new /obj/item/gun_upgrade/scope/watchman(src)
+	new /obj/item/gun_upgrade/muzzle/silencer(src)
+	new /obj/item/melee/onehanded/knife/bayonet(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/gun/ballistic/automatic/autopipe(src)
+	new /obj/item/gun/ballistic/revolver/hobo/piperifle(src)
+	new /obj/item/gun/ballistic/revolver/winchesterrebored(src)
+	new /obj/item/gun/ballistic/automatic/hobo/zipgun(src)
+	new /obj/item/ammo_box/magazine/zipgun(src)
+	new /obj/item/gun/ballistic/revolver/hobo/knucklegun(src)
+	new /obj/item/gun/ballistic/revolver/hobo/knifegun(src)
+	new /obj/item/gun/ballistic/revolver/hobo/single_shotgun(src)
+	new /obj/item/ammo_box/m5mmbox(src)
+	new /obj/item/ammo_box/a762box(src)
+	new /obj/item/ammo_box/a762box(src)
+	new /obj/item/ammo_box/a50MGbox(src)
+	new /obj/item/ammo_box/shotgun/slug(src)
+	new /obj/item/ammo_box/shotgun/buck(src)
+	new /obj/item/ammo_box/shotgun/improvised(src)
+	new /obj/item/ammo_box/m22(src)
+	new /obj/item/ammo_box/c9mm(src)
+	new /obj/item/ammo_box/c10mm(src)
+	new /obj/item/ammo_box/m44(src)
+	new /obj/item/ammo_box/m14mm(src)
+
 /obj/item/storage/backpack/debug_gun_kitauto
 	name = "Bag of Gunstuff"
 	desc = "Cool shit for testing various guns!"
 
-/obj/item/storage/backpack/debug_gun_kit/PopulateContents()
+/obj/item/storage/backpack/debug_gun_kitauto/PopulateContents()
 	. = ..()
 	new /obj/item/screwdriver/abductor(src)
 	new /obj/item/crowbar/abductor(src)
@@ -1632,7 +1730,7 @@ ATTACHING SLING
 HOOK GUN CODE. Bizarre but could be made into something useful.
 /obj/item/gun/ballistic/shotgun/doublebarrel/hook
 	name = "hook modified sawn-off shotgun"
-	desc = "Range isn't an issue when you can bring your victim to you."
+	desc = "Range isn't an issue when you can bring your user to you."
 	icon_state = "hookshotgun"
 	item_state = "shotgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/bounty

--- a/code/modules/projectiles/guns/hoboguns.dm
+++ b/code/modules/projectiles/guns/hoboguns.dm
@@ -3,7 +3,7 @@
 
 
 /obj/item/gun/ballistic/automatic/hobo
-	slowdown = 0.3
+	slowdown = GUN_SLOWDOWN_PISTOL_LIGHT
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -14,7 +14,7 @@
 	)
 
 /obj/item/gun/ballistic/revolver/hobo
-	slowdown = 0.2
+	slowdown = GUN_SLOWDOWN_PISTOL_MEDIUM
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -25,7 +25,7 @@
 	)
 
 /obj/item/gun/ballistic/rifle/hobo
-	slowdown = 0.4
+	slowdown = GUN_SLOWDOWN_PISTOL_MEDIUM
 	icon = 'icons/fallout/objects/guns/energy.dmi'
 	gun_tags = list(GUN_SCOPE)
 	can_scope = TRUE
@@ -66,10 +66,9 @@
 	icon_state = "zipgun"
 	desc = "A clever little makeshift pistol, one of the few easily-constructed firearms that accept more rounds than it has barrels. \
 		Light, compact, and packing a surprising punch, the zip gun serves as a waster's insurance policy when doing business, \
-		small enough to whip out of a coat when someone doesn't feel like paying for your raccoon pelts. <br><br> \
-		A brave, enterprising waster can change what this gun fires! Simply " + span_notice("unscrew") + " the bolts, " + span_notice("insert") + " \
-		some metal parts into the breech block, " + span_notice("weld") + " it until its good and soft, and then " + span_notice("insert") + " a new \
-		casing in there. Be sure to unload it first!"
+		small enough to whip out of a coat when someone doesn't feel like paying for your raccoon pelts. \
+		A brave, enterprising waster can stuff just about anything into the improvised clipazine, though anything more powerful \
+		than a handloaded 9mm round will run the risk of voiding the warranty on your fingers."
 	item_state = "gun"
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -89,8 +88,9 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	prefered_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_SURPLUS
 	misfire_possibilities = list(
-		GUN_MISFIRE_HURTS_USER(1, 5, 15, BRUTELOSS),
+		GUN_MISFIRE_HURTS_USER(5, 5, 15, BRUTELOSS),
 		GUN_MISFIRE_THROWS_GUN(2),
 		GUN_MISFIRE_UNLOADS_GUN(0.5, 50)
 	)
@@ -137,6 +137,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	prefered_power = CASING_POWER_LIGHT_RIFLE * CASING_POWER_MOD_HANDLOAD
 	misfire_possibilities = list(
 		GUN_MISFIRE_HURTS_USER(5, 15, 25, BRUTELOSS | FIRELOSS | OXYLOSS),
 		GUN_MISFIRE_THROWS_GUN(0.5),
@@ -182,6 +183,7 @@
 		SEMI_AUTO_NODELAY,
 		list(mode_name="Fire all barrels", mode_desc = "Fire all four barrels at once", automatic = 0, burst_size=4, fire_delay=15, icon="burst", burst_shot_delay = 0.1)
 	)
+	prefered_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_HANDLOAD
 	misfire_possibilities = list(
 		GUN_MISFIRE_HURTS_USER(5, 15, 25, BRUTELOSS | FIRELOSS | OXYLOSS),
 		GUN_MISFIRE_THROWS_GUN(0.5),
@@ -205,7 +207,7 @@
 	desc = "A heavy home-run worthy baseball bat bolted onto the side of a sturdy slam-fire shotgun barrel thing. \
 		While the bat itself would make for a poor, painful stock, the trigger plate on the other side of the bat \
 		would suggest that, yes, it'll likely shoot someone if you hit them with it. Hopefully that someone isn't you. \
-		Also doubles as a pipebomb when you least expect it."
+		Also doubles as a pipebomb when you least expect it. Especially if you stick a .50 MG round in there. Which you totally can do."
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
@@ -215,6 +217,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 
+	added_spread = 5 // its a melee weapon lol
 	slowdown = GUN_SLOWDOWN_RIFLE_LIGHT_SEMI
 	force = GUN_MELEE_FORCE_RIFLE_HEAVY
 	weapon_weight = GUN_ONE_HAND_ONLY
@@ -223,16 +226,17 @@
 	autofire_shot_delay = GUN_AUTOFIRE_DELAY_SLOW
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_SLOWER
 	burst_size = 1
-	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	damage_multiplier = GUN_EXTRA_DAMAGE_T2
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(3.1)
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
+	prefered_power = CASING_POWER_SHOTGUN * CASING_POWER_MOD_SURPLUS // can fire handloadeds fine, everything else has *a price~*
 	misfire_possibilities = list(
-		GUN_MISFIRE_HURTS_USER(5, 15, 25, BRUTELOSS | FIRELOSS | OXYLOSS),
-		GUN_MISFIRE_THROWS_GUN(5),
+		GUN_MISFIRE_HURTS_USER(20, 15, 15, BRUTELOSS | FIRELOSS | OXYLOSS),
+		GUN_MISFIRE_THROWS_GUN(30),
 		GUN_MISFIRE_UNLOADS_GUN(5, 50)
 	)
 
@@ -278,6 +282,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	prefered_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_SURPLUS // very likely to explode, cept with 9mm and 38
 	misfire_possibilities = list(
 		GUN_MISFIRE_HURTS_USER(5, 5, 10, BRUTELOSS | FIRELOSS),
 		GUN_MISFIRE_THROWS_GUN(10),
@@ -321,6 +326,7 @@
 	init_firemodes = list(
 		list(mode_name="Fire all barrels", mode_desc = "Fire all four barrels at once", automatic = 0, burst_size=4, fire_delay=15, icon="burst", burst_shot_delay = 0.1)
 	)
+	prefered_power = CASING_POWER_LIGHT_PISTOL * CASING_POWER_MOD_SURPLUS // very likely to explode, cept with 9mm and 38
 	misfire_possibilities = list(
 		GUN_MISFIRE_HURTS_USER(1, 10, 25, BRUTELOSS | FIRELOSS),
 		GUN_MISFIRE_THROWS_GUN(5),
@@ -448,7 +454,7 @@
 
 /obj/item/gun/ballistic/automatic/hobo/destroyer
 	name = "destroyer carbine"
-	desc = "There are many ways to describe this, very few of them nice. This is a 9mm silenced bolt action rifle - that via the expertise of a gun runner mainlining 50 liters of psycho, mentats, and turbo - has been converted into a semi auto."
+	desc = "There are many ways to describe this, very few of them nice. This is a .45ACP silenced bolt action rifle - that via the expertise of a gun runner mainlining 50 liters of psycho, mentats, and turbo - has been converted into a semi auto."
 	icon_state = "destroyer-carbine"
 	item_state = "varmintrifle"
 	mag_type = /obj/item/ammo_box/magazine/greasegun
@@ -539,6 +545,7 @@
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY
 	)
+	prefered_power = CASING_POWER_MEDIUM_RIFLE * CASING_POWER_MOD_SURPLUS
 
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'


### PR DESCRIPTION
## About The Pull Request

Zipgun no longer can have its magazine caliber changed. Instead, it supports multiple casings by default.

Autopipe can take a few more calibers.

Piperifle and rebored can be made to take 40mm grenades.

Knucklegun and knifegun can take a few different calibers.

Shotgun bat can also accept .50MG.

Scaled misfire damage and chance to how much heavier the casing is compared to what it normally shoots. So, smaller than the casing it comes with will never misfire, and bigger will misfire a lot more.

Misfire damage is lessened by armor. It does melee damage.