### PR TITLE
Fixes in wasteland plants

### DIFF
--- a/code/modules/hydroponics/grown/buffalogourd.dm
+++ b/code/modules/hydroponics/grown/buffalogourd.dm
@@ -14,7 +14,7 @@
 	icon_grow = "gourd-grow"
 	icon_dead = "gourd-dead"
 	icon_harvest = "gourd-harvest"
-	reagents_add = list(/datum/reagent/water = 0.2,  /datum/reagent/toxin = 0.1)
+	reagents_add = list(/datum/reagent/water = 0.2, /datum/reagent/toxin = 0.1)
 	lifespan = 50
 	endurance = 40
 	maturation = 10

--- a/code/modules/hydroponics/grown/horsenettle.dm
+++ b/code/modules/hydroponics/grown/horsenettle.dm
@@ -14,7 +14,7 @@
 	icon_dead = "horsenettle-dead"
 	icon_harvest = "horsenettle-harvest"
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
-	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04,  /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/styptic_powder = 0.1)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/medicine/styptic_powder = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/horsenettle
 	seed = /obj/item/seeds/horsenettle

--- a/code/modules/hydroponics/grown/pinyon.dm
+++ b/code/modules/hydroponics/grown/pinyon.dm
@@ -1,6 +1,6 @@
 /obj/item/seeds/pinyon
 	name = "pack of pinyon pine seeds"
-	desc = "The seeds of the pinyon pine, known as pine nuts or pi��ns, are an important food for settlers and tribes living in the mountains of the North American Southwest. All species of pine produce edible seeds, but in North America only the pinyon produces seeds large enough to be a major source of food."
+	desc = "The seeds of the pinyon pine, known as pine nuts or piñóns, are an important food for settlers and tribes living in the mountains of the North American Southwest. All species of pine produce edible seeds, but in North America only the pinyon produces seeds large enough to be a major source of food."
 	icon_state = "seed-pinyon"
 	species = "pinyon pine"
 	plantname = "Pinyon Pine"
@@ -22,7 +22,7 @@
 /obj/item/reagent_containers/food/snacks/grown/pinyon
 	seed = /obj/item/seeds/pinyon
 	name = "pinyon nuts"
-	desc = "The seeds of the pinyon pine, known as pine nuts or pi��ns, are an important food for settlers and tribes living in the mountains of the North American Southwest. All species of pine produce edible seeds, but in North America only the pinyon produces seeds large enough to be a major source of food."
+	desc = "The seeds of the pinyon pine, known as pine nuts or piñóns, are an important food for settlers and tribes living in the mountains of the North American Southwest. All species of pine produce edible seeds, but in North America only the pinyon produces seeds large enough to be a major source of food."
 	gender = PLURAL
 	icon_state = "Pinyon Nuts"
 	filling_color = "#F0E68C"


### PR DESCRIPTION
## About The Pull Request
This PR fixes the typos in gourd, horsenettle and pinyon nut.
Gourd and horsenettle fixes the reagent typos and pinyon nuts is the description of seed and plant alike.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: typos in gourd, horsenettle and pinyon nut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
