### PR TITLE
Removes ghoul glow and changes their stamina recovery

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -108,14 +108,14 @@
 		if(0)
 			healpwr = 0
 			is_healing = FALSE
-			H.set_light(0)
+			//H.set_light(0)
 		else
 			healpwr = 3
 			is_healing = TRUE
-			H.set_light(2, 15, LIGHT_COLOR_GREEN)
+			//H.set_light(2, 15, LIGHT_COLOR_GREEN)
 	H.adjustCloneLoss(-healpwr)
 	H.adjustToxLoss(-0.3) //ghouls always heal toxin very slowly no matter what
-	H.adjustStaminaLoss(-20) //ghouls don't get tired ever
+	H.adjustStaminaLoss(-1000) //ghouls don't get tired ever. Really. This may include stuns, fuck you.
 	H.heal_overall_damage(healpwr, healpwr, healpwr)
 	if(is_healing)
 		H.apply_status_effect(/datum/status_effect/ghoulheal)


### PR DESCRIPTION
## About The Pull Request
Removes glow from ghouls and gives them more stamina regen so they TRULY never get tired.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
commented out the ghoul glow, and upped their stamina regen. Yes, it's 1000 now, but they can never get tired. (Sprinting used to make them tired so that's why I changed it, yeah)
/:cl: