### PR TITLE
Clinic workings and research change up!

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Dungeons.dmm
@@ -14466,6 +14466,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
+"lab" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/implants,
+/turf/open/floor/f13{
+	icon_state = "greendirtyfull"
+	},
+/area/f13/underground/cave)
 "lar" = (
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
@@ -60869,7 +60876,7 @@ thd
 atm
 jyu
 nsS
-cFY
+lab
 lpq
 whY
 cFY

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -1360,6 +1360,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -8835,6 +8836,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /obj/effect/spawner/lootdrop/ammo/military,
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -10458,6 +10460,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"gqs" = (
+/obj/effect/spawner/lootdrop/implants,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/radiation)
 "gqG" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/subway,
@@ -11421,6 +11429,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/tunnel)
 "hiR" = (
@@ -14656,6 +14665,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "jQC" = (
@@ -83406,7 +83416,7 @@ bWe
 jnp
 taP
 taP
-taP
+gqs
 xkI
 lcF
 pua

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -1118,6 +1118,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -13879,6 +13880,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/caves)
+"jhO" = (
+/obj/structure/rack,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/tunnel)
 "jhP" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -16084,6 +16090,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bar)
+"lag" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/stockparts/deluxe,
+/turf/open/floor/plasteel/f13/vault_floor/dark,
+/area/f13/building/hospital)
 "lak" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -57951,7 +57962,7 @@ apg
 bDt
 bDf
 apg
-ust
+jhO
 kef
 kCu
 apg
@@ -76278,7 +76289,7 @@ ira
 dEX
 uUZ
 tYi
-uUZ
+lag
 dEX
 kyb
 gYI

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -524,6 +524,7 @@
 /area/f13/building/hospital)
 "jL" = (
 /obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jT" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -8447,8 +8447,7 @@
 /area/f13/building)
 "kqG" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
-/obj/effect/spawner/lootdrop/f13/medical/rnd/good,
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
 	},
@@ -11720,6 +11719,7 @@
 	color = "#968d87";
 	dir = 4
 	},
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "oAZ" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -5552,6 +5552,7 @@
 "gSj" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/waste,
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
 	},

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -43615,6 +43615,8 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
 	name = "tile"
