### PR TITLE
Booze exports!

### DIFF
--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -396,7 +396,7 @@
 		/obj/item/grown/log/bamboo
 	)
 
-	/datum/export/item/liquor
+/datum/export/item/liquor
 	k_elasticity = 0
 	cost = 25
 	unit_name = "cheap liquor"
@@ -418,7 +418,7 @@
 	/obj/item/export/bottle/kahlua,
 	)
 	
-	/datum/export/item/highliquor
+/datum/export/item/highliquor
 	k_elasticity = 0
 	cost = 75
 	unit_name = "classy liquor"

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -29,6 +29,7 @@
 	cost = 80
 	unit_name = "super stimpak"
 	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super) */
+	
 
 /datum/export/item/lightpistol
 	cost = 100
@@ -393,4 +394,38 @@
 		/obj/item/reagent_containers/food/snacks/grown/tomato/blue,
 		/obj/item/reagent_containers/food/snacks/grown/tomato/killer,
 		/obj/item/grown/log/bamboo
+	)
+
+	/datum/export/item/liquor
+	k_elasticity = 0
+	cost = 25
+	unit_name = "cheap liquor"
+	export_types = list(/obj/item/export/bottle/gin,
+	/obj/item/export/bottle/whiskey,
+	/obj/item/export/bottle/wine,
+	/obj/item/export/bottle/vodka,
+	/obj/item/export/bottle/rum,
+	/obj/item/export/bottle/tequila,
+	/obj/item/export/bottle/minikeg,
+	/obj/item/export/bottle/applejack,
+	/obj/item/export/bottle/cognac,
+	/obj/item/export/bottle/sake,
+	/obj/item/export/bottle/hcider,
+	/obj/item/export/bottle/vermouth,
+	/obj/item/export/bottle/absinthe,
+	/obj/item/export/bottle/grappa,
+	/obj/item/export/bottle/fernet,
+	/obj/item/export/bottle/kahlua,
+	)
+	
+	/datum/export/item/highliquor
+	k_elasticity = 0
+	cost = 75
+	unit_name = "classy liquor"
+	export_types = list(/obj/item/export/bottle/champagne,
+	/obj/item/export/bottle/blazaam,
+	/obj/item/export/bottle/nukashine,
+	/obj/item/export/bottle/trappist,
+	/obj/item/export/bottle/goldschlager,
+	/obj/item/export/bottle/patron,
 	)


### PR DESCRIPTION
## About The Pull Request
I noticed we could make bottle presses, seal booze and then it was worthless. I felt this was kinda irksome, considering in a wasteland, I wouldn't mind a drink now and then... So I've given booze export value. So you could use it as trade fodder, if you don't want to go and farm caps or aren't capable.

There's two bands; Cheap liquour (worth about 10-12 caps) and Classy liquour (worth about 25-30).
Cheap is your usual, easy to brew suspects like beer, whiskey, wine and the kin, Classy is harder to obtain things like champagne, goldschlager and nukashine.

Now the doctors don't need to salvage every car in the area to be able to afford fancy tools, they can brew beer in their downtime. Which is something that they would do, since grain alcohol is an antiseptic.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added export value to brewskies. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
