### PR TITLE
Gardenbelt fix

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -167,6 +167,7 @@
 	icon = 'icons/fallout/clothing/belts.dmi'
 	icon_state = "gardener"
 	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
+	component_type = /datum/component/storage/concrete/belt/specialized/utility
 
 /obj/item/storage/belt/janitor
 	name = "janibelt"


### PR DESCRIPTION
## About The Pull Request
This should hopefully make it so that gardening tools can once again be stored in the gardening belt, it seemed to have lost it's utility storage datum.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: hopefully fixed the gardening belt's storage abilities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
