### PR TITLE
Credits and Caps Hotfix

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -133,7 +133,7 @@
 	export_types = list(/obj/item/stack/sheet/animalhide/chitin)
 
 /datum/export/material/f13cash
-	cost = 2
+	cost = 10
 	unit_name = "caps"
 	material_id = /datum/material/f13cash
 	export_types = list(/obj/item/stack/f13Cash/caps)

--- a/code/modules/cargo/packs/misc.dm
+++ b/code/modules/cargo/packs/misc.dm
@@ -311,14 +311,14 @@
 /datum/supply_pack/misc/capstwofifty
 	name = "Caps Conversion 250"
 	desc = "Converts credits into caps! 250 Version"
-	cost = 5000
+	cost = 2500
 	contains = list(/obj/item/stack/f13Cash/caps/twofivezero)
 	crate_name = "caps crate 1"
 
 /datum/supply_pack/misc/capsfivehundred
 	name = "Caps Conversion 500"
 	desc = "Converts credits into caps! 500 Version"
-	cost = 10000
+	cost = 5000
 	contains = list(/obj/item/stack/f13Cash/caps/fivezerozero)
 	crate_name = "caps crate 2"
 


### PR DESCRIPTION
Changing caps to be 1:10 Caps:Credits so that you can actually use caps in the train to buy things and sell things at reasonable rates.

Also fixes turning Credits into Caps so you're not longer doing that at a MASSIVE loss.

## About The Pull Request

Pretty much the above. Just trying to hotfix cargo to be less of an utter mess and at least nominally viable.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
balance: Changed caps to have a Credit value of 10 per cap.
fix: Fixed the ordering of caps (converting credits to caps) to match the new value of caps so you're breaking even instead of trading at a loss.
/:cl: