### PR TITLE
Adds Irkallas shitty custom loadout

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -546,7 +546,7 @@
     new /obj/item/circuitboard/machine/biogenerator(src)
     new /obj/item/circuitboard/machine/seed_extractor(src)
     new /obj/item/clothing/mask/gas/syndicate(src)
-	
+
 // J
 
 /datum/gear/donator/kits/jackalface

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -536,6 +536,17 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 
+/datum/gear/donator/kits/irkallaepsilon_01
+    name = "Protective Equipment and Analysis Tools"
+    path = /obj/item/storage/box/large/custom_kit/irkallaepsilon_01
+    ckeywhitelist = list("irkallaepsilon")
+
+/obj/item/storage/box/large/custom_kit/irkallaepsilon/PopulateContents()
+    new /obj/item/circuitboard/machine/plantgenes(src)
+    new /obj/item/circuitboard/machine/biogenerator(src)
+    new /obj/item/circuitboard/machine/seed_extractor
+    new /obj/item/clothing/mask/gas/syndicate
+	
 // J
 
 /datum/gear/donator/kits/jackalface

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -536,9 +536,9 @@
 	new /obj/item/melee/classic_baton/telescopic(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 
-/datum/gear/donator/kits/irkallaepsilon_01
+/datum/gear/donator/kits/irkallaepsilon
     name = "Protective Equipment and Analysis Tools"
-    path = /obj/item/storage/box/large/custom_kit/irkallaepsilon_01
+    path = /obj/item/storage/box/large/custom_kit/irkallaepsilon
     ckeywhitelist = list("irkallaepsilon")
 
 /obj/item/storage/box/large/custom_kit/irkallaepsilon/PopulateContents()

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -544,8 +544,8 @@
 /obj/item/storage/box/large/custom_kit/irkallaepsilon/PopulateContents()
     new /obj/item/circuitboard/machine/plantgenes(src)
     new /obj/item/circuitboard/machine/biogenerator(src)
-    new /obj/item/circuitboard/machine/seed_extractor
-    new /obj/item/clothing/mask/gas/syndicate
+    new /obj/item/circuitboard/machine/seed_extractor(src)
+    new /obj/item/clothing/mask/gas/syndicate(src)
 	
 // J
 


### PR DESCRIPTION
Combine LARPs a sad people. I am a sad person.

## About The Pull Request
Adds a custom kit so I get faster to support slutting instead of loot rushing. As discussed within a ticket on discord this is mostly fine. Mask is the only one giving that combine larp feel that fits symmmchts. Didnt bother with the ultra lightly armored labcoat considering I usually only go out of town with escort with that character and the Wattz 1000 beam reskin should be a separate PR so everyone can access it via a radial menu or something.

## Why is this good for the game?

Support pwayers want to have some fun too. LARPing as combine can be fun, albeit its dumb.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

--> I ripped the format from another persons custom kit and changed it around that. It should work.

## Changelog
:cl:
add: Support slut kit for Irkallas symmmftchhh
/:cl:


