### PR TITLE
Minor fixes and additions to Nash and the tribal camp

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1048,7 +1048,8 @@
 /obj/item/stack/rods,
 /obj/structure/stone_tile/slab,
 /obj/structure/table/reinforced{
-	color = "#3c2c21"
+	color = "#3c2c21";
+	max_integrity = 1000000
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal)
@@ -9928,6 +9929,13 @@
 /obj/structure/flora/twig2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"mlp" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/f13/wasteland)
 "mnK" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -10431,6 +10439,8 @@
 	dir = 8;
 	light_color = "#f4e3b0"
 	},
+/obj/item/key,
+/obj/item/lock_construct,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "mRK" = (
@@ -11227,6 +11237,10 @@
 /obj/structure/flora/tree/oak_four,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nRo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/blue,
+/area/f13/wasteland)
 "nRq" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -15898,7 +15912,7 @@
 /obj/structure/simple_door/room{
 	name = "Heaven's Night"
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/carpet/blue,
 /area/f13/bar)
 "ubO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17674,6 +17688,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"wNZ" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel/cult,
+/area/f13/building/tribal)
 "wOa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -19076,7 +19094,7 @@ lvU
 mRK
 sRu
 sRu
-sRu
+mlp
 uHi
 vfM
 gYZ
@@ -19570,7 +19588,7 @@ qgz
 qgz
 qgz
 qgz
-mzi
+wNZ
 qgz
 qgz
 pzp
@@ -23417,7 +23435,7 @@ aUi
 aUi
 bYj
 aUi
-aUi
+nRo
 bYj
 yhg
 gHi

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -64899,7 +64899,8 @@
 /obj/item/stack/rods,
 /obj/structure/stone_tile/slab,
 /obj/structure/table/reinforced{
-	color = "#3c2c21"
+	color = "#3c2c21";
+	max_integrity = 1000000
 	},
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#999999"
@@ -83668,7 +83669,8 @@
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/item/stack/rods,
 /obj/structure/table/reinforced{
-	color = "#3c2c21"
+	color = "#3c2c21";
+	max_integrity = 1000000
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"


### PR DESCRIPTION
Fixes an errant desert tile under the upper Heaven's Night
Gives the Tribal Chief a lockable door as well as a key and lock.

## About The Pull Request
More minor map fixes

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Fixed some map issues and gave the tribal Chief a lockable door with key and lock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
