### PR TITLE
Improved Weaponsmith + Fixes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -256,6 +256,7 @@
 #define TRAIT_HYDRA_HEADS "hydra_heads"
 #define TRAIT_SHELTERED "sheltered"
 #define TRAIT_PIEDPIPER "rat_lord"
+#define TRAIT_WEAPONSMITH "Weaponsmith"
 
 // mobility flag traits
 // IN THE FUTURE, IT WOULD BE NICE TO DO SOMETHING SIMILAR TO https://github.com/tgstation/tgstation/pull/48923/files (ofcourse not nearly the same because I have my.. thoughts on it)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -256,7 +256,7 @@
 #define TRAIT_HYDRA_HEADS "hydra_heads"
 #define TRAIT_SHELTERED "sheltered"
 #define TRAIT_PIEDPIPER "rat_lord"
-#define TRAIT_WEAPONSMITH "Weaponsmith"
+#define TRAIT_WEAPONSMITH "weaponsmith"
 
 // mobility flag traits
 // IN THE FUTURE, IT WOULD BE NICE TO DO SOMETHING SIMILAR TO https://github.com/tgstation/tgstation/pull/48923/files (ofcourse not nearly the same because I have my.. thoughts on it)

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -648,7 +648,7 @@
 //Caravan Shotgun
 /datum/crafting_recipe/caravanshotty
 	name = "Caravan Shotgun"
-	result = /obj/item/gun/ballistic/rifle/hunting
+	result = /obj/item/gun/ballistic/revolver/caravan_shotgun
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
 				/obj/item/stack/crafting/metalparts = 2,
 				/obj/item/stack/sheet/metal = 2,)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	/datum/crafting_recipe/ninemil,
 	/datum/crafting_recipe/huntingrifle,
 	/datum/crafting_recipe/n99,
-	/datum/crafting_recipe/huntingrifle,
+	/datum/crafting_recipe/huntingshotgun,
 	/datum/crafting_recipe/m1911,
 	/datum/crafting_recipe/varmintrifle,
 	/datum/crafting_recipe/autoaxe,
@@ -48,7 +48,16 @@ GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	/datum/crafting_recipe/tools/forged/entrenching_tool,
 	/datum/crafting_recipe/chainsaw,
 	/datum/crafting_recipe/steeltower,
-	/datum/crafting_recipe/durathread_vest))
+	/datum/crafting_recipe/durathread_vest,
+	/datum/crafting_recipe/scope,
+	/datum/crafting_recipe/suppressor,
+	/datum/crafting_recipe/ergonomic_grip,
+	/datum/crafting_recipe/metal_guard,
+	/datum/crafting_recipe/forged_barrel,
+	/datum/crafting_recipe/booster,
+	/datum/crafting_recipe/heatsink,
+	/datum/crafting_recipe/laserguide,
+	/datum/crafting_recipe/gigalens))
 
 GLOBAL_LIST_INIT(former_tribal_recipes, list(
 	/datum/crafting_recipe/tribal/bonetalisman,
@@ -295,7 +304,8 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 
 /datum/quirk/technophreak
 	name = "Technophreak"
-	desc = "You're skilled at breaking down old-war rubble more precisely and therefor you gain more salvage from cars and piles than before."
+	desc = "You're skilled at breaking down old-war rubble more precisely and therefor you gain more salvage from cars and piles than before. Your time with understanding complex technology also \
+	allows you to craft more complex machine parts."
 	value = 2
 	mob_trait = TRAIT_TECHNOPHREAK
 	gain_text = span_notice("Old-War rubble seems considerably more generous to you.")
@@ -315,8 +325,9 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 
 /datum/quirk/gunsmith
 	name = "Weaponsmith"
-	desc = "You know how to make various weapons and protective vests. The list is too large to try and put here."
+	desc = "You know how to make various weapons, protective vests, and gun mods. The list is too large to try and put here."
 	value = 2
+	mob_trait = TRAIT_WEAPONSMITH
 	gain_text = span_notice("You are adept at crafting makeshift weapons.")
 	lose_text = span_danger("You seem less adept at crafting makeshift weapons.")
 
@@ -622,6 +633,8 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 		return //welp
 	QDEL_NULL(our_tongue.lick_bandage)
 
+// This does the same thing as basic explosive crafting by giving basic_recipe and adv_recipe. -Possum
+/*
 /datum/quirk/advanced_explosive_crafting
 	name = "Advanced Explosive Crafting"
 	desc = "Decades of engineering knowledge have taught you to make all kinds of horrible explosives."
@@ -644,7 +657,7 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 	if(H)
 		H.mind.learned_recipes -= GLOB.basic_explosive_recipes
 		H.mind.learned_recipes -= GLOB.adv_explosive_recipes
-
+*/
 
 /datum/quirk/whitelegstraditions
 	name = "White Legs traditions"

--- a/modular_coyote/eris/code/mods/_upgrades.dm
+++ b/modular_coyote/eris/code/mods/_upgrades.dm
@@ -335,7 +335,7 @@
 		G.recoil_dat = G.recoil_dat.modifyRating(1, 1, weapon_upgrades[GUN_UPGRADE_ONEHANDPENALTY])
 	if(weapon_upgrades[UPGRADE_COLOR])
 		G.color = weapon_upgrades[UPGRADE_COLOR]
-	
+
 	if(!isnull(weapon_upgrades[GUN_UPGRADE_FORCESAFETY]))
 		G.restrict_safety = TRUE
 		G.safety = weapon_upgrades[GUN_UPGRADE_FORCESAFETY]
@@ -351,7 +351,7 @@
 
 	for(var/datum/firemode/F in G.firemodes)
 		apply_values_firemode(F)
-	
+
 	G.update_firemode()
 
 /datum/component/item_upgrade/proc/add_values_gun(obj/item/gun/G)
@@ -509,7 +509,7 @@
 			examine_list += span_warning("Disables the safety toggle of the weapon.")
 		else if(weapon_upgrades[GUN_UPGRADE_FORCESAFETY] == 1)
 			examine_list += span_warning("Forces the safety toggle of the weapon to always be on.")
-		
+
 		if(weapon_upgrades[GUN_UPGRADE_DNALOCK] == 1)
 			examine_list += span_warning("Adds a biometric scanner to the weapon.")
 
@@ -601,7 +601,7 @@
 		if(toremove == "Cancel")
 			return 1
 		var/datum/component/item_upgrade/IU = toremove.GetComponent(/datum/component/item_upgrade)
-		if(IU.removable == FALSE)
+		if(IU.removable == FALSE && !(HAS_TRAIT(user,TRAIT_WEAPONSMITH)))
 			to_chat(user, span_danger("\the [toremove] seems to be fused with the [upgrade_loc]"))
 		else
 			if(C.use_tool(user = user, target =  upgrade_loc, delay = IU.removal_time))

--- a/modular_coyote/eris/code/mods/_upgrades.dm
+++ b/modular_coyote/eris/code/mods/_upgrades.dm
@@ -601,7 +601,7 @@
 		if(toremove == "Cancel")
 			return 1
 		var/datum/component/item_upgrade/IU = toremove.GetComponent(/datum/component/item_upgrade)
-		if(IU.removable == FALSE && !(HAS_TRAIT(user,TRAIT_WEAPONSMITH)))
+		if(IU.removable == FALSE)
 			to_chat(user, span_danger("\the [toremove] seems to be fused with the [upgrade_loc]"))
 		else
 			if(C.use_tool(user = user, target =  upgrade_loc, delay = IU.removal_time))


### PR DESCRIPTION
Weaponsmithing is... useless, annoyingly useless. A 2 point trait which can be outpaced by five minutes of searching junk piles inside Nash. It serves next to no true mechanical purpose besides flavors. My hope with these changes is to give it a reason to exist and maybe encourage more crafter types then everyone rushing speed + HP + damage.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
-Added a trait_weaponsmith define
-Added said define to the weaponsmith trait.
-Fixed an issue with hunting rifles being given twice by the weapon smith trait, corrected to hunting shotgun. 
-Commented out advanced explosive crafting since everything iit did was done by regular explosives crafting, giving it no purpose.
 -Fixed a missing descriptor to technophreak so it details that it gives T3 machine part recipes.
 -Added a wide selection of basic gun mods to the weaponsmith perk given its lack of use otherwise. 
-Fixed the caravan shotgun recipe producing hunting rifles instead of caravan shotguns when crafted.

--Removed due to code limitations
 _-Added in a check for faulty gun mods found on scavenged guns that allows them to be removed if you have the weaponsmith perk._
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
