### PR TITLE
Tribal guns, access and crafting.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -661,8 +661,8 @@
 	subcategory = CAT_WEAPON
 	always_available = FALSE
 	
-//Coyote Repeater
-/datum/crafting_recipe/CoyoteRepeater
+//coyote repeater
+/datum/crafting_recipe/coyoterepeater
 	name = "Coyote Repeater"
 	result = /obj/item/gun/ballistic/rifle/repeater/cowboy/tribal
 	reqs = list(/obj/item/gun/ballistic/rifle/repeater/cowboy,
@@ -674,8 +674,8 @@
 	subcategory = CAT_WEAPON
 	always_available = TRUE
 
-//Rainstick
-/datum/crafting_recipe/Rainstick
+//rainstick
+/datum/crafting_recipe/rainstick
 	name = "Rainstick"
 	result = /obj/item/gun/ballistic/rifle/repeater/trail/tribal
 	reqs = list(/obj/item/gun/ballistic/rifle/repeater/trail,
@@ -688,8 +688,8 @@
 	subcategory = CAT_WEAPON
 	always_available = TRUE
 	
-//MedicineStick
-/datum/crafting_recipe/MedicineStick
+//medicinestick
+/datum/crafting_recipe/medicinestick
 	name = "Medicine Stick"
 	result = /obj/item/gun/ballistic/rifle/repeater/brush/tribal
 	reqs = list(/obj/item/gun/ballistic/rifle/repeater/brush,
@@ -703,8 +703,8 @@
 	subcategory = CAT_WEAPON
 	always_available = TRUE
 	
-//SmellTheRoses
-/datum/crafting_recipe/SmellTheRoses
+//smelltheroses
+/datum/crafting_recipe/smelltheroses
 	name = "Smell-The-Roses"
 	result = /obj/item/gun/ballistic/rifle/repeater/ranger/tribal
 	reqs = list(/obj/item/gun/ballistic/rifle/repeater/ranger,
@@ -717,8 +717,8 @@
 	subcategory = CAT_WEAPON
 	always_available = TRUE
 	
-//MourningSunrise
-/datum/crafting_recipe/MourningSunrise
+//mourningsunrise
+/datum/crafting_recipe/mourningsunrise
 	name = "Mourning Sunrise"
 	result = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
 	reqs = list(/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever,

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -660,6 +660,77 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 	always_available = FALSE
+	
+//Coyote Repeater
+/datum/crafting_recipe/CoyoteRepeater
+	name = "Coyote Repeater"
+	result = /obj/item/gun/ballistic/rifle/repeater/cowboy/tribal
+	reqs = list(/obj/item/gun/ballistic/rifle/repeater/cowboy,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/bone = 4)
+	tools = list(TOOL_ALCHEMY_TABLE)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = TRUE
+
+//Rainstick
+/datum/crafting_recipe/Rainstick
+	name = "Rainstick"
+	result = /obj/item/gun/ballistic/rifle/repeater/trail/tribal
+	reqs = list(/obj/item/gun/ballistic/rifle/repeater/trail,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/bone = 3,
+				/obj/item/grown/rose = 1)
+	tools = list(TOOL_ALCHEMY_TABLE)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = TRUE
+	
+//MedicineStick
+/datum/crafting_recipe/MedicineStick
+	name = "Medicine Stick"
+	result = /obj/item/gun/ballistic/rifle/repeater/brush/tribal
+	reqs = list(/obj/item/gun/ballistic/rifle/repeater/brush,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/bone = 2,
+				/obj/item/grown/rose = 1,
+				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 1)
+	tools = list(TOOL_ALCHEMY_TABLE)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = TRUE
+	
+//SmellTheRoses
+/datum/crafting_recipe/SmellTheRoses
+	name = "Smell-The-Roses"
+	result = /obj/item/gun/ballistic/rifle/repeater/ranger/tribal
+	reqs = list(/obj/item/gun/ballistic/rifle/repeater/ranger,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/bone = 2,
+				/obj/item/grown/rose = 1)
+	tools = list(TOOL_ALCHEMY_TABLE)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = TRUE
+	
+//MourningSunrise
+/datum/crafting_recipe/MourningSunrise
+	name = "Mourning Sunrise"
+	result = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
+	reqs = list(/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/bone = 2,
+				/obj/item/grown/rose = 1,
+				/obj/item/stack/sheet/mineral/wood = 2)
+	tools = list(TOOL_ALCHEMY_TABLE)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_available = TRUE
 
 //varmint rifle
 /datum/crafting_recipe/varmintrifle

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -200,6 +200,45 @@
 		SP_DISTANT_RANGE(RIFLE_MEDIUM_RANGE_DISTANT)
 	)
 /* * * * * * * * * * *
+ * Coyote Repeater
+ * Baseline Repeater Tribal Skin
+ * .357 Magnum
+ * Tribal Only
+ * * * * * * * * * * */
+
+/obj/item/gun/ballistic/rifle/repeater/cowboy/tribal
+	name = "coyote repeater"
+	desc = "A sanctified .357 lever action rifle, bearing a paw print, teeth painted on the handguard and what appears to be a severed paw."
+	icon_state = "cowboyrepeaterT"
+	item_state = "cowboyrepeater"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube357
+
+	slowdown = GUN_SLOWDOWN_REPEATER
+	force = GUN_MELEE_FORCE_RIFLE_LIGHT
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_NORMAL
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	cock_delay = GUN_COCK_RIFLE_BASE
+	init_recoil = RIFLE_RECOIL(3)
+	init_firemodes = list(
+		/datum/firemode/semi_auto/fast
+	)
+	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
+	gun_sound_properties = list(
+		SP_VARY(FALSE),
+		SP_VOLUME(RIFLE_MEDIUM_VOLUME),
+		SP_VOLUME_SILENCED(RIFLE_MEDIUM_VOLUME * SILENCED_VOLUME_MULTIPLIER),
+		SP_NORMAL_RANGE(RIFLE_MEDIUM_RANGE),
+		SP_NORMAL_RANGE_SILENCED(SILENCED_GUN_RANGE),
+		SP_IGNORE_WALLS(TRUE),
+		SP_DISTANT_SOUND(RIFLE_MEDIUM_DISTANT_SOUND),
+		SP_DISTANT_RANGE(RIFLE_MEDIUM_RANGE_DISTANT)
+	)
+/* * * * * * * * * * *
  * Trail Repeater
  * Big Repeater
  * .44 Magnum
@@ -210,6 +249,45 @@
 	name = "trail carbine"
 	desc = "A lever action rifle chambered in .44 Magnum."
 	icon_state = "trailcarbine"
+	item_state = "trailcarbine"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44
+
+	slowdown = GUN_SLOWDOWN_REPEATER
+	force = GUN_MELEE_FORCE_RIFLE_LIGHT
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_SLOW
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	cock_delay = GUN_COCK_RIFLE_BASE
+	init_recoil = RIFLE_RECOIL(3.3)
+	init_firemodes = list(
+		/datum/firemode/semi_auto
+	)
+	fire_sound = 'sound/f13weapons/44mag.ogg'
+	gun_sound_properties = list(
+		SP_VARY(FALSE),
+		SP_VOLUME(RIFLE_MEDIUM_VOLUME),
+		SP_VOLUME_SILENCED(RIFLE_MEDIUM_VOLUME * SILENCED_VOLUME_MULTIPLIER),
+		SP_NORMAL_RANGE(RIFLE_MEDIUM_RANGE),
+		SP_NORMAL_RANGE_SILENCED(SILENCED_GUN_RANGE),
+		SP_IGNORE_WALLS(TRUE),
+		SP_DISTANT_SOUND(RIFLE_MEDIUM_DISTANT_SOUND),
+		SP_DISTANT_RANGE(RIFLE_MEDIUM_RANGE_DISTANT)
+	)
+/* * * * * * * * * * *
+ * Trail Repeater Tribal
+ * Rain Stick
+ * .44 Magnum
+ * Tribal Only
+ * * * * * * * * * * */
+
+/obj/item/gun/ballistic/rifle/repeater/trail/Tribal
+	name = "Rainstick"
+	desc = "A sactified .44 lever action rifle, coated in detailed markings and a carved bead chain that sounds like rain."
+	icon_state = "trailcarbineT"
 	item_state = "trailcarbine"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube44
 
@@ -278,7 +356,46 @@
 		SP_DISTANT_SOUND(RIFLE_HEAVY_DISTANT_SOUND),
 		SP_DISTANT_RANGE(RIFLE_HEAVY_RANGE_DISTANT)
 	)
+/* * * * * * * * * * *
+ * Brush Repeater Tribal
+ * Medicine Stick
+ * .45-70 Bigboy
+ * Tribal Only
+ * * * * * * * * * * */
 
+/obj/item/gun/ballistic/rifle/repeater/brush/Tribal
+	name = "Medicine Stick"
+	desc = "A heavy .45-70 Lever-action rifle. Beautiful paintings coat the fine weapon, a bead that whistles when spun hangs from a hand woven cord."
+	icon_state = "brushgunT"
+	item_state = "brushgun"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube4570
+
+	slowdown = GUN_SLOWDOWN_REPEATER
+	force = GUN_MELEE_FORCE_RIFLE_HEAVY
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_SLOW
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	cock_delay = GUN_COCK_RIFLE_BASE
+	init_recoil = RIFLE_RECOIL(3.6)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
+	init_firemodes = list(
+		/datum/firemode/semi_auto/slow
+	)
+	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
+	gun_sound_properties = list(
+		SP_VARY(FALSE),
+		SP_VOLUME(RIFLE_HEAVY_VOLUME),
+		SP_VOLUME_SILENCED(RIFLE_HEAVY_VOLUME * SILENCED_VOLUME_MULTIPLIER),
+		SP_NORMAL_RANGE(RIFLE_HEAVY_RANGE),
+		SP_NORMAL_RANGE_SILENCED(SILENCED_GUN_RANGE),
+		SP_IGNORE_WALLS(TRUE),
+		SP_DISTANT_SOUND(RIFLE_HEAVY_DISTANT_SOUND),
+		SP_DISTANT_RANGE(RIFLE_HEAVY_RANGE_DISTANT)
+	)
 /* * * * * * * * * * *
  * Ranger repeater
  * Biggest repeater
@@ -319,7 +436,46 @@
 		SP_DISTANT_SOUND(RIFLE_HEAVY_DISTANT_SOUND),
 		SP_DISTANT_RANGE(RIFLE_HEAVY_RANGE_DISTANT)
 	)
+/* * * * * * * * * * *
+ * Ranger repeater tribal
+ * Smell-The-Roses
+ * .308
+ * Tribal Only
+ * * * * * * * * * * */
 
+/obj/item/gun/ballistic/rifle/repeater/ranger
+	name = "Smell-The-Roses"
+	desc = "A .308 lever action. Clunky, Heavy and decorated by someone with a sick sense of humor. A flowering rose around the bore, it's stem trailing along and petals on a string."
+	icon_state = "smell-the-roses"
+	item_state = "brushgun"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube380
+
+	slowdown = GUN_SLOWDOWN_REPEATER
+	force = GUN_MELEE_FORCE_RIFLE_HEAVY
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_BASE
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	cock_delay = GUN_COCK_RIFLE_BASE
+	init_recoil = RIFLE_RECOIL(2.4)
+	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
+	init_firemodes = list(
+		/datum/firemode/semi_auto
+	)
+	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
+	gun_sound_properties = list(
+		SP_VARY(FALSE),
+		SP_VOLUME(RIFLE_HEAVY_VOLUME),
+		SP_VOLUME_SILENCED(RIFLE_HEAVY_VOLUME * SILENCED_VOLUME_MULTIPLIER),
+		SP_NORMAL_RANGE(RIFLE_HEAVY_RANGE),
+		SP_NORMAL_RANGE_SILENCED(SILENCED_GUN_RANGE),
+		SP_IGNORE_WALLS(TRUE),
+		SP_DISTANT_SOUND(RIFLE_HEAVY_DISTANT_SOUND),
+		SP_DISTANT_RANGE(RIFLE_HEAVY_RANGE_DISTANT)
+	)
 /* * * * * * * * * * *
  * Three oh hate
  * unique repeater

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -443,7 +443,7 @@
  * Tribal Only
  * * * * * * * * * * */
 
-/obj/item/gun/ballistic/rifle/repeater/ranger
+/obj/item/gun/ballistic/rifle/repeater/ranger/Tribal
 	name = "Smell-The-Roses"
 	desc = "A .308 lever action. Clunky, Heavy and decorated by someone with a sick sense of humor. A flowering rose around the bore, it's stem trailing along and petals on a string."
 	icon_state = "smell-the-roses"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -284,8 +284,8 @@
  * Tribal Only
  * * * * * * * * * * */
 
-/obj/item/gun/ballistic/rifle/repeater/trail/Tribal
-	name = "Rainstick"
+/obj/item/gun/ballistic/rifle/repeater/trail/tribal
+	name = "rainstick"
 	desc = "A sactified .44 lever action rifle, coated in detailed markings and a carved bead chain that sounds like rain."
 	icon_state = "trailcarbineT"
 	item_state = "trailcarbine"
@@ -363,8 +363,8 @@
  * Tribal Only
  * * * * * * * * * * */
 
-/obj/item/gun/ballistic/rifle/repeater/brush/Tribal
-	name = "Medicine Stick"
+/obj/item/gun/ballistic/rifle/repeater/brush/tribal
+	name = "medicine stick"
 	desc = "A heavy .45-70 Lever-action rifle. Beautiful paintings coat the fine weapon, a bead that whistles when spun hangs from a hand woven cord."
 	icon_state = "brushgunT"
 	item_state = "brushgun"
@@ -443,7 +443,7 @@
  * Tribal Only
  * * * * * * * * * * */
 
-/obj/item/gun/ballistic/rifle/repeater/ranger/Tribal
+/obj/item/gun/ballistic/rifle/repeater/ranger/tribal
 	name = "Smell-The-Roses"
 	desc = "A .308 lever action. Clunky, Heavy and decorated by someone with a sick sense of humor. A flowering rose around the bore, it's stem trailing along and petals on a string."
 	icon_state = "smell-the-roses"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -570,6 +570,74 @@
 	knife_y_offset = 23
 
 /* * * * * * * * * * *
+ * Lever-Action shotgun Restocked
+ * Speedy pump shotgun, with stock
+ * 12g
+ * Uncommon
+ * * * * * * * * * * */
+
+/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock
+	name = "lever action shotgun"
+	desc = "A speedy lever action shotgun with a five-shell capacity underneath plus one in chamber."
+	icon_state = "LAShotgunStocked"
+	item_state = "shotgunlever"
+	icon_prefix = "shotgunlever"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+
+	slowdown = GUN_SLOWDOWN_SHOTGUN_AUTO
+	force = GUN_MELEE_FORCE_RIFLE_HEAVY
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_NORMAL
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	cock_delay = GUN_COCK_SHOTGUN_FAST
+	init_recoil = RIFLE_RECOIL(2.8)
+	init_firemodes = list(
+		/datum/firemode/semi_auto
+	)
+
+	fire_sound = 'sound/f13weapons/shotgun.ogg'
+	can_bayonet = FALSE
+/* * * * * * * * * * *
+ * Lever-Action shotgun Restocked Tribal
+ * Speedy pump shotgun, with stock
+ * 12g
+ * Uncommon
+ * * * * * * * * * * */
+
+/obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever/stock/tribal
+	name = "Mourning Sunrise"
+	desc = "A speedy lever action shotgun with a sunrise painted on the furnishings, morbid in context of it's purpose."
+	icon_state = "LATribal"
+	item_state = "shotgunlever"
+	icon_prefix = "shotgunlever"
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/trench
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+
+	slowdown = GUN_SLOWDOWN_SHOTGUN_AUTO
+	force = GUN_MELEE_FORCE_RIFLE_HEAVY
+	weapon_weight = GUN_TWO_HAND_ONLY
+	draw_time = GUN_DRAW_LONG
+	fire_delay = GUN_FIRE_DELAY_NORMAL
+	autofire_shot_delay = GUN_AUTOFIRE_DELAY_NORMAL
+	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
+	burst_size = 1
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	cock_delay = GUN_COCK_SHOTGUN_FAST
+	init_recoil = RIFLE_RECOIL(2.8)
+	init_firemodes = list(
+		/datum/firemode/semi_auto
+	)
+
+	fire_sound = 'sound/f13weapons/shotgun.ogg'
+	can_bayonet = FALSE
+/* * * * * * * * * * *
  * Neostead shotgun
  * Two-Tube semi-auto shotgun
  * 12g


### PR DESCRIPTION
## About The Pull Request
I love my tribe and wanted to make it feel less... restrictive, everything usually ended up in the well and there was little interaction with the town's merchant. Now, tribals can sanctify a handful of guns to use themselves, meaning they will buy them and potentially the ammunition. The list is; Lever action shotgun, cowboy repeater, trailcarbine, brushgun and .308 repeater. (See the pattern here?)
![image](https://user-images.githubusercontent.com/53197594/208567031-7124ab44-0650-415b-afde-84142057a04b.png)
![image](https://user-images.githubusercontent.com/53197594/208567107-7edac98c-68fc-4903-9a8b-4dc49f04cd33.png)
![image](https://user-images.githubusercontent.com/53197594/208567187-51cebb7f-8965-4be9-b987-ce80868cfa7d.png)
![image](https://user-images.githubusercontent.com/53197594/208567224-8d92bb4b-76e7-4a83-a18b-dd7cea764719.png)
![image](https://user-images.githubusercontent.com/53197594/208567235-c76ed11b-feae-4dca-91c4-02792985e28e.png)

Edit: Okay, Fixed capitalization errors, should be good.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added access to the five gunsprites I added earlier.
/:cl:
