### PR TITLE
HOPEFULLY WORKS

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -609,3 +609,5 @@
 ///living players needed to activate limited mob ability powers
 #define MOB_POWER_SOME_MIN_PLAYERS 9
 
+/// Drop everything in the mob loot list
+#define MOB_LOOT_ALL "allofit"

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -204,12 +204,20 @@ GLOBAL_LIST_INIT(trash_ammo, list(
 ))
 
 GLOBAL_LIST_INIT(trash_chem, list(
-	/obj/item/storage/pill_bottle/chem_tin/radx = 5,
-	/obj/item/reagent_containers/food/drinks/bottle/orangejuice = 10,
+	/obj/item/storage/pill_bottle/chem_tin/radx = 10,
+	/obj/item/reagent_containers/food/drinks/bottle/orangejuice = 20,
 	/obj/item/reagent_containers/food/drinks/bottle/cognac = 10,
-	/obj/item/reagent_containers/food/drinks/bottle/whiskey = 10,
+	/obj/item/reagent_containers/food/drinks/bottle/whiskey = 20,
 	/obj/item/stock_parts/chem_cartridge/garbage = 10,
-	/obj/item/stock_parts/chem_cartridge/simple = 1
+	/obj/item/stock_parts/chem_cartridge/simple = 1,
+	/obj/item/reagent_containers/pill/patch/jet = 5,
+	/obj/item/reagent_containers/pill/patch/turbo = 1,
+	/obj/item/reagent_containers/pill/healingpowder = 10,
+	/obj/item/reagent_containers/pill/stimulant = 1,
+	/obj/item/reagent_containers/hypospray/medipen/medx = 5,
+	/obj/item/storage/pill_bottle/chem_tin/buffout = 5,
+	/obj/item/reagent_containers/hypospray/medipen/steady = 5,
+	/obj/item/reagent_containers/hypospray/medipen/psycho = 5
 ))
 
 GLOBAL_LIST_INIT(trash_craft, list(
@@ -223,14 +231,23 @@ GLOBAL_LIST_INIT(trash_craft, list(
 ))
 
 GLOBAL_LIST_INIT(trash_gun, list(
-	/obj/item/gun/ballistic/automatic/hobo/zipgun = 2,
-	/obj/item/gun/ballistic/revolver/shotpistol = 1,
-	/obj/item/gun/ballistic/revolver/hobo/pepperbox = 2,
-	/obj/item/gun/ballistic/automatic/varmint = 1,
-	/obj/item/gun/ballistic/automatic/sportcarbine = 1,
-	/obj/item/gun/ballistic/automatic/pistol/ninemil = 1,
-	/obj/item/gun/ballistic/automatic/pistol/pistol22 = 1,
-	/obj/item/gun/ballistic/revolver/widowmaker = 1
+	/obj/item/gun/ballistic/automatic/sportcarbine = 50, //we need these for turrets. may make craftable later
+	/obj/item/gun/ballistic/automatic/hobo/zipgun = 10,
+	/obj/item/gun/ballistic/revolver/hobo/piperifle = 10,
+	/obj/item/gun/ballistic/revolver/hobo/pepperbox = 10,
+	/obj/item/gun/ballistic/revolver/hobo/single_shotgun = 10,
+	/obj/item/gun/ballistic/revolver/hobo/knifegun = 10,
+	/obj/item/gun/ballistic/revolver/hobo/knucklegun = 1,
+	/obj/item/gun/ballistic/automatic/autopipe = 1,
+	/obj/item/gun/ballistic/revolver/winchesterrebored = 10,
+	/obj/item/melee/onehanded/machete/scrapsabre = 5,
+	/obj/item/melee/onehanded/knife/cosmicdirty = 5,
+	/obj/item/melee/onehanded/club/tireiron = 10,
+	/obj/item/twohanded/fireaxe/bmprsword = 5,
+	/obj/item/melee/onehanded/club = 10,
+	/obj/item/twohanded/spear/scrapspear = 10,
+	/obj/item/melee/unarmed/lacerator = 5,
+	/obj/item/shishkebabpack = 1
 ))
 
 GLOBAL_LIST_INIT(trash_money, list(

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -569,7 +569,8 @@
 				/obj/item/reagent_containers/medspray/styptic,
 				/obj/item/reagent_containers/medspray/silver_sulf,
 				/obj/item/reagent_containers/medspray/sterilizine,
-				/obj/item/storage/pill_bottle/chem_tin/fixer
+				/obj/item/storage/pill_bottle/chem_tin/fixer,
+				/obj/item/reagent_containers/hypospray/medipen/psycho,
 				)
 
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug //remove equipment, has nothing on it
@@ -579,11 +580,12 @@
 	loot = list(
 				/obj/item/reagent_containers/pill/patch/jet,
 				/obj/item/reagent_containers/pill/patch/turbo,
-				// /obj/item/reagent_containers/pill/healingpowder,
+				/obj/item/reagent_containers/pill/healingpowder,
 				/obj/item/reagent_containers/pill/stimulant,
 				/obj/item/reagent_containers/hypospray/medipen/medx,
 				/obj/item/storage/pill_bottle/chem_tin/buffout,
-				/obj/item/reagent_containers/hypospray/medipen/steady
+				/obj/item/reagent_containers/hypospray/medipen/steady,
+				/obj/item/reagent_containers/hypospray/medipen/psycho,
 				)
 
 

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -106,6 +106,12 @@
 	idlesound = list('sound/f13npc/ghoul/idle.ogg')
 	death_sound = 'sound/f13npc/ghoul/ghoul_death.ogg'
 	loot = list(/obj/item/stack/f13Cash/random/low/lowchance)
+	/// How many things to drop on death? Set to MOB_LOOT_ALL to just drop everything in the list
+	loot_drop_amount = 1
+	/// Drop 1 - loot_drop_amount? False always drops loot_drop_amount items
+	loot_amount_random = TRUE
+	/// slots in a list of trash loot
+	var/random_trash_loot = TRUE
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = TRUE
 	call_backup = /obj/effect/proc_holder/mob_common/summon_backup/ghoul
@@ -119,6 +125,9 @@
 		icon_state = rare_icon
 		icon_living = rare_icon
 		icon_dead = "[rare_icon]_dead"
+	if(random_trash_loot)
+		loot = GLOB.trash_ammo + GLOB.trash_chem + GLOB.trash_clothing + GLOB.trash_craft + GLOB.trash_gun + GLOB.trash_misc + GLOB.trash_money + GLOB.trash_mob + GLOB.trash_part + GLOB.trash_tool + GLOB.trash_attachment
+
 
 // Ghoul Reaver
 /mob/living/simple_animal/hostile/ghoul/reaver
@@ -144,6 +153,7 @@
 	melee_damage_lower = 8
 	melee_damage_upper = 14
 	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
+	loot_drop_amount = 2
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = TRUE
 	pop_required_to_jump_into = BIG_MOB_MIN_PLAYERS
@@ -198,6 +208,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
+	loot_drop_amount = 2
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
 
@@ -215,6 +226,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
+	loot_drop_amount = 4
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
 
@@ -238,6 +250,8 @@
 	wound_bonus = 0
 	bare_wound_bonus = 0
 	loot = list(/obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 5
+	loot_amount_random = FALSE
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE //heeeeeell no
 	call_backup = null
@@ -272,6 +286,7 @@
 	can_ghost_into = TRUE
 	pop_required_to_jump_into = BIG_MOB_MIN_PLAYERS
 	desc_short = "A glowing creature that may or may not be a reanimated corpse."
+	loot_drop_amount = 2
 
 /mob/living/simple_animal/hostile/ghoul/glowing/Initialize(mapload)
 	. = ..()
@@ -318,6 +333,7 @@
 	maxHealth = 60 
 	health = 60
 	loot = list(/obj/item/stack/f13Cash/random/low/medchance)
+	loot_drop_amount = 2
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
 
@@ -334,6 +350,7 @@
 	health = 80
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
+	loot_drop_amount = 3
 
 //Alive Ghoul
 /mob/living/simple_animal/hostile/ghoul/scorched
@@ -357,6 +374,7 @@
 	attack_sound = "punch"
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
+	loot_drop_amount = 4
 
 //Alive Ghoul Ranged
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged
@@ -385,6 +403,7 @@
 	attack_sound = "punch"
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
+	loot_drop_amount = 5
 
 //Sunset mob of some sort?
 /mob/living/simple_animal/hostile/ghoul/wyomingghost
@@ -415,6 +434,7 @@
 	sharpness = SHARP_EDGED //They need to cut their finger nails
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	can_ghost_into = FALSE
+	loot_drop_amount = 5
 
 //Halloween Event Ghouls
 /mob/living/simple_animal/hostile/ghoul/zombie

--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -27,6 +27,12 @@
 	status_flags = CANPUSH
 	del_on_death = FALSE
 	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/stack/f13Cash/random/med)
+	/// How many things to drop on death? Set to MOB_LOOT_ALL to just drop everything in the list
+	loot_drop_amount = 2
+	/// Drop 1 - loot_drop_amount? False always drops loot_drop_amount items
+	loot_amount_random = TRUE
+	/// slots in a list of trash loot
+	var/random_trash_loot = TRUE
 	footstep_type = FOOTSTEP_MOB_SHOE
 	rapid_melee = 2
 	melee_queue_distance = 5
@@ -42,6 +48,11 @@
 		MOB_NAME_FROM_GLOBAL_LIST(\
 			MOB_RANDOM_NAME(MOB_NAME_RANDOM_MALE, 1)\
 		))
+
+/mob/living/simple_animal/hostile/raider/Initialize()
+	. = ..()
+	if(random_trash_loot)
+		loot = GLOB.trash_ammo + GLOB.trash_chem + GLOB.trash_clothing + GLOB.trash_craft + GLOB.trash_gun + GLOB.trash_misc + GLOB.trash_money + GLOB.trash_mob + GLOB.trash_part + GLOB.trash_tool + GLOB.trash_attachment
 
 /obj/effect/mob_spawn/human/corpse/raider
 	name = "Raider"
@@ -111,6 +122,7 @@
 	projectiletype = /obj/item/projectile/bullet/c9mm/simple
 	projectilesound = 'sound/f13weapons/ninemil.ogg'
 	loot = list(/obj/effect/spawner/lootdrop/f13/npc_raider, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 	variation_list = list(
 		MOB_NAME_FROM_GLOBAL_LIST(\
@@ -140,6 +152,9 @@
 	obj_damage = 300
 	rapid_melee = 1
 	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/reagent_containers/food/snacks/kebab/human, /obj/item/stack/f13Cash/random/high)
+	loot_drop_amount = MOB_LOOT_ALL
+	loot_amount_random = FALSE
+	random_trash_loot = FALSE
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 // LEGENDARY RANGED RAIDER
@@ -161,6 +176,9 @@
 	extra_projectiles = 1
 	obj_damage = 300
 	loot = list(/obj/item/gun/ballistic/revolver/m29, /obj/item/stack/f13Cash/random/high)
+	loot_drop_amount = MOB_LOOT_ALL
+	loot_amount_random = FALSE
+	random_trash_loot = FALSE
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -191,6 +209,9 @@
 	auto_fire_delay = GUN_AUTOFIRE_DELAY_FAST
 	projectiletype = /obj/item/projectile/bullet/c10mm/improvised
 	loot = list(/obj/item/gun/ballistic/automatic/smg/smg10mm, /obj/item/clothing/head/helmet/f13/combat/mk2/raider, /obj/effect/spawner/lootdrop/f13/armor/randomraiderchest, /obj/item/clothing/under/f13/ravenharness, /obj/item/stack/f13Cash/random/high)
+	loot_drop_amount = MOB_LOOT_ALL
+	loot_amount_random = FALSE
+	random_trash_loot = FALSE
 	footstep_type = FOOTSTEP_MOB_SHOE
 	move_to_delay = 4.0 //faster than average, but not a lot
 	retreat_distance = 4 //mob retreats 1 tile when in min distance
@@ -346,6 +367,7 @@
 	projectiletype = /obj/item/projectile/bullet/c45/simple
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	loot = list(/obj/item/gun/ballistic/automatic/pistol/m1911/custom, /obj/item/clothing/suit/armor/heavy/metal/reinforced, /obj/item/clothing/head/helmet/f13/metalmask/mk2, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 5
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -367,6 +389,7 @@
 	maxHealth = 100
 	health = 100
 	loot = list(/obj/item/twohanded/fireaxe, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 	rapid_melee = 1
 
@@ -386,6 +409,7 @@
 	projectiletype = /obj/item/projectile/bullet/a762/sport/simple
 	projectilesound = 'sound/f13weapons/magnum_fire.ogg'
 	loot = list(/obj/item/gun/ballistic/revolver/thatgun, /obj/item/clothing/suit/armor/medium/combat/rusted, /obj/item/clothing/head/helmet/f13/raidercombathelmet, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 5
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -421,6 +445,7 @@
 	health = 125
 	rapid_melee = 1
 	loot = list(/obj/item/twohanded/baseball, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 
@@ -443,6 +468,7 @@
 	melee_damage_lower = 12
 	melee_damage_upper = 37
 	loot = list(/obj/item/twohanded/spear)
+	loot_drop_amount = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 	rapid_melee = 1
 
@@ -470,6 +496,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 37
 	loot = list(/obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 5
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /////////////
@@ -506,6 +533,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 38
 	footstep_type = FOOTSTEP_MOB_SHOE
+	loot_drop_amount = 5
 
 /mob/living/simple_animal/hostile/raider/junker/creator
 	name = "Junker Field Creator"
@@ -530,6 +558,7 @@
 	var/spawn_time = 15 SECONDS
 	var/spawn_text = "flies from"
 	footstep_type = FOOTSTEP_MOB_SHOE
+	loot_drop_amount = 5
 
 
 /mob/living/simple_animal/hostile/raider/junker/creator/Initialize()
@@ -570,6 +599,9 @@
 	projectilesound = 'sound/f13weapons/auto5.ogg'
 	loot = list(/obj/item/stack/f13Cash/random/high)
 	footstep_type = FOOTSTEP_MOB_SHOE
+	loot_drop_amount = 10
+	loot_amount_random = FALSE
+	
 
 // Cultist Stuff
 
@@ -595,6 +627,7 @@
 	status_flags = CANPUSH
 	del_on_death = FALSE
 	loot = list(/obj/item/melee/onehanded/knife/survival, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 2
 	footstep_type = FOOTSTEP_MOB_SHOE
 	rapid_melee = 2
 	melee_queue_distance = 5
@@ -630,6 +663,7 @@
 	projectiletype = /obj/item/projectile/bullet/c10mm/simple
 	projectilesound = 'sound/f13weapons/ninemil.ogg'
 	loot = list(/obj/item/gun/ballistic/automatic/pistol/n99, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 3
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -667,6 +701,7 @@
 	sound_after_shooting = 'sound/weapons/shotguninsert.ogg'
 	extra_projectiles = 1
 	loot = list(/obj/item/gun/ballistic/shotgun/trench, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 6
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -704,6 +739,7 @@
 	sound_after_shooting = 'sound/weapons/shotguninsert.ogg'
 	extra_projectiles = 2
 	loot = list(/obj/item/gun/ballistic/automatic/smg/mini_uzi/smg22, /obj/item/stack/f13Cash/random/med)
+	loot_drop_amount = 8
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -741,6 +777,7 @@
 	sound_after_shooting = 'sound/f13weapons/rcwfire.ogg'
 	extra_projectiles = 2
 	loot = list(/obj/item/gun/energy/laser/auto/oasis, /obj/item/stack/f13Cash/random/high)
+	loot_drop_amount = 8
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),
@@ -778,6 +815,7 @@
 	sound_after_shooting = 'sound/f13weapons/rcwfire.ogg'
 	extra_projectiles = 1
 	loot = list(/obj/item/gun/energy/gammagun, /obj/item/stack/f13Cash/random/high)
+	loot_drop_amount = 10
 	footstep_type = FOOTSTEP_MOB_SHOE
 	projectile_sound_properties = list(
 		SP_VARY(FALSE),

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -806,6 +806,13 @@
 	guaranteed_butcher_results = list(/obj/item/reagent_containers/food/snacks/soup/amanitajelly = 2)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/soup/amanitajelly = 1)
 	butcher_difficulty = 1.5
+	loot = list(/obj/item/stack/f13Cash/random/med)
+	/// How many things to drop on death? Set to MOB_LOOT_ALL to just drop everything in the list
+	loot_drop_amount = 10
+	/// Drop 1 - loot_drop_amount? False always drops loot_drop_amount items
+	loot_amount_random = TRUE
+	/// slots in a list of trash loot
+	var/random_trash_loot = TRUE
 	response_help_simple = "jiggles"
 	response_disarm_simple = "wiggles"
 	response_harm_simple = "shakes"
@@ -834,3 +841,8 @@
 	waddle_up_time = 3
 	waddle_side_time = 2
 	desc_short = "Big, squishy, and gelatinous."
+
+/mob/living/simple_animal/hostile/gelcube/Initialize()
+	. = ..()
+	if(random_trash_loot)
+		loot = GLOB.trash_ammo + GLOB.trash_chem + GLOB.trash_clothing + GLOB.trash_craft + GLOB.trash_gun + GLOB.trash_misc + GLOB.trash_money + GLOB.trash_mob + GLOB.trash_part + GLOB.trash_tool + GLOB.trash_attachment

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -124,6 +124,10 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 
 	///list of things spawned at mob's loc when it dies.
 	var/list/loot = list()
+	///How do we handle the loot list? Should be either MOB_LOOT_ALL or a number. If its a number, use an associated weighted list for `loot`!
+	var/loot_drop_amount = MOB_LOOT_ALL
+	///Drop a random number, 1 through loot_drop_amount? only applicable if loot_drop_amount is a number
+	var/loot_amount_random = TRUE
 	///causes mob to be deleted on death, useful for mobs that spawn lootable corpses.
 	var/del_on_death = FALSE
 	var/deathmessage = ""
@@ -553,9 +557,18 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 
 
 /mob/living/simple_animal/proc/drop_loot()
-	for(var/drop in loot)
-		for(var/i in 1 to max(1, loot[drop]))
-			new drop(drop_location())
+	if(loot_drop_amount == MOB_LOOT_ALL || !isnum(loot_drop_amount))
+		for(var/drop in loot)
+			for(var/i in 1 to max(1, loot[drop]))
+				new drop(drop_location())
+		return
+	var/list/lootlist = loot
+	for(var/i in 1 to loot_amount_random ? rand(1,loot_drop_amount) : loot_drop_amount)
+		if(!LAZYLEN(lootlist))
+			return
+		var/atom/dropthing = pickweight_n_take(lootlist)
+		if(isatom(dropthing))
+			new dropthing(drop_location())
 
 /mob/living/simple_animal/death(gibbed)
 	movement_type &= ~FLYING

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -566,8 +566,8 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	for(var/i in 1 to loot_amount_random ? rand(1,loot_drop_amount) : loot_drop_amount)
 		if(!LAZYLEN(lootlist))
 			return
-		var/atom/dropthing = pickweight_n_take(lootlist)
-		if(isatom(dropthing))
+		var/dropthing = pickweight_n_take(lootlist)
+		if(ispath(dropthing))
 			new dropthing(drop_location())
 
 /mob/living/simple_animal/death(gibbed)


### PR DESCRIPTION
Co-authored-by: Superlagg should make raiders, ghouls, and gelatinous cubes drop variable amounts of trash.
adds psycho to drug spawns, adds drug spawns to trash

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
