### PR TITLE
Try to fix the wasteland drops

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -31,6 +31,11 @@
 			loot_spawned++
 	return INITIALIZE_HINT_QDEL
 
+/obj/effect/spawner/lootdrop/Destroy()
+	if (loot)
+		QDEL_LIST(loot)
+	return ..()
+
 /obj/effect/spawner/lootdrop/bedsheet
 	icon = 'icons/obj/bedsheets.dmi'
 	icon_state = "random_bedsheet"

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(desolate_plant_spawn_list, list(
 						/obj/item/stack/crafting/metalparts/five = 30,
 						/obj/item/stack/crafting/goodparts/five = 30,
 						/obj/item/stack/ore/blackpowder/twenty = 10,
-						//obj/effect/spawner/lootdrop/f13/weapon/wasteland = 6,
+						/obj/effect/spawner/lootdrop/f13/weapon/wasteland = 6,
 						//obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid = 3,
 						//obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low = 3
 						)
@@ -248,6 +248,11 @@ GLOBAL_LIST_INIT(desolate_plant_spawn_list, list(
 		salvage = new derp()
 	if(icon_state != "wasteland")
 		icon_state = "wasteland[rand(1,31)]"
+
+/turf/open/indestructible/ground/outside/desert/Destroy()
+	if (salvage)
+		QDEL_NULL(salvage)
+	return ..()
 
 /obj/effect/overlay/desert_side
 	name = "desert"


### PR DESCRIPTION
## About The Pull Request
QDEL the wasteland drops in the sand when the turf is destroyed.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
