### PR TITLE
Flirting 2.0

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -35,6 +35,7 @@
 	var/audio_cooldown = 2 SECONDS
 	/// emote does not have the player's name on the left.
 	var/omit_left_name = FALSE
+	var/message_range = 7
 
 /datum/emote/New()
 	if(restraint_check)
@@ -91,9 +92,9 @@
 		ENABLE_BITFIELD(message_flags, PUT_NAME_IN)
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, deaf_message = msg, audible_message_flags = message_flags)
+		user.audible_message(msg, deaf_message = msg, audible_message_flags = message_flags, hearing_distance = message_range)
 	else
-		user.visible_message(msg, blind_message = msg, visible_message_flags = message_flags)
+		user.visible_message(msg, blind_message = msg, visible_message_flags = message_flags, vision_distance = message_range)
 
 
 /// Sends the given emote message for all ghosts with ghost sight enabled, excluding close enough to listen normally.

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -339,17 +339,14 @@
 		if(isinsect(human_user))
 			return 'sound/voice/moth/mothchitter.ogg'
 
-/*
+
 /datum/emote/living/look
 	key = "look"
 	key_third_person = "looks"
 	message = "looks."
 	key_third_person = "seems to be looking around for something."
 	message = "seems to be looking around for something."
-	if(ckey = "tk420634")
-		key_third_person = "tries to look look around, but can't look up because they're a dog."
-		message = "tries to look look around, but can't look up because they're a dog."
-*/
+
 
 /datum/emote/living/nod
 	key = "nod"
@@ -1621,3 +1618,170 @@ GLOBAL_LIST_INIT(special_phrases, list(
 			self_message = message_second,
 			blind_message = message_second)
 		user.emote_for_ghost_sight(message_second)
+
+
+
+//Fenny Adds Flirtatious Fucking Emotes For Furries//
+
+
+//	key_third_person = "blushes"
+//	message = "blushes."
+//	message_param = "blushes at %t."
+
+/datum/emote/living/flirt/
+	key = "flirt"
+	key_third_person = "is being a little <span class='love'>flirty!</span>"
+	message = "is being a little <span class='love'>flirty!</span>"
+	message_param = "is <span class='love'>flirting with</span> %t sneakily!"
+	message_range = 1
+
+/* For making new flirt/affection options
+datum/emote/living/flirt/blank
+	key = "flirtblank"
+	key_third_person = "<span class='love'></span> someone!"
+	message = "<span class='love'></span> someone!"
+	message_param = "<span class='love'></span> %t!"
+*/
+
+datum/emote/living/flirt/custom
+	key = "flirtcustom"
+	key_third_person = "is trying to <span class='love'>%t</span>"
+	message = "is trying to <span class='love'>%t</span>"
+	message_param = "is trying to <span class='love'>%t</span>"
+
+/datum/emote/living/flirt/flirtlookat
+	key = "flirtlookat"
+	key_third_person = "is <span class='love'>eyeing up</span> somebody!"
+	message = "is <span class='love'>eyeing up</span> somebody!"
+	message_param = "is <span class='love'>eyeing up</span> %t sneakily!"
+	sound = 'sound/effects/blink.ogg'
+
+datum/emote/living/flirt/flirtaccept
+	key = "flirtaccept"
+	key_third_person = "lets whoever continue whatever it is they were <span class='userlove'>doing!</span>"
+	message = "lets whoever continue whatever it is they were <span class='userlove'>doing!</span>"
+	message_param = "lets %t continue whatever it is they were <span class='userlove'>doing!</span>"
+	sound = 'sound/f13effects/sunsetsounds/blush.ogg'
+
+datum/emote/living/flirt/flirtreject
+	key = "flirtreject"
+	key_third_person = "<span class='danger'>stops someone cold</span>, refusing to go on with this."
+	message = "<span class='danger'>stops someone cold</span>, refusing to go on with this."
+	message_param = "<span class='>danger'stops %t cold</span>, refusing to go on with this."
+	sound = 'sound/effects/ding.ogg'
+
+datum/emote/living/flirt/flirtblush
+	key = "flirtblush"
+	key_third_person = "is <span class='love'>blushing deeply</span> at %t, their mind has clearly wandered a bit!"
+	message = "is <span class='love'>blushing deeply</span> at %t, their mind has clearly wandered a bit!"
+	message_param = "is <span class='love'>blushing deeply</span> at %t, their mind has clearly wandered a bit!"
+	sound = 'sound/f13effects/sunsetsounds/blush.ogg'
+
+datum/emote/living/flirt/flirtsniff
+	key = "flirtsniff"
+	key_third_person = "sniffs at somebody disapprovingly, but <span class='love'>do they mean it?</span>"
+	message = "sniffs at somebody disapprovingly, but <span class='love'>do they mean it?</span>"
+	message_param = "sniffs at %t disapprovingly, but <span class='love'>do they mean it?</span>"
+
+datum/emote/living/flirt/flirtsmell
+	key = "flirtsmell"
+	key_third_person = "leans in close and tries to sneak a <span class='love'>snif of someone!</span>"
+	message = "leans in close and tries to sneak a <span class='love'>snif of someone!</span>"
+	message_param = "leans in close and tries to sneak a <span class='love'>snif of %t!</span>"
+
+datum/emote/living/flirt/flirtcoo
+	key = "flirtcoo"
+	key_third_person = "makes a <span class='love'>quiet cooing noise at</span>, urging them on!"
+	message = "makes a <span class='love'>quiet cooing noise at</span>, urging them on!"
+	message_param = "makes a <span class='love'>quiet cooing noise at %t</span>, urging them on!"
+
+datum/emote/living/flirt/flirtpinch
+	key = "flirtpinch"
+	key_third_person = "is <span class='love'>trying to pinch</span> somebody, look out they're a lil' handsy!"
+	message = "is <span class='love'>trying to pinch</span> somebody, look out they're a lil' handsy!"
+	message_param = "is <span class='love'>trying to pinch</span> %t, look out they're a lil' handsy!"
+
+datum/emote/living/flirt/flirtcaress
+	key = "flirtcaress"
+	key_third_person = "is <span class='love'>trying to caress</span> somebody softly!"
+	message = "is <span class='love'>trying to caress</span> somebody softly!"
+	message_param = "is <span class='love'>trying to caress</span> %t softly!"
+
+datum/emote/living/flirt/flirtbrush
+	key = "flirtbrush"
+	key_third_person = "is <span class='love'>trying to brush</span> someone!"
+	message = "is <span class='love'>trying to to brush</span> someone!"
+	message_param = "is <span class='love'>trying to brush</span> %t!"
+
+datum/emote/living/flirt/flirtgrope
+	key = "flirtgrope"
+	key_third_person = "is <span class='love'>trying to grope</span> somebody, very handsy!"
+	message = "is <span class='love'>trying to grope</span> somebody, very handsy!"
+	message_param = "is <span class='love'>trying to grope</span> %t, very handsy!"
+
+datum/emote/living/flirt/flirtkissy
+	key = "flirtkissy"
+	key_third_person = "makes a <span class='love'>kissy face at</span> someone!"
+	message = "makes a <span class='love'>kissy face at</span> someone!"
+	message_param = "makes a <span class='love'>kissy face at</span> %t!"
+
+datum/emote/living/flirt/eyebrow
+	key = "flirteyebrow"
+	key_third_person = "<span class='love'>quirks their eyebrow</span> at someone knowingly!"
+	message = "<span class='love'>quirks their eyebrow</span> at someone knowingly!"
+	message_param = "<span class='love'>quirks their eyebrow</span> at %t knowingly!"
+
+datum/emote/living/flirt/wink
+	key = "flirtwink"
+	key_third_person = "<span class='love'>winks</span> at someone knowingly!"
+	message = "<span class='love'>winks</span> at someone knowingly!"
+	message_param = "<span class='love'>winks</span> at %t knowingly!"
+
+datum/emote/living/flirt/wave
+	key = "flirtwave"
+	key_third_person = "<span class='love'>waves</span> someone over languidly!"
+	message = "<span class='love'>waves</span> someone over languidly!"
+	message_param = "<span class='love'>waves</span> %t over languidly!"
+
+datum/emote/living/flirt/lean
+	key = "flirtlean"
+	key_third_person = "tries to lean warmly on <span class='love'>lean warmly on</span> someone!"
+	message = "tries to <span class='love'>lean warmly on</span> someone!"
+	message_param = "tries to <span class='love'>lean warmly on</span> %t!"
+
+datum/emote/living/flirt/snuggle
+	key = "flirtsnuggle"
+	key_third_person = "tries to <span class='love'>snuggle up against</span> someone!"
+	message = "tries to <span class='love'>snuggle up against</span> someone!"
+	message_param = "tries to <span class='love'>snuggle up against</span> %t!"
+
+datum/emote/living/flirt/littlespoon
+	key = "flirtspoonlittle"
+	key_third_person = "is trying to be <span class='love'>the little spoon</span> for someone!"
+	message = "is trying to be <span class='love'>the little spoon</span> for someone!"
+	message_param = "is trying to be <span class='love'>the little spoon</span> for %t!"
+
+datum/emote/living/flirt/bigspoon
+	key = "flirtspoonbig"
+	key_third_person = "is trying to be <span class='love'>the big spoon</span> for someone!"
+	message = "is trying to be <span class='love'>the big spoon</span> for someone!"
+	message_param = "is trying to be <span class='love'>the big spoon</span> for %t!"
+
+datum/emote/living/flirt/kisslight
+	key = "flirtkisslight"
+	key_third_person = "is trying to <span class='love'>lightly kiss</span> someone!"
+	message = "is trying to <span class='love'>lightly kiss</span> someone!"
+	message_param = "is trying to <span class='love'>lightly kiss</span> %t!"
+
+datum/emote/living/flirt/kiss
+	key = "flirtkiss"
+	key_third_person = "is trying to <span class='userlove'>kiss</span> someone!"
+	message = "is trying to <span class='userlove'>kiss</span> someone!"
+	message_param = "is trying to <span class='userlove'>kiss</span> %t!"
+
+datum/emote/living/flirt/kissdeep
+	key = "flirtkissdeep"
+	key_third_person = "is trying to <span class='userlove'>kiss someone deeply!</span>"
+	message = "is trying to <span class='userlove'>kiss someone deeply!</span>"
+	message_param = "is trying to <span class='userlove'>kiss %t deeply!</span>"
+

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -32,7 +32,7 @@ proc/get_top_level_mob(mob/S)
 	message = null
 	//mob_type_blacklist_typecache = list(/mob/living/brain)
 	var/subtler = FALSE
-	var/message_range = 1
+	message_range = 1
 
 /datum/emote/living/subtle/subtler
 	key = "subtler"


### PR DESCRIPTION
Sat down with Dan and we mashed out a simple system for flirty emotes.

This includes such bangers as

-*flirt - vague initiation verb
-*flirtaccept - IC agreeing
-*flirtreject - IC rejecting
-*flirtlean - leaning on someone
-*flirtblush - blushing at someone, or something.
-*flirtbrush - brushing someone, or something.
-*flirtcaress - carressing someone or something.
-*flirtcoo - cooing at someone or something.
-*flirteyebrow - quirking an eyebrow at someone or something.
-*flirtgrope - getting a hold of someone or something
-*flirtkiss - kissing someone or something.
-*flirtkissdeep - deeply kissing someone or something.
-*flirtkisslight - lightly kissing someone or something.
-*flirtkissy - making a kissy face at someone or something.
-*flirtlookat - eyeying someone or something up.
-*flirtpinch - pinching someone or something.
-*flirtsmell - getting a smell of someone or something.
-*flirtsniff - a disapproving sniff of someone or something, kinda bratty
-*flirtsnuggle - snuggling someone or something
-*flirtspoonbig - being the big spoon for someone or something
-*flirtspoonlittle - being the little spoon for someone or something
-*flirtwave - languidly waving someone or something over.
-*flirtwink - giving someone or something a wink.
-*flirtcustom - you try to do (whatever you enter in the parameter.)

All of these use the parameter system, allowing a player to clarify who and what they may be interacting with when using them using the very simple system of just writing out the emote to a degree.

The benefit of this system is that for players who -want- to throw subtle options to the wind they can make it very clear very rapidly what their intentions appear to be.  Allowing for hook ups to happen more naturally, which should help with the Wallflower problem.

It also includes a *flirtcustom that can use its parameter to write a freeform (love span'd) emote.

Reject and Accept are designed to be used as an IC way to encourage or refuse an advance, and until Dan can get around to automating the system should not be relied on to inform the other person you're stopping them, that is what Local Out of Character is for.

Because sometimes you gotta be a little bratty.

These are ALL range ONE emotes, like subtles are.  Huzzah.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
