### PR TITLE
Harm intend disables clickdragging

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -12,6 +12,15 @@
 		return
 	if(over == src)
 		return usr.client.Click(src, src_location, src_control, params)
+	var/is_mob_in_harm_intent // "harm" intent
+	if(ismob(usr))
+		var/mob/clicker = usr
+		if(clicker.a_intent == INTENT_HARM)
+			is_mob_in_harm_intent = TRUE
+	if(is_mob_in_harm_intent) // in harm intent, disable clickdragging and try to click on whatever your mouse is over when you let up a click
+		if(over == usr && src != usr) // If you clickdrag something out of range to yourself, click what you originaly clicked
+			return usr.client.Click(src, over_location, src_control, params)
+		return usr.client.Click(over, over_location, src_control, params)
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -5,6 +5,9 @@
 	receiving object instead, so that's the default action.  This allows you to drag
 	almost anything into a trash can.
 */
+
+GLOBAL_VAR_INIT(use_experimental_clickdrag_thing, TRUE)
+
 /atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	if(!usr || !over)
 		return
@@ -12,15 +15,16 @@
 		return
 	if(over == src)
 		return usr.client.Click(src, src_location, src_control, params)
-	var/is_mob_in_harm_intent // "harm" intent
-	if(ismob(usr))
-		var/mob/clicker = usr
-		if(clicker.a_intent == INTENT_HARM)
-			is_mob_in_harm_intent = TRUE
-	if(is_mob_in_harm_intent) // in harm intent, disable clickdragging and try to click on whatever your mouse is over when you let up a click
-		if(over == usr && src != usr) // If you clickdrag something out of range to yourself, click what you originaly clicked
-			return usr.client.Click(src, over_location, src_control, params)
-		return usr.client.Click(over, over_location, src_control, params)
+	if(GLOB.use_experimental_clickdrag_thing)
+		var/is_mob_in_harm_intent // "harm" intent
+		if(ismob(usr))
+			var/mob/clicker = usr
+			if(clicker.a_intent == INTENT_HARM)
+				is_mob_in_harm_intent = TRUE
+		if(is_mob_in_harm_intent) // in harm intent, disable clickdragging and try to click on whatever your mouse is over when you let up a click
+			if(over == usr && src != usr) // If you clickdrag something out of range to yourself, click what you originaly clicked
+				return usr.client.Click(src, over_location, src_control, params)
+			return usr.client.Click(over, over_location, src_control, params)
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
 /world/proc/AVerbsAdmin()
 	return list(
+	/client/proc/toggle_experimental_clickdrag_thing,				/*allows our mob to go invisible/visible*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
@@ -404,6 +405,18 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		else
 			mob.invisibility = INVISIBILITY_OBSERVER
 			to_chat(mob, "<span class='adminnotice'><b>Invisimin on. You are now as invisible as a ghost.</b></span>")
+
+/client/proc/toggle_experimental_clickdrag_thing()
+	set name = "Toggle Clickdrag Changes"
+	set category = "Debug"
+	set desc = "Toggles harm-intent clickdrag disabling. Its experimental, click this if people complain clickdragging being broken, and tell Superlagg what broke."
+	GLOB.use_experimental_clickdrag_thing = !GLOB.use_experimental_clickdrag_thing
+	log_admin("[key_name(usr)] toggled the harm intent clickdrag disabling thing.")
+	message_admins("[key_name_admin(usr)] toggled the harm intent clickdrag disabling thing.")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggled clickdrag thing")
+	if(alert("Tell everyone the experimental clickdrag thing was [GLOB.use_experimental_clickdrag_thing ? "enabled" : "disabled"]?",,"Yes","No") != "Yes")
+		return
+	to_chat(world, "<B>The experimental harm-intent clickdrag disable thing has been [GLOB.use_experimental_clickdrag_thing ? "enabled" : "disabled"].</B>")
 
 /client/proc/check_antagonists()
 	set name = "Check Antagonists"


### PR DESCRIPTION
## About The Pull Request

With harm intent on, when you click, when you mouse-up, it clicks there. Simple as.

Comes with an admin killswitch in case it fucks everything up.