### PR TITLE
'Class Act' trait (deathgasp buff?????)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -254,6 +254,7 @@
 #define TRAIT_MUTATION_STASIS			"mutation_stasis" //Prevents processed genetics mutations from processing.
 #define TRAIT_FAST_PUMP				"fast_pump"
 #define TRAIT_AUTO_DRAW				"auto_draw" //can use bows good
+#define TRAIT_PLAY_DEAD "play_dead" // gives 10u ghoul powder every *deathgasp
 #define TRAIT_NO_PROCESS_FOOD	"no-process-food" // You don't get benefits from nutriment, nor nutrition from reagent consumables
 #define TRAIT_NICE_SHOT			"nice_shot" //hnnnnnnnggggg..... you're pretty good...
 #define TRAIT_PERFECT_ATTACKER	"perfect_attacker"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -900,6 +900,15 @@ GLOBAL_LIST_INIT(energyweapon_crafting, list(
 	lose_text = span_danger("After picking some 250 year old cosmoline out from under one of your nails you realize that... Uh, no, the Mosin Nagant is a piece of shit.")
 	locked =  FALSE
 
+/datum/quirk/playdead
+	name = "Class Act"
+	desc = "You're good at acting! *deathgasp will be extra convincing to rudimentary tests, such as healthhuds and examine."
+	value = 1
+	mob_trait = TRAIT_PLAY_DEAD
+	gain_text = span_notice("You feel confident at playing dead.")
+	lose_text = span_danger("You feel that laying down in a field of gunfire may not be such a good idea after all.")
+	locked =  FALSE
+
 /datum/quirk/ratfriend
 	name = "Beast Friend - Rats"
 	desc = "Rattos and wild mice outright ignore you now."

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -148,6 +148,8 @@
 		playsound(user, user.deathsound, 200, TRUE, TRUE)
 	if(. && isalienadult(user))
 		playsound(user.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
+	if(HAS_TRAIT(user, TRAIT_PLAY_DEAD))
+		user.reagents.add_reagent(/datum/reagent/toxin/ghoulpowder, 10)
 
 /datum/emote/living/drool
 	key = "drool"


### PR DESCRIPTION
## About The Pull Request
Adds 'Class Act', a 1-point trait that gives the user 10u ghoul powder on *deathgasp
Ghoul powder slows the user down considerably while also making them appear dead on examine, health hud, and health analyzer. (Though it doesn't fake the damage for it, so you can shoot someone, 'kill them', then look at them funny with your health anal-yzer says they died with only 20 damage)
Yes you could spam it to have it naturally since it lacks overdose, why would you? It's slow as shit and gives you no benefits against mobs, nor any against players if you're, you know, standing.
![superpill](https://media.tenor.com/8pLR-RfX77YAAAAM/opossum-fall.gif)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
