### PR TITLE
Panzer's Custom Loadout Nonsense

### DIFF
--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -2102,6 +2102,12 @@
 	icon_state = "battlecoat_tan"
 	item_state = "battlecoat_tan"
 
+/obj/item/clothing/suit/armor/medium/duster/armoredcoat/panzer
+	name = "dishevelled tan battlecoat"
+	desc = "A heavy padded leather coat with faded colors, worn over an armor vest. This particular coat is torn around the edges with small holes along the shoulders and arms wherein one might denote their rank, while the underlying armor vest would be marred by burn marks and bullet holes - clearly having seen better days."
+	icon_state = "battlecoat_tan"
+	item_state = "battlecoat_tan"
+
 /obj/item/clothing/suit/armor/medium/duster/duster_renegade
 	name = "renegade duster"
 	desc = "Metal armor worn under a stylish duster. For the bad boy who wants to look good while commiting murder."

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -19,7 +19,7 @@
 	move_to_delay = 3
 	robust_searching = 1
 	mob_armor = ARMOR_VALUE_ROBOT_CIVILIAN
-	maxHealth = 40 
+	maxHealth = 40
 	health = 40
 	stamcrit_threshold = SIMPLEMOB_NO_STAMCRIT
 	emp_flags = list(
@@ -158,6 +158,11 @@
 		return
 	var/emp_damage = round((maxHealth * 0.1) * (severity * 0.1)) // 10% of max HP * 10% of severity(Usually around 20-40)
 	adjustBruteLoss(emp_damage)
+
+/mob/living/simple_animal/pet/dog/eyebot/panzer
+	name = "Pvt. Eye"
+	desc = "This eyebot's weapons module has been removed and replaced with a transmitter of some kind. It appears to be simply observing and feeding information to something passively."
+	emote_see = list("buzzes.","pings.","floats in place","beeps.","bobs left and right","bobs up and down")
 
 /mob/living/simple_animal/pet/dog/eyebot/playable
 	health = 200

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -691,6 +691,23 @@
 // O
 // P
 
+/datum/gear/donator/kits/panzer
+	name = "Val's Equipment"
+	path = /obj/item/storage/box/large/custom_kit/panzer
+	ckeywhitelist = list("panzer1944")
+
+/obj/item/storage/box/large/custom_kit/panzer/PopulateContents()
+	new /obj/item/clothing/suit/armor/medium/duster/armoredcoat/panzer(src)
+	new /obj/item/clothing/mask/gas/sechailer(src)
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/clothing/under/f13/enclave/officer(src)
+	new /mob/living/simple_animal/pet/dog/eyebot/panzer(src)
+	new /obj/item/gun/ballistic/revolver/m29/alt(src)
+	new /obj/item/ammo_box/m44(src)
+	new /obj/item/ammo_box/m44(src)
+	new /obj/item/card/id/selfassign/brotherenclave(src)
+	new /obj/item/pda/warden(src)
+
 /datum/gear/donator/kits/pappavol
 	name = "Tribal Power Kit"
 	path = /obj/item/storage/box/large/custom_kit/pappavol


### PR DESCRIPTION
## About The Pull Request

loadout nonsense for a character of mine. hopefully this is all fine :)

- adds in a rename and re-desc battlecoat & eyebot (dog?)
- adds in the loadout box /w whitelist; 
 | x2 44 ammo box (For the .44, ripped straight from a similar loadout) 
 | x1 reskin .44 (Statistically identical to the one you can get on spawn, just looks better. Also ripped from a similar loadout) 
 | x1 reskin self-assign ID (Just looks more akin to brotherhood / enclave holotags) 
 | x1 red-tint PDA (Red warden pipboy, looks good and holds no other non-rp value outside of that really.)
 | x1 sec glasses (Cool red glasses, sec-hud is useless here really.) 
 | x1 Pvt. Eye (Rename, re-desc custom eyebot for character lore purposes and to save renaming every round) 
 | x1 half gasmask (Sec gasmask. Holds no real function outside of looking good and acting as a gas mask)
 | x1 officer uniform (This uniform is agonizing to get each round. It is thus here.)
 | x1 re-desc + re-name battlecoat (Bog-standard medium armour - stuff you can get nigh immediately on spawn)

## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [Y ] You documented all of your changes.
(_If somehow I cause a runtime should this be merged, even though I didn't see any during my own tests, then I truly apologise and am willing to contribute to fixing the issue(s) with them_)

## Changelog
add: custom tan battlecoat variant
add: custom eyebot dog variant
add: custom loadout for my character