@@ -54054,8 +54056,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "mAv" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
 	name = "tile"

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -2125,6 +2125,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/abandoned)
+"bns" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/implants,
+/turf/open/floor/plasteel{
+	icon_state = "asteroidfloor"
+	},
+/area/f13/building/abandoned)
 "bnx" = (
 /obj/structure/fence/door,
 /turf/open/indestructible/ground/outside/dirt{
@@ -3468,6 +3475,13 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"caf" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/implants,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "cam" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -13221,6 +13235,10 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"hLt" = (
+/obj/effect/spawner/lootdrop/implants,
+/turf/open/floor/plating/rust,
 /area/f13/building)
 "hLx" = (
 /obj/structure/closet/cabinet/anchored{
@@ -37562,6 +37580,7 @@
 /area/f13/wasteland)
 "whb" = (
 /obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -48259,7 +48278,7 @@ rYb
 fSr
 fSr
 kMc
-vvX
+hLt
 eZf
 vvR
 fSr
@@ -48527,7 +48546,7 @@ fSr
 dDr
 vKs
 nSg
-jbv
+caf
 xTV
 gCR
 rvt
@@ -53178,7 +53197,7 @@ cdc
 fMw
 psA
 rVZ
-xRU
+bns
 cdc
 mAj
 kAN

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -12425,6 +12425,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -17649,6 +17650,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/spawner/lootdrop/implants,
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_nodes_experimental = list()	//Node ids that are exclusive to the BEPIS.
 
 	var/list/techweb_point_items = list(		//path = list(point type = value)
-	/obj/item/blueprint/research                   = list(TECHWEB_POINT_TYPE_GENERIC = 10000),
+	/obj/item/blueprint/research                   = list(TECHWEB_POINT_TYPE_GENERIC = 5000),
 	/obj/item/scrap/research                       = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
 
 	/obj/item/assembly/signaler/anomaly            = list(TECHWEB_POINT_TYPE_GENERIC = 10000),
@@ -365,9 +365,9 @@ SUBSYSTEM_DEF(research)
 		for(var/obj/machinery/rnd/server/miner in VAULTservers)
 			if(miner.working)
 				VAULTbitcoins = VAULTsingle_server_income.Copy()
-				break	
+				break
 	var/income_time_difference = world.time - last_income
-		
+
 	science_tech.last_bitcoins = VAULTbitcoins  // Doesn't take tick drift into account
 	bos_tech.last_bitcoins = BOSbitcoins
 	unknown_tech.last_bitcoins = bitcoins

--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -384,7 +384,7 @@ SUBSYSTEM_DEF(traumas)
 						/turf/closed/wall/clockwork,
 						/turf/open/floor/plasteel/cult,
 						/turf/closed/wall/mineral/cult)),
-					
+
 					"aliens" = typecacheof(list(
 						/turf/open/floor/plating/abductor,
 						/turf/open/floor/plating/abductor2,
@@ -424,9 +424,9 @@ SUBSYSTEM_DEF(traumas)
 							),
 
 						"aliens" = typecacheof(list(
-						/datum/species/abductor, 
-						/datum/species/jelly, 
-						/datum/species/pod, 
+						/datum/species/abductor,
+						/datum/species/jelly,
+						/datum/species/pod,
 						/datum/species/shadow)
 						),
 

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -424,3 +424,60 @@
 /obj/item/storage/box/medicine/antivenom5/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/antivenom(src)
+
+// IMPLANTS
+
+/datum/crafting_recipe/cyberimp_toolset
+	name = "Toolset Arm Implant"
+	result = /obj/item/organ/cyberimp/arm/toolset
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/sheet/glass = 1,
+				/obj/item/stack/sheet/mineral/silver = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_MEDICAL
+	always_available = FALSE
+
+/datum/crafting_recipe/cyberimp_surgical
+	name = "Surgical Arm Implant"
+	result = /obj/item/organ/cyberimp/arm/surgery
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/sheet/glass = 1,
+				/obj/item/stack/sheet/mineral/silver = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_MEDICAL
+	always_available = FALSE
+
+/datum/crafting_recipe/cyberimp_janitor
+	name = "Janitor Arm Implant"
+	result = /obj/item/organ/cyberimp/arm/janitor
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/sheet/glass = 1,
+				/obj/item/stack/sheet/mineral/silver = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_MEDICAL
+	always_available = FALSE
+
+/datum/crafting_recipe/cyberimp_service
+	name = "Service Arm Implant"
+	result = /obj/item/organ/cyberimp/arm/service
+	reqs = list(/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/sheet/glass = 1,
+				/obj/item/stack/sheet/mineral/silver = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_MEDICAL
+	always_available = FALSE
+
+/datum/crafting_recipe/cyberimp_nutriment
+	name = "Nutriment Pump Implant"
+	result = /obj/item/organ/cyberimp/chest/nutriment
+	reqs = list(/obj/item/stack/sheet/metal = 1,
+				/obj/item/stack/sheet/glass = 1,
+				/obj/item/stack/sheet/mineral/gold = 1)
+	tools = list(TOOL_WORKBENCH)
+	time = 15
+	category = CAT_MEDICAL
+	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -432,7 +432,8 @@
 	result = /obj/item/organ/cyberimp/arm/toolset
 	reqs = list(/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/sheet/glass = 1,
-				/obj/item/stack/sheet/mineral/silver = 1)
+				/obj/item/stack/sheet/mineral/silver = 1,
+				/obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_MEDICAL
@@ -443,7 +444,8 @@
 	result = /obj/item/organ/cyberimp/arm/surgery
 	reqs = list(/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/sheet/glass = 1,
-				/obj/item/stack/sheet/mineral/silver = 1)
+				/obj/item/stack/sheet/mineral/silver = 1,
+				/obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_MEDICAL
@@ -454,7 +456,8 @@
 	result = /obj/item/organ/cyberimp/arm/janitor
 	reqs = list(/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/sheet/glass = 1,
-				/obj/item/stack/sheet/mineral/silver = 1)
+				/obj/item/stack/sheet/mineral/silver = 1,
+				/obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_MEDICAL
@@ -465,7 +468,8 @@
 	result = /obj/item/organ/cyberimp/arm/service
 	reqs = list(/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/sheet/glass = 1,
-				/obj/item/stack/sheet/mineral/silver = 1)
+				/obj/item/stack/sheet/mineral/silver = 1,
+				/obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_MEDICAL
@@ -476,7 +480,8 @@
 	result = /obj/item/organ/cyberimp/chest/nutriment
 	reqs = list(/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/sheet/glass = 1,
-				/obj/item/stack/sheet/mineral/gold = 1)
+				/obj/item/stack/sheet/mineral/gold = 1,
+				/obj/item/advanced_crafting_components/alloys = 1)
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_MEDICAL

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -126,6 +126,55 @@
 //Scavenging and Tinkering//
 ///////////////////////////
 
+/datum/crafting_recipe/pico_manip
+	name = "Delicate Mechanism"
+	result = /obj/item/stock_parts/manipulator/pico
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stock_parts/manipulator/nano = 1)
+	time = 5
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/super_matter_bin
+	name = "Storage Bin"
+	result = /obj/item/stock_parts/matter_bin/super
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stock_parts/matter_bin/adv = 1)
+	time = 5
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/phasic_scanning
+	name = "Advanced Antenna"
+	result = /obj/item/stock_parts/scanning_module/phasic
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stock_parts/scanning_module/adv = 1)
+	time = 5
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/super_capacitor
+	name = "Advanced Capacitor"
+	result = /obj/item/stock_parts/capacitor/super
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stock_parts/capacitor/adv = 1)
+	time = 5
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/ultra_micro_laser
+	name = "Laser Diode"
+	result = /obj/item/stock_parts/micro_laser/ultra
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stock_parts/micro_laser/high = 1)
+	time = 5
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
 
 /datum/crafting_recipe/pin_removal
 	name = "Render gun unusable"

--- a/code/datums/components/crafting/recipes/recipes_robot.dm
+++ b/code/datums/components/crafting/recipes/recipes_robot.dm
@@ -47,7 +47,7 @@
 	time = 40
 	category = CAT_ROBOT
 
-/datum/crafting_recipe/medbot
+/*/datum/crafting_recipe/medbot
 	name = "Medbot"
 	result = /mob/living/simple_animal/bot/medbot
 	reqs = list(/obj/item/healthanalyzer = 1,
@@ -55,7 +55,7 @@
 				/obj/item/assembly/prox_sensor = 1,
 				/obj/item/bodypart/r_arm/robot = 1)
 	time = 40
-	category = CAT_ROBOT
+	category = CAT_ROBOT*/
 
 /datum/crafting_recipe/Firebot
 	name = "Firebot"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -425,6 +425,19 @@
 				/obj/item/lighter/bullet = 10,
 				)
 
+/obj/effect/spawner/lootdrop/implants
+	lootcount = 1
+	loot = list(
+				/obj/item/organ/eyes/robotic/shield = 20,
+				/obj/item/organ/cyberimp/brain/anti_drop = 20,
+				/obj/item/organ/cyberimp/brain/anti_stun = 10,
+				/obj/item/organ/cyberimp/chest/nutriment/plus = 10,
+				/obj/item/organ/cyberimp/chest/reviver = 10,
+				/obj/item/organ/heart/cybernetic/upgraded = 5,
+				/obj/item/organ/liver/cybernetic/upgraded = 10,
+				/obj/item/organ/ears/cybernetic/upgraded =15,
+				)
+
 /obj/effect/spawner/lootdrop/space_cash
 	lootcount = 1
 	loot = list(

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -182,7 +182,7 @@ GLOBAL_LIST_INIT(blueprint_fluff, list(
 
 /obj/item/blueprint/research
 	name = "mysterious blueprint"
-	desc = "Some kind of collection of pre-war 'information'. Might be something in here worthwhile to people interested in that kind of thing. <br><br>(grants 10k research points when destructively analyzed)"
+	desc = "Some kind of collection of pre-war 'information'. Might be something in here worthwhile to people interested in that kind of thing. <br><br>(grants 5k research points when destructively analyzed)"
 	icon ='icons/obj/bureaucracy.dmi'
 	icon_state = "docs_generic"
 

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -45,9 +45,9 @@ Administrator
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "No one."
-	description = "You are the Senior Doctor. You are the supervisor and director for the on-site followers and the facility. While there is no tradtional chain of command that is used, you have been chosen to lead due to your expert knowledge in the field of medicine and other general knowledges. Make sure that the supplies donated are being put to use, help secure more donations, and fill in as needed whenever short staffed or if the clinic is busy."
-	forbids = "Causing harm to others except in times of self-defense. Leaving the hospital without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
-	enforces = "Preach the values of the Followers of Apocolypse. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
+	description = "You are the Senior Doctor. You are the supervisor and director for the on-site doctors and the facility. While there is no tradtional chain of command that is used, you have been chosen to lead due to your expert knowledge in the field of medicine and other general knowledges. Make sure that the supplies donated are being put to use, help secure more donations, and fill in as needed whenever short staffed or if the clinic is busy."
+	forbids = "Causing harm to others except in times of self-defense. Leaving the clinic without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
+	enforces = "Preach the values of Good Will. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
 	selection_color = "#FF95FF"
 	exp_requirements = 750
 
@@ -133,10 +133,10 @@ Administrator
 	faction = "Followers"
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = "Followers having no strict command structure, don't report to anyone- though they will look to the Administrator for guidance."
-	description = "You are a Follower Scientist. As a Scientist it is your job to teach the wastes- be it teaching them how to make medicine, grow crops or treat toxic water. You are a learned individual in your chosen field, you know how to do research and have all the basic tools to teach others how to handle the technology they will come across. You are free to expand upon what projects you wish to accomplish as long as they align with the principles of the Followers."
-	forbids = "Causing harm to others except in times of self-defense. Leaving the hospital without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
-	enforces = "Preach the values of the Followers of Apocolypse. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
+	supervisors = "Having no strict command structure, scientists don't report to anyone- though they will look to the Senior Doctor for guidance."
+	description = "You are a Town Scientist. As a Scientist it is your job to teach the wastes- be it teaching them how to make medicine, grow crops or treat toxic water. You are a learned individual in your chosen field, you know how to do research and have all the basic tools to teach others how to handle the technology they will come across. You are free to expand upon what projects you wish to accomplish as long as they align with the principles of the doctors."
+	forbids = "Causing harm to others except in times of self-defense. Leaving the clinic without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
+	enforces = "Preach the values of the clinic. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"
 	exp_requirements = 540
 	exp_type = EXP_TYPE_FOLLOWERS
@@ -173,6 +173,11 @@ Administrator
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cyberimp_toolset)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cyberimp_surgical)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cyberimp_janitor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cyberimp_service)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/cyberimp_nutriment)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
@@ -223,10 +228,10 @@ Practitioner
 	faction = "Followers"
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = "Followers having no strict command structure, don't report to anyone- though they will look to the Administrator for guidance."
-	description = "You are a Followers Doctor. As a Followers Doctor it is your responsibility to maintain working order in the hospital and to manage its staff and to treat patients who come in regardless of whether or not they can afford care. Some Doctors are known for leaving the hospital with a guard to look for injured or those who need help who may not come to a health facility, however it is key that those who do travel around to give aid keep in touch with the rest of staff and if there are no other able physicans or chemist that they stay to offer the best aid possible."
-	forbids = "Causing harm to others except in times of self-defense. Leaving the hospital without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
-	enforces = "Preach the values of the Followers of Apocolypse. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
+	supervisors = "The clinic, having no strict command structure, doesn't report to anyone- though they will look to the Senior Doctor for guidance."
+	description = "You are a Town Doctor. As a Town Doctor it is your responsibility to maintain working order in the clinic and to manage its staff and to treat patients who come in regardless of whether or not they can afford care. Some Doctors are known for leaving the clinic with a guard to look for injured or those who need help who may not come to a health facility, however it is key that those who do travel around to give aid keep in touch with the rest of staff and if there are no other able physicans or chemist that they stay to offer the best aid possible."
+	forbids = "Causing harm to others except in times of self-defense. Leaving the clinic without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
+	enforces = "Preach the values of the clinic. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"
 	exp_requirements = 300
 
@@ -354,10 +359,10 @@ Follower Volunteer
 	faction = "Followers"
 	total_positions = 6
 	spawn_positions = 6
-	supervisors = "Followers having no strict command structure, don't report to anyone- though they will look to the Administrator for guidance and the other Doctors as well."
-	description = "You are a Follower Volunteer. As a Volunteer, you make sure they get connected to the right people to find treatment, assist in the functions of the hospital, learn from senior Followers, and utilize first aid to the best of your capacity when Doctors are not present."
-	forbids = "Causing harm to others except in times of self-defense. Leaving the hospital without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
-	enforces = "Preach the values of the Followers of Apocolypse. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
+	supervisors = "The doctors, having no strict command structure, don't report to anyone- though they will look to the Senior Doctor for guidance and the other Doctors as well."
+	description = "You are a Town Medical Assistant. As a Medical Assistant, you make sure they get connected to the right people to find treatment, assist in the functions of the clinic, learn from senior Doctors, and utilize first aid to the best of your capacity when Doctors are not present."
+	forbids = "Causing harm to others except in times of self-defense. Leaving the clinic without a plan or being accompanied by a guard. Treating raiders or slavers without a good reason."
+	enforces = "Preach the values of the clinic. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"
 	outfit = /datum/outfit/job/followers/f13followervolunteer
 	loadout_options = list(
@@ -444,10 +449,10 @@ Follower Volunteer
 	faction = "Followers"
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "Followers having no strict command structure, don't report to anyone- though they will look to the Administrator for guidance and the other Doctors as well."
-	description = "You are a Followers Guard. As a Guard for the Followers of Apocalypse, you are responsible for the safety and the maintenance of order in the hospital and among your peers. Your reason for being here is to make sure the other staff can provide education and medical services to those in need, furthering research in non-military matters, as well as helping their communities get access to basic necessities. You may also be responsible as an escort to the various non-combat staff at the hospital."
-	forbids = "Causing harm to others except in times of self-defense. Leaving the hospital without a plan or notifying non-combat personnel. Treating or otherwise aiding raiders or slavers without a good reason."
-	enforces = "Preach the values of the Followers of Apocolypse. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
+	supervisors = "The clinic, having no strict command structure, don't report to anyone- though they will look to the Senior Doctor for guidance and the other Doctors as well."
+	description = "You are a Town Paramedic. As a Paramedic for the clinic, you are responsible for the safety and the maintenance of order in the clinic and among your peers. Your reason for being here is to make sure the other staff can provide education and medical services to those in need, furthering research in non-military matters, as well as helping their communities get access to basic necessities. You may also be responsible as an escort to the various non-combat staff at the clinic."
+	forbids = "Causing harm to others except in times of self-defense. Leaving the clinic without a plan or notifying non-combat personnel. Treating or otherwise aiding raiders or slavers without a good reason."
+	enforces = "Preach the values of the clinic. Assist and provide medical services to those in need. Provide free education for all those who are willing to learn."
 	selection_color = "#FFDDFF"
 
 	outfit = /datum/outfit/job/followers/f13followerguard

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -54,8 +54,7 @@ Administrator
 	outfit = /datum/outfit/job/followers/f13leadpractitioner
 	loadout_options = list(
 	/datum/outfit/loadout/surgical_specialist,
-	/datum/outfit/loadout/chemical_specialist,
-	/datum/outfit/loadout/research_specialist
+	/datum/outfit/loadout/chemical_specialist
 	)
 
 	access = list(ACCESS_FOLLOWER, ACCESS_COMMAND, ACCESS_MILITARY, ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_ATMOSPHERICS)
@@ -82,6 +81,11 @@ Administrator
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/rechargerpistol)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pico_manip)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_matter_bin)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_MEDICALEXPERT, src)
@@ -112,23 +116,12 @@ Administrator
 	name =	"Surgical Specialist"
 	backpack_contents = list(
 		/obj/item/storage/belt/medical/surgery_belt_adv = 1,
-		/obj/item/organ/cyberimp/arm/medibeam = 1,
 	)
 
 /datum/outfit/loadout/chemical_specialist
 	name =	"Chemical Specialist"
 	backpack_contents = list(
-		/obj/item/circuitboard/machine/chem_master/advanced = 1,
 		/obj/item/hypospray/mkii/CMO = 1,
-	)
-
-/datum/outfit/loadout/research_specialist
-	name =	"Research Specialist"
-	backpack_contents = list(
-		/obj/item/disk/medical/defib_heal = 1,
-		/obj/item/disk/medical/defib_shock = 1,
-		/obj/item/disk/medical/defib_speed = 1,
-		/obj/item/blueprint/research = 1,
 	)
 
 //Professor
@@ -175,6 +168,11 @@ Administrator
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/rechargerpistol)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pico_manip)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_matter_bin)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
 	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 
@@ -269,6 +267,11 @@ Practitioner
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/superstimpak5)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/buffout)
 	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steady)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pico_manip)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_matter_bin)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
 	ADD_TRAIT(H, TRAIT_MEDICALGRADUATE, src)
 	ADD_TRAIT(H, TRAIT_GENERIC, src)
 	ADD_TRAIT(H, TRAIT_SURGERY_MID, src)
@@ -452,7 +455,7 @@ Follower Volunteer
 /*
 	loadout_options = list(
 		/datum/outfit/loadout/guard_ranged,
-		/datum/outfit/loadout/guard_close, 
+		/datum/outfit/loadout/guard_close,
 		/datum/outfit/loadout/guard_energy
 	)
 	*/

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -107,7 +107,6 @@ Administrator
 		/obj/item/storage/firstaid/ancient = 1,
 		/obj/item/storage/survivalkit/medical/follower = 1,
 		/obj/item/reagent_containers/medspray/synthflesh = 2,
-		/obj/item/clothing/glasses/hud/health = 1,
 		/obj/item/book/granter/trait/techno = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 	)
@@ -210,7 +209,6 @@ Administrator
 	name =	"Medical Specialist"
 	neck = /obj/item/clothing/neck/stethoscope
 	gloves = /obj/item/clothing/gloves/color/latex
-	glasses =	/obj/item/clothing/glasses/hud/health
 	backpack_contents = list(
 		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/circuitboard/machine/bloodbankgen = 1,
@@ -309,7 +307,6 @@ Practitioner
 	suit =	/obj/item/clothing/suit/toggle/labcoat/followers
 	mask =	/obj/item/clothing/mask/surgical
 	gloves =	/obj/item/clothing/gloves/color/latex/nitrile
-	glasses =	/obj/item/clothing/glasses/hud/health
 	backpack_contents = list(
 		/obj/item/clothing/suit/hooded/surgical = 1,
 		/obj/item/reagent_containers/medspray/synthflesh = 1,
@@ -330,7 +327,6 @@ Practitioner
 	name =	"Paramedic"
 	head =	/obj/item/clothing/head/soft/emt
 	suit =	/obj/item/clothing/suit/toggle/labcoat/emt
-	glasses =	/obj/item/clothing/glasses/hud/health
 	belt =	/obj/item/storage/belt/medical
 	backpack_contents = list(
 		/obj/item/reagent_containers/medspray/synthflesh = 2,

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -680,7 +680,6 @@ Mayor
 	belt = /obj/item/kit_spawner/townie/doctor
 	ears = /obj/item/radio/headset/headset_town/medical
 	uniform = /obj/item/clothing/under/f13/medic
-	glasses = /obj/item/clothing/glasses/hud/health
 	neck = /obj/item/clothing/neck/stethoscope
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	backpack = /obj/item/storage/backpack/medic

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -1112,7 +1112,7 @@
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/autosurgeon
+/datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "An automatic surgeon used to install organs or implants automatically."
 	id = "autosurgeon"
@@ -1121,5 +1121,5 @@
 	construction_time = 100
 	build_path = /obj/item/autosurgeon
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -373,7 +373,7 @@
 	name = "Welding Shield Eyes"
 	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
 	id = "ci-welding"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 40
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 400)
 	build_path = /obj/item/organ/eyes/robotic/shield
@@ -384,7 +384,7 @@
 	name = "Luminescent Eyes"
 	desc = "A pair of cybernetic eyes that can emit multicolored light"
 	id = "ci-gloweyes"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 40
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 1000)
 	build_path = /obj/item/organ/eyes/robotic/glow
@@ -395,7 +395,7 @@
 	name = "Breathing Tube Implant"
 	desc = "This simple implant adds an internals connector to your back, allowing you to use internals without a mask and protecting you from being choked."
 	id = "ci-breather"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 35
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 250)
 	build_path = /obj/item/organ/cyberimp/mouth/breathing_tube
@@ -406,7 +406,7 @@
 	name = "Surgical Arm Implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
 	id = "ci-surgery"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1500, /datum/material/silver = 1500)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/surgery
@@ -417,7 +417,7 @@
 	name = "Toolset Arm Implant"
 	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm."
 	id = "ci-toolset"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1500, /datum/material/silver = 1500)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/toolset
@@ -439,7 +439,7 @@
 	name = "Janitor Arm Implant"
 	desc = "A set of janitor tools fitted into an arm implant, designed to be installed on subject's arm."
 	id = "ci-janitor"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	materials = list (/datum/material/iron = 3500, /datum/material/glass = 1500, /datum/material/silver = 1500)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/janitor
@@ -450,7 +450,7 @@
 	name = "Service Arm Implant"
 	desc = "Everything a cook or barkeep needs in an arm implant, designed to be installed on subject's arm."
 	id = "ci-service"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	materials = list (/datum/material/iron = 3500, /datum/material/glass = 1500, /datum/material/silver = 1500)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/service
@@ -461,7 +461,7 @@
 	name = "Medical HUD Implant"
 	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
 	id = "ci-medhud"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 50
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 500, /datum/material/gold = 500)
 	build_path = /obj/item/organ/cyberimp/eyes/hud/medical
@@ -472,7 +472,7 @@
 	name = "Security HUD Implant"
 	desc = "These cybernetic eyes will display a security HUD over everything you see. Wiggle eyes to control."
 	id = "ci-sechud"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 50
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 750, /datum/material/gold = 750)
 	build_path = /obj/item/organ/cyberimp/eyes/hud/security
@@ -505,7 +505,7 @@
 	name = "Anti-Drop Implant"
 	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
 	id = "ci-antidrop"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 400, /datum/material/gold = 400)
 	build_path = /obj/item/organ/cyberimp/brain/anti_drop
@@ -516,7 +516,7 @@
 	name = "CNS Rebooter Implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	id = "ci-antistun"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver = 500, /datum/material/gold = 1000)
 	build_path = /obj/item/organ/cyberimp/brain/anti_stun
@@ -527,7 +527,7 @@
 	name = "Nutriment Pump Implant"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."
 	id = "ci-nutriment"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 40
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/gold = 500)
 	build_path = /obj/item/organ/cyberimp/chest/nutriment
@@ -538,7 +538,7 @@
 	name = "Nutriment Pump Implant PLUS"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are hungry."
 	id = "ci-nutrimentplus"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 50
 	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/gold = 500, /datum/material/uranium = 750)
 	build_path = /obj/item/organ/cyberimp/chest/nutriment/plus
@@ -549,7 +549,7 @@
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	id = "ci-reviver"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 60
 	materials = list(/datum/material/iron = 800, /datum/material/glass = 800, /datum/material/gold = 300, /datum/material/uranium = 500)
 	build_path = /obj/item/organ/cyberimp/chest/reviver
@@ -617,7 +617,7 @@
 	name = "Cybernetic Liver"
 	desc = "A cybernetic liver"
 	id = "cybernetic_liver"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/organ/liver/cybernetic
 	category = list("Medical Designs")
@@ -627,7 +627,7 @@
 	name = "Cybernetic Heart"
 	desc = "A cybernetic heart"
 	id = "cybernetic_heart"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/organ/heart/cybernetic
 	category = list("Medical Designs")
@@ -637,7 +637,7 @@
 	name = "Upgraded Cybernetic Heart"
 	desc = "An upgraded cybernetic heart"
 	id = "cybernetic_heart_u"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 50
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 500)
 	build_path = /obj/item/organ/heart/cybernetic/upgraded
@@ -648,7 +648,7 @@
 	name = "Upgraded Cybernetic Liver"
 	desc = "An upgraded cybernetic liver"
 	id = "cybernetic_liver_u"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/organ/liver/cybernetic/upgraded
 	category = list("Medical Designs")
@@ -658,7 +658,7 @@
 	name = "Cybernetic Lungs"
 	desc = "A pair of cybernetic lungs."
 	id = "cybernetic_lungs"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/organ/lungs/cybernetic
 	category = list("Medical Designs")
@@ -668,7 +668,7 @@
 	name = "Upgraded Cybernetic Lungs"
 	desc = "A pair of upgraded cybernetic lungs."
 	id = "cybernetic_lungs_u"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 500)
 	build_path = /obj/item/organ/lungs/cybernetic/upgraded
 	category = list("Medical Designs")
@@ -678,7 +678,7 @@
 	name = "Cybernetic tongue"
 	desc = "A fancy cybernetic tongue."
 	id = "cybernetic_tongue"
-	build_type = PROTOLATHE
+	build_type = MECHFAB
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
 	build_path = /obj/item/organ/tongue/cybernetic
 	category = list("Medical Designs")
@@ -688,7 +688,7 @@
 	name = "Cybernetic Ears"
 	desc = "A pair of cybernetic ears."
 	id = "cybernetic_ears"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 30
 	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
 	build_path = /obj/item/organ/ears/cybernetic
@@ -699,7 +699,7 @@
 	name = "Upgraded Cybernetic Ears"
 	desc = "A pair of upgraded cybernetic ears."
 	id = "cybernetic_ears_u"
-	build_type = PROTOLATHE | MECHFAB
+	build_type = MECHFAB
 	construction_time = 40
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/silver = 500)
 	build_path = /obj/item/organ/ears/cybernetic/upgraded
@@ -1112,7 +1112,7 @@
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/autosurgeon
+/*/datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "An automatic surgeon used to install organs or implants automatically."
 	id = "autosurgeon"
@@ -1121,5 +1121,5 @@
 	construction_time = 100
 	build_path = /obj/item/autosurgeon
 	category = list("Misc","Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE*/
 

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -12,7 +12,7 @@
 	category = list("Stock Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/BS_RPED
+/*/datum/design/BS_RPED
 	name = "Bluespace RPED"
 	desc = "Powered by bluespace technology, this RPED variant can upgrade buildings from a distance, without needing to remove the panel first."
 	id = "bs_rped"
@@ -20,7 +20,7 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 5000, /datum/material/silver = 2500) //hardcore
 	build_path = /obj/item/storage/part_replacer/bluespace
 	category = list("Stock Parts")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 //Capacitors
 /datum/design/basic_capacitor
@@ -45,7 +45,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/super_capacitor
+/*/datum/design/super_capacitor
 	name = "Advanced Capacitor"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_capacitor"
@@ -65,7 +65,7 @@
 	build_path = /obj/item/stock_parts/capacitor/quadratic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 //Scanning modules
 /datum/design/basic_scanning
@@ -90,7 +90,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/phasic_scanning
+/*/datum/design/phasic_scanning
 	name = "Advanced Antenna"
 	desc = "A stock part used in the construction of various devices."
 	id = "phasic_scanning"
@@ -110,7 +110,7 @@
 	build_path = /obj/item/stock_parts/scanning_module/triphasic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 //Maipulators
 /datum/design/micro_mani
@@ -135,7 +135,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/pico_mani
+/*/datum/design/pico_mani
 	name = "Delicate Mechanism"
 	desc = "A stock part used in the construction of various devices."
 	id = "pico_mani"
@@ -155,7 +155,7 @@
 	build_path = /obj/item/stock_parts/manipulator/femto
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 //Micro-lasers
 /datum/design/basic_micro_laser
@@ -180,7 +180,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/ultra_micro_laser
+/*/datum/design/ultra_micro_laser
 	name = "Laser Diode"
 	desc = "A stock part used in the construction of various devices."
 	id = "ultra_micro_laser"
@@ -200,7 +200,7 @@
 	build_path = /obj/item/stock_parts/micro_laser/quadultra
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 /datum/design/basic_matter_bin
 	name = "Funnel"
@@ -224,7 +224,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/super_matter_bin
+/*/datum/design/super_matter_bin
 	name = "Storage Bin"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_matter_bin"
@@ -244,7 +244,7 @@
 	build_path = /obj/item/stock_parts/matter_bin/bluespace
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
 
 //T-Comms devices
 /datum/design/subspace_ansible

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -12,7 +12,7 @@
 	category = list("Stock Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/BS_RPED
+/datum/design/BS_RPED
 	name = "Bluespace RPED"
 	desc = "Powered by bluespace technology, this RPED variant can upgrade buildings from a distance, without needing to remove the panel first."
 	id = "bs_rped"
@@ -20,7 +20,7 @@
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 5000, /datum/material/silver = 2500) //hardcore
 	build_path = /obj/item/storage/part_replacer/bluespace
 	category = list("Stock Parts")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 //Capacitors
 /datum/design/basic_capacitor
@@ -45,7 +45,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/super_capacitor
+/datum/design/super_capacitor
 	name = "Advanced Capacitor"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_capacitor"
@@ -65,7 +65,7 @@
 	build_path = /obj/item/stock_parts/capacitor/quadratic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 //Scanning modules
 /datum/design/basic_scanning
@@ -90,7 +90,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/phasic_scanning
+/datum/design/phasic_scanning
 	name = "Advanced Antenna"
 	desc = "A stock part used in the construction of various devices."
 	id = "phasic_scanning"
@@ -110,7 +110,7 @@
 	build_path = /obj/item/stock_parts/scanning_module/triphasic
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 //Maipulators
 /datum/design/micro_mani
@@ -135,7 +135,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/pico_mani
+/datum/design/pico_mani
 	name = "Delicate Mechanism"
 	desc = "A stock part used in the construction of various devices."
 	id = "pico_mani"
@@ -155,7 +155,7 @@
 	build_path = /obj/item/stock_parts/manipulator/femto
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 //Micro-lasers
 /datum/design/basic_micro_laser
@@ -180,7 +180,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/ultra_micro_laser
+/datum/design/ultra_micro_laser
 	name = "Laser Diode"
 	desc = "A stock part used in the construction of various devices."
 	id = "ultra_micro_laser"
@@ -200,7 +200,7 @@
 	build_path = /obj/item/stock_parts/micro_laser/quadultra
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/basic_matter_bin
 	name = "Funnel"
@@ -224,7 +224,7 @@
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
-/*/datum/design/super_matter_bin
+/datum/design/super_matter_bin
 	name = "Storage Bin"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_matter_bin"
@@ -244,7 +244,7 @@
 	build_path = /obj/item/stock_parts/matter_bin/bluespace
 	category = list("Stock Parts")
 	lathe_time_factor = 0.2
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE*/
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 //T-Comms devices
 /datum/design/subspace_ansible

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -96,7 +96,7 @@
 //////////////Alien Tools////////////////
 /////////////////////////////////////////
 
-/datum/design/alienwrench
+/*/datum/design/alienwrench
 	name = "Experimental Wrench" //Start Fortuna edit: alien tech -> experimental
 	desc = "An experimental wrench obtained through advanced technology."
 	id = "alien_wrench"
@@ -154,13 +154,13 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 5000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING*/
 
 /////////////////////////////////////////
 /////////Alien Surgical Tools////////////
 /////////////////////////////////////////
 
-/datum/design/alienscalpel
+/*/datum/design/alienscalpel
 	name = "Experimental Scalpel"
 	desc = "An experimental scalpel obtained through advanced technology."
 	id = "alien_scalpel"
@@ -218,7 +218,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/silver = 1500, /datum/material/plasma = 500, /datum/material/titanium = 1500)
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL*/
 
 
 //////////////////////
@@ -235,7 +235,7 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/retractor_adv
+/*/datum/design/retractor_adv
 	name = "Advanced Retractor"
 	desc = "An almagation of rods and gears, able to function as both a surgical clamp and retractor. "
 	id = "retractor_adv"
@@ -263,4 +263,4 @@
 	materials = list(/datum/material/iron = 1500, /datum/material/glass = 1500, /datum/material/silver = 4000, /datum/material/gold = 2500)
 	build_path = /obj/item/scalpel/advanced
 	category = list("Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE*/

--- a/code/modules/research/techweb/nodes/alien_nodes.dm
+++ b/code/modules/research/techweb/nodes/alien_nodes.dm
@@ -24,7 +24,7 @@
 	display_name = "Experimental Biological Tools" //Fortuna edit: Alien tech -> Experimental tech
 	description = "Highly advanced surgical tools."
 	prereq_ids = list("alientech", "advance_surgerytools")
-	design_ids = list("alien_scalpel", "alien_hemostat", "alien_retractor", "alien_saw", "alien_drill", "alien_cautery", "ayyplantgenes")
+/*	design_ids = list("alien_scalpel", "alien_hemostat", "alien_retractor", "alien_saw", "alien_drill", "alien_cautery", "ayyplantgenes")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/alien_engi
@@ -32,5 +32,5 @@
 	display_name = "Experimental Engineering" //Fortuna edit: Alien tech -> Experimental tech
 	description = "Highly advanced engineering tools."
 	prereq_ids = list("alientech", "exp_tools")
-	design_ids = list("alien_wrench", "alien_wirecutters", "alien_screwdriver", "alien_crowbar", "alien_welder", "alien_multitool")
+/*	design_ids = list("alien_wrench", "alien_wirecutters", "alien_screwdriver", "alien_crowbar", "alien_welder", "alien_multitool")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)

--- a/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Applied Quantum Research"
 	description = "Using quantum technology to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "xenobio_slimebasic")
+/*	design_ids = list("bs_rped", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "xenobio_slimebasic")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_bluespace
@@ -21,7 +21,7 @@
 	display_name = "Advanced Quantum Research"
 	description = "Deeper understanding of how the Quantum Theory works"
 	prereq_ids = list("practical_bluespace", "high_efficiency")
-	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "bluespace_crystal", "xenobio_slimeadv")
+/*	design_ids = list("bluespace_matter_bin", "femto_mani", "triphasic_scanning", "bluespace_crystal", "xenobio_slimeadv")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 /datum/techweb_node/bluespace_power
@@ -29,7 +29,7 @@
 	display_name = "Quantum Power Technology"
 	description = "Even more powerful.. power!"
 	prereq_ids = list("adv_power", "adv_bluespace")
-	design_ids = list("bluespace_cell", "quadratic_capacitor")
+/*	design_ids = list("bluespace_cell", "quadratic_capacitor")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /*8

--- a/code/modules/research/techweb/nodes/computer_hud_nodes.dm
+++ b/code/modules/research/techweb/nodes/computer_hud_nodes.dm
@@ -42,7 +42,7 @@
 	display_name = "Integrated HUDs"
 	description = "The usefulness of computerized records, projected straight onto your eyepiece!"
 	prereq_ids = list("comp_recordkeeping", "emp_basic")
-	design_ids = list("health_hud", "security_hud", "diagnostic_hud", "scigoggles", "health_hud_prescription", "security_hud_prescription", "diagnostic_hud_prescription")
+/*	design_ids = list("health_hud", "security_hud", "diagnostic_hud", "scigoggles", "health_hud_prescription", "security_hud_prescription", "diagnostic_hud_prescription")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
 /*

--- a/code/modules/research/techweb/nodes/engineering_nodes.dm
+++ b/code/modules/research/techweb/nodes/engineering_nodes.dm
@@ -34,7 +34,7 @@
 	display_name = "High Efficiency Parts"
 	description = "Finely-tooled manufacturing techniques allowing for picometer-perfect precision levels."
 	prereq_ids = list("engineering", "datatheory")
-	design_ids = list("pico_mani", "super_matter_bin")
+/*	design_ids = list("pico_mani", "super_matter_bin")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_power
@@ -42,7 +42,7 @@
 	display_name = "Advanced Power Manipulation"
 	description = "How to get more zap."
 	prereq_ids = list("engineering")
-	design_ids = list("smes", "super_cell", "hyper_cell", "super_capacitor", "superpacman", "mrspacman", "power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
+	design_ids = list("smes", "super_cell", "hyper_cell", "superpacman", "mrspacman", "power_turbine", "power_turbine_console", "power_compressor", "circulator", "teg")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 /*

--- a/code/modules/research/techweb/nodes/engineering_nodes.dm
+++ b/code/modules/research/techweb/nodes/engineering_nodes.dm
@@ -6,7 +6,7 @@
 	description = "A refresher course on modern engineering technology."
 	prereq_ids = list("base")
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin",
-	"atmosalerts", "atmos_control", "recycler", "autolathe", "autolathe_secure", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
+	"atmosalerts", "atmos_control", "recycler", "autolathe", "autolathe_secure", "high_micro_laser", "nano_mani", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine", "rcd_ammo","oxygen_tank",
 	"plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "colormate")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
@@ -16,7 +16,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "forcefield_projector", "weldingmask" , // Removed "rcd_loaded" because we commented it out :v
+	design_ids = list("forcefield_projector", "weldingmask" , // Removed "rcd_loaded" because we commented it out :v
 	"tray_goggles_prescription", "engine_goggles_prescription", "mesons_prescription", "rcd_upgrade_frames",
 	"rcd_upgrade_simple_circuits", "rcd_ammo_large", "sheetifier")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -52,7 +52,7 @@
 	description = "Basic fragile prosthetics for the impaired."
 	starting_node = TRUE
 	prereq_ids = list("biotech")
-	design_ids = list("basic_l_arm", "basic_r_arm", "basic_r_leg", "basic_l_leg", "autosurgeon")
+	design_ids = list("basic_l_arm", "basic_r_arm", "basic_r_leg", "basic_l_leg")
 
 /datum/techweb_node/advance_limbs
 	id = "advance_limbs"

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -83,7 +83,7 @@
 	display_name = "Upgraded Cybernetic Organs"
 	description = "We have the technology to upgrade him."
 	prereq_ids = list("cyber_organs")
-	design_ids = list("cybernetic_ears_u", "cybernetic_heart_u", "cybernetic_liver_u", "cybernetic_lungs_u")
+/*	design_ids = list("cybernetic_ears_u", "cybernetic_heart_u", "cybernetic_liver_u", "cybernetic_lungs_u")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
 /datum/techweb_node/cyber_implants
@@ -91,7 +91,7 @@
 	display_name = "Cybernetic Implants"
 	description = "Electronic implants that improve humans."
 	prereq_ids = list("adv_biotech", "adv_datatheory")
-	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-service")
+/*	design_ids = list("ci-nutriment", "ci-breather", "ci-gloweyes", "ci-welding", "ci-medhud", "ci-sechud", "ci-service")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/adv_cyber_implants
@@ -99,7 +99,7 @@
 	display_name = "Advanced Cybernetic Implants"
 	description = "Upgraded and more powerful cybernetic implants."
 	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDs")
-	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus")
+/*	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/combat_cyber_implants
@@ -107,7 +107,7 @@
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
 	prereq_ids = list("adv_cyber_implants","weaponry","high_efficiency")
-	design_ids = list("ci-antidrop", "ci-antistun")
+/*	design_ids = list("ci-antidrop", "ci-antistun")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /////////////////////////Advanced Surgery/////////////////////////
@@ -124,7 +124,7 @@
 	display_name = "Advanced Surgery Tools"
 	description = "Refined and improved redesigns for the run-of-the-mill medical utensils."
 	prereq_ids = list("adv_biotech", "adv_surgery")
-	design_ids = list("drapes", "retractor_adv", "surgicaldrill_adv", "scalpel_adv", "bonesetter", "surgical_tape")
+/*	design_ids = list("drapes", "retractor_adv", "surgicaldrill_adv", "scalpel_adv", "bonesetter", "surgical_tape")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/adv_surgery

--- a/code/modules/research/techweb/nodes/misc_nodes.dm
+++ b/code/modules/research/techweb/nodes/misc_nodes.dm
@@ -46,7 +46,7 @@
 	display_name = "Advanced Electromagnetic Theory"
 	description = "Determining whether reversing the polarity will actually help in a given situation."
 	prereq_ids = list("emp_basic")
-	design_ids = list("ultra_micro_laser")
+/*	design_ids = list("ultra_micro_laser")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 /datum/techweb_node/emp_super
@@ -54,7 +54,7 @@
 	display_name = "Quantum Electromagnetic Technology"	//bs
 	description = "Even better electromagnetic technology."
 	prereq_ids = list("emp_adv")
-	design_ids = list("quadultra_micro_laser")
+/*	design_ids = list("quadultra_micro_laser")*/
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 

--- a/code/modules/research/techweb/nodes/tools_nodes.dm
+++ b/code/modules/research/techweb/nodes/tools_nodes.dm
@@ -44,7 +44,7 @@
 	id = "exp_tools"
 	display_name = "Experimental Tools"
 	description = "Highly advanced construction tools."
-	design_ids = list("exwelder", "jawsoflife", "handdrill", "holosigncombifan", "ranged_analyzer")
+/*	design_ids = list("exwelder", "jawsoflife", "handdrill", "holosigncombifan", "ranged_analyzer")*/
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2750)
 


### PR DESCRIPTION
Removed most of the high tier research stuff that can be printed. (Can't be printed from the lathe anymore)

Removed medihuds from the kits. (Reason being they both show mobs health and remove the main point of a certain quirk and health analyzers. That being checking health.)

All clinic workers get tier 3 parts recipes.

Scientists get low level implant recipes.

Nerfed research notes points amount by half. (Putting emphasis on rationing more.)

Nerfed most of the Senior doctors stuff. You can get the pre war chem master in dungeons anyway, and that arm medbeam gun is too strong.

Put the tier 4 parts in dungeons along with a good portion of the good quality implants.

Changed up the spawn texts of the town doctors. They never were changed to not reference the followers anymore. While they can still be considered followers, seems corners were cut when we fixed them up. 😅 

Heck, also have a surgery computer for the new players.