### PR TITLE
Motorbike mount food fix

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -676,3 +676,11 @@
 	category = CAT_CRAFTING
 	subcategory = CAT_SCAVENGING
 
+/datum/crafting_recipe/welding_fuel
+	name = "Process Welding Fuel"
+	result = /obj/item/reagent_containers/food/snacks/welding_fuel
+	reqs = list(/datum/reagent/fuel = 30)
+	tools = list(TOOL_WORKBENCH)
+	time = 10
+	category = CAT_MISC
+	subcategory = CAT_MISCELLANEOUS

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -675,6 +675,13 @@
 			burn()
 	..()
 
+/obj/item/reagent_containers/food/snacks/welding_fuel
+	name = "Processed Welding Fuel"
+	desc = "A bottle of processed welding fuel, perfect for long road trips."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle3"
+	list_reagents = list(/datum/reagent/fuel = 30)
+
 //Easter Stuff
 
 /obj/item/reagent_containers/food/snacks/chocolatebunny

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -843,10 +843,7 @@
 	waddle_up_time = 1
 	waddle_side_time = 2
 	attack_sound = 'sound/weapons/punch1.ogg'
-	food_types = list(
-		/obj/item/reagent_containers/glass/bottle/welding_fuel,
-		/obj/item/reagent_containers/glass/bottle/welding_fuel/big
-		)
+	food_types = list(/obj/item/reagent_containers/food/snacks/welding_fuel)
 	young_type = /mob/living/simple_animal/cow/brahmin/motorbike
 	footstep_type = FOOTSTEP_MOB_HOOF
 	guaranteed_butcher_results = list(


### PR DESCRIPTION


## About The Pull Request
adds a misc crafting recipe for "processed welding fuel" that requires 30u of welding fuel to make. "processed welding fuel" is now a snack item, you can eat it, but its main purpose is to be 'fed' to a motorbike mount. Changes the motorbike's accepted food to allow for the new snack to be "eaten" by it. Yes, you can still milk the bike, this just makes it so you can feed it now.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: "processed welding fuel" snack
add: "processed welding fuel" misc crafting recipe
tweak: motorbike now "eats" processed welding fuel.
/:cl:
