### PR TITLE
Fixes an overlapping recipe on anvils

### DIFF
--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -33,7 +33,7 @@
 #define RECIPE_UNITOOL "bbu"  //bend bend upset
 
 //Legion specific
-#define RECIPE_LANCE "dbdf" //draw bend fold fold
+#define RECIPE_LANCE "ddfp" //draw draw fold punch
 #define RECIPE_GLADIUS "fbf" //fold bend fold
 #define RECIPE_SPATHA "ffbf" // fold fold bend fold
 #define RECIPE_WARHONED "udup" //upset draw upset punch


### PR DESCRIPTION
This is just a simple change to make the throwing spear and lance recipes not overlap.

## About The Pull Request
I made this to hopefully resolve the overlapping recipe between the throwing spear and lance. This is literally my first ever PR and I'm just winging it. I changed one line of forging, so hopefully it does not require a local test.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changed the lance recipe to make it actually produceable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
