### PR TITLE
Adds merchant kit to worker tools

### DIFF
--- a/code/game/objects/items/loadout_toolkits.dm
+++ b/code/game/objects/items/loadout_toolkits.dm
@@ -120,6 +120,21 @@
 	entry_flags = LOADOUT_FLAG_TOOL_WASTER
 	entry_class = LOADOUT_CAT_WORKER
 	spawn_thing = /obj/item/storage/box/tools/mining
+	
+/obj/item/storage/box/tools/merchant
+	name = "merchant tools"
+
+/obj/item/storage/box/tools/merchant/PopulateContents()
+	new /obj/item/stack/f13Cash/caps/twofive
+	new /obj/item/stack/f13Cash/caps/fivezero
+	new /obj/item/storage/box/vendingmachine
+
+
+/datum/loadout_box/merchant
+	entry_tag = "merchant tools"
+	entry_flags = LOADOUT_FLAG_TOOL_WASTER
+	entry_class = LOADOUT_CAT_WORKER
+	spawn_thing = /obj/item/storage/box/tools/merchant
 
 /obj/item/storage/box/tools/smithing
 	name = "smithing tools"


### PR DESCRIPTION
## About The Pull Request
Adds a merchant toolkit, bringing back the vending machine box from the old wastelander merchant loadout (contains every component for 1 (one) custom vending machine) and 75 caps, almost half of what you can get with the sellout loadout (200)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Added new things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
