### PR TITLE
[ready] Makes Profile Picture Preview Window Larger

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -331,7 +331,7 @@ GLOBAL_VAR_INIT(crotch_call_cooldown, 0)
 	// Gremling is just gonna do gremlin things and add this here > w> Cant be assed trying to fit this in somewhere else for now.
 	if(href_list["enlargeImage"])
 		var/dat = {"<img src='[DiscordLink(profilePicture)]'>"}
-		var/datum/browser/popup = new(usr, "enlargeImage", "Full Sized Picture!")
+		var/datum/browser/popup = new(usr, "enlargeImage", "Full Sized Picture!",500,500)
 		popup.set_content(dat)
 		popup.open()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -645,7 +645,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		onclose(usr, "[name]")
 	if(href_list["enlargeImageCreature"])
 		var/dat = {"<img src='[DiscordLink(profilePicture)]'>"}
-		var/datum/browser/popup = new(usr, "enlargeImage", "Full Sized Picture!")
+		var/datum/browser/popup = new(usr, "enlargeImage", "Full Sized Picture!",500,500)
 		popup.set_content(dat)
 		popup.open()
 

--- a/modular_coyote/code/modules/examine_images.dm
+++ b/modular_coyote/code/modules/examine_images.dm
@@ -51,7 +51,7 @@
 	if(!client)
 		return
 	
-	var/input = stripped_input(usr,"Right click an image from discord (do not expand the image by clicking it) and click 'Copy Link' and paste it here. Must be a png", i_will_sanitize_dont_worry = TRUE)
+	var/input = stripped_input(usr,"Right click an image from discord (do not expand the image by clicking it) and click 'Copy Link' and paste it here. Must be a png. Preferred image size: 500x500 or smaller.", i_will_sanitize_dont_worry = TRUE)
 	if(length(input))	
 		if(!SanitizeDiscordLink(input))
 			to_chat(usr, span_warning("Link is incorrect, make sure you just right click the image in discord and copy link, do NOT click it to expand the image. It must end in '.png'"))


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

- Makes the profile picture preview image (the popup when you click on somebody's profile picture in their examine) 500x500 pixels big by default instead of being really small and forcing you to resize it manually.
- Also tells you that your image should be about 500 pixels big in the prompt when setting it up in character creation.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->