### PR TITLE
Re-adds Druid's and Shaman's roundstart traits.

### DIFF
--- a/code/modules/jobs/job_types/tribals.dm
+++ b/code/modules/jobs/job_types/tribals.dm
@@ -164,14 +164,13 @@ Tribal Shaman
 		),
 	)
 
-/*
+
 /datum/outfit/job/tribal/f13shaman/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 	ADD_TRAIT(H, TRAIT_SPIRITUAL, src)
-*/
+
 
 /datum/outfit/job/tribal/f13shaman
 	name = "Shaman"
@@ -309,14 +308,15 @@ Druid
 		),
 	)
 
-/*
+
 /datum/outfit/job/tribal/f13druid/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_SPIRITUAL, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_LOW, src)
-*/
+	ADD_TRAIT(H, TRAIT_MACHINE_SPIRITS, src)
+
 
 /datum/outfit/job/tribal/f13druid
 	name = "Druid"


### PR DESCRIPTION
This is just to give Druid's their surgery and primative tech traits as well as giving the Druid and Shaman their Spiritual Traits.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: Gave back druids and shamans some roundstart traits back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
