### PR TITLE
Tweaks Smoke Signals To Be Seen Indoors

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -377,7 +377,7 @@
 			to_chat(player, msg_dead)
 			continue
 		if(player.has_language(/datum/language/tribal) && !HAS_TRAIT(player, TRAIT_BLIND))
-			if(!is_type_in_list(get_area(player), GLOB.outdoor_areas))
+			if(!player.z == Z_LEVEL_NASH_UNDERGROUND) //Can be seen while indoors, just not sent. Still, can't see while underground.
 				continue
 			var/dirmessage = "somewhere in the distance"
 			if(player.z == B.z)


### PR DESCRIPTION
## About The Pull Request
When originally designing smoke signals, I was worried that they might be just a little too close to radio to give to tribals. I may have been a little hasty for balance, though, because in their current state it is very difficult to tell if a signal is being sent unless you are, by happenstance, outside at the time.

I figure preventing people from seeing the signal while underground, but giving them the ability to see while indoors (windows generally exist in Nash!) is a good halfway point.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

If someone else could do me the favor of testing this quickly locally, I'd appreciate it - I've run into the updated-byond-client issue from before and am too split between servers at the moment to downgrade for testing.

## Changelog
:cl:
tweak: Smoke signals can be seen from anywhere except underground. You can still only send them from outside, though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
