### PR TITLE
Reduces Smithing Sounds by a third

### DIFF
--- a/code/modules/smithing/anvil.dm
+++ b/code/modules/smithing/anvil.dm
@@ -191,46 +191,46 @@ GLOBAL_LIST_INIT(anvil_recipes, list(
 	var/steptime = 50
 	switch(stepdone)
 		if("weak hit")
-			playsound(src, 'code/modules/smithing/sound/anvil_weak.ogg',100)
+			playsound(src, 'code/modules/smithing/sound/anvil_weak.ogg',65)
 			user.visible_message("<span class='notice'>[user] carefully hammers out imperfections in the metal.</span>", \
 						"<span class='notice'>You carefully hammer out imperfections in the metal.</span>")
 		if("strong hit")
-			playsound(src, 'code/modules/smithing/sound/anvil_strong.ogg',80)
+			playsound(src, 'code/modules/smithing/sound/anvil_strong.ogg',45)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] hammers out imperfections in the metal.</span>", \
 						"<span class='notice'>You hammer out imperfections in the metal.</span>")
 		if("heavy hit")
-			playsound(src, 'code/modules/smithing/sound/anvil_heavy.ogg',90)
+			playsound(src, 'code/modules/smithing/sound/anvil_heavy.ogg',60)
 			do_smithing_sparks(2, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] forcefully hammers out imperfections in the metal.</span>", \
 						"<span class='notice'>You forcefuly hammer out imperfections in the metal.</span>")
 		if("fold")
-			playsound(src, 'code/modules/smithing/sound/anvil_double1.ogg',90)
+			playsound(src, 'code/modules/smithing/sound/anvil_double1.ogg',60)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] folds the metal.</span>", \
 						"<span class='notice'>You fold the metal.</span>")
 		if("draw")
-			playsound(src, 'code/modules/smithing/sound/anvil_double2.ogg',90)
+			playsound(src, 'code/modules/smithing/sound/anvil_double2.ogg',60)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] hammers both sides of the metal, drawing it out.</span>", \
 						"<span class='notice'>You hammer both sides of the metal, drawing it out.</span>")
 		if("shrink")
-			playsound(src, 'code/modules/smithing/sound/anvil_rapid.ogg',110)
+			playsound(src, 'code/modules/smithing/sound/anvil_rapid.ogg',60)
 			do_smithing_sparks(1, TRUE, src)
 			user.visible_message("<span class='notice'>[user] flattens the metal, shrinking it.</span>", \
 						"<span class='notice'>You flatten the metal, shrinking it.</span>")
 		if("bend")
-			playsound(src, 'code/modules/smithing/sound/anvil_single1.ogg',80)
+			playsound(src, 'code/modules/smithing/sound/anvil_single1.ogg',55)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] bends the metal, using the rounded end of the anvil.</span>", \
 						"<span class='notice'>You bend the metal, using the rounded end of the anvil.</span>")
 		if("punch")
-			playsound(src, 'code/modules/smithing/sound/anvil_single2.ogg',90)
+			playsound(src, 'code/modules/smithing/sound/anvil_single2.ogg',65)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] uses the puncher to make holes in the metal.</span>", \
 						"<span class='notice'>You use the puncher to make holes in the metal.</span>")
 		if("upset")
-			playsound(src, 'code/modules/smithing/sound/anvil_double3.ogg',90)
+			playsound(src, 'code/modules/smithing/sound/anvil_double3.ogg',65)
 			do_smithing_sparks(1, TRUE, src) 
 			user.visible_message("<span class='notice'>[user] upsets the metal by hammering the thick end.</span>", \
 						"<span class='notice'>You upset the metal by hammering the thick end.</span>")

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -2,10 +2,11 @@
 /obj/item/melee/smith
 	name = "base class obj/item/melee/smith" //tin. handles overlay and quality and shit.
 	desc = "cringe"
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "claymore"
-	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
+	lefthand_file = 'code/modules/smithing/icons/onmob/lefthand.dmi'
+	righthand_file = 'code/modules/smithing/icons/onmob/righthand.dmi'
+	mob_overlay_icon = 'code/modules/smithing/icons/onmob/slot.dmi'
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON //yeah ok
 	slot_flags = ITEM_SLOT_BELT
@@ -29,9 +30,9 @@
 
 
 /obj/item/melee/smith/twohand
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
-	lefthand_file = 'icons/fallout/onmob/weapons/melee2h_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/melee2h_righthand.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
+	lefthand_file = 'code/modules/smithing/icons/onmob/lefthand.dmi'
+	righthand_file = 'code/modules/smithing/icons/onmob/righthand.dmi'
 	item_flags = NEEDS_PERMIT //it's a bigass sword/spear. beepsky is going to give you shit for it.
 	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
@@ -70,7 +71,7 @@
 // Blacksmithing hammer, not useful for anything else.
 /obj/item/melee/smith/hammer
 	name = "smithing hammer"
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "hammer"
 	lefthand_file = 'icons/fallout/onmob/tools/tools_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/tools/tools_righthand.dmi'
@@ -88,7 +89,7 @@
 	name = "prospectors pick"
 	desc = "A pick that can sound rocks to find mineral deposits."
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "prospect_smith"
 	lefthand_file = 'icons/fallout/onmob/tools/tools_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/tools/tools_righthand.dmi'
@@ -118,7 +119,7 @@
 	name = "pickaxe"
 	desc = "A pickaxe."
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "pickaxe"
 	lefthand_file = 'icons/fallout/onmob/tools/tools_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/tools/tools_righthand.dmi'
@@ -142,7 +143,7 @@
 /obj/item/shovel/smithed
 	name = "shovel"
 	desc = "A shovel."
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "shovel"
 	lefthand_file = 'icons/fallout/onmob/tools/tools_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/tools/tools_righthand.dmi'
@@ -162,7 +163,7 @@
 
 // Smithed crowbars top out at 0.2 toolspeed max quality. Not bad. Not that useful either, its just a crowbar, still.
 /obj/item/crowbar/smithed
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "crowbar_smith"
 	item_state = "crowbar"
 	toolspeed = 0.8
@@ -180,10 +181,10 @@
 // Crowbar-axe. Just a crowbar with more force and a homemade vibe.
 /obj/item/crowbar/smithedunitool
 	name = "crowbaxe"
-	icon = 'icons/fallout/objects/crafting/blacksmith.dmi'
+	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	icon_state = "unitool_smith"
-	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
-	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
+	lefthand_file = 'code/modules/smithing/icons/onmob/lefthand.dmi'
+	righthand_file = 'code/modules/smithing/icons/onmob/righthand.dmi'
 	item_state = "unitool_smith"
 	sharpness = SHARP_EDGED
 	material_flags = MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
@@ -329,7 +330,6 @@
 	block_parry_data = /datum/block_parry_data/smithrapier
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	slot_flags = ITEM_SLOT_BELT
-	mob_overlay_icon = 'icons/fallout/onmob/clothes/belt.dmi'
 	layer = MOB_UPPER_LAYER
 
 /datum/block_parry_data/smithrapier //Old rapier code reused. parry into riposte. i am pretty sure this is going to be nearly fucking impossible to land.
@@ -356,7 +356,6 @@
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON * 2
 	force = WEAPON_FORCE_AXE_LARGE
 	wielded_mult = WEAPON_AXE_TWOHAND_MULT
-	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	layer = MOB_UPPER_LAYER
 

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -14,7 +14,7 @@
 	force = WEAPON_FORCE_TOOL_SMALL
 	obj_flags = UNIQUE_RENAME
 	var/quality
-	var/overlay_state = "stick"
+	var/overlay_state = "woodenrod"
 	var/mutable_appearance/overlay
 	//var/wielded_mult = 1
 


### PR DESCRIPTION
As it says on the tin, All Smithing sounds reduced by about 30%.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked Smithing Sounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
