### PR TITLE
loincloths hide boobs when toggled

### DIFF
--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -752,6 +752,7 @@
 	body_parts_covered = GROIN
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = TRUE
+	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/f13/wayfarer/shamanblue
 	name = "blue shaman garbs"
@@ -791,6 +792,7 @@
 	item_color = "hunter"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = TRUE
+	alt_covers_chest = TRUE
 
 //OUTLAW DESERTERS
 /obj/item/clothing/under/f13/exile
@@ -824,6 +826,7 @@
 	body_parts_covered = GROIN
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = TRUE
+	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/f13/exile/enclave
 	name = "disheveled peacekeeper uniform"

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -431,16 +431,8 @@
 
 /// cure the whole wasteland of the *scourge* that is not having mountainous tits
 /obj/item/storage/box/large/custom_kit/fireclaw787/PopulateContents()
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
-	new /obj/item/storage/pill_bottle/breast_enlarger(src)
+	for(var/i in 1 to 7)
+		new /obj/item/storage/pill_bottle/breast_enlarger(src)
 
 /datum/gear/donator/kits/fuzlet
 	name = "fuzzy supply box"

--- a/modular_citadel/code/modules/client/loadout/kits.dm
+++ b/modular_citadel/code/modules/client/loadout/kits.dm
@@ -3,5 +3,5 @@
 /obj/item/storage/box/large/custom_kit
 	name = "Custom Loadout"
 	desc = "Your custom loadout items!"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	


### PR DESCRIPTION
## About The Pull Request

Loincloths have a chest wrap, and should now cover ur boobs when the wrap is on. Also modifies custom loadout boxes to be normal sized, and made Jade's BE box hold a possible number of boobie bottles.