### PR TITLE
fixes blunt arrow crafting

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -399,7 +399,7 @@
 
 /datum/crafting_recipe/tribalwar/arrowblunt
 	name = "Blunt Arrow (Nonlethal)"
-	result = /obj/item/projectile/bullet/reusable/arrow/blunt
+	result = /obj/item/ammo_casing/caseless/arrow/blunt
 	time = 10
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 1,


### PR DESCRIPTION
## About The Pull Request
No longer are the days of crafting blunt arrows as mid-air projectiles.
that's it
that's the whole thing.
You couldn't load them, the item was just broken since it wasn't an item at all, but the projectile held in your hand.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
fix: blunthead arrows.
/:cl: