### PR TITLE
Makes bows able to draw from a quiver

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -506,6 +506,58 @@ obj/item/storage/bag/chemistry/tribal
 	icon_state = "tribal_quiver"
 	item_state = "tribal_quiver"
 	component_type = /datum/component/storage/concrete/bag/quiver
+	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_HUGE
+
+/* /obj/item/storage/bag/tribe_quiver/Initialize()
+	. = ..()
+
+/obj/item/storage/bag/tribe_quiver/Destroy()
+	if(istype(associated_bow))
+		if(associated_bow.associated_quiver == src)
+			associated_bow.associated_quiver = null
+		associated_bow = null
+	return ..()
+
+//Associates a bow with this thing
+/obj/item/storage/bag/tribe_quiver/proc/associate_bow(obj/item/gun/ballistic/bow/the_bow, mob/user)
+	if(!istype(the_bow))
+		return
+	if(istype(the_bow, /obj/item/gun/ballistic/bow/xbow) || istype(the_bow, /obj/item/gun/ballistic/bow/crossbow))
+		if(user)
+			user.show_message("Crossbows dont work with this!")
+		return
+	if(istype(associated_bow))
+		return
+	associated_bow = the_bow
+	associated_bow.associated_quiver = src
+	if(user)
+		user.show_message("You link the bow to the quiver.")
+
+//Disassociates a bow with this thing
+/obj/item/storage/bag/tribe_quiver/proc/disassociate_bow(mob/user)
+	if(!istype(associated_bow))
+		return
+	associated_bow.associated_quiver = null
+	associated_bow = null
+	if(user)
+		user.show_message("You unlink the bow from the quiver.")
+
+/obj/item/storage/bag/tribe_quiver/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/gun/ballistic/bow))
+		var/obj/item/gun/ballistic/bow/bowo = W
+		if(bowo.can_link_to_quiver && can_link_to_bow)
+			if(!associated_bow)
+				associate_bow(W, user)
+				return
+			if(W == associated_bow)
+				disassociate_bow(user)
+				return
+			else
+				disassociate_bow(W, user)
+				associate_bow(W, user)
+				return
+	..() */
 
 /obj/item/storage/bag/tribe_quiver/PopulateContents()
 	new /obj/item/ammo_casing/caseless/arrow(src)
@@ -576,4 +628,3 @@ obj/item/storage/bag/chemistry/tribal
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "sack"
 	item_state = "sack"
-

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -22,7 +22,7 @@
 	var/replace_spent_rounds = 0
 	var/multiload = 1
 	var/fixed_mag = FALSE
-	var/unloadable = FALSE
+	var/unloadable = FALSE // ITS SO INTUITIVE WHAT THIS DOES
 	/// Can this magazine have its caliber changed?
 	var/can_change_caliber = FALSE
 	var/caliber_change_step = MAGAZINE_CALIBER_CHANGE_STEP_0

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	if(can_link_to_quiver)
 		. += "Currently [drawing_from_quiver?"":"not"] drawing from a worn quiver, if any."
-		. += "Alt-click the bow to [drawing_from_quiver?"stop"] drawing from a quiver."
+		. += "Alt-click the bow to [drawing_from_quiver?"stop":"start"] drawing from a quiver."
 
 /obj/item/gun/ballistic/bow/can_shoot()
 	return chambered

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -44,12 +44,13 @@
 	if(istype(AC)) //there's a chambered round
 		AC.forceMove(drop_location()) //Eject casing onto ground.
 		chambered = null
-/* 
+
 /obj/item/gun/ballistic/bow/examine(mob/user)
 	. = ..()
-	. += "Currently [drawing_from_quiver?"":"not"] drawing from a worn quiver, if any."
-	. += "Alt-click the bow to [drawing_from_quiver?"stop"] drawing from a quiver."
- */
+	if(can_link_to_quiver)
+		. += "Currently [drawing_from_quiver?"":"not"] drawing from a worn quiver, if any."
+		. += "Alt-click the bow to [drawing_from_quiver?"stop"] drawing from a quiver."
+
 /obj/item/gun/ballistic/bow/can_shoot()
 	return chambered
 
@@ -134,7 +135,8 @@
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return FALSE
 	drawing_from_quiver = !drawing_from_quiver
-	user.show_message("You're [drawing_from_quiver?"now":"no longer"] drawing from a quiver, if one is worn.")
+	if(can_link_to_quiver)
+		user.show_message("You're [drawing_from_quiver?"now":"no longer"] drawing from a quiver, if one is worn.")
 	return TRUE
 
 /obj/item/gun/ballistic/bow/xbow

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -36,17 +36,20 @@
 		SP_DISTANT_SOUND(null),
 		SP_DISTANT_RANGE(null)
 	)
+	var/can_link_to_quiver = FALSE
+	var/drawing_from_quiver = FALSE
 
 /obj/item/gun/ballistic/bow/process_chamber(mob/living/user, empty_chamber = 0)
 	var/obj/item/ammo_casing/AC = chambered //Find chambered round
 	if(istype(AC)) //there's a chambered round
 		AC.forceMove(drop_location()) //Eject casing onto ground.
 		chambered = null
-		/* if(casing_ejector)
-			AC.bounce_away(TRUE)
-		else if(empty_chamber)
-			chambered = null */
-
+/* 
+/obj/item/gun/ballistic/bow/examine(mob/user)
+	. = ..()
+	. += "Currently [drawing_from_quiver?"":"not"] drawing from a worn quiver, if any."
+	. += "Alt-click the bow to [drawing_from_quiver?"stop"] drawing from a quiver."
+ */
 /obj/item/gun/ballistic/bow/can_shoot()
 	return chambered
 
@@ -57,25 +60,58 @@
 		update_icon()
 		to_chat(user, span_notice("You gently release the bowstring, removing the arrow."))
 		return
-	if(recentdraw > world.time || !get_ammo(FALSE))
-		return
+	/* if(recentdraw > world.time)
+		return */
 	draw(user, TRUE)
-	recentdraw = world.time + 2
+	/* recentdraw = world.time + 2 */
 	return
 
 /obj/item/gun/ballistic/bow/proc/draw(mob/M, visible = TRUE)
+	if(!draw_load(M))
+		return TRUE
 	if(visible)
 		M.visible_message(span_warning("[M] draws the string on [src]!"), span_warning("You draw the string on [src]!"))
 	playsound(M, draw_sound, 60, 1)
-	draw_load(M)
 	update_icon()
 	return 1
 
 /obj/item/gun/ballistic/bow/proc/draw_load(mob/M)
-	if(!magazine.ammo_count())
-		return 0
+	if(chambered)
+		return FALSE
+	if(!magazine.ammo_count() && !load_from_quiver(M)) // if its empty, try sticking a new ammo in there
+		return FALSE
 	var/obj/item/ammo_casing/AC = magazine.get_round() //load next casing.
 	chambered = AC
+	. = TRUE
+	var/room_left_in_mag = magazine.max_ammo - LAZYLEN(magazine.stored_ammo)
+	if(room_left_in_mag) // and fill up the rest of the bow if possible
+		var/did_a_load = FALSE
+		for(var/i in 1 to room_left_in_mag)
+			if(!load_from_quiver(M))
+				break
+			did_a_load = TRUE
+		if(did_a_load)
+			M.show_message(span_notice("You ready some arrows from your quiver."))
+
+/obj/item/gun/ballistic/bow/proc/load_from_quiver(mob/user)
+	if(!drawing_from_quiver)
+		return FALSE
+	if(!can_link_to_quiver)
+		return FALSE
+	if(!istype(user))
+		return FALSE
+	if(LAZYLEN(magazine.stored_ammo) >= magazine.max_ammo)
+		return FALSE
+	var/obj/item/storage/bag/tribe_quiver/got_quiver = user.get_item_by_slot(SLOT_BELT)
+	if(!istype(got_quiver))
+		return FALSE
+	for(var/obj/item/ammo_casing/isit_pointy in got_quiver.contents)
+		if(!isit_pointy.BB)
+			continue
+		if(!SEND_SIGNAL(got_quiver, COMSIG_TRY_STORAGE_TAKE, isit_pointy, magazine))
+			continue
+		if(magazine.give_round(isit_pointy))
+			return TRUE
 
 /obj/item/gun/ballistic/bow/attackby(obj/item/A, mob/user, params)
 	if(magazine.attackby(A, user, params, 1))
@@ -93,6 +129,14 @@
 		draw(user, FALSE)
 		recentdraw = world.time + 2
 
+/obj/item/gun/ballistic/bow/AltClick(mob/living/carbon/user)
+	. = ..()
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return FALSE
+	drawing_from_quiver = !drawing_from_quiver
+	user.show_message("You're [drawing_from_quiver?"now":"no longer"] drawing from a quiver, if one is worn.")
+	return TRUE
+
 /obj/item/gun/ballistic/bow/xbow
 	name = "magazine-fed crossbow"
 	desc = "A somewhat primitive projectile weapon. Has a spring-loaded magazine, but still requires drawing back before firing. Fires arrows slightly faster than regular bows, improving damage"
@@ -102,6 +146,7 @@
 	zoom_factor = 1
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/xbow
 	extra_speed = 400
+	can_link_to_quiver = FALSE
 
 
 //Regular Bow
@@ -162,3 +207,4 @@
 	zoom_amt = 10
 	zoom_out_amt = 13
 	can_scope = FALSE
+	can_link_to_quiver = FALSE


### PR DESCRIPTION
## About The Pull Request

Still in development!!!!!

makes bows able to draw from an attached quiver. Currently disabled, but able to be var-edited to work.

Just set can_link_to_quiver to 1 and altclick the bow.