### PR TITLE
Adding Alchemy Table as a tool define

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -34,6 +34,7 @@
 #define TOOL_AWORKBENCH     "advanced workbench"
 #define TOOL_LOOM			"Loom"
 #define TOOL_CHEMMASTER		"ChemMaster / refinery"
+#define TOOL_ALCHEMYTABLE   "Alchemy Table"
 //
 #define TOOL_GUNTIER1		"Guns and Bullets: Part 1"
 #define TOOL_GUNTIER2		"Guns and Bullets: Part 2"


### PR DESCRIPTION
This is groundwork for making primal medicine not need a workbench, instead using a thematic alchemy table.

I'm still working out how github works, this whole thing confuses me.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Added "TOOL_ALCHEMY_TABLE" for crafting with primitive alchemy table.
/:cl:

