### PR TITLE
beeg thicc changes hotfix (reboring no longer broke)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -116,7 +116,7 @@
 	max_ammo = 2
 	multiload = 0
 
-/obj/item/ammo_box/magazine/internal/cylinder/improvised762/Initialize()
+/obj/item/ammo_box/magazine/internal/cylinder/improvised308/Initialize()
 	. = ..()
 	name += " [pick(GLOB.hobo_gun_mag_fluff["prefix"])] [pick(GLOB.hobo_gun_mag_fluff["suffix"])][prob(20) ? pick(GLOB.hobo_gun_mag_fluff["prefix"]) : ""]"
 	valid_new_calibers = GLOB.pipe_rifle_valid_calibers


### PR DESCRIPTION
## About The Pull Request

improvised762 was made into improvised308
improvised762/Initialize() was not made into improvised308/Initialize()
This caused the code that handled winchester reboring to do nothing, since it was attributed to a magazine type that no longer exists
1 line fix, not even that, a 3 letter fix

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:

fix: improvised762 is no more

/:cl:

