### PR TITLE
nerfs rocks + bricks to require all your stamina to put 'em to crit

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -180,6 +180,11 @@
 	key_third_person = "rocks"
 	restraint_check = TRUE
 	COOLDOWN_DECLARE(rock_cooldown)
+	var/damageMult
+	var/hasPickedUp = FALSE
+	var/timerEnabled
+	var/damageNerf = 2.2
+
 
 /datum/emote/living/carbon/rocker/run_emote(mob/user)
 	. = ..()
@@ -190,11 +195,25 @@
 		to_chat(user, span_warning("Your hands are too full to go looking for rocks!"))
 		return
 	var/obj/item/ammo_casing/caseless/rock/rock = new(user)
+
+	if(hasPickedUp)
+		rock.throwforce = damageMult / damageNerf
+
 	if(user.put_in_active_hand(rock))
+		hasPickedUp = TRUE
+		damageMult = rock.throwforce
+		if(!timerEnabled)
+			addtimer(CALLBACK(src, .proc/reset_damage), 2.5 SECONDS)
+			timerEnabled = TRUE
 		COOLDOWN_START(src, rock_cooldown, 2.5 SECONDS)
 		to_chat(user, span_notice("You find a nice hefty throwing rock!"))
 	else
 		qdel(rock)
+
+/datum/emote/living/carbon/rocker/proc/reset_damage()
+	hasPickedUp = FALSE
+	timerEnabled = FALSE
+	damageMult = initial(damageMult)
 
 //brick//
 /datum/emote/living/carbon/bricker
@@ -202,6 +221,10 @@
 	key_third_person = "bricks"
 	restraint_check = TRUE
 	COOLDOWN_DECLARE(brick_cooldown)
+	var/damageMult
+	var/hasPickedUp = FALSE
+	var/timerEnabled
+	var/damageNerf = 2.2
 
 /datum/emote/living/carbon/bricker/run_emote(mob/user)
 	. = ..()
@@ -212,8 +235,22 @@
 		to_chat(user, span_warning("Your hands are too full to go looking for bricks!"))
 		return
 	var/obj/item/ammo_casing/caseless/brick/brick = new(user)
+
+	if(hasPickedUp)
+		brick.throwforce = damageMult / damageNerf
+
 	if(user.put_in_active_hand(brick))
+		hasPickedUp = TRUE
+		damageMult = brick.throwforce
+		if(!timerEnabled)
+			addtimer(CALLBACK(src, .proc/reset_damage), 2.5 SECONDS)
+			timerEnabled = TRUE
 		COOLDOWN_START(src, brick_cooldown, 2.5 SECONDS)
 		to_chat(user, span_notice("You find a nice weighty brick!"))
 	else
 		qdel(brick)
+
+/datum/emote/living/carbon/bricker/proc/reset_damage()
+	hasPickedUp = FALSE
+	timerEnabled = FALSE
+	damageMult = initial(damageMult)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Basically you can't spam the rocks/bricks, they still do the same damage without the trait, but the more you spam it the less damage it deals.

It takes all your stamina in order to take someone into crit with rocks.
With bricks you just have to have a quick breather before finishing them with one.

Real world performance will vary, however the variable is adjustable for the future. I found 2.2 to be the most... reasonable damage output when spammed.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->
