### PR TITLE
[Ready if CI Passes] Simplemob movement balance

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -613,6 +613,7 @@
 		//Disable their mob's AI so they don't wander after the player ghosts out of them
 		C.AIStatus = AI_OFF
 		C.wander = FALSE
+		C.can_have_ai = FALSE
 		//Set them as a player-character simplemob so examine and such changes to show their character prefs
 		C.player_character = ckey
 		C.grant_all_languages()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -787,7 +787,6 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 /mob/living/simple_animal/update_mobility()
 	. = ..()
 	if(IsUnconscious() || IsStun() || IsParalyzed() || stat || resting)
-		drop_all_held_items(TRUE)
 		mobility_flags = NONE
 	else if(buckled)
 		mobility_flags = ~MOBILITY_MOVE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -685,10 +685,10 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 		lying = 1
 		..()
 
-/mob/living/simple_animal/drop_all_held_items()
-	if(internal_storage)
+/mob/living/simple_animal/drop_all_held_items(skip_worn = FALSE)
+	if(internal_storage && !skip_worn)
 		dropItemToGround(internal_storage)
-	if(head)
+	if(head && !skip_worn)
 		dropItemToGround(head)
 	. = ..()
 
@@ -778,18 +778,18 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	else
 		..()
 
-/* /mob/living/simple_animal/update_mobility()
+/mob/living/simple_animal/update_mobility()
 	. = ..()
 	if(IsUnconscious() || IsStun() || IsParalyzed() || stat || resting)
-		drop_all_held_items()
+		drop_all_held_items(TRUE)
 		mobility_flags = NONE
 	else if(buckled)
 		mobility_flags = ~MOBILITY_MOVE
 	else
 		mobility_flags = MOBILITY_FLAGS_DEFAULT
-	update_transform()
+//	update_transform()
 	update_action_buttons_icon()
-	return mobility_flags */
+	return mobility_flags
 
 /* /mob/living/simple_animal/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -459,6 +459,12 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 /mob/living/simple_animal/updatehealth()
 	..()
 	health = clamp(health, 0, maxHealth)
+	var/slow = 0
+	if(client && !HAS_TRAIT(src, TRAIT_IGNOREDAMAGESLOWDOWN))//Player controlled animal
+		var/health_percent = ((health/maxHealth)*100)//1-100 scale for health
+		if(health_percent <= 50)//Start slowdown at half health
+			slow += ((50/health_percent)/2)//0.5 slowdown at 1/2 health, 1 slowdown at 1/4 health, etc
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, slow)
 
 /mob/living/simple_animal/update_stat()
 	if(status_flags & GODMODE)

--- a/modular_coyote/code/pmon_actions.dm
+++ b/modular_coyote/code/pmon_actions.dm
@@ -5,7 +5,6 @@
 //	desc = "Lie down and rest in order to slowly heal or just relax." Swap this in when the healing works.
 	icon_icon = 'modular_coyote/icons/mob/pokemon32.dmi'
 	button_icon_state = "a_rest"
-	background_icon_state = "bg_default"
 	check_flags = AB_CHECK_CONSCIOUS
 	required_mobility_flags = MOBILITY_RESIST
 	cooldown_time = 2 SECONDS


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

- Fixes simple mobs ignoring their resting state. They now stop moving while resting. Crawling functionality may come later.
- Makes player controlled simple mobs slow down when their health gets low, just like carbons.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->
