### PR TITLE
Commie Killer, part 3 (Good to merge if passes checks)

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1376,7 +1376,7 @@ GLOBAL_LIST_INIT(fuzzy_license, list(
 /obj/item/card/lowbounty
 	name = "Small Roller Bounty Ticket"
 	color = "#00ff00"
-	desc = "Turn this in at the banks vending machine for fast caps!"
+	desc = "Turn this in at the bank's vending machine for fast caps!"
 	icon = 'icons/obj/card.dmi'
 	icon_state = "data_1"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
@@ -1386,7 +1386,7 @@ GLOBAL_LIST_INIT(fuzzy_license, list(
 /obj/item/card/midbounty
 	name = "Medium Roller Bounty Ticket"
 	color = "#0000ff"
-	desc = "Turn this in at the banks vending machine for fast caps!"
+	desc = "Turn this in at the bank's vending machine for fast caps!"
 	icon = 'icons/obj/card.dmi'
 	icon_state = "data_1"
 	item_state = "card-id"
@@ -1397,7 +1397,7 @@ GLOBAL_LIST_INIT(fuzzy_license, list(
 /obj/item/card/highbounty
 	name = "High Roller Bounty Ticket"
 	color = "#ff0000"
-	desc = "Turn this in at the banks vending machine for fast caps!"
+	desc = "Turn this in at the bank's vending machine for fast caps!"
 	icon = 'icons/obj/card.dmi'
 	icon_state = "data_1"
 	item_state = "card-id"
@@ -1406,9 +1406,9 @@ GLOBAL_LIST_INIT(fuzzy_license, list(
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/card/kingbounty
-	name = "A Kings Bounty Ticket"
+	name = "A King's Bounty Ticket"
 	color = "#ffe600"
-	desc = "At last, your just reward! Turn this in at the banks vending machine for fast caps!"
+	desc = "At last, your just reward! Turn this in at the bank's vending machine for fast caps!"
 	icon = 'icons/obj/card.dmi'
 	icon_state = "data_1"
 	item_state = "card-id"

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -14,9 +14,10 @@
 	var/expected_price = 0
 	var/list/prize_list = list()  // Once this is readded to the map, I need to do some testing regarding gunpowder. See if I can't bully the commie reloading bench to death.
 
-	var/list/goods_list = list( /obj/item/stack/crafting/metalparts = 1,
-								/obj/item/stack/crafting/goodparts = 3,
-								/obj/item/stack/crafting/electronicparts = 3,
+	var/list/goods_list = list( /obj/item/stack/sheet/metal = 1,
+								/obj/item/stack/sheet/mineral/titanium = 3,
+								/obj/item/stack/sheet/plasteel =3,
+								/obj/item/stack/sheet/mineral/plastitanium = 6,
 								/obj/item/advanced_crafting_components/flux = 15,
 								/obj/item/advanced_crafting_components/lenses = 15,
 								/obj/item/advanced_crafting_components/conductors = 15,
@@ -46,7 +47,7 @@
 								/obj/item/export/bottle/goldschlager = 30,
 								/obj/item/export/bottle/patron = 30,
 								/obj/item/stealthboy = 100,
-								/obj/item/blueprint/research = 50,
+								/obj/item/blueprint/research = 25,
 								// pistols/revolvers, 5 caps
 								/obj/item/gun/ballistic/revolver/detective = 5,
 								/obj/item/gun/ballistic/revolver/revolver45 = 5,
@@ -246,15 +247,17 @@
 	dat += "<br>"
 	dat +="<div class='statusDisplay'>"
 	dat += "<b>Accepted goods and prices:</b><br>"
-	dat += "Handguns: 5 caps<br>"
-	dat += "Rifles and Shotguns: 10 caps<br>"
-	dat += "Submachine Guns and Automatic Rifles: 15 caps<br>"
-	dat += "Improvised Firearms: 0 caps<br>"
-	dat += "Metal and Electronic Parts: 1 - 3 caps<br>"
+	dat += "Metal Sheet: 1 cap<br>"
+	dat += "Titanium Sheet: 3 caps<br>"
+	dat += "Plasteel Sheet: 3 caps<br>"
+	dat += "Plastitanium Sheet: 6 caps<br>"
 	dat += "Advanced Components: 15 caps<br>"
 	dat += "Sealed Alcohol Bottles: 15 - 30 caps<br>"
-	dat += "Research Papers: 50 caps<br>"
+	dat += "Research Papers: 25 caps<br>"
 	dat += "Stealthboy: 100 caps<br>"
+	dat += "Handguns: 5 caps<br>"
+	dat += "Bolt Action Rifles and Shotguns: 10 caps<br>"
+	dat += "SMGs, Semi-auto, and Automatic Rifles: 15 caps<br>"
 	dat += ""
 	dat += "</div>"
 
@@ -410,46 +413,13 @@ Fence
 */
 
 /obj/machinery/mineral/wasteland_trader/brotherhood
-	name = "Brotherhood of Steal"
+	name = "Nash Bounty Ticket Machine"
+	desc = "This vending machine accepts bounty tickets in exchange for caps. Make the Wasteland safer, and yourself richer, one bullet at a time."
 
-	goods_list = list( /obj/item/radio/headset/headset_bos = 15,
-								/obj/item/clothing/under/syndicate/brotherhood = 15,
-								/obj/item/card/id/dogtag = 30,
-								/obj/item/clothing/shoes/combat/swat = 5,
-								/obj/item/clothing/gloves/combat = 5,
-								/obj/item/clothing/accessory/bos/initiateS = 5,
-								/obj/item/clothing/accessory/bos/initiateK = 5,
-								/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate = 30,
-								/obj/item/clothing/suit/armor/medium/combat/brotherhood/initiate = 30,
-								/obj/item/clothing/accessory/bos/juniorknight = 5,
-								/obj/item/clothing/accessory/bos/knight = 15,
-								/obj/item/clothing/head/helmet/f13/combat/brotherhood = 45,
-								/obj/item/clothing/suit/armor/medium/combat/brotherhood = 45,
-								/obj/item/clothing/suit/armor/medium/combat/brotherhood/senior = 60,
-								/obj/item/clothing/head/helmet/f13/combat/brotherhood/senior = 60,
-								/obj/item/clothing/glasses/night = 150,
-								/obj/item/clothing/accessory/bos/seniorknight = 30,
-								/obj/item/clothing/accessory/bos/scribe = 15,
-								/obj/item/clothing/accessory/bos/juniorscribe = 5,
-								/obj/item/clothing/suit/armor/light/duster/bos/scribe = 45,
-								/obj/item/clothing/suit/armor/light/duster/bos/scribe/seniorscribe = 60,
-								/obj/item/clothing/accessory/bos/seniorscribe = 30,
-								/obj/item/clothing/accessory/bos/juniorpaladin = 15,
-								/obj/item/clothing/accessory/bos/paladin = 30,
-								/obj/item/clothing/accessory/bos/seniorpaladin = 45,
-								/obj/item/clothing/suit/armor/medium/combat/brotherhood/captain = 75,
-								/obj/item/clothing/accessory/bos/knightcaptain = 60,
-								/obj/item/clothing/head/helmet/f13/combat/brotherhood/captain = 75,
-								/obj/item/clothing/accessory/bos/headscribe = 60,
-								/obj/item/clothing/suit/armor/light/duster/bos/scribe/headscribe = 75,
-								/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 75,
-								/obj/item/clothing/under/f13/recon = 30,
-								/obj/item/clothing/accessory/bos/sentinel = 30,
-								/obj/item/clothing/suit/armor/light/duster/bos/scribe/elder = 300,
-								/obj/item/clothing/accessory/bos/elder = 300,
-								/obj/item/gun/energy/laser/laer = 600,
-								/obj/item/clothing/neck/mantle/bos/right = 300
-
+	goods_list = list( 	/obj/item/card/lowbounty = 100,
+						/obj/item/card/midbounty = 200,
+						/obj/item/card/highbounty = 400,
+						/obj/item/card/kingbounty = 800
 								)
 
 /obj/machinery/mineral/wasteland_trader/brotherhood/ui_interact(mob/user)
@@ -460,7 +430,11 @@ Fence
 	dat += "</div>"
 	dat += "<br>"
 	dat +="<div class='statusDisplay'>"
-	dat += "<b>Buying a wide variety of Brotherhood gear.</b><br>"
+	dat += "<b>Turn your kills into caps today!</b><br>"
+	dat += "Small Roller Bounty Ticket: 100 caps<br>"
+	dat += "Medium Roller Bounty Ticket: 200 caps<br>"
+	dat += "High Roller Bounty Ticket: 400 caps<br>"
+	dat += "King's Bounty Ticket: 800 caps<br>"
 	dat += ""
 	dat += "</div>"
 

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -400,7 +400,7 @@
 	)
 
 /datum/export/item/liquor
-	cost = 500
+	cost = 1000
 	unit_name = "cheap liquor"
 	export_types = list(/obj/item/export/bottle/gin,
 	/obj/item/export/bottle/whiskey,
@@ -433,7 +433,7 @@
 
 
 /datum/export/item/toyslow
-	cost = 200
+	cost = 500
 	unit_name = "basic toy"
 	export_types = list(/obj/item/toy,
 	)
@@ -469,6 +469,22 @@
 	unit_name = "armor item"
 	export_types = list(/obj/item/clothing/suit/armor,
 	)
+
+/datum/export/item/lowfish
+	cost = 150
+	unit_name = "common fish"
+	export_types = list(/obj/item/fishy/carp,
+						/obj/item/fishy/salmon,
+						/obj/item/fishy/crawdad,
+						/obj/item/fishy/shrimp,
+	)
+
+/datum/export/item/highfish
+	cost = 500
+	unit_name = "rare fish"
+	export_types = list(/obj/item/fishy/eel,
+	)
+
 
 /* k_elasticity 0 - the price degredation thing, in case we need it. Might need to be applied to toys in the future. */
 

--- a/code/modules/clothing/head/f13factionhead.dm
+++ b/code/modules/clothing/head/f13factionhead.dm
@@ -228,10 +228,13 @@
 	name = "enclave envirosuit hood"
 	icon_state = "envirohead"
 	item_state = "envirohead"
-	desc = "A white hazmat helmet with a coupling system, the visor looks to be made out of orange plexiglas."
+	desc = "A white hazmat helmet designed and produced by the Enclave post-war. It's probably not a good idea to be seen wearing this."
 	clothing_flags = THICKMATERIAL
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
-	armor_tokens = list(ARMOR_MODIFIER_UP_DT_T1, ARMOR_MODIFIER_UP_ENV_T3)
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.01
+	armor = ARMOR_VALUE_LIGHT
+	armor_tokens = list(ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_UP_ENV_T4)
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3453,13 +3453,13 @@
 	name = "reinforced hazard hood"
 	desc = "A lead-lined hood that's been reinforced with a kevlar weave."
 	icon_state = "bio_security"
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T3)
 
 /obj/item/clothing/suit/bio_suit/security
 	name = "reinforced hazard suit"
 	desc = "A CBRN hazard suit that's been paired with a ballistic vest. Surprisingly lightweight for all of its bulk."
 	icon_state = "bio_security"
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T1)
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T3)
 
 //Janitor's biosuit, grey with purple arms
 /obj/item/clothing/head/bio_hood/janitor


### PR DESCRIPTION
## About The Pull Request
Mostly WVM stuff, but some other small tweaks

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Since metal parts, high qual parts, and electronic parts seem to be scuffed, the commie killer now accepts metal, titanium, plasteel, and plastit instead. No gunpowder sheets for now.
- Lowered research papers to 25/paper to give the clinic a chance to buy them
- Popular opinion was the reinforced hazmat suit needed more armor, so it has 3 DT now. Makes it better against shotguns (it *is* a ballistic vest over a hazard suit) but otherwise doesn't actually do much.
- The bounty card vendor is now made using the old brotherhood gear-buying vendor because lol. Prices subject to change. Sprite subject to change by someone who is not me.
- Low booze got bumped to 1000 in cargo. Still feels too high, but it's not really in the loot pool afaik so how good/bad this is can't really be tested.
- Added fish to cargo's list of acceptable goods. Basically geckohide+
- Minor grammar fix with the bounty cards.
- Very slightly buffed basic toy prices.
- Fixed the Enclave hood having whack stats and not lining up with its body item.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
