### PR TITLE
Light sec loadout change

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -114,8 +114,8 @@
 	tint = 2
 
 /obj/item/clothing/head/helmet/blueshirt
-	name = "light security helmet"
-	desc = "A reliable, blue tinted helmet reminding you that you <i>still</i> owe that engineer a beer."
+	name = "Vault-Tec security helmet"
+	desc = "A light, open-faced helmet commonly worn by Vault-Tec security personnel."
 	icon_state = "blueshift"
 	item_state = "blueshift"
 

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -1846,8 +1846,8 @@
 	item_state = "vest_flak"
 
 /obj/item/clothing/suit/armor/medium/vest/oasis
-	name = "NPD vest"
-	desc = "a lightweight ballistic vest that combines protection and comfort. This one has pockets sewn into the front and a badge pinned on it."
+	name = "Vault-Sec vest"
+	desc = "a lightweight ballistic vest that is commonly worn by Vault-Tec security personnel. This one still has the badge attached."
 	icon_state = "blueshift"
 	item_state = "blueshift"
 

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -468,18 +468,18 @@ datum/gear/head/steelpot_bandolier
 						)*/
 
 /datum/gear/head/oasishelmet
-	name = "light security helmet"
+	name = "Vault-Tec security helmet"
 	path = /obj/item/clothing/head/helmet/blueshirt
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_HELMETS
 	cost = 1
-	restricted_desc = "Nash PD, Nash officials"
+	/*restricted_desc = "Nash PD, Nash officials"
 	restricted_roles = list("Chief of Police",
 							"Officer",
 							"Mayor",
 							"Detective",
 							"Secretary",
 							"Shopkeeper",
-						)
+						)*/
 
 /datum/gear/head/goner_red
 	name = "cheap helmet, red"

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -419,18 +419,18 @@
 							)
 
 /datum/gear/suit/deputyvest
-	name = "NPD armor vest"
+	name = "Vault-Sec armor vest"
 	path = /obj/item/clothing/suit/armor/medium/vest/oasis
 	subcategory = LOADOUT_SUBCATEGORY_SUIT_ARMOR
 	cost = 2
-	restricted_desc = "Nash Police, Nash Officials"
+	/*restricted_desc = "Nash Police, Nash Officials"
 	restricted_roles = list("Chief of Police",
 							"Officer",
 							"Mayor",
 							"Detective",
 							"Secretary",
 							"Shopkeeper",
-						)
+						)*/
 
 /datum/gear/suit/hazardvest
 	name = "Hazard Vest"


### PR DESCRIPTION
## About The Pull Request
Changes light security vest and helm to be usable in loadout again (No job restrictions), and renames them to be a Vault-Sec armor set.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
edited loadout to remove job restrictions from light security head and vest to allow usage for loadouts again.
renamed the light security helm and vest to 'Vault-Tec security helmet' and 'Vault-Sec vest', respectively. 
/:cl: