### PR TITLE
Removes broken synth race

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -468,7 +468,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES silver
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
-ROUNDSTART_RACES synth
+#ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton


### PR DESCRIPTION
Simple change to disable the race Synthetic in the character menu. This DOES NOT affect the Synthetic Lizardperson race, nor does it affect or remove any underlying code for the Synthetics.

## About The Pull Request
<!-- Write here -->
The race 'Synthetic' is currently totally broken with invisible sprites, no Species Markings, disabled genitals, etc. This simply removes the broken race as a QOL patchfix until such time in the future as the race's code issues get actually addressed.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
config: Disables Synthetic race in Setup Character menu's Species Selection list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
