### PR TITLE
Hazard Armor MK2 (step 1) (Good to merge if it passes checks)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -145,6 +145,30 @@ datum/crafting_recipe/steelbib/heavy
 	subcategory = CAT_ARMOR
 	always_available = FALSE
 
+datum/crafting_recipe/combathazardsuit // sec biosuit
+	name = "Reinforced CBRN Suit"
+	result = /obj/item/clothing/suit/bio_suit/security
+	reqs = list(/obj/item/clothing/suit/radiation = 1,
+				/obj/item/clothing/suit/armor/medium/vest/breastplate = 1,
+				/obj/item/stack/sheet/prewar = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_available = FALSE
+
+datum/crafting_recipe/combathazardhood // sec biohood
+	name = "Reinforced CBRN Hood"
+	result = /obj/item/clothing/head/bio_hood/security
+	reqs = list(/obj/item/clothing/head/helmet/armyhelmet = 1,
+				/obj/item/clothing/head/radiation = 1,
+				/obj/item/stack/sheet/prewar = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_CLOTHING
+	subcategory = CAT_ARMOR
+	always_available = FALSE
+
 /datum/crafting_recipe/metalmask
 	name = "Metal Mask"
 	result = /obj/item/clothing/head/helmet/f13/metalmask

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -144,7 +144,7 @@
 	name = "Enhanced Energy Cell"
 	result = /obj/item/stock_parts/cell/ammo/ec/large
 	reqs = list(/obj/item/stock_parts/cell/ammo/ec = 1, //Don't wanna require 2 cells just to condense them down to 1 slot.
-				/obj/item/stack/crafting/electronicparts = 5,,
+				/obj/item/stack/crafting/electronicparts = 5,
 				/obj/item/advanced_crafting_components/flux = 1,
 				/obj/item/advanced_crafting_components/conductors = 1) //Uses up high end mats and cells you don't get a lot of.
 	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
@@ -178,7 +178,7 @@
 	name = "Enhanced Microfusion Cell"
 	result = /obj/item/stock_parts/cell/ammo/mfc/large
 	reqs = list(/obj/item/stock_parts/cell/ammo/mfc = 1, //Don't wanna require 2 cells just to condense them down to 1 slot.
-				/obj/item/stack/crafting/electronicparts = 5,,
+				/obj/item/stack/crafting/electronicparts = 5,
 				/obj/item/advanced_crafting_components/flux = 1,
 				/obj/item/advanced_crafting_components/conductors = 1) //Uses up high end mats and cells you don't get a lot of.
 	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)
@@ -212,7 +212,7 @@
 	name = "Enhanced Electron Charge Pack"
 	result = /obj/item/stock_parts/cell/ammo/ecp/large
 	reqs = list(/obj/item/stock_parts/cell/ammo/ecp = 1, //Don't wanna require 2 cells just to condense them down to 1 slot for not much other benefit.
-				/obj/item/stack/crafting/electronicparts = 5,,
+				/obj/item/stack/crafting/electronicparts = 5,
 				/obj/item/advanced_crafting_components/flux = 1,
 				/obj/item/advanced_crafting_components/conductors = 1) //Uses up high end mats and cells you don't get a lot of.
 	tools = list(TOOL_WORKBENCH, TOOL_MULTITOOL)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 		H.mind.learned_recipes -= GLOB.energyweapon_cell_crafting
 		H.mind.learned_recipes -= GLOB.energyweapon_crafting
 		H.mind.learned_recipes -= GLOB.pa_repair
-		H.mind.learned_recipes |= GLOB.armored_hazard_suit
+		H.mind.learned_recipes -= GLOB.armored_hazard_suit
 
 /datum/quirk/gunsmith
 	name = "Weaponsmith"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -43,8 +43,8 @@ GLOBAL_LIST_INIT(energyweapon_cell_crafting, list(
 
 	// armored_hazard_suit is going to get SEVA Mk. 2 and Explorer Mk. 2 in the future. Might tie it to Hardsuits as well.
 GLOBAL_LIST_INIT(armored_hazard_suit, list(
-	datum/crafting_recipe/combathazardsuit,
-	datum/crafting_recipe/combathazardhood))
+	/datum/crafting_recipe/combathazardsuit,
+	/datum/crafting_recipe/combathazardhood))
 
 GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	/datum/crafting_recipe/ninemil,

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -41,6 +41,11 @@ GLOBAL_LIST_INIT(energyweapon_cell_crafting, list(
 	/datum/crafting_recipe/enhancedmfcell,
 	/datum/crafting_recipe/enhancedecp))
 
+	// armored_hazard_suit is going to get SEVA Mk. 2 and Explorer Mk. 2 in the future. Might tie it to Hardsuits as well.
+GLOBAL_LIST_INIT(armored_hazard_suit, list(
+	datum/crafting_recipe/combathazardsuit,
+	datum/crafting_recipe/combathazardhood))
+
 GLOBAL_LIST_INIT(weaponcrafting_gun_recipes, list(
 	/datum/crafting_recipe/ninemil,
 	/datum/crafting_recipe/huntingrifle,
@@ -324,6 +329,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	H.mind.learned_recipes |= GLOB.energyweapon_cell_crafting
 	H.mind.learned_recipes |= GLOB.energyweapon_crafting
 	H.mind.learned_recipes |= GLOB.pa_repair
+	H.mind.learned_recipes |= GLOB.armored_hazard_suit
 
 /datum/quirk/technophreak/remove()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -332,6 +338,7 @@ GLOBAL_LIST_INIT(pa_repair, list(
 		H.mind.learned_recipes -= GLOB.energyweapon_cell_crafting
 		H.mind.learned_recipes -= GLOB.energyweapon_crafting
 		H.mind.learned_recipes -= GLOB.pa_repair
+		H.mind.learned_recipes |= GLOB.armored_hazard_suit
 
 /datum/quirk/gunsmith
 	name = "Weaponsmith"

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3447,14 +3447,18 @@
 	icon_state = "bio_virology"
 
 
-//Security biosuit, grey with red stripe across the chest
+//Security biosuit, grey with red stripe across the chest || Craftable, has good ballistic/laser armor, but not good against melee. It's a light armor, use that speed dummy -Kelprunner
 /obj/item/clothing/head/bio_hood/security
+	name = "reinforced hazard hood"
+	desc = "A lead-lined hood that's been reinforced with a kevlar weave."
 	icon_state = "bio_security"
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
 
 /obj/item/clothing/suit/bio_suit/security
+	name = "reinforced hazard suit"
+	desc = "A CBRN hazard suit that's been paired with a ballistic vest. Surprisingly lightweight for all of its bulk."
 	icon_state = "bio_security"
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
 
 //Janitor's biosuit, grey with purple arms
 /obj/item/clothing/head/bio_hood/janitor

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -152,7 +152,7 @@
 	desc = "A suit that protects against radiation. The label reads, 'Made with lead. Please do not consume insulation.'"
 	icon_state = "rad"
 	item_state = "rad_suit"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	gas_transfer_coefficient = 0.9
 	permeability_coefficient = 0.5
 	clothing_flags = THICKMATERIAL


### PR DESCRIPTION
## About The Pull Request
Primarily adds a new Light hazard suit.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog
:cl:

- Hazard suit thing attached to Technophreak for future hazard armor crafting (its own trait later, maybe???)
- Gave the Security Biosuit a new name, a crafting recipe, and updated armor tokens
- Fixed regular radsuits being Bulky
- Reinforced hazard suit is INTENTIONALLY Bulky. It's basically peak Light Armor, even if the stats are sub par.
- Also a misc fix with enhanced cells 'cause they had extra commas

:cl:

