### PR TITLE
Fixes a bunch of runtimes

### DIFF
--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -37,7 +37,7 @@
 	hypnotic_phrase = phrase
 
 /datum/brain_trauma/hypnosis/on_gain()
-	message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
+	//message_admins("[ADMIN_LOOKUPFLW(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	log_game("[key_name(owner)] was hypnotized with the phrase '[hypnotic_phrase]'.")
 	to_chat(owner, "<span class='reallybig hypnophrase'>[hypnotic_phrase]</span>")
 	to_chat(owner, "<span class='notice'>[pick("You feel your thoughts focusing on this phrase... you can't seem to get it out of your head.",\
@@ -52,7 +52,7 @@
 	..()
 
 /datum/brain_trauma/hypnosis/on_lose()
-	message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
+	//message_admins("[ADMIN_LOOKUPFLW(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	log_game("[key_name(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	to_chat(owner, span_userdanger("You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you."))
 	owner.clear_alert("hypnosis")

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -611,6 +611,8 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 
 /datum/quirk/lick_heal/on_spawn()
 	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(!quirk_holder)
+		return //oh no
 	var/obj/item/organ/tongue/our_tongue = human_holder.getorganslot(ORGAN_SLOT_TONGUE)
 	if(!our_tongue)
 		return //welp
@@ -618,6 +620,8 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 
 /datum/quirk/lick_heal/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(!quirk_holder)
+		return //oh no
 	var/obj/item/organ/tongue/our_tongue = human_holder.getorganslot(ORGAN_SLOT_TONGUE)
 	if(!our_tongue)
 		return //welp

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -336,6 +336,8 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	// RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINATE, .proc/looks_at_floor)
 
 /datum/quirk/social_anxiety/remove()
+	if(!quirk_holder)
+		return // guy don't exist no more, therefore stop it.
 	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE))
 
 /datum/quirk/social_anxiety/on_process()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -272,7 +272,7 @@
 			return TRUE
 	return FALSE
 
-/obj/machinery/firealarm/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/machinery/firealarm/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	if(.) //damage received
 		if(obj_integrity > 0 && !(stat & BROKEN) && buildstage != 0)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -443,7 +443,7 @@
 			playsound(loc, 'sound/effects/empulse.ogg', 75, 1)
 
 //the shield wall is immune to damage but it drains the stored power of the generators.
-/obj/machinery/shieldwall/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/machinery/shieldwall/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	if(damage_type == BRUTE || damage_type == BURN)
 		drain_power(damage_amount)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -6,7 +6,7 @@
 			return facing_modifiers[FRONT_ARMOUR]
 	return facing_modifiers[SIDE_ARMOUR] //if its not a front hit or back hit then assume its from the side
 
-/obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	if(. && obj_integrity > 0)
 		spark_system.start()

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -9,7 +9,7 @@
 
 	vis_flags = VIS_INHERIT_PLANE
 
-/obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	return
 
 /obj/effect/fire_act(exposed_temperature, exposed_volume)

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -111,7 +111,7 @@
 /obj/structure/projected_forcefield/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	playsound(loc, 'sound/weapons/egloves.ogg', 80, 1)
 
-/obj/structure/projected_forcefield/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/structure/projected_forcefield/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 	generator.shield_integrity = max(generator.shield_integrity - damage_amount, 0)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -76,7 +76,7 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, 1)
 
-/obj/structure/fireaxecabinet/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/structure/fireaxecabinet/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	if(open)
 		return
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -20,7 +20,7 @@
 	var/broken_type = /obj/structure/grille/broken
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
-/obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	update_icon()
 

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -287,7 +287,7 @@
 		damage_amount = overmind.blobstrain.damage_reaction(src, damage_amount, damage_type, damage_flag)
 	return damage_amount
 
-/obj/structure/blob/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/structure/blob/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	if(. && obj_integrity > 0)
 		update_icon()

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -51,7 +51,7 @@
 		else
 			to_chat(user, span_brass("You decide against activating the ark.. for now."))
 
-/obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	if(.)
 		flick("clockwork_gateway_damaged", glow)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -201,12 +201,12 @@ GLOBAL_LIST_INIT(warning_ckeys, list())
 
 //This stops files larger than UPLOAD_LIMIT being sent from client to server via input(), client.Import() etc.
 /client/AllowUpload(filename, filelength)
-	var/upLimiit = UPLOAD_LIMIT
+	var/upLimit = UPLOAD_LIMIT
 	if(check_rights(R_ADMIN))
 		upLimit *= 5
 	
-	if(filelength > upLimiit)
-		to_chat(src, "<font color='red'>Error: AllowUpload(): File Upload too large. Upload Limit: [upLimiit/1024]KiB.</font>")
+	if(filelength > upLimit)
+		to_chat(src, "<font color='red'>Error: AllowUpload(): File Upload too large. Upload Limit: [upLimit/1024]KiB.</font>")
 		return 0
 	return 1
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -201,8 +201,12 @@ GLOBAL_LIST_INIT(warning_ckeys, list())
 
 //This stops files larger than UPLOAD_LIMIT being sent from client to server via input(), client.Import() etc.
 /client/AllowUpload(filename, filelength)
-	if(filelength > UPLOAD_LIMIT)
-		to_chat(src, "<font color='red'>Error: AllowUpload(): File Upload too large. Upload Limit: [UPLOAD_LIMIT/1024]KiB.</font>")
+	var/upLimiit = UPLOAD_LIMIT
+	if(check_rights(R_ADMIN))
+		upLimit *= 5
+	
+	if(filelength > upLimiit)
+		to_chat(src, "<font color='red'>Error: AllowUpload(): File Upload too large. Upload Limit: [upLimiit/1024]KiB.</font>")
 		return 0
 	return 1
 

--- a/code/modules/fallout/obj/trash_stack.dm
+++ b/code/modules/fallout/obj/trash_stack.dm
@@ -46,7 +46,7 @@
 			//		bonusitem.from_trash = TRUE
 			if(istype(newthing))
 				var/obj/item/newitem = newthing
-				newitem.from_trash = TRUE
+				newitem?.from_trash = TRUE // Fixes some objects not having the "from_trash" var
 				if(isgun(newitem))
 					var/obj/item/gun/trash_gun = newitem
 					var/prob_trash = 80

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -55,7 +55,7 @@
 	sterile = TRUE
 	stat = DEAD
 
-/obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	..()
 	if(obj_integrity < 90)
 		Die()

--- a/code/modules/newscaster/newscaster_machine.dm
+++ b/code/modules/newscaster/newscaster_machine.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 			stat |= NOPOWER
 			update_icon()
 
-/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, atom/attacked_by)
+/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0, atom/attacked_by)
 	. = ..()
 	update_icon()
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -27,10 +27,10 @@
 	M.CheckBloodsuckerEatFood(nutriment_factor)
 	holder?.remove_reagent(type, metabolization_rate)
 	if (canbrew)
-		if (holder.has_reagent(/datum/reagent/medicine/spaceacillin))
+		if (holder?.has_reagent(/datum/reagent/medicine/spaceacillin))
 			return
 		if (HAS_TRAIT(M, TRAIT_AUTOBREW))
-			holder.add_reagent(/datum/reagent/consumable/ethanol, 0.5) //foods and drinks metabolize 0.4 per tick. 0.5 added per tick is just enough to cause slight buildup
+			holder?.add_reagent(/datum/reagent/consumable/ethanol, 0.5) //foods and drinks metabolize 0.4 per tick. 0.5 added per tick is just enough to cause slight buildup
 
 /datum/reagent/consumable/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method == INGEST)

--- a/code/modules/vending/brahminvendordm.dm
+++ b/code/modules/vending/brahminvendordm.dm
@@ -84,7 +84,7 @@ GLOBAL_VAR(orbital_cow_cooldown)
 		user.show_message(span_notice("...and the uplink starts making noises like it's doing something!"))
 	addtimer(CALLBACK(src, .proc/drop_cow, user), 7.5 SECONDS)
 	addtimer(VARSET_CALLBACK(GLOB, orbital_cow_catapult_ready, TRUE), COW_CANNON_RELOAD_DELAY)
-	addtimer(CALLBACK(GLOB, .proc/reset_beacon), COW_CANNON_RELOAD_DELAY)
+	addtimer(CALLBACK(src, .proc/reset_beacon), COW_CANNON_RELOAD_DELAY)
 
 /obj/item/brahmin_beacon/proc/drop_cow(mob/user)
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()

--- a/strings/wounds/bone_scar_desc.json
+++ b/strings/wounds/bone_scar_desc.json
@@ -31,7 +31,21 @@
 		"has a deeply sliced crack, exposing marrow"
 	],
 
+	"burnmoderate": [
+		"is slightly bleached white",
+		"is slightly discolored"
+	],
 
+	"burnsevere": [
+		"would have black burn marks",
+		"has cracked and became brittle from heat"
+	],
+
+	"burncritical": [
+		"has been cremated and turned into charcoal",
+		"has a deep black color, cracked and ruined",
+		"has flakes of burnt bone shedding off"
+	],
 
 	"piercemoderate": [
 		"has a visible knick"


### PR DESCRIPTION
# R e a d y

## About The Pull Request
<!-- Write here -->

Couldn't find the issue with the ladder so I thought I'd poke at some of the runtimes we have happening on the server.

So far the fixes:
- Sometimes canbrew reagents lack a holder. So I added a sanity check there. (reagents.dm)
- Some objects which are spawned from trash lack the variable to indicate it's from trash, sanity added (trash_stack.dm)
- Grilles and some other structures havent had their take_damage params up to date, leading to runtimes with running checking armor damage. (Whole bunch of .dms)
- Brahmin vendor tries to invoke a proc which doesn't exist globally, so I scoped it to src. (brahminvendordm.dm)
- Something about trying to delete a tongue on a mob when they are deleted, some reason they delete faster than the quirk, so we just check if the mob is deleted. (good.dm)
- Soxial anxiety does this too, so I've just added a remove there too <3 (negative.dm)
- Bone scars didnt have descriptions for burn types, added those. (bone_scar_desc.json)

Optional extras:
- Hypnosis no longer messages admins!
- Admins get 5x more upload limit than players. (5MB for admins)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

