### PR TITLE
New tribal items added to Sacred well.

### DIFF
--- a/modular_coyote/code/game/objects/structures/sacredwell.dm
+++ b/modular_coyote/code/game/objects/structures/sacredwell.dm
@@ -48,7 +48,13 @@ GLOBAL_LIST_INIT(sacredwellitems_high, typecacheof(list(/obj/item/gun/energy/las
 				/obj/item/gun/energy/laser/wattz/sacredpistol,
 				/obj/item/gun/energy/laser/wattz/sacred,
 				/obj/item/gun/energy/laser/wattz2k/extended/blessed,
-				/obj/item/gun/ballistic/shotgun/automatic/combat/auto5/sacred)
+				/obj/item/gun/ballistic/shotgun/automatic/combat/auto5/sacred,
+				/obj/item/gun/ballistic/automatic/smg/tommygun/whitelegs,
+				/obj/item/gun/ballistic/bow/claw,
+				/obj/item/gun/ballistic/bow/sturdy,
+				/obj/item/gun/ballistic/bow/silver,
+				/obj/item/clothing/suit/armor/medium/tribal/tribe_heavy_armor,
+				/obj/item/clothing/suit/armor/medium/tribal)
 
 // sacred items
 


### PR DESCRIPTION
I added a few items to the sacred well list, namely bows, the stormdrum and some regular tribal outfits. So they don't geep getting the same three items over and over.

## About The Pull Request
I was sick of seeing the tribals constantly get the same three items over and over. I decided to change that, I added two tribal armours (One medium, one heavy.), Three bows and a ballistic weapon in the form of the stormdrum. (Considering tribal wastelanders can just spawn with one with the right loadout, I see no harm in them getting something.)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
add: Added new things; Three bows, one SMG and two armours.
/:cl:

