### PR TITLE
gimme those hands boi

### DIFF
--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -32,8 +32,9 @@
 	icon = 'modular_coyote/icons/mob/slugcat.dmi'
 
 	faction = "catslug"
-	maxHealth = 50
-	health = 50
+	maxHealth = 500
+	health = 500
+	healable = 1
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 
 	response_help_simple = "hugs"
@@ -47,14 +48,14 @@
 	melee_damage_upper = 5
 
 	dextrous = TRUE
-	dextrous_hud_type = /datum/hud/dextrous
+	held_items = list(null, null)
 	see_in_dark = 8
 
 	var/picked_color = FALSE
 
 /mob/living/simple_animal/catslug/proc/catslug_color()
 	set name = "Pick Color"
-	set category = "Ability"
+	set category = "IC"
 	set desc = "You can set your color!"
 	if(picked_color)
 		to_chat(src, "<span class='notice'>You have already picked a color! If you picked the wrong color, ask an admin to change your picked_color variable to 0.</span>")
@@ -68,3 +69,7 @@
 /mob/living/simple_animal/catslug/Initialize()
     . = ..()
     verbs += /mob/living/simple_animal/catslug/proc/catslug_color
+
+/mob/living/simple_animal/catslug/Initialize()
+	. = ..()
+	add_verb(src, /mob/living/proc/lay_down)


### PR DESCRIPTION
Can't throw, but can drop and use guns. Also upped their health.

Still want too
- Fix their resting sprite, as it's not wanting to pull it from their icon file
- Add throwing, if it can on simple mobs
- Get the pick color verb in a tab, instead of having to type it out

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
