### PR TITLE
Tuning cartridge values

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
@@ -51,13 +51,13 @@
 	icon_state = "crafted"
 	item_state = "crafted"
 	custom_price = PRICE_ABOVE_EXPENSIVE
-	maxCharge = 15000
+	maxCharge = 7000
 	custom_materials = list(/datum/material/iron=1000, /datum/material/glass=500)
 
 /obj/item/stock_parts/chem_cartridge/simple
 	name = "Knock-off chemical cartridge"
 	desc = "A casing holding a mix of raw material for use in chem dispensors. It looks like a mass produced knock-off."
-	maxCharge = 10000
+	maxCharge = 5000
 	custom_price = PRICE_ABOVE_EXPENSIVE
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500, /datum/material/plasma = 100)
 
@@ -67,5 +67,5 @@
 	icon_state = "pristine"
 	item_state = "pristine"
 	custom_price = PRICE_REALLY_EXPENSIVE
-	maxCharge = 20000
+	maxCharge = 10000
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=1000, /datum/material/plasma = 500)


### PR DESCRIPTION
## About The Pull Request
It's come time for me to do what I said I was going to do in #873
Chem Cartridges are having their reagent values nerfed. Now that players have had time to get used to how they work it's now time to make them a more significant factor in game. Over the three months or so this mechanic has existed doctors have had no trouble continuing to stockpile medicine and even the cartridges themselves.

Actual value changes. (For a un-upgraded chem dispenser.)
Ancient Cartridges (Old crusty red) 200 Units.. (Value Unchanged.)
Knock-Off Cartridges (Blue): 800 Units -> 400 Units.
Improvised Cartridges (Brown Crafted):1200 Units ->600 Units.
Pristine Cartridges (Vibrant Red): 1600 Units -> 800 Units.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Chemical Cartridges have had their charge amounts halved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
