### PR TITLE
Changes up the Captains spare, and Removes Mayor slots (able to still be admin added)

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -544,8 +544,8 @@
 	bank_support = ID_LOCKED_BANK_ACCOUNT
 
 /obj/item/card/id/captains_spare
-	name = "captain's spare ID"
-	desc = "The spare ID of the High Lord himself."
+	name = "Mayor's spare ID"
+	desc = "A special ID handed to anyone with status of Mayor."
 	icon_state = "gold"
 	item_state = "gold_id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -34,12 +34,12 @@ Mayor
 	exp_type = EXP_TYPE_OASIS
 	faction = FACTION_OASIS
 
-/datum/job/oasis/f13mayor
+/datum/job/oasis/f13mayor   // /obj/item/card/id/captains_spare for any elected mayors. - Blue
 	title = "Mayor"
 	flag = F13MAYOR
 	department_flag = DEP_OASIS
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "Nash"
 	description = "You are the civil leader of the Town of Nash. You were chosen by the people to represent and lead them from your manor. Your town is in a terse situation with the slaver town to the south, Redwater. While not at war, you will have to work to keep your people safe from their predations. The Tribals to the south east are also a nuisance but it's best not to provoke them needlessly. Do what's best for the town, and it's people. All while lining your pockets occasionally, of course."
 	enforces = "The Secretary is your stand-in replacement, and under this the Sheriff."


### PR DESCRIPTION
Any newly elected mayor should get the /obj/item/card/id/captains_spare in their loadout box.

Manage job slots is the admin verb for adding a mayor slot for the elected mayor!