### PR TITLE
Stack tweaks and arrowhead fix

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1944,7 +1944,7 @@ obj/effect/spawner/bundle/f13/combat_rifle
 /obj/effect/spawner/bundle/f13/m1919
 	name = "browning m1919 and ammo spawner"
 	items = list(/obj/item/gun/ballistic/automatic/m1919,
-				/obj/item/ammo_box/magazine/mm762
+				/obj/item/ammo_box/magazine/mm308
 				)
 
 /obj/effect/spawner/bundle/f13/dks

--- a/code/game/objects/items/arrow_crafting.dm
+++ b/code/game/objects/items/arrow_crafting.dm
@@ -10,24 +10,28 @@
 	/// our arrow head type
 	var/obj/item/stack/arrowhead/the_head
 	/// Does it have hay on it?
-	var/has_hay
+	var/has_hay = TRUE // it does
 	/// The result arrow
 	var/obj/item/ammo_casing/caseless/arrow/the_arrow
+
+/obj/item/arrow_shaft/Initialize()
+	. = ..()
+	update_icon() // so the hay shows up
 
 /obj/item/arrow_shaft/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stack/arrowhead) && attach_arrowhead(W, user))
 		return
-	if(istype(W, /obj/item/stack/sheet/hay) && attach_hay(W, user))
-		return
+	//if(istype(W, /obj/item/stack/sheet/hay) && attach_hay(W, user))
+	//	return
 	. = ..()
 
 /obj/item/arrow_shaft/attack_hand(mob/user, act_intent, attackchain_flags)
 	if(ispath(the_head, /obj/item/stack/arrowhead))
 		remove_arrowhead(user)
 		return
-	if(has_hay)
-		remove_hay(user)
-		return
+	//if(has_hay)
+	//	remove_hay(user)
+	//	return
 	. = ..()
 
 
@@ -114,6 +118,7 @@
 	desc = "Some kind of pointy thing made to go fast."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_metal"
+	merge_type = /obj/item/stack/arrowhead
 	/// The head defines the resulting arrow
 	var/obj/item/ammo_casing/caseless/arrow/result_arrow = /obj/item/ammo_casing/caseless/arrow
 
@@ -123,6 +128,7 @@
 	desc = "A sharpened piece of metal, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_metal"
+	merge_type = /obj/item/stack/arrowhead/metal
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/metal
 
 /obj/item/stack/arrowhead/field
@@ -131,6 +137,7 @@
 	desc = "A thin, sharpened piece of metal, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_field"
+	merge_type = /obj/item/stack/arrowhead/field
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/field
 
 /obj/item/stack/arrowhead/titanium
@@ -139,6 +146,7 @@
 	desc = "A sharpened piece of titanium, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_titanium"
+	merge_type = /obj/item/stack/arrowhead/titanium
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/titanium
 
 /obj/item/stack/arrowhead/bone
@@ -147,6 +155,7 @@
 	desc = "A sharpened 'animal' bone, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_bone"
+	merge_type = /obj/item/stack/arrowhead/bone
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/stack/arrowhead/flint
@@ -155,6 +164,7 @@
 	desc = "A sharpened piece of flint, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_flint"
+	merge_type = /obj/item/stack/arrowhead/flint
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/flint
 
 /obj/item/stack/arrowhead/glass
@@ -163,6 +173,7 @@
 	desc = "A sharpened piece of glass, filed down to an aerodynamic point."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_glass"
+	merge_type = /obj/item/stack/arrowhead/glass
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/glass
 
 /obj/item/stack/arrowhead/jagged
@@ -171,6 +182,7 @@
 	desc = "A jagged shard of metal, ready to rearrange someone's guts all over the road."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_jagged"
+	merge_type = /obj/item/stack/arrowhead/jagged
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/jagged
 
 /obj/item/stack/arrowhead/explosive
@@ -179,6 +191,7 @@
 	desc = "A sack of explosives, ready to rearrange someone's guts all over the road."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_explosive"
+	merge_type = /obj/item/stack/arrowhead/explosive
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/explosive
 
 /obj/item/stack/arrowhead/ion
@@ -187,6 +200,7 @@
 	desc = "A clump of charged electronic chunks, ready to let out all manner of electrical nonsense on whatever it hits."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_ion"
+	merge_type = /obj/item/stack/arrowhead/ion
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/ion
 
 /obj/item/stack/arrowhead/blunt
@@ -195,6 +209,7 @@
 	desc = "A blunt wad of leather, firm enough to knock someone over."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_blunt"
+	merge_type = /obj/item/stack/arrowhead/blunt
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/blunt
 
 /obj/item/stack/arrowhead/practice
@@ -203,6 +218,7 @@
 	desc = "A blunt sack, ready to gently paff someone from across the road."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_practice"
+	merge_type = /obj/item/stack/arrowhead/practice
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/practice
 
 /obj/item/stack/arrowhead/sticky
@@ -211,5 +227,6 @@
 	desc = "A sticky sack, ready to annoy someone."
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_sticky"
+	merge_type = /obj/item/stack/arrowhead/sticky
 	result_arrow = /obj/item/ammo_casing/caseless/arrow/sticky
 

--- a/code/game/objects/items/arrow_crafting.dm
+++ b/code/game/objects/items/arrow_crafting.dm
@@ -96,11 +96,10 @@
 	return TRUE
 
 /obj/item/arrow_shaft/proc/finish_construction(mob/user)
-	var/obj/item/ammo_casing/caseless/arrow/make_this_arrow = new the_arrow(get_turf(src))
+	var/obj/item/ammo_casing/caseless/arrow/make_this_arrow = new the_arrow(get_turf(user))
 	if(ismob(user))
 		user.visible_message(span_notice("[user] makes \a [make_this_arrow]!"))
-		if(loc == user)
-			user.put_in_hands(make_this_arrow)
+		user.put_in_hands(make_this_arrow) // Try to put it in your hand
 	qdel(src)
 
 /obj/item/arrow_shaft/update_overlays()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("wooden floor tile", /obj/item/stack/tile/wood, 1, 4, 20), \
-	new/datum/stack_recipe("wooden arrow shaft", /obj/item/arrow_shaft, 1, 1, 0.5 SECONDS), \
+	new/datum/stack_recipe("wooden arrow shaft", /obj/item/arrow_shaft, 1, 1, 0.5 SECONDS, is_stack = FALSE), \
 	null, \
 	new/datum/stack_recipe_list("pews", list( \
 		new /datum/stack_recipe("pew (middle)", /obj/structure/chair/pew, 3, one_per_turf = TRUE, on_floor = TRUE),\

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -246,7 +246,11 @@
 
 		var/obj/O
 		if(R.max_res_amount > 1) //Is it a stack?
-			O = new R.result_type(usr.drop_location(), R.res_amount * multiplier)
+			if(R.is_stack)
+				O = new R.result_type(usr.drop_location(), R.res_amount * multiplier)
+			else
+				for(var/i in 1 to multiplier)
+					O = new R.result_type(get_turf(usr))
 		else if(ispath(R.result_type, /turf))
 			var/turf/T = usr.drop_location()
 			if(!isturf(T))
@@ -547,8 +551,10 @@
 	var/applies_mats = FALSE
 	var/trait_booster = null
 	var/trait_modifier = 1
+	/// Is the resulting thing made from this a stack? if so, multi-crafting will make a stack with multiple 'uses' of it. if not, multi-crafting makes several separate items of it
+	var/is_stack = TRUE
 
-/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1,time = 0, one_per_turf = FALSE, on_floor = FALSE, window_checks = FALSE, placement_checks = FALSE, applies_mats = FALSE, trait_booster = null, trait_modifier = 1)
+/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1,time = 0, one_per_turf = FALSE, on_floor = FALSE, window_checks = FALSE, placement_checks = FALSE, applies_mats = FALSE, trait_booster = null, trait_modifier = 1, is_stack = TRUE)
 
 
 	src.title = title
@@ -564,6 +570,7 @@
 	src.applies_mats = applies_mats
 	src.trait_booster = trait_booster
 	src.trait_modifier = trait_modifier
+	src.is_stack = is_stack
 /*
  * Recipe list datum
  */

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -249,7 +249,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	head = /obj/item/clothing/head/helmet/f13/legion/palacent
 	suit_store = /obj/item/gun/ballistic/automatic/m1919
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/mm762 = 1,
+		/obj/item/ammo_box/magazine/mm308 = 1,
 		/obj/item/book/granter/martial/cqc = 1,
 		)
 

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -2,7 +2,8 @@
 	name = "\improper Low Yield Rocket"
 	desc = "The PM-9LHE is an 84mm low-yield High Explosive rocket. Fire at people and pray."
 	caliber = CALIBER_ROCKET
-	icon_state = "srm-8"
+	icon = 'modular_coyote/icons/objects/c13ammo.dmi'
+	icon_state = "m6a1"
 	projectile_type = /obj/item/projectile/bullet/a84mm_he
 	is_pickable = FALSE
 	custom_materials = list(
@@ -12,26 +13,31 @@
 /obj/item/ammo_casing/caseless/rocket/hedp
 	name = "\improper High Explosive Dual Purpose Rocket"
 	desc = "The PM-9HEDP is an 84mm High Explosive Dual Purpose rocket. Pointy end toward mechs."
-	icon_state = "84mm-hedp"
+	icon_state = "og7v"
 	projectile_type = /obj/item/projectile/bullet/a84mm
 
 /obj/item/ammo_casing/caseless/rocket/incendiary
 	name = "\improper Incendiary Rocket"
 	desc = "The PM-9 I is an 84mm incendiary rocket. Fire with care."
-	icon_state = "84mm-incin"
+	icon_state = "rocketshell"
 	projectile_type = /obj/item/projectile/bullet/a84mm_incend
 
 /obj/item/ammo_casing/caseless/rocket/chem
 	name = "\improper Chemical Rocket"
 	desc = "The PM-9C is an 84mm chemical dispersement rocket. Fire with great shame."
-	icon_state = "84mm-chem"
+	icon_state = "pg7v"
 	projectile_type = /obj/item/projectile/bullet/a84mm_chem
 
 /obj/item/ammo_casing/caseless/rocket/big
 	name = "\improper High Yield HE Rocket"
 	desc = " The PM-9 HHE is like the low-yield HE rocket, but bigger."
-	icon_state = "84mm-hedp"
+	icon_state = "m6a1"
 	projectile_type = /obj/item/projectile/bullet/a84mm_he_big
+
+/obj/item/ammo_casing/caseless/rocket/big/Initialize(mapload, set_snowflake_id)
+	. = ..()
+	transform *= 1.5
+	special_transform = transform
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -88,14 +88,14 @@
 	caliber = list(CALIBER_308)
 	custom_materials = list(/datum/material/iron = MATS_MEDIUM_BELT_MAGAZINE)
 
-/obj/item/ammo_box/magazine/mm762/empty
+/obj/item/ammo_box/magazine/mm308/empty
 	start_empty = 1
 
 /* I think we want to be able to load up belts of the stuff
-/obj/item/ammo_box/magazine/mm762/can_load()
+/obj/item/ammo_box/magazine/mm308/can_load()
 	return 0
 */
 	
-/obj/item/ammo_box/magazine/mm762/update_icon()
+/obj/item/ammo_box/magazine/mm308/update_icon()
 	..()
 	icon_state = "762belt-[round(ammo_count(),20)]"

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -128,17 +128,17 @@
 
 /obj/item/ammo_box/magazine/sks
 	name = ".308 SKS clip"
-	icon_state = "enbloc-10"
+	icon_state = "enbloc-8"
 	ammo_type = /obj/item/ammo_casing/a308
 	caliber = list(CALIBER_308)
-	max_ammo = 10
+	max_ammo = 8
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/magazine/sks/update_icon()
 	..()
 	if (ammo_count() >= 10)
-		icon_state = "enbloc-10"
+		icon_state = "enbloc-8"
 	else
 		icon_state = "enbloc-[ammo_count()]"
 
@@ -191,7 +191,7 @@
 
 /obj/item/ammo_box/magazine/m473/small
 	name = "4.7mm carbine magazine"
-	icon_state = "46x30mmt"
+	icon_state = "473small"
 	max_ammo = 20
 	w_class = WEIGHT_CLASS_SMALL
 

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -515,7 +515,7 @@
 	category = list("initial", "Intermediate Magazines")
 
 /datum/design/ammolathe/garand308
-	name = "empty garand en-bloc clip (7.62mm/.308)"
+	name = "empty garand en-bloc clip (.30-06)"
 	id = "garand308"
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/garand3006/empty
@@ -666,7 +666,7 @@
 	name = "empty ammo belt (.308)"
 	id = "mm762"
 	materials = list(/datum/material/iron = 8000)
-	build_path = /obj/item/ammo_box/magazine/mm762/empty
+	build_path = /obj/item/ammo_box/magazine/mm308/empty
 	category = list("initial", "Advanced Magazines")
 
 /datum/design/ammolathe/pps_mag

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
@@ -46,7 +46,7 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtrubber
 	name = "wt550 magazine (Rubber bullets 4.6x30mm)"
-	icon_state = "46x30mmtA-20"
+	icon_state = "473small"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/rubber
 
 /obj/item/projectile/bullet/c46x30mm/rubber


### PR DESCRIPTION
## About The Pull Request

Stacks can now spawn multiple things, in addition to stacks with stuff in them. Only really applies to arrow shafts right now.

Arrowheads should no longer mess with the CI.

Arrow shafts no longer need hay to make arrows.

Makes rockets visible.