### PR TITLE
[ready] Creature Accessory Slot & E Hotkey

### DIFF
--- a/code/modules/keybindings/keybind/human.dm
+++ b/code/modules/keybindings/keybind/human.dm
@@ -3,7 +3,10 @@
 	weight = WEIGHT_MOB
 
 /datum/keybinding/human/can_use(client/user)
-	return ishuman(user.mob)
+	if(ishuman(user.mob))
+		return TRUE
+	if(isanimal(user.mob))
+		return TRUE
 
 /datum/keybinding/human/quick_equip
 	hotkey_keys = list("E")
@@ -12,9 +15,14 @@
 	description = "Quickly puts an item in the best slot available"
 
 /datum/keybinding/human/quick_equip/down(client/user)
-	var/mob/living/carbon/human/H = user.mob
-	H.quick_equip()
-	return TRUE
+	if(ishuman(user.mob))
+		var/mob/living/carbon/human/H = user.mob
+		H.quick_equip()
+		return TRUE
+	else if(isanimal(user.mob))
+		var/mob/living/simple_animal/SA = user.mob
+		SA.quick_equip()
+	
 
 /*
 /datum/keybinding/human/quick_equipbelt

--- a/modular_coyote/code/mobinventory.dm
+++ b/modular_coyote/code/mobinventory.dm
@@ -43,10 +43,10 @@
 
 /mob/living/simple_animal/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, clothing_check = FALSE, list/return_warning)
 	switch(slot)
-		if(SLOT_HEAD)
+		if(SLOT_HEAD)//Anything that can be worn on a head, worn as a mask, held in a mouth, or worn around a neck.
 			if(head)
 				return 0
-			if(!((I.slot_flags & ITEM_SLOT_HEAD) || (I.slot_flags & ITEM_SLOT_MASK)))
+			if(!((I.slot_flags & ITEM_SLOT_HEAD) || (I.slot_flags & ITEM_SLOT_MASK) || (I.slot_flags & ITEM_SLOT_NECK) || (I.slot_flags & ITEM_SLOT_POCKET)))
 				return 0
 			return 1
 		if(SLOT_GENERIC_DEXTROUS_STORAGE)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

- Lets creature characters store flashlights and similar accessories in their mask/head slot so they can see the mystery while doing the dungeon.
- Lets simple mobs use the E hotkey to quickly equip held items into an available slot or into a bag they're wearing.

![preview](https://i.imgur.com/5r5IqVz.png)
