### PR TITLE
Reduces the size of TtG decks

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1545,6 +1545,7 @@
 	desc = "the greatest pre-war TCG. Dangerously addictive."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "deck_nanotrasen_full"
+	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("declares an attack against")
 	
 /obj/item/toy/tragicthegarnering/attack_self(mob/user)


### PR DESCRIPTION
## About The Pull Request
Due to pre-war regulations recently uncovered, Tragic the Garnering tournaments now limit deck sizes. It's a bonus, because now they fit in your pockets, pouches and bags. Those with treasured family decks can now rejoice.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked the weight class of TtG decks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
