### PR TITLE
Fixes wierdness in emotes

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -102,3 +102,5 @@
 #define EMOTE_MESSAGE (1<<0)
 // Only show the overhead thing
 #define ONLY_OVERHEAD (1<<1)
+// Append the player's name to the front
+#define PUT_NAME_IN (1<<2)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -81,16 +81,14 @@
 
 	var/message_flags = (only_overhead ? (EMOTE_MESSAGE | ONLY_OVERHEAD) : (EMOTE_MESSAGE))
 
-	if(omit_left_name)
-		msg = "<span class='emote'>[msg]</span>"
-	else
-		msg = "<span class='emote'><b>[user]</b> [msg]</span>"
-
+	msg = "<span class='emote'>[msg]</span>"
+	if(!omit_left_name)
+		ENABLE_BITFIELD(message_flags, PUT_NAME_IN)
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = message_flags)
+		user.audible_message(msg, deaf_message = msg, audible_message_flags = message_flags)
 	else
-		user.visible_message(msg, blind_message = intentional ? "<b>[user]</b> [msg]" : "<span class='emote'>You hear how <b>[user]</b> [msg]</span>", visible_message_flags = message_flags)
+		user.visible_message(msg, blind_message = msg, visible_message_flags = message_flags)
 
 
 /// Sends the given emote message for all ghosts with ghost sight enabled, excluding close enough to listen normally.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -151,6 +151,8 @@
 		else if(T.lighting_object && T.lighting_object.invisibility <= target.see_invisible && T.is_softly_lit() && !in_range(T,target))
 			msg = blind_message
 		if(msg && !CHECK_BITFIELD(visible_message_flags, ONLY_OVERHEAD))
+			if(CHECK_BITFIELD(visible_message_flags, PUT_NAME_IN))
+				msg = "<b>[src]</b> [msg]"
 			target.show_message(msg, MSG_VISUAL,blind_message, MSG_AUDIBLE)
 	if(self_message)
 		hearers -= src
@@ -171,6 +173,8 @@
 			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = visible_message_flags)
 
 		if(msg && !CHECK_BITFIELD(visible_message_flags, ONLY_OVERHEAD))
+			if(CHECK_BITFIELD(visible_message_flags, PUT_NAME_IN))
+				msg = "<b>[src]</b> [msg]"
 			M.show_message(msg, MSG_VISUAL, blind_message, MSG_AUDIBLE)
 
 ///Adds the functionality to self_message.
@@ -201,6 +205,8 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 	if(self_message)
 		hearers -= src
 	var/raw_msg = message
+	if(CHECK_BITFIELD(audible_message_flags, PUT_NAME_IN))
+		message = "<b>[src]</b> [message]"
 	//if(audible_message_flags & EMOTE_MESSAGE)
 	//	message = "<span class='emote'><b>[src]</b> [message]</span>"
 	for(var/mob/M in hearers)


### PR DESCRIPTION
## About The Pull Request

No more doubling your name in blind/deaf emotes.

In fact, blind/deaf emotes show up the same as if you werent blind or deaf. just pretend you're blind/deaf.

Overhead emotes no longer include your name, unless you put an @ in the emote. Then it'll show your name where the @ is.