### PR TITLE
Dclaw bunker fix mine shaft

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -48,6 +48,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"aaK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
+	},
+/area/f13/building/sewers)
 "aaW" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -1195,9 +1202,11 @@
 /area/f13/caves)
 "aXY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/green,
-/turf/open/floor/wood_wide,
-/area/f13/building/sewers)
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "aYa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -4687,9 +4696,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bRQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/building/sewers)
 "bRR" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -4703,11 +4714,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bSb" = (
-/obj/structure/nest/raider,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/building/sewers)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/tunnel)
 "bSm" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
@@ -4726,8 +4735,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bSG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/f13vaultrusted,
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bSH" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -4738,7 +4748,7 @@
 "bSU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/building/sewers)
+/area/f13/bunker)
 "bTh" = (
 /obj/structure/sign/stop,
 /turf/open/indestructible/ground/inside/subway,
@@ -6425,10 +6435,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
 "cBO" = (
-/obj/structure/simple_door/metal/dirtystore,
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/building/sewers)
 "cBX" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt{
@@ -7042,6 +7054,12 @@
 /area/f13/building/massfusion)
 "dbR" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
+/area/f13/caves)
+"dbX" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
 /area/f13/caves)
 "dcz" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -9994,6 +10012,15 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/caves)
+"frh" = (
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "frm" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/machinery/door/poddoor{
@@ -13701,11 +13728,8 @@
 	},
 /area/f13/tunnel)
 "ino" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider,
-/turf/open/floor/f13{
-	icon_state = "yellowrustychess"
-	},
+/obj/structure/decoration/rag,
+/turf/closed/wall/rust,
 /area/f13/building/sewers)
 "inu" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -14036,9 +14060,9 @@
 /area/f13/tunnel)
 "izx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
+/obj/structure/nest/raider,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building/sewers)
 "izI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -14080,14 +14104,9 @@
 	},
 /area/f13/caves)
 "iAs" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/obj/effect/decal/waste{
-	icon_state = "goo5"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood_wide,
+/area/f13/building/sewers)
 "iAu" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
@@ -18647,9 +18666,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
 "lNV" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/tunnel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/green,
+/turf/open/floor/wood_wide,
+/area/f13/building/sewers)
 "lNX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20785,9 +20805,12 @@
 	},
 /area/f13/caves)
 "nre" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/rust,
-/area/f13/building/sewers)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/deathclaw/mother,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "nrv" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -24194,13 +24217,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/sewers)
-"pOo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "pOs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -26573,12 +26589,6 @@
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"rtu" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
-	},
-/area/f13/caves)
 "rtz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -28634,12 +28644,10 @@
 	},
 /area/f13/caves)
 "sWm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/deathclaw,
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
-	},
-/area/f13/caves)
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building/sewers)
 "sWp" = (
 /obj/structure/bookcase/manuals,
 /turf/open/floor/f13/wood,
@@ -29695,9 +29703,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tJv" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_wide,
-/area/f13/building/sewers)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "tJE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -31367,6 +31376,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"vcf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vck" = (
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "An improvised ballistic turret - it looks exceptionally shoddy, yet stil functional. Safe to assume it's a repaired security system from whatever this place once was";
@@ -31493,13 +31509,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"vgm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/deathclaw/mother,
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
-	},
-/area/f13/caves)
 "vgq" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/low_tools,
@@ -32518,10 +32527,8 @@
 	},
 /area/f13/caves)
 "vWN" = (
-/obj/structure/simple_door/metal/dirtystore,
-/obj/structure/barricade/wooden/strong,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/sewers)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "vWV" = (
 /obj/item/storage/trash_stack{
 	icon_state = "Junk_8"
@@ -32764,16 +32771,10 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/building/sewers)
-"wfg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider,
-/turf/open/floor/f13{
-	icon_state = "greenrustyfull"
-	},
-/area/f13/building/sewers)
 "wfm" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13vaultrusted,
