### PR TITLE
Pre-war Imitation foods

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_wastefood.dm
@@ -347,6 +347,51 @@
 	category = CAT_FOOD
 	subcategory = CAT_WASTEFOOD
 
+/datum/crafting_recipe/food/imitation_cram
+	name = "Imitation Cram"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain = 1,
+		/datum/reagent/consumable/sodiumchloride = 5,
+		/datum/reagent/consumable/blackpepper =5
+	)
+	result = /obj/item/reagent_containers/food/snacks/f13/cram
+	category = CAT_FOOD
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/imitation_ss
+	name = "Imitation Salisbury Steak"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain = 1,
+		/datum/reagent/consumable/nutriment = 5,
+		/datum/reagent/consumable/cream =5
+	)
+	result = /obj/item/reagent_containers/food/snacks/f13/steak
+	category = CAT_FOOD
+	subcategory = CAT_WASTEFOOD
+	
+/datum/crafting_recipe/food/imitation_bcm
+	name = "Imitation BlamCo Mac and Cheese"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/spaghetti = 1,
+		/obj/item/reagent_containers/food/snacks/cheesewedge = 2,
+		/datum/reagent/consumable/cream =5
+	)
+	result = /obj/item/reagent_containers/food/snacks/f13/blamco
+	category = CAT_FOOD
+	subcategory = CAT_WASTEFOOD
+
+/datum/crafting_recipe/food/imitation_pab
+	name = "Imitation Pork and Beans"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/meat/steak/plain = 1,
+		/obj/item/reagent_containers/food/snacks/grown/soybeans = 2,
+		/obj/item/reagent_containers/food/snacks/grown/tomato = 2
+	)
+	result = /obj/item/reagent_containers/food/snacks/f13/canned/porknbeans
+	category = CAT_FOOD
+	subcategory = CAT_WASTEFOOD
+	
+	
 /////////////////
 //Sewer Food.  //
 /////////////////


### PR DESCRIPTION
## About The Pull Request
Certain foods required for recipes are very limited in supply, due to vendors being awkward to get to or only having five or so of each supply. However, why would a wastelander even go scouring the world for macaroni cheese boxes when they can literally make their own... I set out to resolve this by adding a few recipes.

Imitation BlamCo! Mac and Cheese.
Imitation Saddle-Up Salisbury Steaks.
Imitation Cram.
Imitation Pork and beans.

They're so good, they're indistinguishible from the real thing... (p.s. it totally creates the real thing, I didn't want to make entirely new items for no real reason.)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new ways to get some pre-war foods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
