### PR TITLE
Makes lickhealing better

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -553,16 +553,14 @@ GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	var/obj/item/organ/tongue/our_tongue = human_holder.getorganslot(ORGAN_SLOT_TONGUE)
 	if(!our_tongue)
 		return //welp
-	our_tongue.lick_heal_brute = 1
-	our_tongue.lick_heal_burn = 1
+	our_tongue.initialize_lickpack(/obj/item/stack/medical/bruise_pack/lick)
 
 /datum/quirk/lick_heal/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/organ/tongue/our_tongue = human_holder.getorganslot(ORGAN_SLOT_TONGUE)
 	if(!our_tongue)
 		return //welp
-	our_tongue.lick_heal_brute = 0
-	our_tongue.lick_heal_burn = 0
+	QDEL_NULL(our_tongue.lick_healer)
 
 /datum/quirk/lick_bandage
 	name = "Sanguine Saliva"

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -156,46 +156,13 @@
 	if(!iscarbon(licked))
 		return FALSE
 	var/obj/item/organ/tongue/our_tongue = user.getorganslot(ORGAN_SLOT_TONGUE)
-	if(!our_tongue.lick_heal_brute && !our_tongue.lick_heal_burn)
+	if(!istype(our_tongue))
 		return FALSE
-	var/mob/living/carbon/mlemmed = licked
-	var/obj/item/bodypart/target_bodypart = mlemmed.get_bodypart(user.zone_selected)
-	if(!target_bodypart)
+	var/obj/item/stack/medical/tongue_healer = our_tongue.lick_healer
+	if(!istype(tongue_healer))
 		return FALSE
-	if(target_bodypart.status != BODYPART_ORGANIC)
-		return FALSE
-	if(target_bodypart.brute_dam <= 0 && target_bodypart.burn_dam <= 0 && target_bodypart.stamina_dam <= 0)
-		return FALSE
-	licking = TRUE
-	user.visible_message(
-		span_notice("[user] starts tenderly licking the injuries on [user == mlemmed ? "[mlemmed.p_their()]" : "[mlemmed]'s"] [target_bodypart.name]..."), 
-		span_notice("You start tenderly licking at the injuries on [user == mlemmed ? "your" : "[mlemmed]'s"] [target_bodypart.name]..."),
-		span_notice("You hear licking."),
-		LICK_SOUND_TEXT_RANGE
-		)
 	lick_flavor(atom_licked = licked, licker = user)
-	if(!do_mob(user, mlemmed, (user == mlemmed ? 7 SECONDS : 3 SECONDS), progress = TRUE))
-		user.visible_message(span_alert("[user] was interrupted!"))
-		licking = FALSE
-		return LICK_CANCEL
-	licking = FALSE
-	if(QDELETED(our_tongue))
-		user.visible_message(span_notice("[user]'s tongue went missing!"))
-		return LICK_CANCEL
-	target_bodypart.heal_damage(
-		our_tongue.lick_heal_brute,
-		our_tongue.lick_heal_burn,
-		our_tongue.lick_heal_brute + our_tongue.lick_heal_burn,
-		FALSE,
-		TRUE,
-		TRUE,
-		0)
-	user.visible_message(
-		span_green("[user] licks the injuries on [user == mlemmed ? "[mlemmed.p_their()]" : "[mlemmed]'s"] [target_bodypart.name]!"), 
-		span_green("You lick the injuries on [user == mlemmed ? "your" : "[mlemmed]'s"] [target_bodypart.name]!"),
-		span_notice("You hear licking."),
-		LICK_SOUND_TEXT_RANGE)
-	lick_flavor(atom_licked = licked, licker = user)
+	tongue_healer.attack(licked, user)
 	return TRUE
 
 /obj/item/hand_item/licker/proc/get_lick_words(mob/living/carbon/user)

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -173,9 +173,9 @@
 	name = "Bar"
 	icon_state = "bar"
 	ambience_area = list(
-		/datum/looping_sound/ambient/radiomusic,
-		/datum/looping_sound/ambient/radiostatic,
-		/datum/looping_sound/ambient/djswampass,
+		///datum/looping_sound/ambient/radiomusic,
+		///datum/looping_sound/ambient/radiostatic,
+		///datum/looping_sound/ambient/djswampass,
 		/datum/looping_sound/ambient/town,
 		/datum/looping_sound/ambient/woodcreak,
 	)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -35,6 +35,8 @@
 	var/lick_heal_burn
 	/// What kind of bandage is applied by licking someone
 	var/obj/item/stack/medical/gauze/lick_bandage
+	/// What kind of healpack is applied by licking someone
+	var/obj/item/stack/medical/bruise_pack/lick_healer
 
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()
@@ -49,17 +51,28 @@
 	languages_possible = languages_possible_base
 	if(lick_bandage) // ew
 		initialize_bandage(lick_bandage)
+	if(lick_healer) // ew
+		initialize_lickpack(lick_healer)
 
 /obj/item/organ/tongue/Destroy()
 	. = ..()
 	if(istype(lick_bandage))
 		QDEL_NULL(lick_bandage)
+	if(istype(lick_healer))
+		QDEL_NULL(lick_healer)
 
 /// Makes a tongue have a bandage in it, so it can lick wounds and apply some kind of bandage
 /obj/item/organ/tongue/proc/initialize_bandage(obj/item/stack/medical/gauze/lick_gauze)
 	if(!lick_gauze)
 		return FALSE
 	lick_bandage = new lick_gauze(src)
+	return TRUE
+
+/// Makes a tongue have a bandage in it, so it can lick wounds and apply some kind of bandage
+/obj/item/organ/tongue/proc/initialize_lickpack(obj/item/stack/medical/bruise_pack/lick_pack)
+	if(!lick_pack)
+		return FALSE
+	lick_healer = new lick_pack(src)
 	return TRUE
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args) //this wont proc unless there's initial_accents on the tongue


### PR DESCRIPTION
## About The Pull Request

Lickhealing is faster, and loops for the damage healing stuff.

Adds support for medical items playing a sound when starting and ending use.

Removes music from the bar, pending moving it to the jukebox.