### PR TITLE
Mask Mook fix & Loadout Item for LARP

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -11018,18 +11018,6 @@
 /obj/item/clothing/neck/petcollar,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"gjs" = (
-/mob/living/simple_animal/hostile/deathclaw/legendary{
-	name = "Serena Williams";
-	color = "EE3333";
-	melee_damage_upper = 65
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
-	},
-/area/f13/caves)
 "gjx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -98814,7 +98802,7 @@ mPz
 mPz
 tbh
 tGD
-gjs
+lmW
 mPz
 sta
 tbh

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -11018,6 +11018,18 @@
 /obj/item/clothing/neck/petcollar,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"gjs" = (
+/mob/living/simple_animal/hostile/deathclaw/legendary{
+	name = "Serena Williams";
+	color = "EE3333";
+	melee_damage_upper = 65
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "gjx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old"
@@ -98802,7 +98814,7 @@ mPz
 mPz
 tbh
 tGD
-lmW
+gjs
 mPz
 sta
 tbh

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -767,7 +767,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 
 /datum/quirk/masked_mook/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/gas = H.get_item_by_slot(ITEM_SLOT_MASK)
+	var/obj/item/clothing/mask/gas = H.get_item_by_slot(SLOT_WEAR_MASK)
 	if(istype(gas))
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
@@ -789,7 +789,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/mask/gas = new(get_turf(quirk_holder))
-	H.equip_to_slot(gas, ITEM_SLOT_MASK)
+	H.equip_to_slot(gas, SLOT_WEAR_MASK)
 	H.regenerate_icons()
 
 /datum/quirk/paper_skin

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -767,8 +767,8 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 
 /datum/quirk/masked_mook/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/maskmask = H.get_item_by_slot(ITEM_SLOT_MASK)
-	if(istype(maskmask) && !istype(maskmask, /obj/item/clothing/mask/cigarette))
+	var/obj/item/clothing/mask/gas = H.get_item_by_slot(ITEM_SLOT_MASK)
+	if(istype(gas))
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook_incomplete)
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, mood_category, /datum/mood_event/masked_mook)
 	else

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -789,7 +789,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/mask/gas = new(get_turf(quirk_holder))
-	H.equip_to_slot(gasmask, ITEM_SLOT_MASK)
+	H.equip_to_slot(gas, ITEM_SLOT_MASK)
 	H.regenerate_icons()
 
 /datum/quirk/paper_skin

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -788,7 +788,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/masked_mook/on_spawn()
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/clothing/mask/gas/gasmask = new(get_turf(quirk_holder))
+	var/obj/item/clothing/mask/gas = new(get_turf(quirk_holder))
 	H.equip_to_slot(gasmask, ITEM_SLOT_MASK)
 	H.regenerate_icons()
 

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -67,6 +67,10 @@
 	name = "russian balaclava"
 	path = /obj/item/clothing/mask/russian_balaclava
 
+/datum/gear/mask/gasmask
+	name= "gas mask"
+	path = /obj/item/clothing/mask/gas
+	
 /// Bandanas ///
 
 /datum/gear/mask/bandana/


### PR DESCRIPTION
## About The Pull Request
Due to unforseen consequences, it has appeared that masked mook is calling the wrong type of gas mask. I'm not adding additional clothing items here to be considered a gas mask as I added it to the loadout, aka, WYCI >:)

Needs to be tested and verified in a bit.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: The funny perk.
add: loadout gas mask item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
