### PR TITLE
lets humans speak through their pipboy's radio by using the normal radio prefix

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -69,7 +69,7 @@
 		return
 
 	var/obj/item/R //Our radio. Uses the generic /obj/item just in case someone is wearing a non-radio in the ear slot.
-	if(ears)
+	if(ears && istype(ears, /obj/item/radio))//Prioritize headsets first.
 		R = ears
 	else if(gloves && istype(gloves, /obj/item/pda))//Are we wearing a pipboy on our hands?
 		var/obj/item/pda/P = gloves
@@ -77,6 +77,8 @@
 	else if(wear_id && istype(wear_id, /obj/item/pda))//Are we wearing a pipboy in the ID slot?
 		var/obj/item/pda/P = wear_id
 		R = P.radio
+	else if(ears)//Fallback to using a non-radio object on the player's ear.
+		R = ears
 
 	switch(message_mode)
 		if(MODE_HEADSET)


### PR DESCRIPTION
prioritizes a headset if you're wearing one

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Pipboy radios can now be spoken through by using the usual ; prefix so long as it's being worn on your wrists or your PDA slot. If you're wearing a headset, you'll use that instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
