### PR TITLE
adds 'code-stealing' as an insult_adjective

### DIFF
--- a/strings/insult.json
+++ b/strings/insult.json
@@ -134,6 +134,7 @@
         "ugly",
         "repulsive",
         "dumb",
+		"code-stealing",
         "asinine",
         "mongoloid",
         "childish",

--- a/strings/insult.json
+++ b/strings/insult.json
@@ -27,7 +27,8 @@
 		"salvage",
 		"scavenge",
 		"stab",
-		"shoot"
+		"shoot",
+		"lick"
     ],
 
     "verbs_touch": [
@@ -111,6 +112,7 @@
 		"whatever",
         "squid",
 		"dildo",
+		"glizzy",
 		"plush"
     ],
 
@@ -144,7 +146,9 @@
 		"jerk-face",
 		"vomit-inducer",
 		"virgin",
-		"wannabe chad"
+		"wannabe chad",
+		"popufur-wannabe",
+		"catboy"
     ],
 
     "adjective_objects": [
@@ -185,6 +189,7 @@
 		"moron",
 		"fuck",
 		"bitch",
-		"woman"
+		"woman",
+		"swamp-ass"
     ]
 }


### PR DESCRIPTION
## About The Pull Request
lol

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: adds code-stealing as an insult
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