-/area/f13/bunker)
+/area/f13/building/sewers)
 "wft" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -33318,10 +33319,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "wAv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/raider,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/sewers)
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/area/f13/tunnel)
 "wAI" = (
 /obj/machinery/light/broken,
 /obj/structure/table,
@@ -71301,7 +71301,7 @@ tkZ
 tkZ
 hXn
 gcv
-nre
+ino
 wMO
 mby
 sIz
@@ -71815,7 +71815,7 @@ tkZ
 tkZ
 hXn
 gcv
-nre
+ino
 wqJ
 mVE
 mag
@@ -74368,13 +74368,13 @@ boU
 boU
 ceQ
 ceQ
-lNV
+wAv
 ceQ
 eWa
-cBO
+bSG
 boU
 boU
-vWN
+sWm
 taG
 ygb
 taG
@@ -74627,11 +74627,11 @@ ceQ
 qjR
 ceQ
 bMy
-lNV
-cBO
+wAv
+bSG
 boU
 boU
-vWN
+sWm
 taG
 taG
 taG
@@ -75219,9 +75219,9 @@ aah
 aah
 bKb
 pwE
-aXY
+lNV
 aUQ
-bSU
+wfm
 aUQ
 pOs
 bCV
@@ -75735,7 +75735,7 @@ bKb
 vXL
 aUQ
 iCu
-bSU
+wfm
 aUQ
 xEv
 pup
@@ -76249,7 +76249,7 @@ anU
 pwE
 qmd
 rFs
-tJv
+iAs
 vZp
 viM
 gXz
@@ -78315,7 +78315,7 @@ nGt
 cTO
 bCt
 ykz
-wAv
+izx
 kyV
 dVL
 aWr
@@ -79293,7 +79293,7 @@ pTK
 bPs
 sgV
 oJn
-wfm
+vWN
 sgV
 sGn
 sGn
@@ -79550,7 +79550,7 @@ bPs
 lZe
 gQi
 sBV
-wfm
+vWN
 sgV
 rJm
 bPs
@@ -79807,9 +79807,9 @@ ldb
 ldb
 sBV
 sBV
-wfm
+vWN
 urc
-wfm
+vWN
 bPs
 rJm
 sGn
@@ -80064,10 +80064,10 @@ ldb
 ldb
 sBV
 cAg
-wfm
-wfm
-wfm
-wfm
+vWN
+vWN
+vWN
+vWN
 rJm
 sGn
 cvv
@@ -80324,7 +80324,7 @@ gXq
 bPs
 bPz
 bPs
-wfm
+vWN
 sgV
 sGn
 aae
@@ -80579,9 +80579,9 @@ bPs
 cne
 sgV
 pwB
-wfm
+vWN
 sgV
-wfm
+vWN
 bPs
 sGn
 aae
@@ -80618,11 +80618,11 @@ bKb
 pwE
 gQX
 gcv
-wfg
+cBO
 gcv
 gcv
 blM
-ino
+aaK
 duA
 blM
 kyV
@@ -80631,7 +80631,7 @@ kyV
 pOs
 kyV
 kyV
-wAv
+izx
 kyV
 aGK
 blM
@@ -80836,9 +80836,9 @@ sgV
 bPv
 bPs
 iYT
-bRQ
+bSU
 sgV
-wfm
+vWN
 htv
 sGn
 aal
@@ -81092,10 +81092,10 @@ sGn
 sGn
 qWe
 vts
-bRQ
+bSU
 lGl
 bPs
-wfm
+vWN
 bPs
 sGn
 xcS
@@ -81347,12 +81347,12 @@ aae
 aae
 aae
 sGn
-wfm
+vWN
 vts
-bRQ
+bSU
 htv
-wfm
-wfm
+vWN
+vWN
 bPz
 sGn
 aae
@@ -81606,7 +81606,7 @@ aae
 sGn
 tIQ
 qhp
-wfm
+vWN
 bPs
 sgV
 htv
@@ -81862,10 +81862,10 @@ aae
 aae
 sGn
 vts
-wfm
-wfm
-wfm
-bRQ
+vWN
+vWN
+vWN
+bSU
 npf
 htv
 sGn
@@ -81904,7 +81904,7 @@ pwE
 blM
 gcv
 hXn
-bSb
+bRQ
 gcv
 gcv
 gcv
@@ -82122,7 +82122,7 @@ eCp
 pGY
 pGY
 eSw
-wfm
+vWN
 oMg
 vLs
 sGn
@@ -82177,7 +82177,7 @@ xhQ
 bEZ
 nHu
 pwE
-bSG
+bSb
 rpA
 aah
 bPR
@@ -82434,7 +82434,7 @@ blM
 blM
 blM
 dzm
-bSG
+bSb
 aah
 bWd
 bPR
@@ -82637,19 +82637,19 @@ pLf
 kCX
 xYi
 qlg
-bSU
-bSU
-bSU
+wfm
+wfm
+wfm
 pLf
-bSU
+wfm
 pLf
-bSU
-bSU
+wfm
+wfm
 ejN
-bSU
-bSU
+wfm
+wfm
 ejN
-bSU
+wfm
 pDR
 iBf
 iBf
@@ -82697,13 +82697,13 @@ mkF
 nyH
 pLf
 pLf
-bSU
-bSU
+wfm
+wfm
 ejN
 ejN
 ejN
 iEV
-bSU
+wfm
 ejN
 pLf
 pLf
@@ -82714,10 +82714,10 @@ pLf
 gfm
 pLf
 pLf
-bSU
+wfm
 pLf
-bSU
-bSU
+wfm
+wfm
 pLf
 pLf
 pLf
@@ -83463,17 +83463,14 @@ pLf
 pLf
 pLf
 pLf
-bSU
+wfm
 ejN
-bSU
-bSU
-bSU
+wfm
+wfm
+wfm
 pLf
 pLf
-bSU
-pLf
-pLf
-pLf
+wfm
 pLf
 pLf
 pLf
@@ -83483,13 +83480,16 @@ pLf
 pLf
 pLf
 pLf
-bSU
-bSU
-bSU
-bSU
-bSU
 pLf
-bSU
+pLf
+pLf
+wfm
+wfm
+wfm
+wfm
+wfm
+pLf
+wfm
 gAR
 mRt
 mRt
@@ -85500,7 +85500,7 @@ aaa
 aaa
 dzm
 bxO
-iAs
+frh
 bQM
 mVE
 mVE
@@ -93988,7 +93988,7 @@ sCX
 mUb
 dEQ
 aar
-sWm
+aXY
 mPz
 mPz
 tbh
@@ -94240,11 +94240,11 @@ xwF
 xwF
 xwF
 htL
-izx
+tJv
 aaB
 mUb
-pOo
-rtu
+vcf
+dbX
 mPz
 mPz
 tbh
@@ -94496,7 +94496,7 @@ xwF
 xwF
 xwF
 xwF
-izx
+tJv
 aar
 mUb
 aaB
@@ -96038,7 +96038,7 @@ aaB
 mUb
 cJr
 cJr
-izx
+tJv
 aaa
 xwF
 xwF
@@ -96293,7 +96293,7 @@ bXW
 aaB
 sCX
 aar
-izx
+tJv
 htL
 xwF
 xwF
@@ -98329,7 +98329,7 @@ mPz
 axS
 iCD
 iCD
-vgm
+nre
 lGB
 tbh
 oXC

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -337,6 +337,9 @@
 /mob/living/simple_animal/hostile/alien{
 	name = "Jerry"
 	},
+/mob/living/simple_animal/hostile/alien{
+	name = "Steve"
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "akS" = (
@@ -1192,8 +1195,8 @@
 /area/f13/caves)
 "aXY" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/baseball,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/chair/comfy/green,
+/turf/open/floor/wood_wide,
 /area/f13/building/sewers)
 "aYa" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -4684,10 +4687,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bRQ" = (
-/mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "bRR" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/inside/subway,
@@ -4701,9 +4703,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bSb" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/building/sewers)
 "bSm" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/indestructible/ground/inside/subway,
@@ -4722,8 +4726,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "bSG" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/inside/subway,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/tunnel)
 "bSH" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -4732,10 +4736,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "bSU" = (
-/mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/building/sewers)
 "bTh" = (
 /obj/structure/sign/stop,
 /turf/open/indestructible/ground/inside/subway,
@@ -5000,6 +5003,12 @@
 "bXK" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibmid3"
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
@@ -6416,7 +6425,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
 "cBO" = (
-/turf/closed/wall/r_wall,
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "cBX" = (
 /obj/structure/spider/stickyweb,
@@ -8463,7 +8474,7 @@
 "ejN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/sewers)
 "ekf" = (
 /obj/structure/chair/stool/bar,
@@ -13183,6 +13194,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/unique,
+/obj/effect/spawner/lootdrop/f13/weapon/unique,
 /turf/open/indestructible/ground/inside/subway{
 	name = "cave"
 	},
@@ -13689,12 +13701,11 @@
 	},
 /area/f13/tunnel)
 "ino" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "yellowrustychess"
 	},
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13/wood,
 /area/f13/building/sewers)
 "inu" = (
 /obj/effect/overlay/junk/oldpipes{
@@ -14024,11 +14035,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/tunnel)
 "izx" = (
-/obj/structure/nest/scorpion,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
 /area/f13/caves)
 "izI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14071,17 +14080,14 @@
 	},
 /area/f13/caves)
 "iAs" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbroken"
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/effect/decal/waste{
+	icon_state = "goo5"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/building/sewers)
+/turf/open/floor/f13/wood,
+/area/f13/tunnel)
 "iAu" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo,
@@ -14236,7 +14242,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/sewers)
 "iFc" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -14791,7 +14797,7 @@
 "iYT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "iZm" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -17592,7 +17598,7 @@
 /area/f13/building/museum)
 "ldb" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "ldo" = (
 /obj/item/trash/f13/dog,
@@ -18641,9 +18647,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/building/museum)
 "lNV" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood,
+/obj/structure/nest/ghoul,
+/turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "lNX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18794,7 +18799,6 @@
 	icon_state = "mattress2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/sewers)
 "lRL" = (
@@ -19497,6 +19501,9 @@
 "mrH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/junk,
+/obj/machinery/porta_turret/f13/turret_22lr/burstfire/raider{
+	name = "Bottom-Feeder Market Turret"
+	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/sewers)
 "mrN" = (
@@ -20778,12 +20785,8 @@
 	},
 /area/f13/caves)
 "nre" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken"
-	},
 /obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/rust,
 /area/f13/building/sewers)
 "nrv" = (
 /obj/structure/rack,
@@ -24191,6 +24194,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/sewers)
+"pOo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pOs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -26563,6 +26573,12 @@
 /obj/structure/simple_door/repaired,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"rtu" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "rtz" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -28081,7 +28097,7 @@
 "sBV" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "sCj" = (
 /obj/structure/cable{
@@ -28618,9 +28634,12 @@
 	},
 /area/f13/caves)
 "sWm" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/sewers)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "sWp" = (
 /obj/structure/bookcase/manuals,
 /turf/open/floor/f13/wood,
@@ -29676,8 +29695,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "tJv" = (
-/mob/living/simple_animal/hostile/raider/firefighter,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood_wide,
 /area/f13/building/sewers)
 "tJE" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -31474,6 +31493,13 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"vgm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/deathclaw/mother,
+/turf/open/indestructible/ground/inside/subway{
+	name = "cave"
+	},
+/area/f13/caves)
 "vgq" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/low_tools,
@@ -32492,10 +32518,9 @@
 	},
 /area/f13/caves)
 "vWN" = (
-/mob/living/simple_animal/hostile/raider/ranged,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkrusty"
-	},
+/obj/structure/simple_door/metal/dirtystore,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/sewers)
 "vWV" = (
 /obj/item/storage/trash_stack{
@@ -32739,10 +32764,16 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/building/sewers)
-"wfm" = (
-/obj/structure/nest/ghoul,
-/turf/open/indestructible/ground/inside/subway,
+"wfg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/raider,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
 /area/f13/building/sewers)
+"wfm" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/bunker)
 "wft" = (
 /obj/structure/decoration/rag{
 	desc = "A string of bones and skulls.<br>A common warning from tribals and raiders to outsiders.";
@@ -33287,11 +33318,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "wAv" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
+/obj/structure/nest/raider,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building/sewers)
 "wAI" = (
 /obj/machinery/light/broken,
 /obj/structure/table,
@@ -54010,7 +54040,7 @@ aah
 adz
 adz
 adz
-adz
+fQm
 adz
 aae
 aae
@@ -64551,7 +64581,7 @@ aae
 aae
 aae
 bFx
-aah
+bHl
 aah
 bFx
 aae
@@ -65359,9 +65389,9 @@ hXn
 tkZ
 tkZ
 tNM
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
 aae
 aae
 aae
@@ -65618,7 +65648,7 @@ tkZ
 bQs
 kMC
 dGb
-jGk
+pLf
 aae
 aae
 aae
@@ -65873,9 +65903,9 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
 aae
 aae
 aae
@@ -67241,7 +67271,7 @@ jGk
 jGk
 jGk
 jGk
-jGk
+pLf
 mkF
 mkF
 cLe
@@ -67498,7 +67528,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 kyV
 kyV
 gcv
@@ -67755,7 +67785,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 kyV
 kyV
 gcv
@@ -68012,7 +68042,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 ksR
 kyV
 gcv
@@ -68269,7 +68299,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 kyV
 kyV
 gcv
@@ -68526,7 +68556,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 kyV
 kyV
 gcv
@@ -68783,7 +68813,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 kyV
 kyV
 gcv
@@ -69040,7 +69070,7 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -69297,7 +69327,7 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -69554,7 +69584,7 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -69811,7 +69841,7 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -70068,7 +70098,7 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -70325,7 +70355,7 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -70582,7 +70612,7 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bNY
@@ -70839,7 +70869,7 @@ dzm
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -71096,7 +71126,7 @@ dzm
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bPR
@@ -71353,7 +71383,7 @@ bsC
 bsC
 bsC
 bsC
-bsC
+pwE
 bRH
 aah
 bPR
@@ -71610,7 +71640,7 @@ bsC
 bUo
 mNI
 bHC
-bsC
+pwE
 ffm
 aah
 bPR
@@ -71785,7 +71815,7 @@ tkZ
 tkZ
 hXn
 gcv
-ino
+nre
 wqJ
 mVE
 mag
@@ -71867,7 +71897,7 @@ bsC
 ceQ
 fdF
 ppe
-dzm
+pwE
 ffm
 aah
 gck
@@ -72124,7 +72154,7 @@ bsC
 ceQ
 ceQ
 bMZ
-bsC
+pwE
 ffm
 aah
 bPR
@@ -72381,7 +72411,7 @@ bsC
 bsC
 mgO
 bsC
-bsC
+pwE
 aah
 aah
 gck
@@ -72601,20 +72631,20 @@ jGk
 tkZ
 tkZ
 kyV
-jGk
-jGk
-jGk
-bsC
-bsC
-bsC
+pLf
+pLf
+pLf
+pwE
+pwE
+pwE
 hmD
 bNY
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 aah
 aah
 bKb
@@ -72638,7 +72668,7 @@ bsC
 kyV
 kyV
 lWI
-bsC
+pwE
 ffm
 hHK
 bPR
@@ -72858,20 +72888,20 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
 aae
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
 aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 aah
@@ -72895,7 +72925,7 @@ mTF
 kyV
 kyV
 nlg
-dzm
+pwE
 ffm
 aah
 bOs
@@ -73115,7 +73145,7 @@ gcv
 tkZ
 tkZ
 liI
-jGk
+pLf
 aae
 aae
 aae
@@ -73128,7 +73158,7 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
@@ -73152,7 +73182,7 @@ gcv
 gcv
 kyV
 pbU
-dzm
+pwE
 ffm
 afR
 bKb
@@ -73326,7 +73356,7 @@ oNM
 tkZ
 tkZ
 hXn
-iAs
+jGk
 xGN
 xGN
 gCF
@@ -73372,7 +73402,7 @@ gcv
 tkZ
 tkZ
 hXn
-jGk
+pLf
 aae
 aae
 aae
@@ -73385,21 +73415,21 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 bQx
 bQz
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 bNY
 blM
 gcv
@@ -73409,7 +73439,7 @@ pOs
 gcv
 kyV
 jGk
-bsC
+pwE
 ffm
 afR
 bKb
@@ -73629,7 +73659,7 @@ oNM
 vSO
 tkZ
 hXn
-jGk
+pLf
 aae
 aae
 aae
@@ -73642,11 +73672,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 ske
 cKp
 fej
@@ -73664,9 +73694,9 @@ oXH
 blM
 oXH
 gcv
-tJv
+kyV
 pCb
-bsC
+pwE
 aah
 hHK
 bKb
@@ -73886,7 +73916,7 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -73899,11 +73929,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 iix
 ugz
 ugz
@@ -73923,7 +73953,7 @@ bfe
 pOs
 kyV
 gLW
-bsC
+pwE
 rpA
 rpA
 bKb
@@ -74143,7 +74173,7 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -74156,11 +74186,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 xMX
 kyV
 ugz
@@ -74180,7 +74210,7 @@ kyV
 mFZ
 oXH
 gZP
-bsC
+pwE
 aah
 hHK
 bKb
@@ -74338,13 +74368,13 @@ boU
 boU
 ceQ
 ceQ
-ceQ
+lNV
 ceQ
 eWa
-ceQ
+cBO
 boU
 boU
-taG
+vWN
 taG
 ygb
 taG
@@ -74400,7 +74430,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aae
@@ -74413,11 +74443,11 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 bHg
 ikD
 bKb
-bsC
+pwE
 xMX
 bBy
 pOs
@@ -74437,7 +74467,7 @@ pIy
 kyV
 kyV
 tsA
-bsC
+pwE
 rpA
 rpA
 bKb
@@ -74597,13 +74627,13 @@ ceQ
 qjR
 ceQ
 bMy
-ceQ
-ceQ
+lNV
+cBO
 boU
 boU
+vWN
 taG
 taG
-sWm
 taG
 taG
 esP
@@ -74657,7 +74687,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aae
@@ -74670,11 +74700,11 @@ aak
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 olJ
 ugz
 bes
@@ -74694,7 +74724,7 @@ aSr
 oXH
 kyV
 kyV
-bsC
+pwE
 aah
 rpA
 bKb
@@ -74914,7 +74944,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aae
@@ -74927,11 +74957,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 anU
-bsC
+pwE
 jGk
 jGk
 jGk
@@ -74951,7 +74981,7 @@ blM
 ccw
 kyV
 kyV
-bsC
+pwE
 rpA
 rpA
 bKb
@@ -75171,7 +75201,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aae
@@ -75184,14 +75214,14 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
-qmd
+pwE
+aXY
 aUQ
-qmd
+bSU
 aUQ
 pOs
 bCV
@@ -75208,7 +75238,7 @@ blM
 dzm
 ucF
 dzm
-bsC
+pwE
 rpA
 hHK
 bKb
@@ -75428,7 +75458,7 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -75441,14 +75471,14 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 ikD
 aah
 bKb
 vXL
 aUQ
 nLr
-nLr
+pLf
 aUQ
 kyV
 kyV
@@ -75465,7 +75495,7 @@ jGk
 hFl
 aah
 rJl
-bsC
+pwE
 bGZ
 aah
 bKb
@@ -75685,7 +75715,7 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -75698,14 +75728,14 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
 vXL
 aUQ
 iCu
-iCu
+bSU
 aUQ
 xEv
 pup
@@ -75722,7 +75752,7 @@ jGk
 aah
 aah
 oMw
-bsC
+pwE
 aah
 rpA
 bKb
@@ -75920,7 +75950,7 @@ aah
 aah
 aah
 aah
-aah
+bHl
 aah
 aah
 aah
@@ -75942,7 +75972,7 @@ bQp
 tkZ
 tkZ
 bQt
-jGk
+pLf
 aae
 aae
 aae
@@ -75955,14 +75985,14 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 fVR
 vXL
 aUQ
 nLr
-nLr
+pLf
 aUQ
 pup
 gwu
@@ -75979,7 +76009,7 @@ fwC
 cEg
 aah
 qRL
-bsC
+pwE
 aah
 aah
 bKb
@@ -76199,7 +76229,7 @@ kyV
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -76212,14 +76242,14 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 anU
-bsC
+pwE
 qmd
 rFs
-aUQ
+tJv
 vZp
 viM
 gXz
@@ -76236,7 +76266,7 @@ vvq
 iJQ
 rgU
 aDN
-bsC
+pwE
 aah
 rpA
 bKb
@@ -76423,7 +76453,7 @@ iyM
 sQv
 bsC
 bsC
-aah
+bHl
 aah
 bsC
 bsC
@@ -76456,7 +76486,7 @@ jGk
 foJ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -76469,11 +76499,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 jGk
 jGk
 jGk
@@ -76493,7 +76523,7 @@ nFD
 aah
 iJQ
 iUI
-bsC
+pwE
 bHg
 aah
 bKb
@@ -76713,7 +76743,7 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -76726,11 +76756,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bUp
-bsC
+pwE
 dzm
 gRa
 hWk
@@ -76750,7 +76780,7 @@ aah
 aah
 jeq
 okf
-bsC
+pwE
 aah
 rpA
 bPR
@@ -76970,7 +77000,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aak
@@ -76983,11 +77013,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 giC
-bsC
+pwE
 dzm
 eAb
 cEg
@@ -77007,7 +77037,7 @@ eFN
 acC
 eFN
 glB
-bCt
+pwE
 aah
 hHK
 bPR
@@ -77183,14 +77213,14 @@ tkZ
 gcv
 wjN
 kyV
-wfm
+kyV
 kyV
 bGZ
 aah
 aah
 aah
 aah
-aah
+bHl
 aah
 aah
 aah
@@ -77227,7 +77257,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aak
@@ -77240,11 +77270,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 bHg
 eJW
 bKb
-bsC
+pwE
 dzm
 gRa
 tMl
@@ -77264,7 +77294,7 @@ hro
 aWr
 tYU
 kPo
-bCt
+pwE
 aah
 gVT
 bKb
@@ -77484,24 +77514,24 @@ qLb
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 dzm
 dzm
@@ -77521,7 +77551,7 @@ tYU
 oWf
 aWr
 dRV
-cBO
+pwE
 rpA
 rpA
 bPR
@@ -77741,10 +77771,10 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 bDc
 rqX
 lAI
@@ -77752,13 +77782,13 @@ rqX
 lAI
 rqX
 wNV
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 lET
 rcp
@@ -77770,7 +77800,7 @@ bCt
 nGt
 nGt
 bCt
-tJv
+kyV
 kyV
 oXH
 dVL
@@ -77778,7 +77808,7 @@ aWr
 gwu
 tYU
 kPo
-cBO
+pwE
 rpA
 hHK
 bKb
@@ -77998,10 +78028,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 bDc
 rqX
 rqX
@@ -78009,13 +78039,13 @@ rqX
 rqX
 rqX
 rqX
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 lQi
 oal
@@ -78031,11 +78061,11 @@ kyV
 khp
 kyV
 dVL
-vWN
+tYU
 gwu
 tYU
 azD
-bCt
+pwE
 aah
 hHK
 bKb
@@ -78255,10 +78285,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 ihq
 rqX
 rqX
@@ -78266,13 +78296,13 @@ rqX
 rqX
 vIE
 rqX
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 kjv
 rcp
@@ -78285,14 +78315,14 @@ nGt
 cTO
 bCt
 ykz
-pOs
+wAv
 kyV
 dVL
 aWr
 gwu
 aWr
 nuL
-cBO
+pwE
 rpA
 aah
 bPR
@@ -78512,10 +78542,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 nqr
 rqX
 pXF
@@ -78523,13 +78553,13 @@ rxf
 rxf
 mIM
 cyD
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 oUw
 gTm
@@ -78549,7 +78579,7 @@ gwu
 tYU
 tYU
 pfJ
-bCt
+pwE
 aah
 gVT
 bKb
@@ -78769,24 +78799,24 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 bsC
 pHO
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 vJe
 rcp
@@ -78799,14 +78829,14 @@ ovm
 qZn
 bCt
 xbU
-aXY
+pOs
 kyV
 eFN
 byL
 tYU
 tYU
 tSC
-cBO
+pwE
 rpA
 rpA
 bPR
@@ -79026,10 +79056,10 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 eWp
 rqX
 kuI
@@ -79043,7 +79073,7 @@ bGZ
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 dzm
 dzm
@@ -79063,7 +79093,7 @@ eFN
 mFW
 glB
 eFN
-bCt
+pwE
 aah
 hHK
 bPR
@@ -79263,7 +79293,7 @@ pTK
 bPs
 sgV
 oJn
-aaD
+wfm
 sgV
 sGn
 sGn
@@ -79283,10 +79313,10 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 nYS
 rqX
 qVR
@@ -79300,7 +79330,7 @@ aah
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 bLy
 eWa
@@ -79320,7 +79350,7 @@ wlO
 xbU
 eBq
 cPy
-bsC
+pwE
 aah
 hHK
 bKb
@@ -79486,10 +79516,10 @@ aae
 aae
 aae
 aae
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
 oNM
 tkZ
 tkZ
@@ -79520,7 +79550,7 @@ bPs
 lZe
 gQi
 sBV
-aaD
+wfm
 sgV
 rJm
 bPs
@@ -79540,10 +79570,10 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 rqX
 rqX
 rqX
@@ -79557,7 +79587,7 @@ gna
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 kuL
 iDW
@@ -79577,7 +79607,7 @@ lrv
 iZH
 gLZ
 vHE
-bsC
+pwE
 aah
 afR
 bKb
@@ -79743,7 +79773,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 sKz
 gcv
 cLe
@@ -79777,9 +79807,9 @@ ldb
 ldb
 sBV
 sBV
-aaD
+wfm
 urc
-aaD
+wfm
 bPs
 rJm
 sGn
@@ -79797,24 +79827,24 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 bsC
 pHO
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 dzm
 dzm
 dzm
@@ -79834,7 +79864,7 @@ blM
 blM
 blM
 blM
-bsC
+pwE
 aah
 gVT
 bKb
@@ -80000,7 +80030,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 gBg
 gcv
 apO
@@ -80034,10 +80064,10 @@ ldb
 ldb
 sBV
 cAg
-aaD
-aaD
-aaD
-aaD
+wfm
+wfm
+wfm
+wfm
 rJm
 sGn
 cvv
@@ -80054,10 +80084,10 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 rqX
 rqX
 rqX
@@ -80065,13 +80095,13 @@ bsC
 ocz
 mVE
 dUV
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 bsu
 ptn
 gcv
@@ -80091,7 +80121,7 @@ kyV
 xjW
 kyV
 blM
-bsC
+pwE
 aah
 wYJ
 bKb
@@ -80257,10 +80287,10 @@ aae
 aae
 aae
 aae
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
 oNM
 tkZ
 tkZ
@@ -80294,7 +80324,7 @@ gXq
 bPs
 bPz
 bPs
-aaD
+wfm
 sgV
 sGn
 aae
@@ -80311,10 +80341,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 utC
 rqX
 mEb
@@ -80322,13 +80352,13 @@ bsC
 piA
 mVE
 vKy
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 nAr
 bUZ
 tPZ
@@ -80348,7 +80378,7 @@ kyV
 gBF
 kyV
 blM
-bsC
+pwE
 aah
 afR
 bPR
@@ -80549,9 +80579,9 @@ bPs
 cne
 sgV
 pwB
-aaD
+wfm
 sgV
-aaD
+wfm
 bPs
 sGn
 aae
@@ -80568,10 +80598,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 rqX
 rqX
 bHZ
@@ -80579,20 +80609,20 @@ bsC
 aCD
 mVE
 mVE
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 gQX
 gcv
-hXn
+wfg
 gcv
 gcv
 blM
-ckq
+ino
 duA
 blM
 kyV
@@ -80601,11 +80631,11 @@ kyV
 pOs
 kyV
 kyV
-pOs
+wAv
 kyV
 aGK
 blM
-bsC
+pwE
 rpA
 bbT
 bPR
@@ -80806,9 +80836,9 @@ sgV
 bPv
 bPs
 iYT
-adt
+bRQ
 sgV
-aaD
+wfm
 htv
 sGn
 aal
@@ -80825,10 +80855,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 rqX
 rqX
 nYS
@@ -80836,13 +80866,13 @@ bsC
 wbT
 mVE
 han
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 cOH
 aYX
 gcv
@@ -80862,7 +80892,7 @@ pOs
 pOs
 kyV
 blM
-bsC
+pwE
 rpA
 rpA
 bKb
@@ -81062,10 +81092,10 @@ sGn
 sGn
 qWe
 vts
-adt
+bRQ
 lGl
 bPs
-aaD
+wfm
 bPs
 sGn
 xcS
@@ -81082,10 +81112,10 @@ oNM
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 sax
 inc
 rqX
@@ -81093,13 +81123,13 @@ feP
 mVE
 mVE
 mVE
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 blM
 ura
@@ -81118,8 +81148,8 @@ kyV
 pOs
 yiL
 kyV
-bsC
-bsC
+pwE
+pwE
 aGy
 rpA
 bKb
@@ -81317,12 +81347,12 @@ aae
 aae
 aae
 sGn
-aaD
+wfm
 vts
-adt
+bRQ
 htv
-aaD
-aaD
+wfm
+wfm
 bPz
 sGn
 aae
@@ -81339,10 +81369,10 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 ofg
 iAu
 rqX
@@ -81350,13 +81380,13 @@ bsC
 tpI
 mVE
 vKy
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 gcv
 hXn
@@ -81375,7 +81405,7 @@ pOs
 pOs
 mrH
 pMB
-bsC
+pwE
 bGZ
 aah
 yge
@@ -81576,7 +81606,7 @@ aae
 sGn
 tIQ
 qhp
-aaD
+wfm
 bPs
 sgV
 htv
@@ -81596,10 +81626,10 @@ gcv
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
-bsC
+pwE
 inc
 sax
 rqX
@@ -81607,13 +81637,13 @@ bsC
 mVE
 mVE
 mVE
-bsC
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 hXn
 hXn
@@ -81632,7 +81662,7 @@ lkf
 eRS
 qWI
 tUp
-bsC
+pwE
 aah
 agZ
 aah
@@ -81832,10 +81862,10 @@ aae
 aae
 sGn
 vts
-aaD
-aaD
-aaD
-adt
+wfm
+wfm
+wfm
+bRQ
 npf
 htv
 sGn
@@ -81853,28 +81883,28 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
-bsC
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
+pwE
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 gcv
 hXn
-gcv
+bSb
 gcv
 gcv
 gcv
@@ -81889,7 +81919,7 @@ kXx
 pFE
 kyV
 kyV
-bsC
+pwE
 vRN
 rpA
 aah
@@ -82092,7 +82122,7 @@ eCp
 pGY
 pGY
 eSw
-aaD
+wfm
 oMg
 vLs
 sGn
@@ -82110,7 +82140,7 @@ gcv
 tkZ
 tkZ
 bQs
-jGk
+pLf
 aae
 aae
 aae
@@ -82123,11 +82153,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 gcv
 aYX
@@ -82146,8 +82176,8 @@ bEZ
 xhQ
 bEZ
 nHu
-bsC
-mna
+pwE
+bSG
 rpA
 aah
 bPR
@@ -82367,7 +82397,7 @@ bQq
 tkZ
 tkZ
 gcv
-jGk
+pLf
 aae
 aae
 aae
@@ -82380,11 +82410,11 @@ aae
 aae
 aae
 aae
-bsC
+pwE
 aah
 aah
 bKb
-bsC
+pwE
 blM
 blM
 blM
@@ -82404,7 +82434,7 @@ blM
 blM
 blM
 dzm
-mna
+bSG
 aah
 bWd
 bPR
@@ -82572,132 +82602,132 @@ aae
 aae
 aae
 aae
-jGk
-jGk
+pLf
+pLf
 cLe
 bOm
 bOm
 cLe
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 mkF
 mkF
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 kCX
 xYi
 qlg
-pDR
-pDR
-pDR
-jGk
-pDR
-jGk
-pDR
-pDR
+bSU
+bSU
+bSU
+pLf
+bSU
+pLf
+bSU
+bSU
 ejN
-pDR
-pDR
+bSU
+bSU
 ejN
-pDR
+bSU
 pDR
 iBf
 iBf
 jGk
-jGk
-aae
-aae
-aae
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+bCG
+bCG
+bCG
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 mkF
 mkF
 cLe
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 mkF
 mkF
 nyH
-jGk
-jGk
-pDR
-pDR
+pLf
+pLf
+bSU
+bSU
 ejN
 ejN
 ejN
 iEV
-pDR
+bSU
 ejN
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 gfm
-jGk
-jGk
-pDR
-jGk
-pDR
-pDR
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+bSU
+pLf
+bSU
+bSU
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 rHB
 rHB
 aae
@@ -82829,7 +82859,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 bLb
 gcv
 rkp
@@ -83086,7 +83116,7 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 bLb
 gcv
 tkZ
@@ -83343,28 +83373,28 @@ aae
 aae
 aae
 aae
-jGk
-jGk
+pLf
+pLf
 oNM
 tkZ
 tkZ
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 bEJ
 bEJ
 tkZ
@@ -83401,65 +83431,65 @@ icm
 icm
 tkZ
 jSz
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
 meY
 bTi
 bTw
 bTi
 meY
-jGk
-jGk
-jGk
-jGk
-pDR
+pLf
+pLf
+pLf
+pLf
+bSU
 ejN
-pDR
-pDR
-pDR
-jGk
-jGk
-pDR
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-jGk
-pDR
-pDR
-pDR
-pDR
-pDR
-jGk
-pDR
+bSU
+bSU
+bSU
+pLf
+pLf
+bSU
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+pLf
+bSU
+bSU
+bSU
+bSU
+bSU
+pLf
+bSU
 gAR
 mRt
 mRt
@@ -83601,11 +83631,11 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 gcv
 tkZ
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -83858,11 +83888,11 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -84115,11 +84145,11 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 gcv
 tkZ
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -84372,11 +84402,11 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -84629,11 +84659,11 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 dMD
 tkZ
-jGk
-jGk
+pLf
+pLf
 aae
 aae
 aae
@@ -84711,7 +84741,7 @@ aah
 aah
 aah
 hHK
-aah
+toy
 aah
 dzm
 dzm
@@ -84886,10 +84916,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -85143,10 +85173,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 gcv
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -85400,10 +85430,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 mWL
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -85470,7 +85500,7 @@ aaa
 aaa
 dzm
 bxO
-mVE
+iAs
 bQM
 mVE
 mVE
@@ -85657,10 +85687,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -85736,7 +85766,7 @@ mVE
 mVE
 bRd
 dzm
-aah
+toy
 rpA
 cTu
 aah
@@ -85744,7 +85774,7 @@ aah
 bSa
 mby
 mby
-wAv
+lul
 mVE
 dzm
 aae
@@ -85914,10 +85944,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -85990,7 +86020,7 @@ mVE
 bRd
 dZX
 mby
-bRQ
+mby
 xuH
 ikO
 aah
@@ -86171,10 +86201,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 oNM
 tkZ
-jGk
+pLf
 aae
 aae
 aae
@@ -86428,10 +86458,10 @@ aae
 aae
 aae
 aae
-jGk
+pLf
 bxX
 bxX
-jGk
+pLf
 aae
 aae
 aae
@@ -86504,7 +86534,7 @@ bQU
 bRe
 bRq
 mby
-lNV
+mby
 mVE
 cVE
 rpA
@@ -87019,7 +87049,7 @@ bRe
 dZX
 mby
 jMq
-bRQ
+mby
 ikO
 rpA
 aah
@@ -87279,7 +87309,7 @@ mby
 mby
 dzm
 aah
-bSU
+rpA
 rpA
 bQw
 dzm
@@ -87535,15 +87565,15 @@ dzm
 ikO
 ikO
 ikO
-aah
+toy
 rpA
 aah
-bSG
+aah
 bQM
 mVE
 lKP
 mVE
-bRQ
+mVE
 mby
 bUM
 dzm
@@ -88055,7 +88085,7 @@ aah
 aah
 dzm
 dzm
-bRQ
+mby
 bUN
 bVd
 bVK
@@ -89067,7 +89097,7 @@ aae
 aaa
 aae
 dzm
-aah
+toy
 aah
 bQQ
 aah
@@ -89332,7 +89362,7 @@ dzm
 bRt
 mby
 mVE
-bSb
+mVE
 bRq
 dzm
 bFF
@@ -89584,7 +89614,7 @@ aae
 dzm
 dzm
 dzm
-dzm
+aah
 dzm
 mby
 eGB
@@ -93439,7 +93469,7 @@ xwF
 xwF
 xwF
 xwF
-aak
+aaa
 mUb
 xwF
 aak
@@ -93696,7 +93726,7 @@ xwF
 xwF
 xwF
 xwF
-aak
+aaa
 aaB
 aar
 aak
@@ -93953,12 +93983,12 @@ xwF
 xwF
 xwF
 xwF
-xwF
+aaa
 sCX
 mUb
 dEQ
 aar
-tbh
+sWm
 mPz
 mPz
 tbh
@@ -94210,14 +94240,14 @@ xwF
 xwF
 xwF
 htL
-owX
+izx
 aaB
 mUb
-mUb
+pOo
+rtu
 mPz
 mPz
-mPz
-izx
+tbh
 tbh
 mPz
 aak
@@ -94460,13 +94490,13 @@ mPz
 mPz
 mPz
 mPz
-aak
+aaa
 xwF
 xwF
 xwF
 xwF
 xwF
-hNz
+izx
 aar
 mUb
 aaB
@@ -94717,16 +94747,16 @@ mPz
 fQt
 mPz
 mPz
-xwF
+aaa
 xwF
 xwF
 xwF
 xwF
 htL
-aak
+aaa
 sCX
 aaB
-xwF
+aaa
 xcS
 xwF
 xwF
@@ -94979,11 +95009,11 @@ xwF
 xwF
 xwF
 htL
-xwF
+aaa
 pxf
 mUb
 mUb
-xwF
+aaa
 aak
 xwF
 htL
@@ -95232,15 +95262,15 @@ mPz
 mPz
 tbh
 mUb
-aak
-aak
-xwF
-xwF
-htL
+aaa
+aaa
+aaa
+aaa
+cJr
 aaB
 aaB
 aaB
-xwF
+aaa
 xwF
 xwF
 xwF
@@ -95491,13 +95521,13 @@ aar
 aaB
 aaB
 aar
-aak
+aaa
 aar
 aaB
 aaB
 aaB
-aak
-htL
+aaa
+cJr
 htL
 xwF
 xwF
@@ -95744,7 +95774,7 @@ xwF
 aak
 xwF
 htL
-xwF
+aaa
 aaB
 aaB
 aaB
@@ -95752,8 +95782,8 @@ aaB
 aaB
 mUb
 mUb
-htL
-htL
+cJr
+cJr
 htL
 xwF
 xwF
@@ -96001,15 +96031,15 @@ xwF
 xwF
 xwF
 xwF
-xwF
+aaa
 aar
 aaB
 aaB
 mUb
-xcS
-htL
-owX
-xwF
+cJr
+cJr
+izx
+aaa
 xwF
 xwF
 xwF
@@ -96256,14 +96286,14 @@ tbh
 aaB
 htL
 xwF
-xwF
-xwF
+aaa
+aaa
 aar
 bXW
 aaB
 sCX
 aar
-owX
+izx
 htL
 xwF
 xwF
@@ -96513,14 +96543,14 @@ aaB
 aaB
 mUb
 aar
-xwF
+aaa
 mUb
 aaB
 mUb
 aaB
 mUb
 sCX
-xcS
+cJr
 xwF
 xwF
 xwF
@@ -97026,13 +97056,13 @@ xwF
 xwF
 aaB
 mUb
-lUo
+aaB
 aaB
 mUb
-htL
-xwF
-xwF
-xwF
+cJr
+aaa
+aaa
+aaa
 aaB
 aaB
 aaB
@@ -97286,7 +97316,7 @@ sCX
 mUb
 mUb
 bXW
-xwF
+aaa
 xwF
 xwF
 xwF
@@ -97541,9 +97571,9 @@ xwF
 mUb
 aaB
 aaB
-xwF
-xwF
-xwF
+aaB
+aaa
+aaa
 xwF
 xwF
 xwF
@@ -97798,8 +97828,8 @@ xwF
 aaB
 uKv
 mUb
-xwF
-htL
+aaB
+cJr
 htL
 aar
 xwF
@@ -98056,7 +98086,7 @@ aak
 mUb
 mUb
 aaB
-xwF
+aaa
 htL
 mUb
 aaB
@@ -98299,7 +98329,7 @@ mPz
 axS
 iCD
 iCD
-tbh
+vgm
 lGB
 tbh
 oXC
@@ -98313,8 +98343,8 @@ xwF
 aaB
 aaB
 aaB
-xwF
-xwF
+aaa
+aaa
 mUb
 aaB
 aaB


### PR DESCRIPTION
## About The Pull Request
The following PR was made in order to combat cheesing from encounters involving Raiders and Deathclaws. Dclaws have the ability to destroy steel walls which can be used to grief other players AND mob skip extensively. The PR was made to fix that. In the area featured here: 

![image](https://user-images.githubusercontent.com/93557430/232405598-94fa16a4-c76a-4576-bd66-c9d3a6c6af74.png)

You will notice that Dclaw nests NEED to be cleared, as they will respond endlessly, and players are encouraged to work TOGETHER with this one.
4 extra puddles of goo were added to combat campers and make them prepare for this """bunker,"" and an additional weapon spawn was added to accommodate the spike in difficulty.

Also, mobs were fighting each other, making the bunker easier. I've since fixed that.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: The bunker.
add: adds indestructible wall tiles to prevent grief.
/:cl:
