### PR TITLE
Reworks radpuddles into a low-impact mess

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -201,6 +201,8 @@
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"				//from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"				//from base of turf/New(): (turf/source, direction)
+#define COMSIG_TURF_IRRADIATE "turf_irradiate"					//used by radpuddles to check and update a turf's radiation
+#define COMSIG_TURF_RADIOACTIVE "turf_is_radioactive"				//returns whether a turf is radioactive or not
 
 // /atom/movable signals
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -22,6 +22,8 @@
 /// called by datum/cinematic/play() : (datum/cinematic/new_cinematic)
 #define COMSIG_GLOB_PLAY_CINEMATIC "!play_cinematic"
 	#define COMPONENT_GLOB_BLOCK_CINEMATIC 1
+#define COMSIG_GLOB_RADIATION_SHOW "!debug_show_rads"				//Makes turfs that are radioactive green and show a number
+
 
 // signals from globally accessible objects
 /// from SSsun when the sun changes position : (azimuth)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -202,7 +202,7 @@
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"				//from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"				//from base of turf/New(): (turf/source, direction)
 #define COMSIG_TURF_IRRADIATE "turf_irradiate"					//used by radpuddles to check and update a turf's radiation
-#define COMSIG_TURF_RADIOACTIVE "turf_is_radioactive"				//returns whether a turf is radioactive or not
+#define COMSIG_TURF_CHECK_RADIATION "turf_is_radioactive"				//returns whether a turf is radioactive or not
 
 // /atom/movable signals
 #define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1535,6 +1535,15 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
 
+/proc/coords2turf(coords)
+	var/list/c2xyz = splittext(coords, ":")
+	return locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+
+/proc/turf2coords(turf/the_turf)
+	if(!istype(the_turf))
+		return
+	return "[the_turf.x]:[the_turf.y]:[the_turf.z]"
+
 /proc/num2sign(numeric)
 	if(numeric > 0)
 		return 1

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1539,10 +1539,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	var/list/c2xyz = splittext(coords, ":")
 	return locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
 
-/proc/turf2coords(turf/the_turf)
-	if(!istype(the_turf))
+/proc/atom2coords(atom/A)
+	if(!istype(A))
 		return
-	return "[the_turf.x]:[the_turf.y]:[the_turf.z]"
+	return "[A.x]:[A.y]:[A.z]"
 
 /proc/num2sign(numeric)
 	if(numeric > 0)

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,8 +1,73 @@
+GLOBAL_VAR_INIT(rad_puddle_debug, FALSE)
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
 	flags = SS_NO_INIT | SS_BACKGROUND
 
 	var/list/warned_atoms = list()
+	/// Contains a list of coordinates to turfs that are irradiated
+	/// list("x:y:z" = rad_level)
+	var/list/irradiated_turfs = list()
+	/// irradiated mobs, to be blasted with radiation every tick
+	/// list("mob_whatever" = rad_level)
+	var/list/irradiated_mobs = list()
+	/// Occasionally clean up the irradiated mobs and turfs
+	COOLDOWN_DECLARE(cleanup_radiation)
+	/// debug command, dont usr
+	var/greened = FALSE
+
+/datum/controller/subsystem/processing/radiation/fire(resumed)
+	if(COOLDOWN_FINISHED(src, cleanup_radiation))
+		cleanup_radiation()
+		COOLDOWN_START(src, cleanup_radiation, 15 MINUTES)
+	var/list/bad_mobs = list()
+	for(var/glowie in irradiated_mobs)
+		var/mob/living/carbon/human/glowman = locate(glowie)
+		if(!istype(glowman))
+			bad_mobs += glowie
+			continue
+		var/coordz = "[glowman.x]:[glowman.y]:[glowman.z]"
+		if(!(coordz in irradiated_turfs))
+			irradiated_turfs -= coordz
+			bad_mobs += glowie
+			continue
+		var/turf/check_turf = locate(glowman.x, glowman.y, glowman.z)
+		if(!SEND_SIGNAL(check_turf, COMSIG_TURF_RADIOACTIVE)) // is that turf radioactive? if not, then, wierd
+			irradiated_turfs -= coordz
+			bad_mobs += glowie
+			continue
+		glowman.rad_act(irradiated_turfs[coordz])
+	if(LAZYLEN(bad_mobs))
+		for(var/baddie in bad_mobs)
+			irradiated_mobs -= baddie
+	if(GLOB.rad_puddle_debug)
+		for(var/coordie in irradiated_turfs)
+			var/list/c2xyz = splittext(coordie, ":")
+			var/turf/helpme = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+			if(helpme)
+				helpme.color = greened ? initial(helpme.color) : "#00ff00"
+		greened = !greened
+
+/datum/controller/subsystem/processing/radiation/proc/cleanup_radiation()
+	var/list/bad_mobs = list()
+	for(var/glowie in irradiated_mobs)
+		var/mob/living/carbon/human/glowman = locate(glowie)
+		if(!istype(glowman))
+			bad_mobs += glowie
+			continue
+	if(LAZYLEN(bad_mobs))
+		for(var/baddie in bad_mobs)
+			irradiated_mobs -= baddie
+	var/list/bad_turfs = list()
+	for(var/turfie in irradiated_turfs)
+		var/list/c2xyz = splittext(turfie, ":")
+		var/turf/fieturf = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+		if(!fieturf)
+			bad_turfs += turfie
+		if(!SEND_SIGNAL(fieturf, COMSIG_TURF_RADIOACTIVE))
+			bad_turfs += turfie
+	if(LAZYLEN(bad_turfs))
+		for(var/badone in bad_turfs)
+			irradiated_turfs -= badone
 
 /datum/controller/subsystem/processing/radiation/proc/warn(datum/component/radioactive/contamination)
 	if(!contamination || QDELETED(contamination))

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,69 +1,8 @@
-/// Makes irradiated areas flash green and have a number
-/// if it does both, everything is fine. if not, then hecc
-GLOBAL_VAR_INIT(rad_puddle_debug, FALSE)
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
-	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING|SS_NO_INIT
+	flags = SS_NO_INIT | SS_BACKGROUND
 
 	var/list/warned_atoms = list()
-	/// irradiated mobs, to be blasted with radiation every tick
-	/// list("mob_whatever" = rad_level)
-	var/list/irradiated_mobs = list()
-	/// debug command, dont use
-	var/greened = FALSE
-
-/datum/controller/subsystem/processing/radiation/fire(resumed)
-	tick_radpuddles()
-	. = ..()
-
-/datum/controller/subsystem/processing/radiation/proc/tick_radpuddles(resumed)
-	for(var/glowie in irradiated_mobs)
-		var/mob/living/carbon/human/glowman = locate(glowie)
-		if(!istype(glowman))
-			irradiated_mobs -= glowie
-			continue
-		var/turf/check_turf = get_turf(glowman)
-		var/radblastusa = SEND_SIGNAL(check_turf, COMSIG_TURF_CHECK_RADIATION) // is that turf radioactive? if not, then, wierd
-		if(radblastusa <= 0) 
-			irradiated_mobs -= glowie
-			continue
-		glowman.rad_act(radblastusa)
-		if(GLOB.rad_puddle_debug)
-			glowman.emote("scream")
-			glowman.say("[radblastusa]")
-
-/* /// Periodically checks all the turf coordinates are both there and supposed to be radioactive
-/datum/controller/subsystem/processing/radiation/proc/cleanup_radiation()
-	for(var/turfie in irradiated_turfs)
-		var/turf/fieturf = coords2turf(turfie)
-		if(!fieturf)
-			irradiated_turfs -= turfie
-			continue
-		if(QDELETED(fieturf))
-			irradiated_turfs -= turfie
-			continue
-		if(!SEND_SIGNAL(fieturf, COMSIG_TURF_CHECK_RADIATION))
-			irradiated_turfs -= turfie
-			continue */
-
-/// the irradiated tile got changed and its component deleted, check back in a split second and apply a new one there
-/datum/controller/subsystem/processing/radiation/proc/tile_got_changed(turf_coords, list/puddles, new_rads)
-	addtimer(CALLBACK(src, .proc/add_radtile, turf_coords, puddles, new_rads, 5), 2, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
-
-/datum/controller/subsystem/processing/radiation/proc/add_radtile(turf_coords, list/puddles, new_rads, tries = 5)
-	if(new_rads <= 0) // idk
-		return
-	var/turf/new_turf = coords2turf(turf_coords)
-	/// the new turf either doesnt exist, or is still being replaced, check back in another split second
-	if(!new_turf || QDELETED(new_turf))
-		if(tries)
-			addtimer(CALLBACK(src, .proc/add_radtile, turf_coords, puddles, new_rads, tries - 1), 2, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
-		return // okay fine, there's a hole to nothing right here, fucking, cool.
-	// the component itself will figure out of its puddles are still good or not at some point, not our concern
-	if(SEND_SIGNAL(new_turf, COMSIG_TURF_CHECK_RADIATION)) // okay check if there's still a component there first
-		return // and let it be
-	// okay NOW shove a component in there
-	new_turf.AddComponent(/datum/component/radiation_turf, new_rads, puddles)
 
 /datum/controller/subsystem/processing/radiation/proc/warn(datum/component/radioactive/contamination)
 	if(!contamination || QDELETED(contamination))

--- a/code/controllers/subsystem/radturf.dm
+++ b/code/controllers/subsystem/radturf.dm
@@ -1,0 +1,46 @@
+// fuck it i'll just make it its own subsystem whatever
+/// Makes people scream and shout a number when irradiated
+GLOBAL_VAR_INIT(rad_puddle_debug, FALSE)
+SUBSYSTEM_DEF(radturf)
+	name = "RadTurfs"
+	flags = SS_BACKGROUND|SS_NO_INIT
+	wait = 1 SECONDS
+
+	/// irradiated mobs, to be blasted with radiation every tick
+	/// list("mob_whatever" = rad_level)
+	var/list/irradiated_mobs = list()
+
+/datum/controller/subsystem/radturf/fire(resumed)
+	for(var/glowie in irradiated_mobs)
+		var/mob/living/carbon/human/glowman = locate(glowie)
+		if(!istype(glowman))
+			irradiated_mobs -= glowie
+			continue
+		var/turf/check_turf = get_turf(glowman)
+		var/radblastusa = SEND_SIGNAL(check_turf, COMSIG_TURF_CHECK_RADIATION) // is that turf radioactive? if not, then, wierd
+		if(radblastusa <= 0) 
+			irradiated_mobs -= glowie
+			continue
+		glowman.rad_act(radblastusa)
+		if(GLOB.rad_puddle_debug)
+			glowman.emote("scream")
+			glowman.say("[radblastusa]")
+
+/// the irradiated tile got changed and its component deleted, check back in a split second and apply a new one there
+/datum/controller/subsystem/radturf/proc/tile_got_changed(turf_coords, list/puddles, new_rads)
+	addtimer(CALLBACK(src, .proc/add_radtile, turf_coords, puddles, new_rads, 5), 2, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
+
+/datum/controller/subsystem/radturf/proc/add_radtile(turf_coords, list/puddles, new_rads, tries = 5)
+	if(new_rads <= 0) // idk
+		return
+	var/turf/new_turf = coords2turf(turf_coords)
+	/// the new turf either doesnt exist, or is still being replaced, check back in another split second
+	if(!new_turf || QDELETED(new_turf))
+		if(tries)
+			addtimer(CALLBACK(src, .proc/add_radtile, turf_coords, puddles, new_rads, tries - 1), 2, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
+		return // okay fine, there's a hole to nothing right here, fucking, cool.
+	// the component itself will figure out of its puddles are still good or not at some point, not our concern
+	if(SEND_SIGNAL(new_turf, COMSIG_TURF_CHECK_RADIATION)) // okay check if there's still a component there first
+		return // and let it be
+	// okay NOW shove a component in there
+	new_turf.AddComponent(/datum/component/radiation_turf, new_rads, puddles)

--- a/code/datums/components/radiation_turf.dm
+++ b/code/datums/components/radiation_turf.dm
@@ -8,8 +8,8 @@
 	var/our_coordinates
 	/// debug thing, makes flashing happen
 	var/thingtoggle = FALSE
-	/// Turf is changing, dont delete us from the subsystem just yet!
-	var/custody_meeting = FALSE
+	/// it was debug-done
+	var/was_debug = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 /datum/component/radiation_turf/Initialize(rads_per_second, list/ref_n_type)
@@ -19,26 +19,18 @@
 		rads = rads_per_second
 	if(!rads)
 		return COMPONENT_INCOMPATIBLE // gotta have some rads
-	if(!reffie)
+	if(!ref_n_type)
 		return COMPONENT_INCOMPATIBLE // gotta have something irradiating us
 	for(var/reff in ref_n_type)
 		radioactive_things[reff] = ref_n_type[reff]
-	if(!radiation_list_thing_go())
-		return COMPONENT_INCOMPATIBLE // welp
-	RegisterSignal(parent, list(COMSIG_TURF_RADIOACTIVE), .proc/im_still_here)
+	var/turf/our_turf = parent
+	our_coordinates = "[our_turf.x]:[our_turf.y]:[our_turf.z]"
+	RegisterSignal(parent, list(COMSIG_TURF_CHECK_RADIATION), .proc/im_still_here)
 	RegisterSignal(parent, list(COMSIG_TURF_IRRADIATE), .proc/update_rads)
 	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
 	RegisterSignal(parent, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
 	RegisterSignal(parent, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
 	START_PROCESSING(SSradiation, src)
-
-/datum/component/radiation_turf/proc/radiation_list_thing_go()
-	if(!isturf(parent) || QDELETED(parent))
-		return FALSE
-	var/turf/our_turf = parent
-	our_coordinates = "[our_turf.x]:[our_turf.y]:[our_turf.z]"
-	SSradiation.irradiated_turfs[our_coordinates] = rads
-	return TRUE
 
 // from this point onwards, we cannot rely on our parent to be our turf. 
 // So, we'll have to sit here and treat whatever's at our coordinates *as* our parent 
@@ -49,9 +41,8 @@
 	if(!check_puddles())
 		return
 	var/weakie = WEAKERREF(glowy)
-	if((glowy in SSradiation.irradiated_mobs) && SSradiation.irradiated_mobs[weakie] <= rads)
-		return // highest rads win
-	SSradiation.irradiated_mobs[weakie] = rads
+	if(SSradiation.irradiated_mobs[weakie] < rads)
+		SSradiation.irradiated_mobs[weakie] = rads
 
 /datum/component/radiation_turf/proc/RemoveMob(turf/the_turf, mob/living/carbon/human/glowy)
 	if(!istype(glowy))
@@ -65,17 +56,16 @@
 /// Also assume that if something added rads, its either new or changed a bit
 /// And if it goes down, assume the thing was destroyed. either way, check if everything's okay
 /datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0, reff, typee)
-	var/atom/plip = RESOLVEREF(reff)
-	if(plip && !QDELETED(plip))
-		radioactive_things[reff] = typee
 	if(rad_change <= 0)
 		radioactive_things -= reff
 	if((rads += rad_change) <= 0) // check if our tile is radioactive
 		qdel(src)
 		return
+	var/atom/plip = RESOLVEREF(reff)
+	if(plip && !QDELETED(plip))
+		radioactive_things[reff] = typee
 	if(!check_puddles()) // check if we're still tied to anything
 		return
-	SSradiation.irradiated_turfs[our_coordinates] = rads
 	return clamp(abs(rads), 0, (1<<23))
 
 /// Checks if our puddles still exist
@@ -88,7 +78,7 @@
 		if(QDELETED(plip))
 			radioactive_things -= reffie
 			continue
-		if(plip.type != radioactive_things[radioactive_things])
+		if(plip.type != radioactive_things[reffie])
 			radioactive_things -= reffie
 			continue
 		var/plipcoord = atom2coords(plip)
@@ -98,9 +88,6 @@
 	if(!LAZYLEN(radioactive_things)) // MUST have a puddle
 		qdel(src)
 		return FALSE // puddles are missing, likely, so unirradiate this turf
-	if(!SSradiation.irradiated_turfs[our_coordinates]) // the subsystem forgot about us, or something
-		qdel(src)
-		return FALSE
 	return clamp(abs(rads), 0, (1<<23)) // just in case someone makes a turf give 16777217 rads
 	
 /// so the SSradiation can periodically check if the shitload of coordinates its remembering are still radioactive
@@ -110,29 +97,35 @@
 /// tells the radiation subsys (that really does all the work) to remove this tile from its radlist
 /datum/component/radiation_turf/UnregisterFromParent()
 	STOP_PROCESSING(SSradiation, src)
-	if(!custody_meeting)
-		SSradiation.irradiated_turfs -= our_coordinates
 	var/turf/radbgone = coords2turf(our_coordinates)
-	if(thingtoggle)
-		radbgone?.maptext = ""
+	radbgone?.maptext = initial(radbgone.maptext)
 	thingtoggle = -1
 
 /// Tell the radiation system that we're gonna die, put another component at whatever's gonna be here
 /datum/component/radiation_turf/proc/on_turf_change()
 	SIGNAL_HANDLER
-	custody_meeting = TRUE
 	SSradiation.tile_got_changed(our_coordinates, radioactive_things, rads)
 	qdel(src)
 
 /// debug shit
 /datum/component/radiation_turf/process()
 	if(GLOB.rad_puddle_debug && thingtoggle != -1)
+		was_debug = TRUE
 		var/turf/blinker = coords2turf(our_coordinates)
 		if(!isturf(blinker) || QDELETED(blinker))
 			qdel(src)
 			return
 		thingtoggle = !thingtoggle
-		blinker.maptext = thingtoggle ? "[rads]" : ""
+		blinker.maptext = thingtoggle ? "[rads]" : initial(blinker.maptext)
+		blinker.color = thingtoggle ? "#00FF00" : initial(blinker.color)
+		return
+	if(was_debug)
+		var/turf/blinker = coords2turf(our_coordinates)
+		if(!isturf(blinker) || QDELETED(blinker))
+			qdel(src)
+			return
+		blinker.maptext = initial(blinker.maptext)
+		blinker.color = initial(blinker.color)
 
 /obj/item/storage/backpack/debug_radiation
 	name = "Bag of Radstuff"

--- a/code/datums/components/radiation_turf.dm
+++ b/code/datums/components/radiation_turf.dm
@@ -1,42 +1,43 @@
 /datum/component/radiation_turf
 	/// rads per 2 seconds
 	var/rads = 0
+	/// refs to puddles that supposedly make this tile radioactive, used for tile-changes
+	var/list/radioactive_things = list()
 	/// our coordinates, for when our parent disappears and we need to latch on to something
 	var/our_coordinates
 	/// debug thing, makes flashing happen
 	var/thingtoggle = FALSE
-	/// if we need to change mommies, and we cant find one, how many times should we try?
-	var/mommies_left = 5
+	/// Turf is changing, dont delete us from the subsystem just yet!
+	var/custody_meeting = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-/datum/component/radiation_turf/Initialize(rads_per_second)
+/datum/component/radiation_turf/Initialize(rads_per_second, reffie)
 	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(!isnull(rads_per_second))
 		rads = rads_per_second
 	if(!rads)
-		return COMPONENT_INCOMPATIBLE
+		return COMPONENT_INCOMPATIBLE // gotta have some rads
+	if(!reffie)
+		return COMPONENT_INCOMPATIBLE // gotta have something irradiating us
+	radioactive_things |= reffie // could be a single thing, could be a list, either from a puddle, or SSradiation did a switcheroo
 	radiation_list_thing_go()
+	RegisterSignal(parent, list(COMSIG_TURF_RADIOACTIVE), .proc/im_still_here)
+	RegisterSignal(parent, list(COMSIG_TURF_IRRADIATE), .proc/update_rads)
+	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
+	RegisterSignal(parent, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
+	RegisterSignal(parent, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
 	START_PROCESSING(SSprocessing, src)
 
 /datum/component/radiation_turf/proc/radiation_list_thing_go()
 	if(!isturf(parent) || QDELETED(parent))
-		qdel(src)
+		unrad(src)
 		return
 	var/turf/our_turf = parent
 	if("[our_turf.x]:[our_turf.y]:[our_turf.z]" in SSradiation.irradiated_turfs)
 		stack_trace("[our_turf.x]:[our_turf.y]:[our_turf.z] [our_turf] WAS IN THE SSRADIATION IRRADIATED TURFS LIST WHEN IT SHOULDNT!!!")
-		return
 	SSradiation.irradiated_turfs["[our_turf.x]:[our_turf.y]:[our_turf.z]"] = rads
 	our_coordinates = "[our_turf.x]:[our_turf.y]:[our_turf.z]"
-	parentize(our_turf)
-
-/datum/component/radiation_turf/proc/parentize(turf/our_turf)
-	RegisterSignal(our_turf, list(COMSIG_TURF_RADIOACTIVE), .proc/im_still_here)
-	RegisterSignal(our_turf, list(COMSIG_TURF_IRRADIATE), .proc/update_rads)
-	RegisterSignal(our_turf, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
-	RegisterSignal(our_turf, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
-	RegisterSignal(our_turf, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
 
 // from this point onwards, we cannot rely on our parent to be our turf. 
 // So, we'll have to sit here and treat whatever's at our coordinates *as* our parent 
@@ -55,53 +56,53 @@
 	var/weakie = WEAKERREF(glowy)
 	SSradiation.irradiated_mobs -= weakie
 
-/datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0)
-	var/list/c2xyz = splittext(our_coordinates, ":")
-	var/turf/rads_here = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+/datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0, reff)
+	var/turf/rads_here = coords2turf(our_coordinates)
 	if(!isturf(rads_here) || QDELETED(rads_here))
-		qdel(src)
+		unrad()
 		return
-	if((rads += rad_change) <= 0)
+	if(rads > 0)
+		radioactive_things |= reff
+	else
+		radioactive_things -= reff
+	if(!LAZYLEN(radioactive_things |= reff)) // check if we're still tied to anything
+		unrad()
+		return
+	if((rads += rad_change) <= 0) // check if our tile is radioactive
 		unrad()
 		return
 	SSradiation.irradiated_turfs["[rads_here.x]:[rads_here.y]:[rads_here.z]"] = rads
 	return TRUE
 	
-/// so the SSradiation can periodically check if the shitload of turfs its remembering are still radioactive
+/// so the SSradiation can periodically check if the shitload of coordinates its remembering are still radioactive
 /datum/component/radiation_turf/proc/im_still_here()
 	return TRUE
 
-/datum/component/radiation_turf/proc/unrad()
-	var/list/c2xyz = splittext(our_coordinates, ":")
-	var/turf/radbgone = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+/datum/component/radiation_turf/UnregisterFromParent()
+	unrad(TRUE)
+
+/// tells the radiation subsys (that really does all the work) to remove this tile from its radlist
+/datum/component/radiation_turf/proc/unrad(already_qdelling = FALSE)
+	var/turf/radbgone = coords2turf(our_coordinates)
 	if(thingtoggle)
 		radbgone.maptext = ""
 	thingtoggle = -1
-	SSradiation.irradiated_turfs -= "[radbgone.x]:[radbgone.y]:[radbgone.z]"
+	if(!custody_meeting)
+		SSradiation.irradiated_turfs -= "[radbgone.x]:[radbgone.y]:[radbgone.z]"
 	STOP_PROCESSING(SSradiation, src)
-	qdel(src)
+	if(!already_qdelling)
+		qdel(src)
 
+/// Tell the radiation system that we're gonna die, put another component at whatever's gonna be here
 /datum/component/radiation_turf/proc/on_turf_change()
 	SIGNAL_HANDLER
-	addtimer(CALLBACK(src, .proc/find_new_parent), 1, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
-
-/datum/component/radiation_turf/proc/find_new_parent()
-	var/list/c2xyz = splittext(our_coordinates, ":")
-	var/turf/new_mommy = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
-	if(!isturf(new_mommy) || QDELETED(new_mommy))
-		if(mommies_left)
-			addtimer(CALLBACK(src, .proc/find_new_parent), 1, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain //*multipain
-			mommies_left--
-			return
-		unrad()
-		return
-	parentize(new_mommy)
+	custody_meeting = TRUE
+	SSradiation.tile_got_changed(our_coordinates, radioactive_things, rads)
 
 /// debug shit
 /datum/component/radiation_turf/process()
 	if(GLOB.rad_puddle_debug && thingtoggle != -1)
-		var/list/c2xyz = splittext(our_coordinates, ":")
-		var/turf/blinker = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+		var/turf/blinker = coords2turf(our_coordinates)
 		if(!isturf(blinker) || QDELETED(blinker))
 			qdel(src)
 			return

--- a/code/datums/components/radiation_turf.dm
+++ b/code/datums/components/radiation_turf.dm
@@ -2,6 +2,7 @@
 	/// rads per 2 seconds
 	var/rads = 0
 	/// refs to puddles that supposedly make this tile radioactive, used for tile-changes
+	/// list("[0x4206900]" = /obj/item/thing) - double check!
 	var/list/radioactive_things = list()
 	/// our coordinates, for when our parent disappears and we need to latch on to something
 	var/our_coordinates
@@ -11,7 +12,7 @@
 	var/custody_meeting = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-/datum/component/radiation_turf/Initialize(rads_per_second, reffie)
+/datum/component/radiation_turf/Initialize(rads_per_second, list/ref_n_type)
 	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(!isnull(rads_per_second))
@@ -20,30 +21,32 @@
 		return COMPONENT_INCOMPATIBLE // gotta have some rads
 	if(!reffie)
 		return COMPONENT_INCOMPATIBLE // gotta have something irradiating us
-	radioactive_things |= reffie // could be a single thing, could be a list, either from a puddle, or SSradiation did a switcheroo
-	radiation_list_thing_go()
+	for(var/reff in ref_n_type)
+		radioactive_things[reff] = ref_n_type[reff]
+	if(!radiation_list_thing_go())
+		return COMPONENT_INCOMPATIBLE // welp
 	RegisterSignal(parent, list(COMSIG_TURF_RADIOACTIVE), .proc/im_still_here)
 	RegisterSignal(parent, list(COMSIG_TURF_IRRADIATE), .proc/update_rads)
 	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
 	RegisterSignal(parent, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
 	RegisterSignal(parent, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
-	START_PROCESSING(SSprocessing, src)
+	START_PROCESSING(SSradiation, src)
 
 /datum/component/radiation_turf/proc/radiation_list_thing_go()
 	if(!isturf(parent) || QDELETED(parent))
-		unrad(src)
-		return
+		return FALSE
 	var/turf/our_turf = parent
-	if("[our_turf.x]:[our_turf.y]:[our_turf.z]" in SSradiation.irradiated_turfs)
-		stack_trace("[our_turf.x]:[our_turf.y]:[our_turf.z] [our_turf] WAS IN THE SSRADIATION IRRADIATED TURFS LIST WHEN IT SHOULDNT!!!")
-	SSradiation.irradiated_turfs["[our_turf.x]:[our_turf.y]:[our_turf.z]"] = rads
 	our_coordinates = "[our_turf.x]:[our_turf.y]:[our_turf.z]"
+	SSradiation.irradiated_turfs[our_coordinates] = rads
+	return TRUE
 
 // from this point onwards, we cannot rely on our parent to be our turf. 
 // So, we'll have to sit here and treat whatever's at our coordinates *as* our parent 
 
 /datum/component/radiation_turf/proc/AddMob(turf/the_turf, mob/living/carbon/human/glowy)
 	if(!istype(glowy))
+		return
+	if(!check_puddles())
 		return
 	var/weakie = WEAKERREF(glowy)
 	if((glowy in SSradiation.irradiated_mobs) && SSradiation.irradiated_mobs[weakie] <= rads)
@@ -55,49 +58,71 @@
 		return
 	var/weakie = WEAKERREF(glowy)
 	SSradiation.irradiated_mobs -= weakie
+	if(!check_puddles())
+		return
 
-/datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0, reff)
-	var/turf/rads_here = coords2turf(our_coordinates)
-	if(!isturf(rads_here) || QDELETED(rads_here))
-		unrad()
-		return
-	if(rads > 0)
-		radioactive_things |= reff
-	else
+/// Alter the tile's radiation up or down.
+/// Also assume that if something added rads, its either new or changed a bit
+/// And if it goes down, assume the thing was destroyed. either way, check if everything's okay
+/datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0, reff, typee)
+	var/atom/plip = RESOLVEREF(reff)
+	if(plip && !QDELETED(plip))
+		radioactive_things[reff] = typee
+	if(rad_change <= 0)
 		radioactive_things -= reff
-	if(!LAZYLEN(radioactive_things |= reff)) // check if we're still tied to anything
-		unrad()
-		return
 	if((rads += rad_change) <= 0) // check if our tile is radioactive
-		unrad()
+		qdel(src)
 		return
-	SSradiation.irradiated_turfs["[rads_here.x]:[rads_here.y]:[rads_here.z]"] = rads
-	return TRUE
+	if(!check_puddles()) // check if we're still tied to anything
+		return
+	SSradiation.irradiated_turfs[our_coordinates] = rads
+	return clamp(abs(rads), 0, (1<<23))
+
+/// Checks if our puddles still exist
+/datum/component/radiation_turf/proc/check_puddles()
+	for(var/reffie in radioactive_things)
+		var/atom/plip = RESOLVEREF(reffie)
+		if(!plip)
+			radioactive_things -= reffie
+			continue
+		if(QDELETED(plip))
+			radioactive_things -= reffie
+			continue
+		if(plip.type != radioactive_things[radioactive_things])
+			radioactive_things -= reffie
+			continue
+		var/plipcoord = atom2coords(plip)
+		if(plipcoord != our_coordinates)
+			radioactive_things -= reffie
+			continue
+	if(!LAZYLEN(radioactive_things)) // MUST have a puddle
+		qdel(src)
+		return FALSE // puddles are missing, likely, so unirradiate this turf
+	if(!SSradiation.irradiated_turfs[our_coordinates]) // the subsystem forgot about us, or something
+		qdel(src)
+		return FALSE
+	return clamp(abs(rads), 0, (1<<23)) // just in case someone makes a turf give 16777217 rads
 	
 /// so the SSradiation can periodically check if the shitload of coordinates its remembering are still radioactive
 /datum/component/radiation_turf/proc/im_still_here()
-	return TRUE
-
-/datum/component/radiation_turf/UnregisterFromParent()
-	unrad(TRUE)
+	return check_puddles() // technically, signals can only return bitfields. byond treats bitfields as numbers (probably), so, *shruggo*
 
 /// tells the radiation subsys (that really does all the work) to remove this tile from its radlist
-/datum/component/radiation_turf/proc/unrad(already_qdelling = FALSE)
+/datum/component/radiation_turf/UnregisterFromParent()
+	STOP_PROCESSING(SSradiation, src)
+	if(!custody_meeting)
+		SSradiation.irradiated_turfs -= our_coordinates
 	var/turf/radbgone = coords2turf(our_coordinates)
 	if(thingtoggle)
-		radbgone.maptext = ""
+		radbgone?.maptext = ""
 	thingtoggle = -1
-	if(!custody_meeting)
-		SSradiation.irradiated_turfs -= "[radbgone.x]:[radbgone.y]:[radbgone.z]"
-	STOP_PROCESSING(SSradiation, src)
-	if(!already_qdelling)
-		qdel(src)
 
 /// Tell the radiation system that we're gonna die, put another component at whatever's gonna be here
 /datum/component/radiation_turf/proc/on_turf_change()
 	SIGNAL_HANDLER
 	custody_meeting = TRUE
 	SSradiation.tile_got_changed(our_coordinates, radioactive_things, rads)
+	qdel(src)
 
 /// debug shit
 /datum/component/radiation_turf/process()
@@ -106,6 +131,25 @@
 		if(!isturf(blinker) || QDELETED(blinker))
 			qdel(src)
 			return
-		blinker.maptext = thingtoggle ? "[rads]" : ""
 		thingtoggle = !thingtoggle
+		blinker.maptext = thingtoggle ? "[rads]" : ""
+
+/obj/item/storage/backpack/debug_radiation
+	name = "Bag of Radstuff"
+	desc = "Cool shit for testing various radiations!"
+
+/obj/item/storage/backpack/debug_radiation/PopulateContents()
+	. = ..()
+	new /obj/item/crowbar/abductor(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/geiger_counter(src)
+	new /obj/item/storage/firstaid/radbgone(src)
+	new /obj/item/crafting/abraxo(src)
+	new /obj/item/crafting/abraxo(src)
+	new /obj/item/crafting/abraxo(src)
+	new /obj/item/storage/box/dynamite_box(src)
+	new /obj/item/grenade/syndieminibomb(src)
+	new /obj/item/grenade/syndieminibomb(src)
+	new /obj/item/grenade/syndieminibomb(src)
+	new /obj/item/grenade/syndieminibomb(src)
 

--- a/code/datums/components/radiation_turf.dm
+++ b/code/datums/components/radiation_turf.dm
@@ -1,0 +1,110 @@
+/datum/component/radiation_turf
+	/// rads per 2 seconds
+	var/rads = 0
+	/// our coordinates, for when our parent disappears and we need to latch on to something
+	var/our_coordinates
+	/// debug thing, makes flashing happen
+	var/thingtoggle = FALSE
+	/// if we need to change mommies, and we cant find one, how many times should we try?
+	var/mommies_left = 5
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+
+/datum/component/radiation_turf/Initialize(rads_per_second)
+	if(!isturf(parent))
+		return COMPONENT_INCOMPATIBLE
+	if(!isnull(rads_per_second))
+		rads = rads_per_second
+	if(!rads)
+		return COMPONENT_INCOMPATIBLE
+	radiation_list_thing_go()
+	START_PROCESSING(SSprocessing, src)
+
+/datum/component/radiation_turf/proc/radiation_list_thing_go()
+	if(!isturf(parent) || QDELETED(parent))
+		qdel(src)
+		return
+	var/turf/our_turf = parent
+	if("[our_turf.x]:[our_turf.y]:[our_turf.z]" in SSradiation.irradiated_turfs)
+		stack_trace("[our_turf.x]:[our_turf.y]:[our_turf.z] [our_turf] WAS IN THE SSRADIATION IRRADIATED TURFS LIST WHEN IT SHOULDNT!!!")
+		return
+	SSradiation.irradiated_turfs["[our_turf.x]:[our_turf.y]:[our_turf.z]"] = rads
+	our_coordinates = "[our_turf.x]:[our_turf.y]:[our_turf.z]"
+	parentize(our_turf)
+
+/datum/component/radiation_turf/proc/parentize(turf/our_turf)
+	RegisterSignal(our_turf, list(COMSIG_TURF_RADIOACTIVE), .proc/im_still_here)
+	RegisterSignal(our_turf, list(COMSIG_TURF_IRRADIATE), .proc/update_rads)
+	RegisterSignal(our_turf, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
+	RegisterSignal(our_turf, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
+	RegisterSignal(our_turf, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
+
+// from this point onwards, we cannot rely on our parent to be our turf. 
+// So, we'll have to sit here and treat whatever's at our coordinates *as* our parent 
+
+/datum/component/radiation_turf/proc/AddMob(turf/the_turf, mob/living/carbon/human/glowy)
+	if(!istype(glowy))
+		return
+	var/weakie = WEAKERREF(glowy)
+	if((glowy in SSradiation.irradiated_mobs) && SSradiation.irradiated_mobs[weakie] <= rads)
+		return // highest rads win
+	SSradiation.irradiated_mobs[weakie] = rads
+
+/datum/component/radiation_turf/proc/RemoveMob(turf/the_turf, mob/living/carbon/human/glowy)
+	if(!istype(glowy))
+		return
+	var/weakie = WEAKERREF(glowy)
+	SSradiation.irradiated_mobs -= weakie
+
+/datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0)
+	var/list/c2xyz = splittext(our_coordinates, ":")
+	var/turf/rads_here = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+	if(!isturf(rads_here) || QDELETED(rads_here))
+		qdel(src)
+		return
+	if((rads += rad_change) <= 0)
+		unrad()
+		return
+	SSradiation.irradiated_turfs["[rads_here.x]:[rads_here.y]:[rads_here.z]"] = rads
+	return TRUE
+	
+/// so the SSradiation can periodically check if the shitload of turfs its remembering are still radioactive
+/datum/component/radiation_turf/proc/im_still_here()
+	return TRUE
+
+/datum/component/radiation_turf/proc/unrad()
+	var/list/c2xyz = splittext(our_coordinates, ":")
+	var/turf/radbgone = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+	if(thingtoggle)
+		radbgone.maptext = ""
+	thingtoggle = -1
+	SSradiation.irradiated_turfs -= "[radbgone.x]:[radbgone.y]:[radbgone.z]"
+	STOP_PROCESSING(SSradiation, src)
+	qdel(src)
+
+/datum/component/radiation_turf/proc/on_turf_change()
+	SIGNAL_HANDLER
+	addtimer(CALLBACK(src, .proc/find_new_parent), 1, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
+
+/datum/component/radiation_turf/proc/find_new_parent()
+	var/list/c2xyz = splittext(our_coordinates, ":")
+	var/turf/new_mommy = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+	if(!isturf(new_mommy) || QDELETED(new_mommy))
+		if(mommies_left)
+			addtimer(CALLBACK(src, .proc/find_new_parent), 1, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain //*multipain
+			mommies_left--
+			return
+		unrad()
+		return
+	parentize(new_mommy)
+
+/// debug shit
+/datum/component/radiation_turf/process()
+	if(GLOB.rad_puddle_debug && thingtoggle != -1)
+		var/list/c2xyz = splittext(our_coordinates, ":")
+		var/turf/blinker = locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
+		if(!isturf(blinker) || QDELETED(blinker))
+			qdel(src)
+			return
+		blinker.maptext = thingtoggle ? "[rads]" : ""
+		thingtoggle = !thingtoggle
+

--- a/code/datums/components/radiation_turf.dm
+++ b/code/datums/components/radiation_turf.dm
@@ -8,8 +8,6 @@
 	var/our_coordinates
 	/// debug thing, makes flashing happen
 	var/thingtoggle = FALSE
-	/// it was debug-done
-	var/was_debug = FALSE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 /datum/component/radiation_turf/Initialize(rads_per_second, list/ref_n_type)
@@ -30,7 +28,7 @@
 	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED), .proc/AddMob)
 	RegisterSignal(parent, list(COMSIG_ATOM_EXITED), .proc/RemoveMob)
 	RegisterSignal(parent, list(COMSIG_TURF_CHANGE), .proc/on_turf_change)
-	START_PROCESSING(SSradiation, src)
+	RegisterSignal(SSdcs, list(COMSIG_GLOB_RADIATION_SHOW), .proc/ping_rads)
 
 // from this point onwards, we cannot rely on our parent to be our turf. 
 // So, we'll have to sit here and treat whatever's at our coordinates *as* our parent 
@@ -41,14 +39,13 @@
 	if(!check_puddles())
 		return
 	var/weakie = WEAKERREF(glowy)
-	if(SSradiation.irradiated_mobs[weakie] < rads)
-		SSradiation.irradiated_mobs[weakie] = rads
+	SSradturf.irradiated_mobs[weakie] = SSradturf.irradiated_mobs[weakie] < rads ? rads : SSradturf.irradiated_mobs[weakie]
 
 /datum/component/radiation_turf/proc/RemoveMob(turf/the_turf, mob/living/carbon/human/glowy)
 	if(!istype(glowy))
 		return
 	var/weakie = WEAKERREF(glowy)
-	SSradiation.irradiated_mobs -= weakie
+	SSradturf.irradiated_mobs -= weakie
 	if(!check_puddles())
 		return
 
@@ -56,14 +53,15 @@
 /// Also assume that if something added rads, its either new or changed a bit
 /// And if it goes down, assume the thing was destroyed. either way, check if everything's okay
 /datum/component/radiation_turf/proc/update_rads(turf/the_turf, rad_change = 0, reff, typee)
-	if(rad_change <= 0)
-		radioactive_things -= reff
 	if((rads += rad_change) <= 0) // check if our tile is radioactive
 		qdel(src)
 		return
-	var/atom/plip = RESOLVEREF(reff)
-	if(plip && !QDELETED(plip))
-		radioactive_things[reff] = typee
+	if(rad_change <= 0)
+		radioactive_things -= reff
+	else
+		var/atom/plip = RESOLVEREF(reff)
+		if(plip && !QDELETED(plip))
+			radioactive_things[reff] = typee
 	if(!check_puddles()) // check if we're still tied to anything
 		return
 	return clamp(abs(rads), 0, (1<<23))
@@ -81,22 +79,17 @@
 		if(plip.type != radioactive_things[reffie])
 			radioactive_things -= reffie
 			continue
-		var/plipcoord = atom2coords(plip)
-		if(plipcoord != our_coordinates)
-			radioactive_things -= reffie
-			continue
 	if(!LAZYLEN(radioactive_things)) // MUST have a puddle
 		qdel(src)
 		return FALSE // puddles are missing, likely, so unirradiate this turf
 	return clamp(abs(rads), 0, (1<<23)) // just in case someone makes a turf give 16777217 rads
 	
-/// so the SSradiation can periodically check if the shitload of coordinates its remembering are still radioactive
+/// so the SSradturf can periodically check if the shitload of coordinates its remembering are still radioactive
 /datum/component/radiation_turf/proc/im_still_here()
 	return check_puddles() // technically, signals can only return bitfields. byond treats bitfields as numbers (probably), so, *shruggo*
 
 /// tells the radiation subsys (that really does all the work) to remove this tile from its radlist
 /datum/component/radiation_turf/UnregisterFromParent()
-	STOP_PROCESSING(SSradiation, src)
 	var/turf/radbgone = coords2turf(our_coordinates)
 	radbgone?.maptext = initial(radbgone.maptext)
 	thingtoggle = -1
@@ -104,28 +97,28 @@
 /// Tell the radiation system that we're gonna die, put another component at whatever's gonna be here
 /datum/component/radiation_turf/proc/on_turf_change()
 	SIGNAL_HANDLER
-	SSradiation.tile_got_changed(our_coordinates, radioactive_things, rads)
+	SSradturf.tile_got_changed(our_coordinates, radioactive_things, rads)
 	qdel(src)
 
 /// debug shit
-/datum/component/radiation_turf/process()
-	if(GLOB.rad_puddle_debug && thingtoggle != -1)
-		was_debug = TRUE
-		var/turf/blinker = coords2turf(our_coordinates)
-		if(!isturf(blinker) || QDELETED(blinker))
-			qdel(src)
-			return
-		thingtoggle = !thingtoggle
-		blinker.maptext = thingtoggle ? "[rads]" : initial(blinker.maptext)
-		blinker.color = thingtoggle ? "#00FF00" : initial(blinker.color)
+/datum/component/radiation_turf/proc/ping_rads()
+	if(thingtoggle)
 		return
-	if(was_debug)
-		var/turf/blinker = coords2turf(our_coordinates)
-		if(!isturf(blinker) || QDELETED(blinker))
-			qdel(src)
-			return
-		blinker.maptext = initial(blinker.maptext)
-		blinker.color = initial(blinker.color)
+	var/turf/blinker = coords2turf(our_coordinates)
+	if(!isturf(blinker) || QDELETED(blinker))
+		qdel(src)
+		return
+	thingtoggle = TRUE
+	blinker.maptext = thingtoggle ? "[rads]" : initial(blinker.maptext)
+	addtimer(CALLBACK(src, .proc/unping_rads), 2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE) //*pain //*doublepain
+
+/datum/component/radiation_turf/proc/unping_rads()
+	var/turf/blinker = coords2turf(our_coordinates)
+	if(!isturf(blinker) || QDELETED(blinker))
+		qdel(src)
+		return
+	thingtoggle = FALSE
+	blinker.maptext = initial(blinker.maptext)
 
 /obj/item/storage/backpack/debug_radiation
 	name = "Bag of Radstuff"

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -93,3 +93,9 @@
 		var/datum/R = resolve()
 		if(R)
 			usr.client.debug_variables(R)
+
+/// Creates a weakerref to the given input. literally just "\ref[input]"
+/// See /datum/weakref's documentation for more information.
+#define WEAKERREF(input) "\ref[input]"
+/// Turns a ref into a thing. no guarantee its anything, so check that it *is* something
+#define RESOLVEREF(ref) locate(ref)

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -95,7 +95,10 @@
 			usr.client.debug_variables(R)
 
 /// Creates a weakerref to the given input. literally just "\ref[input]"
-/// See /datum/weakref's documentation for more information.
+/// Basically a weakref, minus the datum memory use (and reliability, there's no guarantee this'll point to anything, or even the right thing!!!)
+/// Use with care, and ample checks
 #define WEAKERREF(input) "\ref[input]"
 /// Turns a ref into a thing. no guarantee its anything, so check that it *is* something
-#define RESOLVEREF(ref) locate(ref)
+/// also a proc cus SSradiation compiles before this one. whatever
+/proc/RESOLVEREF(ref) 
+	return locate(ref)

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -99,6 +99,6 @@
 /// Use with care, and ample checks
 #define WEAKERREF(input) "\ref[input]"
 /// Turns a ref into a thing. no guarantee its anything, so check that it *is* something
-/// also a proc cus SSradiation compiles before this one. whatever
+/// also a proc cus SSradturf compiles before this one. whatever
 /proc/RESOLVEREF(ref) 
 	return locate(ref)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -53,6 +53,9 @@
 
 	radiation_count -= radiation_count/RAD_MEASURE_SMOOTHING
 	radiation_count += current_tick_amount/RAD_MEASURE_SMOOTHING
+	var/turf/righthere = get_turf(src)
+	var/radz = isturf(righthere) ? SEND_SIGNAL(righthere, COMSIG_TURF_RADIOACTIVE) : 0
+	radiation_count += radz
 
 	if(current_tick_amount)
 		grace = RAD_GRACE_PERIOD

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -54,7 +54,7 @@
 	radiation_count -= radiation_count/RAD_MEASURE_SMOOTHING
 	radiation_count += current_tick_amount/RAD_MEASURE_SMOOTHING
 	var/turf/righthere = get_turf(src)
-	var/radz = isturf(righthere) ? SEND_SIGNAL(righthere, COMSIG_TURF_RADIOACTIVE) : 0
+	var/radz = isturf(righthere) ? SEND_SIGNAL(righthere, COMSIG_TURF_CHECK_RADIATION) : 0
 	radiation_count += radz
 
 	if(current_tick_amount)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -125,8 +125,9 @@
 	. = ..()
 	if(amount <= RAD_BACKGROUND_RADIATION || !scanning)
 		return
-	var/turfrads = SEND_SIGNAL(get_turf(src), COMSIG_TURF_CHECK_RADIATION) // filter out the turf rads, otherwise it'll double the input
-	current_tick_amount += max(0, amount - turfrads)
+	var/turf/theturf = get_turf(src) // fun fact, get_turf() doesnt work in the target of a signal, the define requires an actual *thing*
+	var/turfrads = SEND_SIGNAL(theturf, COMSIG_TURF_CHECK_RADIATION) // filter out the turf rads, otherwise it'll double the input
+	current_tick_amount += max(0, (amount - turfrads))
 	update_icon()
 
 /obj/item/geiger_counter/equipped(mob/user)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -34,8 +34,6 @@
 
 /obj/item/geiger_counter/Initialize()
 	. = ..()
-	START_PROCESSING(SSobj, src)
-
 	soundloop = new(list(src), FALSE)
 
 /obj/item/geiger_counter/Destroy()
@@ -127,7 +125,8 @@
 	. = ..()
 	if(amount <= RAD_BACKGROUND_RADIATION || !scanning)
 		return
-	current_tick_amount += amount
+	var/turfrads = SEND_SIGNAL(get_turf(src), COMSIG_TURF_CHECK_RADIATION) // filter out the turf rads, otherwise it'll double the input
+	current_tick_amount += max(0, amount - turfrads)
 	update_icon()
 
 /obj/item/geiger_counter/equipped(mob/user)
@@ -161,7 +160,12 @@
 
 /obj/item/geiger_counter/attack_self(mob/user)
 	scanning = !scanning
+	if(scanning)
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
 	update_icon()
+	update_sound()
 	to_chat(user, span_notice("[icon2html(src, user)] You switch [scanning ? "on" : "off"] [src]."))
 
 /obj/item/geiger_counter/afterattack(atom/target, mob/user)
@@ -169,7 +173,8 @@
 	if(user.a_intent == INTENT_HELP)
 		if(!(obj_flags & EMAGGED))
 			user.visible_message(span_notice("[user] scans [target] with [src]."), span_notice("You scan [target]'s radiation levels with [src]..."))
-			addtimer(CALLBACK(src, .proc/scan, target, user), 20, TIMER_UNIQUE) // Let's not have spamming GetAllContents
+			scan(target, user)
+			//addtimer(CALLBACK(src, .proc/scan, target, user), 20, TIMER_UNIQUE) // Let's not have spamming GetAllContents
 		else
 			user.visible_message(span_notice("[user] scans [target] with [src]."), span_danger("You project [src]'s stored radiation into [target]!"))
 			target.rad_act(radiation_count)
@@ -177,26 +182,24 @@
 		return TRUE
 
 /obj/item/geiger_counter/proc/scan(atom/A, mob/user)
-	var/rad_strength = 0
-	for(var/i in get_rad_contents(A)) // Yes it's intentional that you can't detect radioactive things under rad protection. Gives traitors a way to hide their glowing green rocks.
-		var/atom/thing = i
-		if(!thing)
-			continue
-		var/datum/component/radioactive/radiation = thing.GetComponent(/datum/component/radioactive)
-		if(radiation)
-			rad_strength += radiation.strength
-
 	if(isliving(A))
 		var/mob/living/M = A
 		if(!M.radiation)
 			to_chat(user, span_notice("[icon2html(src, user)] Radiation levels within normal boundaries."))
 		else
 			to_chat(user, span_boldannounce("[icon2html(src, user)] Subject is irradiated. Radiation levels: [M.radiation] rad."))
-
+	/* var/rad_strength = 0
+	for(var/i in get_rad_contents(A)) // Yes it's intentional that you can't detect radioactive things under rad protection. Gives traitors a way to hide their glowing green rocks.
+		var/atom/thing = i
+		if(!thing)
+			continue
+		var/datum/component/radioactive/radiation = thing.GetComponent(/datum/component/radioactive)
+		if(radiation)
+			rad_strength += radiation.strength 
 	if(rad_strength)
 		to_chat(user, span_boldannounce("[icon2html(src, user)] Target contains radioactive contamination. Radioactive strength: [rad_strength]"))
 	else
-		to_chat(user, span_notice("[icon2html(src, user)] Target is free of radioactive contamination."))
+		to_chat(user, span_notice("[icon2html(src, user)] Target is free of radioactive contamination.")) */
 
 /obj/item/geiger_counter/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver) && (obj_flags & EMAGGED))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -19,7 +19,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
 /world/proc/AVerbsAdmin()
 	return list(
-	/client/proc/toggle_experimental_clickdrag_thing,				/*allows our mob to go invisible/visible*/
+	/client/proc/toggle_experimental_clickdrag_thing,				/*toggles the harm intent no-clickdrag thing*/
+	/client/proc/toggle_radpuddle_disco_vomit_nightmare,				/*makes radpuddles flash and show numbers. please dont use this*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
@@ -417,6 +418,16 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(alert("Tell everyone the experimental clickdrag thing was [GLOB.use_experimental_clickdrag_thing ? "enabled" : "disabled"]?",,"Yes","No") != "Yes")
 		return
 	to_chat(world, "<B>The experimental harm-intent clickdrag disable thing has been [GLOB.use_experimental_clickdrag_thing ? "enabled" : "disabled"].</B>")
+
+/client/proc/toggle_radpuddle_disco_vomit_nightmare()
+	set name = "Toggle Radpuddle Debug"
+	set category = "Debug"
+	set desc = "Toggles radpuddles making everything flash green. Its experimental and everyone will know you pressed a wierd button and Superlagg *will* laugh at you."
+	GLOB.rad_puddle_debug = !GLOB.rad_puddle_debug
+	log_admin("[key_name(usr)] toggled radpuddle disco vomit nightmare mode.")
+	message_admins("[key_name_admin(usr)] toggled radpuddle disco vomit nightmare mode.")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggled radpuddle debug")
+	to_chat(world, "<B>Radpuddles now look [GLOB.rad_puddle_debug ? "godawful" : "not much better"].</B>")
 
 /client/proc/check_antagonists()
 	set name = "Check Antagonists"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -21,6 +21,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	return list(
 	/client/proc/toggle_experimental_clickdrag_thing,				/*toggles the harm intent no-clickdrag thing*/
 	/client/proc/toggle_radpuddle_disco_vomit_nightmare,				/*makes radpuddles flash and show numbers. please dont use this*/
+	/client/proc/show_radpuddle_scores,				/*makes radpuddles flash and show numbers. please dont use this*/
 	/client/proc/invisimin,				/*allows our mob to go invisible/visible*/
 //	/datum/admins/proc/show_traitor_panel,	/*interface which shows a mob's mind*/ -Removed due to rare practical use. Moved to debug verbs ~Errorage
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
@@ -419,15 +420,22 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		return
 	to_chat(world, "<B>The experimental harm-intent clickdrag disable thing has been [GLOB.use_experimental_clickdrag_thing ? "enabled" : "disabled"].</B>")
 
+/// No longer does what it did, but fuck it im keeping the name
 /client/proc/toggle_radpuddle_disco_vomit_nightmare()
-	set name = "Toggle Radpuddle Debug"
+	set name = "Toggle Radturf Screaming"
 	set category = "Debug"
-	set desc = "Toggles radpuddles making everything flash green. Its experimental and everyone will know you pressed a wierd button and Superlagg *will* laugh at you."
+	set desc = "Toggles whether mobs will scream and shout a number when irradiated."
 	GLOB.rad_puddle_debug = !GLOB.rad_puddle_debug
-	log_admin("[key_name(usr)] toggled radpuddle disco vomit nightmare mode.")
-	message_admins("[key_name_admin(usr)] toggled radpuddle disco vomit nightmare mode.")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggled radpuddle debug")
-	to_chat(world, "<B>Radpuddles now look [GLOB.rad_puddle_debug ? "godawful" : "not much better"].</B>")
+	log_admin("[key_name(usr)] toggled Radturf screaming.")
+	message_admins("[key_name_admin(usr)] toggled Radturf screaming.")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggled Radturf screaming")
+
+/client/proc/show_radpuddle_scores()
+	set name = "Show Radpuddle Numbers"
+	set category = "Debug"
+	set desc = "Makes the redpuddle'd tiles show numbers."
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_RADIATION_SHOW)
+	message_admins("[key_name_admin(usr)] <B>pinged radiation.</B>")
 
 /client/proc/check_antagonists()
 	set name = "Check Antagonists"

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -14,8 +14,6 @@
 	var/range = 2
 	/// rads per 2 seconds to blast someone with per puddle
 	var/intensity = 20
-	/// coordinates to turfs we're irradiating
-	var/list/rad_turfs = list()
 	tastes = list("a flavor thats definitely not green apple" = 2, "a whole lot of regret" = 1)
 
 /obj/effect/decal/waste/Initialize()
@@ -39,18 +37,14 @@
 	if(QDELETED(src))
 		return
 	for(var/turf/rad_turf in view(range, get_turf(src)))
-		if(SEND_SIGNAL(rad_turf, COMSIG_TURF_IRRADIATE, intensity, WEAKERREF(src))) // if we get something back from the turf, its already radioactive
+		if(SEND_SIGNAL(rad_turf, COMSIG_TURF_IRRADIATE, intensity, WEAKERREF(src), type)) // if we get something back from the turf, its already radioactive
 			continue // and made more radioactive~
-		rad_turf.AddComponent(/datum/component/radiation_turf, intensity, WEAKERREF(src)) // the component will handle the SSradiation stuff
-		rad_turfs += turf2coords(rad_turf) // record what turfs are irradiated so we can remove them later
+		rad_turf.AddComponent(/datum/component/radiation_turf, intensity, list(WEAKERREF(src) = type)) // the component will handle the SSradiation stuff
 
 /// Asks all the turfs in range to reduce or remove the radiation
 /obj/effect/decal/waste/proc/unirradiate_turfs()
-	for(var/coor in rad_turfs)
-		var/turf/radioturf = coords2turf(coor)
-		if(!isturf(radioturf) || (QDELETED(radioturf)))
-			continue
-		SEND_SIGNAL(radioturf, COMSIG_TURF_IRRADIATE, -intensity, WEAKERREF(src))
+	for(var/turf/rad_turf in range(range, get_turf(src))) // range, in case some goober changed what the puddle can see
+		SEND_SIGNAL(radioturf, COMSIG_TURF_IRRADIATE, -intensity, WEAKERREF(src), type)
 
 /*
 //Bing bang boom done

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -39,11 +39,9 @@
 	if(QDELETED(src))
 		return
 	for(var/turf/rad_turf in view(range, get_turf(src)))
-		if(rad_turf.density)
-			continue
-		if(SEND_SIGNAL(rad_turf, COMSIG_TURF_IRRADIATE, intensity)) // if we get something back from the turf, its already radioactive
+		if(SEND_SIGNAL(rad_turf, COMSIG_TURF_IRRADIATE, intensity, WEAKERREF(src))) // if we get something back from the turf, its already radioactive
 			continue // and made more radioactive~
-		rad_turf.AddComponent(/datum/component/radiation_turf, intensity) // the component will handle the SSradiation stuff
+		rad_turf.AddComponent(/datum/component/radiation_turf, intensity, WEAKERREF(src)) // the component will handle the SSradiation stuff
 		rad_turfs += turf2coords(rad_turf) // record what turfs are irradiated so we can remove them later
 
 /// Asks all the turfs in range to reduce or remove the radiation
@@ -52,16 +50,7 @@
 		var/turf/radioturf = coords2turf(coor)
 		if(!isturf(radioturf) || (QDELETED(radioturf)))
 			continue
-		SEND_SIGNAL(radioturf, COMSIG_TURF_IRRADIATE, -intensity)
-
-/obj/effect/decal/waste/proc/coords2turf(coords)
-	var/list/c2xyz = splittext(coords, ":")
-	return locate(text2num(c2xyz[1]),text2num(c2xyz[2]),text2num(c2xyz[3]))
-
-/obj/effect/decal/waste/proc/turf2coords(turf/the_turf)
-	if(!istype(the_turf))
-		return
-	return "[the_turf.x]:[the_turf.y]:[the_turf.z]"
+		SEND_SIGNAL(radioturf, COMSIG_TURF_IRRADIATE, -intensity, WEAKERREF(src))
 
 /*
 //Bing bang boom done

--- a/code/modules/fallout/obj/decals.dm
+++ b/code/modules/fallout/obj/decals.dm
@@ -28,7 +28,6 @@
 /obj/effect/decal/waste/Destroy()
 	//STOP_PROCESSING(SSradiation,src)
 	unirradiate_turfs()
-	qdel(rad_turfs)
 	..()
 
 /// gets all the turfs in range, records its coordinates (like heck I'm making a million zillion weakrefs), 
@@ -44,7 +43,7 @@
 /// Asks all the turfs in range to reduce or remove the radiation
 /obj/effect/decal/waste/proc/unirradiate_turfs()
 	for(var/turf/rad_turf in range(range, get_turf(src))) // range, in case some goober changed what the puddle can see
-		SEND_SIGNAL(radioturf, COMSIG_TURF_IRRADIATE, -intensity, WEAKERREF(src), type)
+		SEND_SIGNAL(rad_turf, COMSIG_TURF_IRRADIATE, -intensity, WEAKERREF(src), type)
 
 /*
 //Bing bang boom done

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -365,6 +365,7 @@
 #include "code\controllers\subsystem\profiler.dm"
 #include "code\controllers\subsystem\radiation.dm"
 #include "code\controllers\subsystem\radio.dm"
+#include "code\controllers\subsystem\radturf.dm"
 #include "code\controllers\subsystem\research.dm"
 #include "code\controllers\subsystem\server_maint.dm"
 #include "code\controllers\subsystem\shuttle.dm"

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -507,6 +507,7 @@
 #include "code\datums\components\pellet_cloud.dm"
 #include "code\datums\components\phantomthief.dm"
 #include "code\datums\components\rad_insulation.dm"
+#include "code\datums\components\radiation_turf.dm"
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\remote_materials.dm"
 #include "code\datums\components\riding.dm"


### PR DESCRIPTION
## About The Pull Request
Radpuddles now assign a component to all the turfs it can see. Those components register their coordinates to SSradiation, and listens for anyone who enters the tile. On entry, they're added to a list, that SSradiation blasts with rad until they leave the tile.

Saves a fuckload of performance over spamming view checks, maybe.