### PR TITLE
Catslugs dont runtime as much, also blocks ghosts from inhabiting inhabited mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -220,6 +220,9 @@
 	if(jobban_isbanned(user, ROLE_SYNDICATE))
 		to_chat(user, span_warning("You are jobanned from playing as mobs!"))
 		return
+	if(client)
+		to_chat(user, span_warning("Someone's in there! Wait your turn!"))
+		return
 	if(QDELETED(src) || QDELETED(user))
 		return
 	if(isobserver(user))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -887,6 +887,10 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	return faction_check(faction, target.faction, FALSE)
 
 /proc/faction_check(list/faction_A, list/faction_B, exact_match)
+	if(!islist(faction_A))
+		faction_A = list(faction_A)
+	if(!islist(faction_B))
+		faction_B = list(faction_B)
 	var/list/match_list
 	if(exact_match)
 		match_list = faction_A&faction_B //only items in both lists

--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -31,7 +31,7 @@
 	icon_dead = "catslug_dead"
 	icon = 'modular_coyote/icons/mob/slugcat.dmi'
 
-	faction = "catslug"
+	faction = list("catslug", "neutral")
 	maxHealth = 500
 	health = 500
 	healable = 1


### PR DESCRIPTION
## About The Pull Request

Catslugs no longer runtime when they ask for help.

Ghosts cant hop into mobs that have a ghost in them.