### PR TITLE
Adds the premium crate back

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -563,7 +563,7 @@
 )
 	crate_name = "Rare weapon crate"
 
-/* /datum/supply_pack/security/weapon_unique
+/datum/supply_pack/security/weapon_unique
 	name = "Weapons - Premium"
 	desc = "A single weapon of incredible rarity. there's no telling what was packed into this crate"
 	cost = 50000
@@ -571,7 +571,7 @@
 	contains = list(
 		/obj/effect/spawner/lootdrop/f13/weapon/unique
 )
-	crate_name = "Premium weapon crate" */
+	crate_name = "Premium weapon crate"
 
 /datum/supply_pack/security/weapon_milsurplus
 	name = "Weapons -  Military Surplus"


### PR DESCRIPTION
## About The Pull Request
This adds the premium crate back to the trader console. Why was it even removed? 5 thousand caps is a fair price, if you ask me, for a random roll at a unique weapon, considering that is also, the cost of a minigun

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog
:cl:
add: Added the premium crate back
/:cl:
