### PR TITLE
Creature Spawning

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -24,6 +24,7 @@ SUBSYSTEM_DEF(job)
 	if(CONFIG_GET(flag/load_jobs_from_txt))
 		LoadJobs()
 	generate_selectable_species()
+	generate_selectable_creatures()//Coyote add. Found in _pmon_defines.dm
 	set_overflow_role(CONFIG_GET(string/overflow_job))
 	return ..()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -209,6 +209,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/prefered_security_department = SEC_DEPT_RANDOM
 	var/custom_species = null
 
+	//Creature Preferences
+	var/creature_species = 		"Eevee"
+	var/creature_name = 		"Eevee"
+	var/creature_flavor_text = 	null
+	var/creature_ooc = 			null
+
 	//Quirk list
 	var/list/all_quirks = list()
 
@@ -532,6 +538,26 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Random Body:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=all;task=random'>Randomize!</A><BR>"
 			dat += "<b>Always Random Body:</b><a href='?_src_=prefs;preference=all'>[be_random_body ? "Yes" : "No"]</A><BR>"
 			dat += "<br><b>Cycle background:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=cycle_bg;task=input'>[bgstate]</a><BR>"
+
+			dat += "<h2>Creature Character</h2>"
+			dat += "<b>Creature Species</b><a style='display:block;width:100px' href='?_src_=prefs;preference=creature_species;task=input'>[creature_species ? creature_species : "Eevee"]</a><BR>"
+			dat += "<b>Creature Name</b><a style='display:block;width:100px' href='?_src_=prefs;preference=creature_name;task=input'>[creature_name ? creature_name : "Eevee"]</a><BR>"
+			dat += "<a href='?_src_=prefs;preference=creature_flavor_text;task=input'><b>Set Creature Examine Text</b></a><br>"
+			if(length(creature_flavor_text) <= 40)
+				if(!length(creature_flavor_text))
+					dat += "\[...\]<br>"
+				else
+					dat += "[creature_flavor_text]<br>"
+			else
+				dat += "[TextPreview(creature_flavor_text)]...<br>"
+			dat += "<a href='?_src_=prefs;preference=creature_ooc;task=input'><b>Set Creature OOC Notes</b></a><br>"
+			if(length(creature_ooc) <= 40)
+				if(!length(creature_ooc))
+					dat += "\[...\]<br>"
+				else
+					dat += "[creature_ooc]<br>"
+			else
+				dat += "[TextPreview(creature_ooc)]...<br>"
 			var/use_skintones = pref_species.use_skintones
 			if(use_skintones)
 				dat += APPEARANCE_CATEGORY_COLUMN
@@ -2364,6 +2390,30 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 								player_mob.new_player_panel()
 						else
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
+				if("creature_name")
+					var/new_name = input(user, "Choose your creature character's name:", "Character Preference")  as text|null
+					if(new_name)
+						new_name = reject_bad_name(new_name)
+						if(new_name)
+							creature_name = new_name
+							if(isnewplayer(parent.mob)) // Update the player panel with the new name.
+								var/mob/dead/new_player/player_mob = parent.mob
+								player_mob.new_player_panel()
+						else
+							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
+				if("creature_species")
+					var/result = input(user, "Select a creature species", "Species Selection") as null|anything in GLOB.creature_selectable
+					if(result)
+						//var/newtype = GLOB.creature_selectable["[result]"]
+						creature_species = result
+				if("creature_flavor_text")
+					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb.", "Flavor Text", html_decode(creature_flavor_text), MAX_FLAVOR_LEN, TRUE)
+					if(!isnull(msg))
+						creature_flavor_text = msg
+				if("creature_ooc")
+					var/msg = stripped_multiline_input(usr, "Set out of character notes related to roleplaying content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", html_decode(creature_ooc), MAX_FLAVOR_LEN, TRUE)
+					if(!isnull(msg))
+						creature_ooc = msg
 
 				if("age")
 					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -215,6 +215,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/creature_flavor_text = 	null
 	var/creature_ooc = 			null
 	var/image/creature_image = null
+	var/creature_profilepic = null
 
 	//Quirk list
 	var/list/all_quirks = list()
@@ -398,7 +399,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<center><b>Current Quirks:</b> [all_quirks.len ? all_quirks.Join(", ") : "None"]</center>"
 			dat += "<center><h2>S.P.E.C.I.A.L</h2>"
 			dat += "<a href='?_src_=prefs;preference=special;task=menu'>Allocate Points</a><br></center>"
-			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
+			//Left Column
+			dat += "<table><tr><td width='30%'valign='top'>"
 			dat += "<h2>Identity</h2>"
 			if(jobban_isbanned(user, "appearance"))
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
@@ -411,8 +413,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender;task=input'>[gender == MALE ? "Male" : (gender == FEMALE ? "Female" : (gender == PLURAL ? "Non-binary" : "Object"))]</a><BR>"
 			dat += "<b>Age:</b> <a style='display:block;width:30px' href='?_src_=prefs;preference=age;task=input'>[age]</a><BR>"
 			dat += "</td>"
-
-			dat +="<td width='300px' height='300px' valign='top'>"
+			//Middle Column
+			dat +="<td width='30%' valign='top'>"
 			dat += "<h2>Matchmaking preferences:</h2>"
 			if(SSmatchmaking.initialized)
 				for(var/datum/matchmaking_pref/match_pref as anything in SSmatchmaking.all_match_types)
@@ -426,11 +428,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<b>Loading matchmaking preferences...</b><br>"
 				dat += "<b>Refresh once the game has finished setting up...</b><br>"
 			dat += "</td>"
-
-			dat += "<b>Profile Picture:</b><BR>"
+			//Right column
+			dat +="<td width='30%' valign='top'>"
+			dat += "<h2>Profile Picture:</h2><BR>"
 			dat += "<b>Picture:</b> <a href='?_src_=prefs;preference=ProfilePicture;task=input'>[profilePicture ? "<img src=[DiscordLink(profilePicture)] width='125' height='auto' max-height='300'>" : "Upload a picture!"]</a><BR>"
+			dat += "<h2>Creature Profile Picture:</h2><BR>"
+			dat += "<b>Picture:</b> <a href='?_src_=prefs;preference=CreatureProfilePicture;task=input'>[creature_profilepic ? "<img src=[DiscordLink(creature_profilepic)] width='125' height='auto' max-height='300'>" : "Upload a picture!"]</a><BR>"
 			dat += "</td>"
-
 			/*
 			dat += "<b>Special Names:</b><BR>"
 			var/old_group

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -214,6 +214,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/creature_name = 		"Eevee"
 	var/creature_flavor_text = 	null
 	var/creature_ooc = 			null
+	var/image/creature_image = null
 
 	//Quirk list
 	var/list/all_quirks = list()
@@ -558,6 +559,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "[creature_ooc]<br>"
 			else
 				dat += "[TextPreview(creature_ooc)]...<br>"
+			if(!creature_image && creature_species)
+				var/creature_type = GLOB.creature_selectable["[creature_species]"]
+				var/mob/living/M = new creature_type(user)
+				creature_image = image(icon=M.icon,icon_state=M.icon_state,dir=2)
+				qdel(M)
+			if(creature_image)
+				dat += "[icon2html(creature_image, user)]<br>"
+
 			var/use_skintones = pref_species.use_skintones
 			if(use_skintones)
 				dat += APPEARANCE_CATEGORY_COLUMN
@@ -2404,8 +2413,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("creature_species")
 					var/result = input(user, "Select a creature species", "Species Selection") as null|anything in GLOB.creature_selectable
 					if(result)
-						//var/newtype = GLOB.creature_selectable["[result]"]
 						creature_species = result
+						var/creature_type = GLOB.creature_selectable["[result]"]
+						var/mob/living/M = new creature_type(user)
+						creature_image = image(icon=M.icon,icon_state=M.icon_state,dir=2)
+						qdel(M)
+
 				if("creature_flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb.", "Flavor Text", html_decode(creature_flavor_text), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -675,7 +675,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["creature_name"]				>> creature_name
 	S["creature_flavor_text"]		>> creature_flavor_text
 	S["creature_ooc"]				>> creature_ooc
-
+	S["creature_profilepic"]		>> creature_profilepic
 	//Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		var/savefile_slot_name = custom_name_id + "_name" //TODO remove this
@@ -1033,6 +1033,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	// !! COYOTE SANITISATION !!
 	profilePicture = sanitize_text(profilePicture) // If we still have issues loading save files with this then comment this out, IT SHOULD BE A STRING REEEE
+	creature_profilepic = sanitize_text(creature_profilepic)
 
 	features_override["grad_color"]		= sanitize_hexcolor(features_override["grad_color"], 6, FALSE, default = COLOR_ALMOST_BLACK)
 	features_override["grad_style"]		= sanitize_inlist(features_override["grad_style"], GLOB.hair_gradients, "none")
@@ -1236,6 +1237,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["creature_name"]				,creature_name)
 	WRITE_FILE(S["creature_flavor_text"]		,creature_flavor_text)
 	WRITE_FILE(S["creature_ooc"]				,creature_ooc)
+	WRITE_FILE(S["creature_profilepic"]			,creature_profilepic)
 
 	//Quirks
 	WRITE_FILE(S["all_quirks"]			, all_quirks)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -670,6 +670,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["chosen_limb_id"]					>> chosen_limb_id
 	S["hide_ckey"]						>> hide_ckey //saved per-character
 
+	//Creature character settings
+	S["creature_species"]			>> creature_species
+	S["creature_name"]				>> creature_name
+	S["creature_flavor_text"]		>> creature_flavor_text
+	S["creature_ooc"]				>> creature_ooc
+
 	//Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		var/savefile_slot_name = custom_name_id + "_name" //TODO remove this
@@ -1225,6 +1231,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["job_preferences"] , job_preferences)
 	WRITE_FILE(S["hide_ckey"]		, hide_ckey)
 
+	//Write creature character
+	WRITE_FILE(S["creature_species"]			,creature_species)
+	WRITE_FILE(S["creature_name"]				,creature_name)
+	WRITE_FILE(S["creature_flavor_text"]		,creature_flavor_text)
+	WRITE_FILE(S["creature_ooc"]				,creature_ooc)
 
 	//Quirks
 	WRITE_FILE(S["all_quirks"]			, all_quirks)

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -31,7 +31,7 @@
 					new /mob/living/simple_animal/chicken/rabbit(R.loc)
 
 /mob/living/simple_animal/chicken/rabbit
-	name = "\improper rabbit"
+	name = "rabbit"
 	desc = "The hippiest hop around."
 	icon = 'icons/mob/easter.dmi'
 	icon_state = "rabbit_white"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -569,20 +569,32 @@
 /mob/dead/new_player/proc/CreatureSpawn()
 	if(ckey && client && client.prefs.creature_species)
 		var/datum/preferences/P = client.prefs
+		if(!P.creature_flavor_text || !P.creature_ooc)
+			to_chat(src, "<span class='userdanger'>You must set your Creature OOC Notes and Flavor Text before joining as a creature.</span>")
+			return FALSE
 		var/spawn_selection = input(src, "Select a Creature Spawnpoint", "Spawnpoint Selection") as null|anything in GLOB.creature_spawnpoints
 		if(!spawn_selection || QDELETED(src) || !ckey)
 			return FALSE
-		log_and_message_admins("[src.ckey] joined as \an [P.creature_species] and spawned at [spawn_selection].")
+		log_and_message_admins("joined as \an [P.creature_species] and spawned at [spawn_selection].")
 		spawning = 1
 		close_spawn_windows()
 		var/spawntype = GLOB.creature_spawnpoints["[spawn_selection]"]
 		//Create the new mob
 		var/creature_type = GLOB.creature_selectable["[P.creature_species]"]
-		var/mob/living/C = new creature_type(src)
+		var/mob/living/simple_animal/C = new creature_type(src)
 		//Assign the mob's information based on the player's client preferences
 		C.gender = P.gender
-		C.name = P.real_name
-		C.real_name = P.real_name
+		C.name = P.creature_name
+		C.real_name = P.creature_name
+		C.flavortext = P.creature_flavor_text
+		C.oocnotes = P.creature_ooc
+		C.profilePicture = P.creature_profilepic
+		C.verbose_species = "[P.creature_species]"
+		//Disable their mob's AI so they don't wander after the player ghosts out of them
+		C.AIStatus = AI_OFF
+		C.wander = FALSE
+		//Set them as a player-character simplemob so examine and such changes to show their character prefs
+		C.player_character = ckey
 		C.grant_all_languages()
 		//Prepare their spawnpoint
 		var/list/avail_spawns = list()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -66,6 +66,7 @@
 		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>View the Crew Manifest</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>Join Game!</a></p>"
 		output += "<p>[LINKIFY_READY("Observe", PLAYER_READY_TO_OBSERVE)]</p>"
+		output += "<p><a href='byond://?src=[REF(src)];join_as_creature=1'>Join as Creature!</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];refresh_chat=1)'>(Fix Chat Window)</a></p>"
 
 	if(!IsGuestKey(src.key))
@@ -73,7 +74,7 @@
 
 	output += "</center>"
 
-	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 250, 265)
+	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>New Player Options</div>", 250, 350)
 	popup.set_window_options("can_close=0")
 	popup.set_content(output.Join())
 	popup.open(FALSE)
@@ -234,6 +235,8 @@
 
 		LateChoices()
 
+	if(href_list["join_as_creature"])	
+		CreatureSpawn()
 	if(href_list["manifest"])
 		ViewManifest()
 
@@ -272,7 +275,7 @@
 			SSticker.queue_delay = 4
 			qdel(src)
 
-	else if(!href_list["late_join"])
+	else if(!href_list["late_join"] && client)
 		new_player_panel()
 
 	if(href_list["showpoll"])
@@ -562,7 +565,34 @@
 		var/obj/structure/filingcabinet/employment/employmentCabinet = C
 		if(!employmentCabinet.virgin)
 			employmentCabinet.addFile(employee)
-
+	
+/mob/dead/new_player/proc/CreatureSpawn()
+	if(ckey && client && client.prefs.creature_species)
+		var/datum/preferences/P = client.prefs
+		var/spawn_selection = input(src, "Select a Creature Spawnpoint", "Spawnpoint Selection") as null|anything in GLOB.creature_spawnpoints
+		if(!spawn_selection || QDELETED(src) || !ckey)
+			return FALSE
+		log_and_message_admins("[src.ckey] joined as \an [P.creature_species] and spawned at [spawn_selection].")
+		spawning = 1
+		close_spawn_windows()
+		var/spawntype = GLOB.creature_spawnpoints["[spawn_selection]"]
+		//Create the new mob
+		var/creature_type = GLOB.creature_selectable["[P.creature_species]"]
+		var/mob/living/C = new creature_type(src)
+		//Assign the mob's information based on the player's client preferences
+		C.gender = P.gender
+		C.name = P.real_name
+		C.real_name = P.real_name
+		C.grant_all_languages()
+		//Prepare their spawnpoint
+		var/list/avail_spawns = list()
+		for(var/SP in GLOB.landmarks_list)
+			if(istype(SP, spawntype))
+				avail_spawns += SP
+		var/obj/effect/landmark/rand_spawn = pick(avail_spawns)
+		//Move them to the selected spawnpoint and transfer the player into the new mob
+		C.forceMove(get_turf(rand_spawn))
+		transfer_ckey(C, TRUE)
 
 /mob/dead/new_player/proc/LateChoices()
 	var/list/dat = list()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -29,7 +29,7 @@
 //Corgis and pugs are now under one dog subtype
 
 /mob/living/simple_animal/pet/dog/corgi
-	name = "\improper corgi"
+	name = "corgi"
 	real_name = "corgi"
 	desc = "It's a corgi."
 	icon_state = "corgi"
@@ -62,7 +62,7 @@
 	return ..()
 
 /mob/living/simple_animal/pet/dog/pug
-	name = "\improper pug"
+	name = "pug"
 	real_name = "pug"
 	desc = "It's a pug."
 	icon = 'icons/mob/pets.dmi'
@@ -547,7 +547,7 @@
 
 
 /mob/living/simple_animal/pet/dog/corgi/puppy
-	name = "\improper corgi puppy"
+	name = "corgi puppy"
 	real_name = "corgi"
 	desc = "It's a corgi puppy!"
 	icon_state = "puppy"
@@ -567,7 +567,7 @@
 
 
 /mob/living/simple_animal/pet/dog/corgi/puppy/void		//Tribute to the corgis born in nullspace
-	name = "\improper void puppy"
+	name = "void puppy"
 	real_name = "voidy"
 	desc = "A corgi puppy that has been infused with deep space energy. It's staring back..."
 	icon_state = "void_puppy"

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -69,7 +69,7 @@
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
-	var/flavortext = \
+	flavortext = \
 	"\n<big><span class='userdanger'>DO NOT ABUSE DRONES OR YOU WILL BE DRONE BANNED</span></big>\n"+\
 	"<span class='notify'>Drones are a ghost role that are allowed to fix the station and build things, and to participate in the wasteland in a non-violent, purely helpful fashion. Interfering with the round as a drone is against the rules.</span>\n"+\
 	"<span class='notify'>Actions that constitute interference include, but are not limited to:</span>\n"+\

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -488,7 +488,7 @@
 /////////////
 
 /mob/living/simple_animal/chick
-	name = "\improper chick"
+	name = "chick"
 	desc = "Adorable! They make such a racket though."
 	icon = 'icons/fallout/mobs/animals/farmanimals.dmi'
 	icon_state = "chick"
@@ -543,7 +543,7 @@
 	amount_grown = 0
 
 /mob/living/simple_animal/chicken
-	name = "\improper chicken"
+	name = "chicken"
 	desc = "Hopefully the eggs are good this season."
 	gender = FEMALE
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -650,6 +650,10 @@
 	waddle_up_time = 1
 	waddle_side_time = 1
 
+/mob/living/simple_animal/hostile/stalker/Initialize()
+	. = ..()
+	recenter_wide_sprite()
+
 /mob/living/simple_animal/hostile/stalker/playable
 	health = 80
 	maxHealth = 80

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -202,6 +202,9 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	var/obj/effect/proc_holder/mob_common/make_nest/make_a_nest
 	var/obj/effect/proc_holder/mob_common/unmake_nest/unmake_a_nest
 
+	///If this is a player's ckey then this mob was spawned as a player's character
+	var/player_character = null
+
 /mob/living/simple_animal/Initialize()
 	. = ..()
 	GLOB.simple_animals[AIStatus] += src
@@ -319,6 +322,9 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	if(client)
 		to_chat(user, span_warning("Someone's in there! Wait your turn!"))
 		return FALSE
+	if(player_character && player_character != user.ckey)
+		to_chat(user, span_warning("This mob is someone else's character so you cannot hop into them!"))
+		return FALSE
 	if(!user.key)
 		return FALSE
 	if(!islist(GLOB.playmob_cooldowns[user.key]))
@@ -363,11 +369,67 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 
 	return ..()
 
+//Coyote Add
+/mob
+	///A detailed description of this mob that can be read if you examine them.
+	var/flavortext = ""
+	///A detailed description of the player who's controlling this mob's out-of-character roleplaying preferences. Do not set.
+	var/oocnotes = ""
+	///The specific name of this mob's species or subtype. Used for examine text (ie "this is Nutty a Squirrel", where Squirrel is the verbose_species)
+	var/verbose_species = ""
+
+/mob/living/simple_animal/proc/print_flavor_text()
+	if(flavortext && flavortext != "")
+		var/msg = replacetext(flavortext, "\n", " ")
+		if(length(msg) <= 40)
+			return "<span class='notice'>[msg]</span>"
+		else
+			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='byond://?src=\ref[src];flavor_more=1'>More...</span></a>"
+
 /mob/living/simple_animal/examine(mob/user)
-	. = ..()
-	if(lazarused)
-		. += span_danger("This creature looks like it has been revived!")
-	. += mob_armor_description
+	var/t_He = p_they(TRUE)
+//	var/t_His = p_their(TRUE)
+	var/t_his = p_their()
+//	var/t_him = p_them()
+//	var/t_has = p_have()
+	var/t_is = p_are()
+	var/list/dat = list()
+
+	if(player_character)
+		dat += "<span class='info'>*---------*\n This is [icon2html(src, user)] <EM>[src.name]</EM> \a <EM>[verbose_species]</EM>!</span>"
+		if(profilePicture)
+			dat += "<a href='?src=[REF(src)];enlargeImageCreature=1'><img src='[DiscordLink(profilePicture)]' width='125' height='auto' max-height='300'></a>"
+		for(var/obj/item/I in held_items)
+			if(!(I.item_flags & ABSTRACT))
+				dat += "[t_He] [t_is] holding [I.get_examine_string(user)] in [t_his] [get_held_index_name(get_held_index_of_item(I))]."
+		if(flavortext)
+			dat += "[print_flavor_text()]"
+		if(oocnotes)
+			dat += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];oocnotes=1'>\[View\]</a>"
+		if(src.getBruteLoss())
+			if(src.getBruteLoss() < (maxHealth/2))
+				dat += "<span class='warning'>[t_He] looks bruised.</span>"
+			else
+				dat += "<span class='warning'><B>[t_He] looks severely bruised and bloodied!</B></span>"
+		if(src.getFireLoss())
+			if(src.getFireLoss() < (maxHealth/2))
+				dat += "<span class='warning'>[t_He] looks burned.</span>"
+			else
+				dat += "<span class='warning'><B>[t_He] looks severely burned.</B></span>"
+		if(client && ((client.inactivity / 10) / 60 > 10)) //10 Minutes
+			dat += "\[Inactive for [round((client.inactivity/10)/60)] minutes\]"
+		else if(disconnect_time)
+			dat += "\[Disconnected/ghosted [round(((world.realtime - disconnect_time)/10)/60)] minutes ago\]"
+		if(lazarused)
+			dat += span_danger("[t_He] seems to have been revived!")
+		dat += "<span class='info'>*---------*</span>"
+		return dat
+	else
+		. = ..()
+		. += mob_armor_description
+		if(lazarused)
+			. += span_danger("[t_He] seems to have been revived!")
+	
 	
 /// If user is set, the mob will be told to be loyal to that mob
 /mob/living/simple_animal/proc/make_ghostable(mob/user)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	///A detailed description of the player who's controlling this mob's out-of-character roleplaying preferences. Do not set.
 	var/oocnotes = ""
 	///The specific name of this mob's species or subtype. Used for examine text (ie "this is Nutty a Squirrel", where Squirrel is the verbose_species)
-	var/verbose_species = ""
+	var/verbose_species = null
 
 /mob/living/simple_animal/proc/print_flavor_text()
 	if(flavortext && flavortext != "")
@@ -396,7 +396,7 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	var/list/dat = list()
 
 	if(player_character)
-		dat += "<span class='info'>*---------*\n This is [icon2html(src, user)] <EM>[src.name]</EM> \a <EM>[verbose_species]</EM>!</span>"
+		dat += "<span class='info'>*---------*\n This is [icon2html(src, user)] <EM>[src.name]</EM>[verbose_species ? ", a <EM>[verbose_species]</EM>" : ""]!</span>"
 		if(profilePicture)
 			dat += "<a href='?src=[REF(src)];enlargeImageCreature=1'><img src='[DiscordLink(profilePicture)]' width='125' height='auto' max-height='300'></a>"
 		for(var/obj/item/I in held_items)
@@ -429,8 +429,7 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 		. += mob_armor_description
 		if(lazarused)
 			. += span_danger("[t_He] seems to have been revived!")
-	
-	
+
 /// If user is set, the mob will be told to be loyal to that mob
 /mob/living/simple_animal/proc/make_ghostable(mob/user)
 	can_ghost_into = TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -636,6 +636,18 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 					usr.stripPanelUnequip(what,src,slot)
 			else
 				usr.stripPanelEquip(what,src,slot)
+	//Coyote Add
+	if(href_list["flavor_more"])
+		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavortext, "\n", "<BR>")), text("window=[];size=500x200", name))
+		onclose(usr, "[name]")
+	if(href_list["oocnotes"])
+		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(oocnotes, "\n", "<BR>")), text("window=[];size=500x200", name))
+		onclose(usr, "[name]")
+	if(href_list["enlargeImageCreature"])
+		var/dat = {"<img src='[DiscordLink(profilePicture)]'>"}
+		var/datum/browser/popup = new(usr, "enlargeImage", "Full Sized Picture!")
+		popup.set_content(dat)
+		popup.open()
 
 	if(usr.machine == src)
 		if(Adjacent(usr))

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -34,7 +34,24 @@
 #define P_TRAIT_RIDEABLE	"rideable"
 
 //List of pokemon subtypes that a player can choose from when spawning in. Exclude pokemon by giving them the P_TRAIT_BLACKLIST trait.
-GLOBAL_LIST_EMPTY(pokemon_spawnable)
+GLOBAL_LIST_EMPTY(pokemon_selectable)
+/proc/generate_selectable_pokemon(clear = FALSE)
+	if(clear)
+		GLOB.pokemon_selectable = list()
+	for(var/I in subtypesof(/mob/living/simple_animal/pokemon))
+		var/mob/living/simple_animal/pokemon/P = new I
+		if(!(P_TRAIT_BLACKLIST in P.p_traits))//Not blacklisted from being added to the list
+			GLOB.pokemon_selectable[capitalize("[P.name]")] = P.type
+		qdel(P)
+
+GLOBAL_LIST_EMPTY(creature_selectable)
+/proc/generate_selectable_creatures(clear = FALSE)
+	if(clear)
+		GLOB.creature_selectable = list()
+	if(!LAZYLEN(GLOB.pokemon_selectable))//Pokemon list hasn't been generated so do it now
+		generate_selectable_pokemon()
+ 	GLOB.creature_selectable |= GLOB.pokemon_selectable //Merge pokemon into master creature list
+
 //List of all pokemon on the whole map.
 GLOBAL_LIST_EMPTY(pokemon_list)
 //List of available spawnpoints for pokemon to choose from

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -57,7 +57,8 @@ GLOBAL_LIST_EMPTY(creature_selectable)
 		var/mob/living/simple_animal/SA = T
 		if(initial(SA.gold_core_spawnable) == FRIENDLY_SPAWN)
 			SA = new T()
-			GLOB.creature_selectable[capitalize(SA.name)] = SA.type
+			if(!(SA.type in GLOB.creature_blacklist))
+				GLOB.creature_selectable[capitalize(SA.name)] = SA.type
 			qdel(SA)
 
 ///List of all pokemon on the whole map.
@@ -65,11 +66,27 @@ GLOBAL_LIST_EMPTY(pokemon_list)
 
 ///List of available spawnpoints for creatures to choose from when spawning
 GLOBAL_LIST_INIT(creature_spawnpoints, list(
-	"Citizen" = /obj/effect/landmark/start/f13/settler,
-	"Wastelander" = /obj/effect/landmark/start/f13/wastelander
+	"Nash" = /obj/effect/landmark/start/f13/settler,
+	"Wasteland" = /obj/effect/landmark/start/f13/wastelander
 	))
 
 ///Creatures that are not allowed for players to select for characters
 GLOBAL_LIST_INIT(creature_blacklist, list(
-	/mob/living/simple_animal/chick
+	/mob/living/simple_animal/chick,
+	/mob/living/simple_animal/hostile/retaliate/goat,
+	/mob/living/simple_animal/cow/random,
+	/mob/living/simple_animal/opossum/poppy,
+	/mob/living/simple_animal/radstag/rudostag,
+	/mob/living/simple_animal/cow/brahmin/nightstalker,
+	/mob/living/simple_animal/cow/brahmin/sgtsillyhorn,
+	/mob/living/simple_animal/cow/brahmin/calf,
+	/mob/living/simple_animal/cow/brahmin,
+	/mob/living/simple_animal/cow/brahmin/horse/honse,
+	/mob/living/simple_animal/pet/cat/cak,
+	/mob/living/simple_animal/pet/cat/kitten,
+	/mob/living/simple_animal/pet/bumbles,
+	/mob/living/simple_animal/pet/redpanda/stinky,
+	/mob/living/simple_animal/pet/fox/paws,
+	/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
+	/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck
 	))

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -44,9 +44,8 @@ GLOBAL_LIST_EMPTY(pokemon_selectable)
 			GLOB.pokemon_selectable[capitalize("[P.name]")] = P.type
 		qdel(P)
 
-GLOBAL_LIST_INIT(creature_selectable, list(
-
-	))
+///Creatures that players can select for creature characters
+GLOBAL_LIST_EMPTY(creature_selectable)
 
 /proc/generate_selectable_creatures(clear = FALSE)
 	if(clear)
@@ -61,10 +60,16 @@ GLOBAL_LIST_INIT(creature_selectable, list(
 			GLOB.creature_selectable[capitalize(SA.name)] = SA.type
 			qdel(SA)
 
-//List of all pokemon on the whole map.
+///List of all pokemon on the whole map.
 GLOBAL_LIST_EMPTY(pokemon_list)
-//List of available spawnpoints for pokemon to choose from
+
+///List of available spawnpoints for creatures to choose from when spawning
 GLOBAL_LIST_INIT(creature_spawnpoints, list(
-	"Wastelander" = /obj/effect/landmark/start/f13/wastelander,
-	"Citizen" = /obj/effect/landmark/start/f13/settler
+	"Citizen" = /obj/effect/landmark/start/f13/settler,
+	"Wastelander" = /obj/effect/landmark/start/f13/wastelander
+	))
+
+///Creatures that are not allowed for players to select for characters
+GLOBAL_LIST_INIT(creature_blacklist, list(
+	/mob/living/simple_animal/chick
 	))

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -44,15 +44,27 @@ GLOBAL_LIST_EMPTY(pokemon_selectable)
 			GLOB.pokemon_selectable[capitalize("[P.name]")] = P.type
 		qdel(P)
 
-GLOBAL_LIST_EMPTY(creature_selectable)
+GLOBAL_LIST_INIT(creature_selectable, list(
+
+	))
+
 /proc/generate_selectable_creatures(clear = FALSE)
 	if(clear)
 		GLOB.creature_selectable = list()
 	if(!LAZYLEN(GLOB.pokemon_selectable))//Pokemon list hasn't been generated so do it now
 		generate_selectable_pokemon()
  	GLOB.creature_selectable |= GLOB.pokemon_selectable //Merge pokemon into master creature list
+	for(var/T in typesof(/mob/living/simple_animal))
+		var/mob/living/simple_animal/SA = T
+		if(initial(SA.gold_core_spawnable) == FRIENDLY_SPAWN)
+			SA = new T()
+			GLOB.creature_selectable[capitalize(SA.name)] = SA.type
+			qdel(SA)
 
 //List of all pokemon on the whole map.
 GLOBAL_LIST_EMPTY(pokemon_list)
 //List of available spawnpoints for pokemon to choose from
-GLOBAL_LIST_EMPTY(pokemon_spawnpoints)
+GLOBAL_LIST_INIT(creature_spawnpoints, list(
+	"Wastelander" = /obj/effect/landmark/start/f13/wastelander,
+	"Citizen" = /obj/effect/landmark/start/f13/settler
+	))

--- a/modular_coyote/code/modules/examine_images.dm
+++ b/modular_coyote/code/modules/examine_images.dm
@@ -41,7 +41,7 @@
 	return output
 
 // Mob definitions!!!
-/mob/living/carbon/human
+/mob
 	var/profilePicture
 
 /mob/living/carbon/human/verb/SetProfilePic()
@@ -132,6 +132,17 @@
 						var/deletePicture = alert(usr, "Do you wish to remove your profile picture?", "Remove PFP", "Yes", "No")
 						if(deletePicture == "Yes")
 							profilePicture = ""
+				if("CreatureProfilePicture")
+					var/input = stripped_input(usr,"Right click an image from discord (do not expand the image by clicking it) and click 'Copy Link' and paste it here. Must be a png", i_will_sanitize_dont_worry = TRUE)
+					if(input)	
+						if(SanitizeDiscordLink(input))
+							creature_profilepic = StoreDiscordLink(input)
+						else
+							to_chat(usr, span_warning("Link is incorrect, make sure you just right click the image in discord and copy link, do NOT click it to expand the image. It must end in '.png'"))
+					else
+						var/deletePicture = alert(usr, "Do you wish to remove your profile picture?", "Remove PFP", "Yes", "No")
+						if(deletePicture == "Yes")
+							creature_profilepic = ""
 
 	..()
 

--- a/modular_coyote/code/pmon_mob.dm
+++ b/modular_coyote/code/pmon_mob.dm
@@ -30,17 +30,17 @@
 	dextrous = TRUE
 	//Need this to have the hands appear on the HUD
 	held_items = list(null, null)
-	//The pokemon-types that this mob has. Used to auto-generate moves(abilities) and some other attributes.
+	///The pokemon-types that this mob has. Used to auto-generate moves(abilities) and some other attributes.
 	var/list/p_types = list()
-	//Moves that aren't automatically granted based on their type. Will be assigned during Initialize()
+	///Moves that aren't automatically granted based on their type. Will be assigned during Initialize()
 	var/list/additional_moves = list()
-	//List of passive traits/flags
+	///List of passive traits/flags
 	var/list/p_traits = list()
-	//Moves/Abilities that this mob is currently using
+	///Moves/Abilities that this mob is currently using
 	var/list/active_moves = list()
-	//If this is filled in by the player, it overrides their default description. Can be imported from the player's current character slot
+	///If this is filled in by the player, it overrides their default description. Can be imported from the player's current character slot
 	var/flav_text = null
-	//Roleplaying preferences
+	///Roleplaying preferences
 	var/ooc_text = null
 
 /mob/living/simple_animal/pokemon/Initialize()

--- a/modular_coyote/code/pmon_mob.dm
+++ b/modular_coyote/code/pmon_mob.dm
@@ -53,12 +53,13 @@
 
 //Can be applied to any mob, not just pokemon
 /mob/proc/recenter_wide_sprite()
-	var/icon/I = icon //We have to do this for some reason
+	var/icon/I = icon(icon)
 	var/icon_width = I.Width()
-	if(icon_width<33) //This proc only fixes sprites that are too wide.
-		return FALSE
-	transform = transform.Translate(-((icon_width-32)/2),0) //Adjust pixel offset left by half of their icon's width past 32
-	return TRUE
+	if(icon_width>32) //This proc only fixes sprites that are too wide.
+		var/matrix/M = matrix() //Use a fresh matrix so we start at 0,0
+		transform = M.Translate(-((icon_width-32)/2),0) //Adjust pixel offset left by half of their icon's width past 32
+		return TRUE
+	return FALSE
 
 /mob/living/simple_animal/pokemon/Life()
 	. = ..()

--- a/modular_coyote/code/pmon_mob.dm
+++ b/modular_coyote/code/pmon_mob.dm
@@ -4,8 +4,6 @@
 	name = "eevee"
 	desc = "It has the ability to alter the composition of its body to suit its surrounding environment."
 	icon = 'modular_coyote/icons/mob/pokemon64.dmi'
-	//The width of the icon file in use. Used to center sprites on their respective tiles.
-	var/icon_size_width = 64
 	icon_state = "eevee"
 	icon_living = "eevee"
 	icon_dead = "eevee_d"
@@ -47,16 +45,23 @@
 
 /mob/living/simple_animal/pokemon/Initialize()
 	. = ..()
-	if(icon_size_width>32)
-		transform = transform.Translate(-((icon_size_width-32)/2),0) //Adjust pixel offset left by half of their icon's width above 32
+	recenter_wide_sprite()
 	var/datum/action/cooldown/pokemon_rest/R = new(src)
 	R.Grant(src)
 	regenerate_icons()
 	GLOB.pokemon_list += src
 
+//Can be applied to any mob, not just pokemon
+/mob/proc/recenter_wide_sprite()
+	var/icon/I = icon //We have to do this for some reason
+	var/icon_width = I.Width()
+	if(icon_width<33) //This proc only fixes sprites that are too wide.
+		return FALSE
+	transform = transform.Translate(-((icon_width-32)/2),0) //Adjust pixel offset left by half of their icon's width past 32
+	return TRUE
+
 /mob/living/simple_animal/pokemon/Life()
 	. = ..()
-	regenerate_icons()
 
 /mob/living/simple_animal/pokemon/regenerate_icons()
 	if(stat == DEAD)
@@ -118,7 +123,6 @@
 	icon_living = "articuno"
 	icon_dead = "articuno_d"
 	icon = 'modular_coyote/icons/mob/pokemon96.dmi'
-	icon_size_width = 96
 	p_types = list(P_TYPE_ICE, P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 
@@ -372,7 +376,6 @@
 	icon_living = "lugia"
 	icon_dead = "lugia_d"
 	icon = 'modular_coyote/icons/mob/pokemon96.dmi'
-	icon_size_width = 96
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 
@@ -640,7 +643,6 @@
 	icon_living = "rayquaza"
 	icon_dead = "rayquaza_d"
 	icon = 'modular_coyote/icons/mob/pokemon96.dmi'
-	icon_size_width = 96
 	p_types = list(P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Lets players customize a creature and spawn as them from the main menu.

- [x] Character creation suite
- [x] Savefile operations
- [x] Generic mob-centering proc that can be used for all of our wide-sprited monsters
- [x] Picture on the character creator of your selection
- [x] Button on the main menu somewhere to join as a creature
- [x] Spawnpoint selection prompt on join
- [x] Profile picture for creature character
- [x] Examine expansion for player-controlled creatures

All done, but some known issues that can be sorted out in near-future PRs include:
- Simple mobs who are resting can move at full speed and keep items in their hands
- Simple mobs with hands can't use unarmed interactions, including attacks/hugs/etc
- Simple mobs who wield two-handed items don't have the off-hand item removed correctly, although it can be dropped but it won't delete itself when it should

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: You can now set your options and spawn in as Pokemon or similar creatures instead of a regular character. These are still a WIP, so expect bugs!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
