### PR TITLE
Proletarian Power Armor

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -626,7 +626,7 @@
 	always_available = FALSE
 
 /datum/crafting_recipe/repair_t45
-	name = "Refurbished T-45B Power Armor"
+	name = "Refurbished T-45b Power Armor"
 	result = /obj/item/clothing/suit/armor/power_armor/t45b/raider
 	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b,
 				/obj/item/stack/cable_coil = 5,
@@ -639,7 +639,7 @@
 	always_available = FALSE
 
 /datum/crafting_recipe/repair_t45_helm
-	name = "Refurbished T-45B Power Armor Helmet"
+	name = "Refurbished T-45b Power Armor Helmet"
 	result = /obj/item/clothing/head/helmet/f13/power_armor/t45b
 	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b = 1,
 				/obj/item/stack/cable_coil = 5,

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -593,3 +593,58 @@
 	time = 5 SECONDS
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
+
+/datum/crafting_recipe/scrap_pa
+	name = "Powered Scrap Suit"
+	result = /obj/item/clothing/suit/armor/power_armor/t45b/raider
+	reqs = list(/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/electronicparts = 5,
+				/obj/item/stock_parts/manipulator/pico = 1,
+				/obj/item/advanced_crafting_components/conductors = 1,
+				/obj/item/stock_parts/cell/ammo/mfc = 1,
+				/obj/item/stack/cable_coil = 30,
+				/obj/item/stack/sheet/metal = 35,
+				/obj/item/stack/sheet/bronze = 25)
+	time = 35
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/scrap_pa_helm
+	name = "Powered Scrap Suit Helmet"
+	result = /obj/item/clothing/head/helmet/f13/power_armor/t45b/raider
+	reqs = list(/obj/item/stack/crafting/goodparts = 1,
+				/obj/item/stack/crafting/electronicparts = 2,
+				/obj/item/stock_parts/manipulator/pico = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/sheet/metal = 15,
+				/obj/item/stack/sheet/bronze = 5)
+	time = 25
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/repair_t45
+	name = "Refurbished T-45B Power Armor"
+	result = /obj/item/clothing/suit/armor/power_armor/t45b/raider
+	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/crafting/electronicparts = 5,
+				/obj/item/stock_parts/manipulator/pico = 1,
+				/obj/item/stock_parts/cell/ammo/mfc = 1)
+	time = 35
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/repair_t45_helm
+	name = "Refurbished T-45B Power Armor Helmet"
+	result = /obj/item/clothing/head/helmet/f13/power_armor/t45b
+	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/crafting/electronicparts = 2)
+	time = 25
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -627,7 +627,7 @@
 
 /datum/crafting_recipe/repair_t45
 	name = "Refurbished T-45b Power Armor"
-	result = /obj/item/clothing/suit/armor/power_armor/t45b/raider
+	result = /obj/item/clothing/suit/armor/power_armor/t45b
 	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/stack/crafting/electronicparts = 5,

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -86,6 +86,12 @@ GLOBAL_LIST_INIT(former_tribal_recipes, list(
 GLOBAL_LIST_INIT(energyweapon_crafting, list(
 	/datum/crafting_recipe/aer9_hotwired))
 
+GLOBAL_LIST_INIT(pa_repair, list(
+	/datum/crafting_recipe/repair_t45,
+	/datum/crafting_recipe/repair_t45_helm,
+	/datum/crafting_recipe/scrap_pa,
+	/datum/crafting_recipe/scrap_pa_helm))
+
 //predominantly positive traits
 //this file is named weirdly so that positive traits are listed above negative ones
 
@@ -317,6 +323,7 @@ GLOBAL_LIST_INIT(energyweapon_crafting, list(
 	H.mind.learned_recipes |= GLOB.tier_three_parts
 	H.mind.learned_recipes |= GLOB.energyweapon_cell_crafting
 	H.mind.learned_recipes |= GLOB.energyweapon_crafting
+	H.mind.learned_recipes |= GLOB.pa_repair
 
 /datum/quirk/technophreak/remove()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -324,6 +331,7 @@ GLOBAL_LIST_INIT(energyweapon_crafting, list(
 		H.mind.learned_recipes -= GLOB.tier_three_parts
 		H.mind.learned_recipes -= GLOB.energyweapon_cell_crafting
 		H.mind.learned_recipes -= GLOB.energyweapon_crafting
+		H.mind.learned_recipes -= GLOB.pa_repair
 
 /datum/quirk/gunsmith
 	name = "Weaponsmith"

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -353,11 +353,20 @@
 			return "<span class='warning'>The connections ports have been <i>unanchored</i> and only <i>wires</i> remain.</span>"
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45b
-	name = "T-45b helmet"
-	desc = "It's a T-45b power armor helmet."
+	name = "Refurbished T-45b helmet"
+	desc = "It's a refurbished T-45b power armor helmet."
 	icon_state = "t45bhelmet"
 	item_state = "t45bhelmet"
+	armor = ARMOR_VALUE_SALVAGE
 	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b
+
+/obj/item/clothing/head/helmet/f13/power_armor/t45b/raider
+	name = "powered scrap helmet"
+	desc = "It's a helmet made of scrap metal and wires, some poor attempt at a power armor helmet."
+	icon_state = "raiderpa_helm"
+	item_state = "raiderpa_helm"
+	armor = ARMOR_VALUE_SALVAGE
+	salvaged_type = /obj/item/clothing/head/helmet/f13/raidermetal
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45d
 	name = "T-45d power helmet"

--- a/code/modules/clothing/head/f13head.dm
+++ b/code/modules/clothing/head/f13head.dm
@@ -365,7 +365,6 @@
 	desc = "It's a helmet made of scrap metal and wires, some poor attempt at a power armor helmet."
 	icon_state = "raiderpa_helm"
 	item_state = "raiderpa_helm"
-	armor = ARMOR_VALUE_SALVAGE
 	salvaged_type = /obj/item/clothing/head/helmet/f13/raidermetal
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45d

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3273,7 +3273,7 @@
 	armor = ARMOR_VALUE_SALVAGE
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
-/obj/item/clothing/suit/armor/power_armor/t45b
+/obj/item/clothing/suit/armor/power_armor/t45b/raider
 	name = "Powered scrap suit"
 	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substite sits embedded under all that rust. Is this some attempt at power armor???"
 	armor = ARMOR_VALUE_SALVAGE

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3271,6 +3271,7 @@
 	name = "Refurbished T-45b power armor"
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
 	armor = ARMOR_VALUE_SALVAGE
+	slowdown = ARMOR_SLOWDOWN_SALVAGE * ARMOR_SLOWDOWN_GLOBAL_MULT
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3276,7 +3276,8 @@
 /obj/item/clothing/suit/armor/power_armor/t45b/raider
 	name = "Powered scrap suit"
 	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substite sits embedded under all that rust. Is this some attempt at power armor???"
-	armor = ARMOR_VALUE_SALVAGE
+	icon_state = "raider_salvaged"
+	item_state = "raider_salvaged"
 	salvaged_type = /obj/item/clothing/suit/armor/medium/raider/raidermetal
 
 /obj/item/clothing/suit/armor/power_armor/t45d

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3279,11 +3279,6 @@
 	armor = ARMOR_VALUE_SALVAGE
 	salvaged_type = /obj/item/clothing/suit/armor/medium/raider/raidermetal
 
-/obj/item/clothing/suit/armor/power_armor/t45b
-	name = "T-45b power armor"
-	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
-	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
-
 /obj/item/clothing/suit/armor/power_armor/t45d
 	name = "T-45d power armor"
 	desc = "Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle."

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3268,6 +3268,18 @@
 	return ..()
 
 /obj/item/clothing/suit/armor/power_armor/t45b
+	name = "Refurbished T-45b power armor"
+	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
+	armor = ARMOR_VALUE_SALVAGE
+	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
+
+/obj/item/clothing/suit/armor/power_armor/t45b
+	name = "Powered scrap suit"
+	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substite sits embedded under all that rust. Is this some attempt at power armor???"
+	armor = ARMOR_VALUE_SALVAGE
+	salvaged_type = /obj/item/clothing/suit/armor/medium/raider/raidermetal
+
+/obj/item/clothing/suit/armor/power_armor/t45b
 	name = "T-45b power armor"
 	desc = "It's a set of early-model T-45 power armor with a custom air conditioning module and restored servomotors. Bulky, but almost as good as the real thing."
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3274,7 +3274,7 @@
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider
-	name = "Powered scrap suit"
+	name = "powered scrap suit"
 	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substite sits embedded under all that rust. Is this some attempt at power armor???"
 	icon_state = "raider_salvaged"
 	item_state = "raider_salvaged"

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3275,7 +3275,7 @@
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider
 	name = "powered scrap suit"
-	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substite sits embedded under all that rust. Is this some attempt at power armor???"
+	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substitute sits embedded under all that rust. Is this some attempt at power armor???"
 	icon_state = "raider_salvaged"
 	item_state = "raider_salvaged"
 	salvaged_type = /obj/item/clothing/suit/armor/medium/raider/raidermetal


### PR DESCRIPTION
## About The Pull Request
Adds refurbished T45b (cheaper to make but requires salvaged T45 in the first place) and powered scrap PA (expensive, but can be made from just components and materials) to the technophreak trait.
These armors are no better then salvaged PA armor-wise. However, at the cost of all the downsides of PA (power management, the skill requirement, EMP vulnerability), you get the benefits of PA (stunimmune, recoil reduction, etc).

pa goes clunk clunk, who's to say the dungeon rushers get to have all the fun? Now normal players can use the PA trait as a generic heavy armor trait, with low tier garbage PA.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
