### PR TITLE
Adds proper verbs to the base mob for Eevees

### DIFF
--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -93,6 +93,14 @@
 	health = 200
 	maxHealth = 200
 	healable = 1
+	response_help_continuous = "pets"
+	response_help_simple = "pet"
+	response_disarm_continuous = "bops"
+	response_disarm_simple = "bop"
+	response_harm_continuous = "kicks"
+	response_harm_simple = "kick"
+	attack_verb_continuous = "nuzzles"
+	attack_verb_simple = "nuzzle"
 
 /mob/living/simple_animal/pet/pokemon/update_mobility()
 	. = ..()


### PR DESCRIPTION
Should work.

## About The Pull Request
Makes it so the cute eevee mobs nuzzle and get pet instead of poked or attack others.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed verbs for eevees
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
