### PR TITLE
Clinic Fixes and misc map viscera.

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -461,10 +461,6 @@
 /obj/item/locked_box/weapon/range/tier3,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"eB" = (
-/obj/effect/landmark/start/f13/followersscientist,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital)
 "eC" = (
 /mob/living/simple_animal/parrot,
 /turf/open/transparent/openspace,
@@ -1143,10 +1139,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building/church)
-"lL" = (
-/obj/effect/landmark/start/f13/followersdoctor,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital)
 "lO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -4689,7 +4681,6 @@
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
 	},
-/obj/effect/landmark/start/f13/followersscientist,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/hospital)
 "XU" = (
@@ -9931,8 +9922,8 @@ hm
 hm
 sK
 rB
-lL
-eB
+eV
+eV
 eV
 eV
 Td
@@ -10188,8 +10179,8 @@ hm
 hm
 sK
 Js
-lL
-lL
+eV
+eV
 eV
 eV
 kd
@@ -10445,7 +10436,7 @@ hm
 hm
 sK
 GM
-lL
+eV
 XR
 eV
 eV

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -5855,7 +5855,8 @@
 "gCx" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22
+	pixel_y = 22;
+	density = 0
 	},
 /obj/item/flashlight/littlelamp{
 	pixel_x = 1;
@@ -6054,21 +6055,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
-"gOa" = (
-/obj/structure/nightstand/small{
-	pixel_x = 2;
-	pixel_y = 22;
-	density = 0
-	},
-/obj/item/flashlight/littlelamp{
-	pixel_x = 1;
-	pixel_y = 25;
-	light_on = 1
-	},
-/turf/open/floor/f13/wood{
-	color = "#C2B280"
-	},
-/area/f13/building)
 "gOF" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13/wood{
@@ -14218,7 +14204,8 @@
 "pEp" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22
+	pixel_y = 22;
+	density = 0
 	},
 /obj/item/flashlight/littlelamp{
 	pixel_x = 1;
@@ -36951,7 +36938,7 @@ tXH
 rrM
 rrM
 eFm
-gOa
+gCx
 knV
 lSv
 cdN

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -6054,6 +6054,21 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
+"gOa" = (
+/obj/structure/nightstand/small{
+	pixel_x = 2;
+	pixel_y = 22;
+	density = 0
+	},
+/obj/item/flashlight/littlelamp{
+	pixel_x = 1;
+	pixel_y = 25;
+	light_on = 1
+	},
+/turf/open/floor/f13/wood{
+	color = "#C2B280"
+	},
+/area/f13/building)
 "gOF" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13/wood{
@@ -36936,7 +36951,7 @@ tXH
 rrM
 rrM
 eFm
-gCx
+gOa
 knV
 lSv
 cdN

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -14103,6 +14103,34 @@
 	pixel_y = -32;
 	id = "NashClinicChem"
 	},
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/building/hospital)
 "aYc" = (
@@ -14326,50 +14354,7 @@
 /area/f13/building/coyote/nash/firestation)
 "aZa" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
 /area/f13/building/hospital)
 "aZb" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -25182,11 +25182,11 @@
 /turf/open/floor/f13,
 /area/f13/building/abandoned)
 "cPq" = (
-/obj/machinery/vending/medical/nash,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/machinery/vending/medical/nash,
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital)
 "cPt" = (
@@ -25429,10 +25429,10 @@
 	},
 /area/f13/wasteland/massfusion/entrance)
 "cSk" = (
-/obj/machinery/defibrillator_mount{
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
 	pixel_x = 32
 	},
-/obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building/hospital)
 "cSm" = (
@@ -28534,6 +28534,11 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital)
+"dMA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/followersguard,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "dMQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rockcrete_slab{
@@ -43896,6 +43901,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/coyote/nash/museum/groundfloor)
+"icA" = (
+/obj/machinery/mineral/wasteland_vendor/medical,
+/obj/structure/spacevine,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/wasteland/city/nash/downtown)
 "icL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -47913,6 +47925,7 @@
 	dir = 1;
 	light_color = "red"
 	},
+/obj/effect/landmark/start/f13/followersscientist,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "jcW" = (
@@ -53487,6 +53500,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ruins)
+"kKW" = (
+/obj/effect/landmark/start/f13/followersadministrator,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "kKX" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/spacevine,
@@ -53642,7 +53659,7 @@
 	},
 /area/f13/building/abandoned)
 "kNn" = (
-/obj/effect/landmark/poster_spawner/prewar{
+/obj/structure/sign/poster/prewar/poster74{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white/whitegreenchess,
@@ -61687,6 +61704,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/coyote/nash/mall/groundfloor)
+"mRd" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 14
+	},
+/obj/effect/landmark/start/f13/followersdoctor,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "mRk" = (
 /obj/structure/rack,
 /obj/item/wirerod,
@@ -65094,6 +65119,7 @@
 	},
 /area/f13/wasteland/city/nash/theloop)
 "nMr" = (
+/obj/structure/wreck/trash/machinepiletwo,
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -66317,6 +66343,12 @@
 	icon_state = "horizontalbottomborderbottom1"
 	},
 /area/f13/wasteland/city/nash/theloop)
+"odY" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland/city/nash/downtown)
 "oec" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72239,6 +72271,7 @@
 /area/f13/wasteland/city/nash/downtown)
 "pEh" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/followersadministrator,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "pEn" = (
@@ -83270,6 +83303,10 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"sJC" = (
+/obj/effect/landmark/start/f13/followersvolunteer,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "sJI" = (
 /obj/item/storage/trash_stack,
 /obj/structure/spacevine,
@@ -87241,6 +87278,10 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/coyote/nash/school/groundfloor)
+"tLw" = (
+/obj/effect/landmark/start/f13/followersscientist,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "tLD" = (
 /obj/item/rcl/pre_loaded{
 	pixel_y = 6
@@ -90027,10 +90068,10 @@
 	},
 /area/f13/building/coyote/nash/massfus/groundfloor/west)
 "uAQ" = (
-/obj/machinery/defibrillator_mount{
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
 	pixel_x = -32
 	},
-/obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building/hospital)
 "uBb" = (
@@ -92573,6 +92614,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"vmq" = (
+/obj/effect/landmark/start/f13/followersguard,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "vmy" = (
 /obj/structure/flora/tree/oak_one,
 /turf/open/indestructible/ground/outside/desert,
@@ -95230,6 +95275,10 @@
 	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland/city/nash/downtown)
+"vZe" = (
+/obj/effect/landmark/start/f13/followersdoctor,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "vZh" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -110730,8 +110779,8 @@ gRW
 gRW
 jsI
 bkj
-fyh
-pEh
+vmq
+dMA
 wZB
 nDN
 djK
@@ -110987,8 +111036,8 @@ hCu
 gRW
 uHs
 bkj
-fyh
-fyh
+sJC
+sJC
 gnr
 mDi
 xgL
@@ -111245,7 +111294,7 @@ gRW
 uba
 hlS
 jcS
-fyh
+kKW
 pEh
 wux
 ecW
@@ -111503,7 +111552,7 @@ myM
 hlS
 phG
 xRe
-fyh
+tLw
 dNl
 ids
 jxA
@@ -111760,7 +111809,7 @@ dHD
 hlS
 hkZ
 ybq
-fyh
+vZe
 qkr
 hKx
 mJH
@@ -112017,7 +112066,7 @@ uba
 hlS
 tZH
 wtb
-aWc
+mRd
 xUx
 vCH
 mJH
@@ -136640,7 +136689,7 @@ aSp
 aSz
 mBN
 vfw
-gVf
+icA
 rfn
 pJZ
 oqP
@@ -136897,7 +136946,7 @@ aUM
 aUM
 ufV
 cwW
-ccZ
+odY
 rfn
 uZu
 pnF


### PR DESCRIPTION


## About The Pull Request
Fixed a poster being off the wall, the senior doc, nurse, and paramed spawns being missing as well as moving them to the town spawn, and fixed the defibs being unfilled at round-start.

Also fixed one of the nash houses having a hyperdense night-stand preventing movement into it and placed a wasteland Medivend next to the disheveled Tex-Arkana clinic to make up for there not being one (incentivizes the clinic to actually fill theirs for more convenient med access and makes people who want the book go outside the walls a second or two to snag it.)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add:Wasteland medivend to texarkana side clinic.
fix: Poster, town doc spawns, clinic defibs, Nash bedroom hyperdense nightstand.
/:cl:
