### PR TITLE
More Cargo Hotfixes

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -70,7 +70,7 @@
 	material_id = /datum/material/iron
 	export_types = list(
 		/obj/item/stack/sheet/metal, /obj/item/stack/tile/plasteel,
-		/obj/item/stack/sheet/plasteel, /obj/item/stack/rods, 
+		/obj/item/stack/sheet/plasteel, /obj/item/stack/rods,
 		/obj/item/stack/ore, /obj/item/coin)
 
 /datum/export/material/glass
@@ -109,25 +109,25 @@
 	material_id = /datum/material/runite
 
 /datum/export/material/leather
-	cost = 7
+	cost = 15
 	unit_name = "sheets of leather"
 	material_id = /datum/material/leather
 	export_types = list(/obj/item/stack/sheet/leather)
 
 /datum/export/material/bone
-	cost = 3
+	cost = 10
 	unit_name = "bone"
 	material_id = /datum/material/bone
 	export_types = list(/obj/item/stack/sheet/bone)
 
 /datum/export/material/sinew
-	cost = 3
+	cost = 10
 	unit_name = "pieces of sinew"
 	material_id = /datum/material/sinew
 	export_types = list(/obj/item/stack/sheet/sinew)
 
 /datum/export/material/chitin
-	cost = 4
+	cost = 100
 	unit_name = "pieces of chitin"
 	material_id = /datum/material/chitin
 	export_types = list(/obj/item/stack/sheet/animalhide/chitin)
@@ -139,37 +139,37 @@
 	export_types = list(/obj/item/stack/f13Cash/caps)
 
 /datum/export/material/deathclawhide
-	cost = 175
+	cost = 750
 	unit_name = "deathclaw hide"
 	material_id = /datum/material/deathclawhide
 	export_types = list(/obj/item/stack/sheet/animalhide/deathclaw)
 
 /datum/export/material/geckohide
-	cost = 15 //will see if this works out...
+	cost = 100 //will see if this works out...
 	unit_name = "gecko hide"
 	material_id = /datum/material/geckohide
 	export_types = list(/obj/item/stack/sheet/animalhide/gecko)
 
 /datum/export/material/molerathide
-	cost = 15
+	cost = 100
 	unit_name = "molerat hide"
 	material_id = /datum/material/molerathide
 	export_types = list(/obj/item/stack/sheet/animalhide/molerat)
 
 /datum/export/material/wolfhide
-	cost = 25
+	cost = 125
 	unit_name = "dog hide"
 	material_id = /datum/material/wolfhide
 	export_types = list(/obj/item/stack/sheet/animalhide/wolf)
 
 /datum/export/material/radstaghide
-	cost = 40
+	cost = 200
 	unit_name = "radstag hide"
 	material_id = /datum/material/radstaghide
 	export_types = list(/obj/item/stack/sheet/animalhide/radstag)
 
 /datum/export/material/brahminhide
-	cost = 25
+	cost = 150
 	unit_name = "brahmin hide"
 	material_id = /datum/material/brahminhide
 	export_types = list(/obj/item/stack/sheet/animalhide/brahmin)

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -3,7 +3,7 @@
 // medicine
 
 /datum/export/item/chems
-	cost = 65
+	cost = 200
 	unit_name = "chems (low)"
 	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak,
 	/obj/item/reagent_containers/hypospray/medipen/medx,
@@ -20,7 +20,7 @@
 	)
 
 /datum/export/item/chemshigh
-	cost = 150
+	cost = 400
 	unit_name = "chems (high)"
 	export_types = list(,
 	/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -32,10 +32,10 @@
 	cost = 80
 	unit_name = "super stimpak"
 	export_types = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super) */
-	
+
 
 /datum/export/item/lightpistol
-	cost = 100
+	cost = 400
 	unit_name = "light pistol"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99,
@@ -53,7 +53,7 @@
 		)
 
 /datum/export/item/heavypistol
-	cost = 225
+	cost = 600
 	unit_name = "heavy pistol"
 	export_types = list(
 		/obj/item/gun/energy/laser/wattz/magneto,
@@ -65,7 +65,7 @@
 		)
 
 /datum/export/item/advpistol
-	cost = 350
+	cost = 800
 	unit_name = "advanced pistol"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/pistol/deagle,
@@ -80,7 +80,7 @@
 		)
 
 /datum/export/item/smg
-	cost = 375
+	cost = 1000
 	unit_name = "submachine gun"
 	export_types = list(
 		/obj/item/gun/energy/laser/plasma/pistol,
@@ -96,7 +96,7 @@
 		)
 
 /datum/export/item/carbine
-	cost = 325
+	cost = 800
 	unit_name = "carbine"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/m1carbine,
@@ -111,14 +111,14 @@
 	)
 
 /datum/export/item/dbshotgun
-	cost = 275
+	cost = 600
 	unit_name = "double-barreled shotgun"
 	export_types = list(/obj/item/gun/ballistic/revolver/caravan_shotgun,
 	/obj/item/gun/ballistic/revolver/widowmaker,
 	)
 
 /datum/export/item/pumpshotgun
-	cost = 350
+	cost = 800
 	unit_name = "pump-action shotgun"
 	export_types = list(
 		/obj/item/gun/ballistic/shotgun/hunting,
@@ -127,7 +127,7 @@
 		)
 
 /datum/export/item/semishotgun
-	cost = 475
+	cost = 1500
 	unit_name = "semi-auto shotgun"
 	export_types = list(
 		/obj/item/gun/ballistic/shotgun/automatic/combat/auto5,
@@ -137,7 +137,7 @@
 	)
 
 /datum/export/item/advshotgun
-	cost = 650
+	cost = 2000
 	unit_name = "advanced shotgun"
 	export_types = list(
 		/obj/item/gun/ballistic/shotgun/automatic/combat/neostead,
@@ -147,7 +147,7 @@
 		)
 
 /datum/export/item/semirifle
-	cost = 550
+	cost = 2000
 	unit_name = "semi-automatic rifle"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/varmint/verminkiller,
@@ -168,7 +168,7 @@
 	)
 
 /datum/export/item/autorifle
-	cost = 850
+	cost = 2500
 	unit_name = "automatic rifle"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/service/r82,
@@ -187,7 +187,7 @@
 	)
 
 /datum/export/item/lmg
-	cost = 950
+	cost = 4000
 	unit_name = "light machine gun"
 	export_types = list(
 		/obj/item/gun/ballistic/automatic/r84,
@@ -239,7 +239,7 @@
 	export_types = list(/obj/item/stock_parts/cell/ammo/ecp)
 
 /datum/export/item/traitbookslow
-	cost = 400
+	cost = 800
 	unit_name = "low-quality technical manual"
 	export_types = list(/obj/item/book/granter/trait/lowsurgery,
 				/obj/item/book/granter/trait/chemistry,
@@ -252,7 +252,7 @@
 				/obj/item/book/granter/crafting_recipe/gunsmith_one)
 
 /datum/export/item/traitbooks
-	cost = 550
+	cost = 1000
 	unit_name = "high-quality technical manual"
 	export_types = list(/obj/item/book/granter/trait/lowsurgery,
 				/obj/item/book/granter/trait/chemistry,
@@ -266,7 +266,7 @@
 				/obj/item/book/granter/crafting_recipe/gunsmith_four)
 
 /datum/export/item/crops
-	cost = 20
+	cost = 50
 	unit_name = "produce"
 	export_types = list(/obj/item/reagent_containers/food/snacks/grown/agave,
 		/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
@@ -342,7 +342,7 @@
 	)
 
 /datum/export/item/rarecrops
-	cost = 50
+	cost = 100
 	unit_name = "exotic produce"
 	export_types = list(/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
 		/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
@@ -420,7 +420,7 @@
 	/obj/item/export/bottle/fernet,
 	/obj/item/export/bottle/kahlua,
 	)
-	
+
 /datum/export/item/highliquor
 	k_elasticity = 0
 	cost = 75

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -435,7 +435,7 @@
 /datum/supply_pack/security/traitbooks
 	name = "Technical manuals"
 	desc = "A box crammed full of manuals, for reading. SCAV issues, Guns and Ammo, how to operate chem-machines, it's all here! Come in groups of three."
-	cost = 2200
+	cost = 2500
 	num_contained = 3
 	contains = list(/obj/effect/spawner/lootdrop/f13/traitbooks,
 					/obj/effect/spawner/lootdrop/f13/traitbooks/low,
@@ -518,7 +518,7 @@
 /datum/supply_pack/security/minigun5mm
 	name = "Weapons - Minigun"
 	desc = "Holy moly, it's here. A refurbished minigun chambered in US five-aught. Heavy, impractical, expensive to buy, expensive to fire, expensive to maintain, and an absolute killer."
-	cost = 30000
+	cost = 50000
 	contains = list(/obj/item/minigunpackbal5mm)
 	crate_name = "minigun crate"
 
@@ -527,7 +527,7 @@
 /datum/supply_pack/security/weapon_wasteland
 	name = "Weapons - Wasteland"
 	desc = "Half a dozen commonly found wasteland weaponry. you might find something nice, sifting through these."
-	cost = 2500
+	cost = 5000
 	num_contained = 6
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/wasteland,
@@ -542,7 +542,7 @@
 /datum/supply_pack/security/weapon_dungeon
 	name = "Weapons - Uncommon"
 	desc = "A set of four good quality weapons."
-	cost = 5000
+	cost = 7500
 	num_contained = 4
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/dungeon,
@@ -566,7 +566,7 @@
 /datum/supply_pack/security/weapon_unique
 	name = "Weapons - Premium"
 	desc = "A single weapon of incredible rarity. there's no telling what was packed into this crate"
-	cost = 30000
+	cost = 50000
 	num_contained = 1
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/unique
@@ -576,7 +576,7 @@
 /datum/supply_pack/security/weapon_milsurplus
 	name = "Weapons -  Military Surplus"
 	desc = "A crate of long forgotten American weapons from the second world war."
-	cost = 7500
+	cost = 15000
 	num_contained = 8
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/milsurplus,
@@ -593,7 +593,7 @@
 /datum/supply_pack/security/weapon_combloc
 	name = "Weapons - Communist Bloc"
 	desc = "An old crate packed with surplus Chinese and Russian weaponry. you may have to clean off the old cosmoline."
-	cost = 7500
+	cost = 15000
 	num_contained = 8
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/combloc,
@@ -610,7 +610,7 @@
 /datum/supply_pack/security/vault
 	name = "Weapons - Vault"
 	desc = "A crate of common vault security firearms that never made it to their assigned vault"
-	cost = 5000
+	cost = 10000
 	num_contained = 6
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/vault,
@@ -625,7 +625,7 @@
 /datum/supply_pack/security/weapon_police
 	name = "Weapons - Law Enforcement"
 	desc = "A crate full of common police and riot weapons"
-	cost = 7500
+	cost = 10000
 	num_contained = 4
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/police,
@@ -668,7 +668,7 @@
 /datum/supply_pack/security/weapon_junk
 	name = "Weapons - Junk"
 	desc = "A haphazard pile of ethically sourced, barely functioning pipes and pieces of wood pretending to be guns. "
-	cost = 1000
+	cost = 2000
 	num_contained = 8
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/junk,
@@ -685,7 +685,7 @@
 /datum/supply_pack/security/weapon_western
 	name = "Weapons - Western"
 	desc = "A collection of classy lever actions, revolvers, and scatterguns fitting for lawmen and outlaws alike. yeehaw!"
-	cost = 5000
+	cost = 7500
 	num_contained = 6
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/western,


### PR DESCRIPTION
Some changes done to make it so players can actually make a profit going out and doing things and selling crap to the shop, including trash guns.

Gonna need some watching, though, to make sure this doesn't break the economy. I'm kind of afraid to touch raw mats to be perfectly honest.

## About The Pull Request
Basically what it says above. Shorthand to check for how many caps each thing is worth is to divide by ten. So an export value of 750 is 75 caps. It's expected traders will buy things from people at ~1/2 its value. Guns might legitimately sell for a little too much, though cargo depreciation keeps that from being an exploit at least.

Might need to go back and lower gun credit values to be lower depending on how things play out. But it just seems weird to sell a BAR or Sniper Rifle for less than a hundred caps on the train.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:
- Tweaked the prices of both guns and animal mob drops so players can actually make a profit hunting stuff and selling it to the shop.
- Tweaked the prices of gun crates to (hopefully) adjust for the new gun prices so you can't just infinitely buy and sell them. Ngl kind of did it sloppy and will probably need to look at it again. Standardizing the amount of guns you get from each crate would probably help.
- Also removed a space by rods because for whatever reason, my code does NOT like that space being there. 
/:cl:
