### PR TITLE
toolspeed and sale stuff (should be good to merge)

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -190,20 +190,21 @@
 /obj/item/melee/onehanded/knife/hunting
 	name = "hunting knife"
 	icon_state = "knife_hunting"
-	desc = "Dependable hunting knife."
+	desc = "A dependable hunting knife. Good for skinning one's kills."
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
 	force = 23
 	throwforce = 25
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
-	toolspeed = 0.8
+	toolspeed = 0.7
 
 /obj/item/melee/onehanded/knife/survival
 	name = "survival knife"
 	icon_state = "knife_survival"
-	desc = "Multi-purpose knife with blackened steel."
+	desc = "A high-quality pre-war survival knife. Perfect for a survivalist or hunter."
 	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
 	force = 23
 	throwforce = 25
+	toolspeed = 0.3
 
 /obj/item/melee/onehanded/knife/bayonet
 	name = "bayonet knife"
@@ -216,11 +217,11 @@
 	name = "bowie knife"
 	icon_state = "knife_bowie"
 	item_state = "knife_bowie"
-	desc = "A large clip point fighting knife."
+	desc = "Now this is a knife! Better as both a tool and weapon than most knives, but loses out to specialized tools."
 	force = 28
 	throwforce = 25
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
-	toolspeed = 0.8
+	toolspeed = 0.5
 
 /obj/item/melee/onehanded/knife/trench
 	name = "trench knife"
@@ -327,7 +328,7 @@ obj/item/melee/onehanded/knife/switchblade
 	force = 25
 	throwforce = 15
 	armour_penetration = 0.2
-	toolspeed = 0.9
+	toolspeed = 0.8
 
 // Heat it with a welder
 /obj/item/melee/onehanded/knife/cosmic/welder_act(mob/living/user, obj/item/I)

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -466,6 +466,29 @@
 	export_types = list(/obj/item/toy/prize, /obj/item/toy/talking,
 	)
 
+/datum/export/item/prewarsalvage
+	cost = 50 // 1600 credits or 160 caps for the shop per full bag. Avg 80 caps for customers per bag
+	unit_name = "saleable scrap"
+	export_types = list(/obj/item/salvage/low,
+	)
+
+/datum/export/item/toolsalvage
+	cost = 2000 // Tools are nice, but often clutter places up. This should help.
+	unit_name = "tool salvage"
+	export_types = list(/obj/item/salvage/tool,
+	)
+
+/datum/export/item/advancedsalvage
+	cost = 5000 // advanced salvage is VERY in demand in and outside the shop. Very valuable.
+	unit_name = "quality salvage"
+	export_types = list(/obj/item/salvage/high,
+	)
+
+/datum/export/item/armorgeneric
+	cost = 500 // just a test so the shop can actually move armor since nobody ever buys it
+	unit_name = "armor item"
+	export_types = list(/obj/item/clothing/suit/armor,
+	)
 
 /* k_elasticity 0 - the price degredation thing, in case we need it. Might need to be applied to toys in the future. */
 


### PR DESCRIPTION
## About The Pull Request

adds stuff I forgot earlier and updates knife toolspeeds after having tested it a bunch in game

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:

- salvage added to cargo exports so they can just directly sell it. When WVM buyer gets nibbled, gonna have it so you can sell salvage there too without cargo at worse prices. Good test for that.

- adjusted knife toolspeeds after having tested that for a week-ish. Higher speeds should make it much easier to skin critters before they explode
- adjusted descriptions to better reflect each knife's role (hunting knife = basic moneymaker, Bowie = middleground of combat and tool, survival knife = upgraded hunting knife)

:cl:
