### PR TITLE
Renaming Pens

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -31,6 +31,7 @@
 	var/font = PEN_FONT
 	embedding = list()
 	sharpness = SHARP_POINTY
+	var/naming = FALSE
 
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku..."))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -145,32 +145,51 @@
 	else
 		. = ..()
 
-/obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
+/obj/item/pen/AltClick(mob/user)
+	if(!naming)
+		naming = TRUE
+		w_class = WEIGHT_CLASS_GIGANTIC
+		sharpness = SHARP_NONE
+		to_chat(usr, "<span class='notice'>You firmly grip the pen in preparation to rename something.</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
+	if(naming)
+		naming = FALSE
+		w_class = WEIGHT_CLASS_TINY
+		sharpness = SHARP_POINTY
+		to_chat(usr, "<span class='notice'>You reset the grip on the pen</span>")
+		playsound(src, 'sound/machines/button2.ogg', 100, 1)
+		return
+
+
+/obj/item/pen/afterattack(obj/O, mob/living/user, proximity, params)
 	. = ..()
-	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
-		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
-		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-			return
-		if(penchoice == "Rename")
-			var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
-			var/oldname = O.name
+	if (naming)
+		//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
+		if(isobj(O) && proximity)
+			var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(oldname == input)
-				to_chat(user, span_notice("You changed \the [O.name] to... well... \the [O.name]."))
-			else
-				O.name = input
-				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
-				O.renamedByPlayer = TRUE
+			if(penchoice == "Rename")
+				var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+				var/oldname = O.name
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				if(oldname == input)
+					to_chat(user, "<span class='notice'>You changed \the [O.name] to... well... \the [O.name].</span>")
+				else
+					O.name = input
+					to_chat(user, "<span class='notice'>\The [oldname] has been successfully been renamed to \the [input].</span>")
+					O.renamedByPlayer = TRUE
 
-		if(penchoice == "Change description")
-			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
-			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
-				return
-			O.desc = input
-			to_chat(user, span_notice("You have successfully changed \the [O.name]'s description."))
-
+			if(penchoice == "Change description")
+				var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+				if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+					return
+				O.desc = input
+				to_chat(user, "<span class='notice'>You have successfully changed \the [O.name]'s description.</span>")
+	else	
+		return
 /*
  * Sleepypens
  */


### PR DESCRIPTION
## About The Pull Request
Ports the ability to universally rename items with a pen by alt-clicking it from other versions of fallout 13 (In this particular instance, atom bomb.)

This should be a boon to RP, letting players customize their gear and do counterfeit shenanigans—the clear next step in the Stanford prison experiment that is Nash. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog
:cl:
balance: rebalanced the pen
/:cl:
