### PR TITLE
Makes bloatflies part of the beastfriendly perk

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
@@ -466,7 +466,7 @@
 	attack_sound = 'sound/creatures/bloatfly_attack.ogg'
 	speak_emote = list("chitters")
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
-	faction = list("hostile", "gecko")
+	faction = list("hostile", "gecko", "critter-friend")
 	gold_core_spawnable = HOSTILE_SPAWN
 	pass_flags = PASSTABLE | PASSMOB
 	density = FALSE


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

ye ye, I personally think they are a small creature enough to be friendly, makes it so you only have to worry about raiders and ghouls and many other creatures other than the ones close to nash.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->
