### PR TITLE
Facelifts Ashdown Bar

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -2136,7 +2136,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "biI" = (
-/obj/structure/window/fulltile/ruins,
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bjc" = (
@@ -7831,9 +7833,8 @@
 	},
 /area/f13/building)
 "eey" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eeA" = (
@@ -8813,6 +8814,9 @@
 /obj/structure/sign/poster/contraband/free_tonto{
 	pixel_y = -32
 	},
+/obj/structure/toilet{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eGM" = (
@@ -9600,12 +9604,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fde" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/fence/wooden{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet{
+	pixel_x = -5;
+	pixel_y = 18
 	},
-/turf/closed/wall/f13/wood,
+/obj/item/reagent_containers/hypospray/medipen/medx,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "fdv" = (
 /obj/structure/flora/small_bush,
@@ -10201,15 +10209,10 @@
 	},
 /area/f13/wasteland)
 "fqZ" = (
-/mob/living/simple_animal/hostile/wolf{
-	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Guerrilla";
-	tame = 1
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "frh" = (
 /turf/open/floor/plasteel/neutral/side{
@@ -14161,11 +14164,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hze" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/turf/closed/wall/f13/wood/house,
+/area/f13/caves)
 "hzq" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/relaxedwear{
@@ -15170,6 +15170,10 @@
 	pixel_x = 32
 	},
 /obj/machinery/computer/slot_machine,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4;
+	light_color = "#a83131"
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -16088,15 +16092,10 @@
 	},
 /area/f13/wasteland)
 "iyT" = (
-/obj/structure/table,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/vending/cola/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/obj/structure/decoration/rag,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "iyW" = (
 /obj/machinery/light/small/broken{
@@ -16625,14 +16624,14 @@
 	},
 /area/f13/building)
 "iKV" = (
-/obj/structure/wreck/car/bike{
-	density = 0;
-	dir = 4;
-	pixel_y = 11;
-	pixel_x = -13
+/obj/structure/table/wood/poker{
+	name = "felt table"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/item/storage/box/dice,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "iKY" = (
 /obj/effect/decal/waste{
 	icon_state = "goo11"
@@ -21647,13 +21646,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "lqe" = (
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/obj/structure/table,
-/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "lqm" = (
 /obj/structure/spacevine,
@@ -22582,11 +22578,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_x = 32
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lWn" = (
 /obj/structure/table/reinforced{
@@ -22865,6 +22859,15 @@
 "mcC" = (
 /obj/structure/sign/poster/prewar/poster79{
 	pixel_x = 32
+	},
+/obj/structure/decoration/vent/rusty{
+	desc = "It's very old and rusty.";
+	name = "rusty grate";
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/machinery/shower{
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
@@ -23657,6 +23660,18 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/city)
+"mzv" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "mzH" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -24118,9 +24133,10 @@
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
 "mMg" = (
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood/house,
+/obj/structure/table/wood/settler,
+/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "mMo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24824,11 +24840,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ngB" = (
-/obj/machinery/mineral/wasteland_trader{
-	pixel_y = 19;
-	density = 0
+/obj/structure/table/wood/poker{
+	name = "felt table"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "ngR" = (
 /obj/structure/chair/office,
@@ -25552,13 +25569,8 @@
 	},
 /area/f13/building/abandoned)
 "nzE" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 4;
-	light_color = "#a83131"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/dresser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nzP" = (
 /obj/effect/decal/cleanable/dirt{
@@ -26789,9 +26801,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "okQ" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_x = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "olc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -27439,12 +27455,19 @@
 	},
 /area/f13/building/abandoned)
 "oDo" = (
-/obj/structure/table,
-/obj/item/reagent_containers/pill/patch/jet{
-	pixel_x = 5;
-	pixel_y = 5
+/mob/living/simple_animal/hostile/wolf/alpha{
+	desc = "Sheepdogs are known for their intelligence and have worked alongside humans for thousands of years. This one has a dopey smile and smells of barbecue sauce.";
+	faction = list("neutral");
+	health = 200;
+	icon_dead = "tippen_dead";
+	icon_living = "tippen";
+	icon_state = "tippen";
+	name = "Dreams-of-Moonlight"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "oDp" = (
 /obj/structure/statue_fal,
@@ -31400,9 +31423,12 @@
 	},
 /area/f13/wasteland)
 "qKY" = (
-/obj/item/trade_sign,
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qLB" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
@@ -33789,9 +33815,18 @@
 	},
 /area/f13/building/abandoned)
 "sdR" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/mob/living/simple_animal/hostile/wolf{
+	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
+	faction = list("neutral");
+	health = 200;
+	maxHealth = 200;
+	name = "Guerrilla";
+	tame = 1
+	},
+/obj/structure/chair/stool/bar,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "sen" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35675,8 +35710,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "taA" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "taE" = (
 /obj/item/stack/ore/slag,
@@ -36887,6 +36924,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
+"tGA" = (
+/obj/structure/flora/small_bush,
+/obj/structure/flora/grass/jungle,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "tGM" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38258,6 +38300,19 @@
 /obj/structure/spacevine,
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
+"uoY" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/gear_harness,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "upg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -38935,14 +38990,13 @@
 	},
 /area/f13/wasteland)
 "uIX" = (
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper/mankini,
 /obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper/mankini,
-/obj/item/clothing/under/misc/stripper/mankini,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uJq" = (
@@ -39003,16 +39057,8 @@
 	},
 /area/f13/wasteland)
 "uKL" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 8;
-	light_color = "#a83131"
-	},
-/obj/structure/sign/poster/prewar/poster80{
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uKM" = (
 /obj/machinery/light/lampost,
@@ -39339,18 +39385,9 @@
 	},
 /area/f13/building/abandoned)
 "uTQ" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_x = 32
 	},
-/obj/item/clothing/under/misc/gear_harness,
-/obj/item/clothing/under/misc/gear_harness,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/green,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uTZ" = (
@@ -39425,6 +39462,14 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland)
+"uWA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "uXa" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -40196,7 +40241,9 @@
 	},
 /area/f13/building/abandoned)
 "vtp" = (
-/obj/structure/simple_door/glass,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -41536,12 +41583,13 @@
 	},
 /area/f13/wasteland)
 "wjn" = (
-/obj/structure/sign/poster/contraband/pinup_bed{
-	pixel_x = -32
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "wjo" = (
 /obj/structure/flora/grass/wasteland{
@@ -41554,9 +41602,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wjs" = (
-/obj/structure/table,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "wjt" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -43808,19 +43861,9 @@
 	},
 /area/f13/wasteland)
 "xwj" = (
-/mob/living/simple_animal/hostile/wolf/alpha{
-	desc = "Sheepdogs are known for their intelligence and have worked alongside humans for thousands of years. This one has a dopey smile and smells of barbecue sauce.";
-	faction = list("neutral");
-	health = 200;
-	icon_dead = "tippen_dead";
-	icon_living = "tippen";
-	icon_state = "tippen";
-	name = "Dreams-of-Moonlight"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xws" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -44478,11 +44521,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xOy" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xOE" = (
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/obj/effect/overlay/junk/sink{
+/obj/structure/sink{
 	pixel_y = 15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -44602,8 +44649,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "xRG" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood/house,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "xRJ" = (
 /obj/item/kirbyplants/dead{
@@ -99447,13 +99499,13 @@ iKf
 iKf
 tiN
 hia
-tiN
+lmY
+lmY
+frx
+frx
 iKf
-lmY
-lmY
-frx
-frx
-mYM
+tGA
+eQD
 qES
 qES
 qES
@@ -99705,12 +99757,12 @@ tiN
 pkw
 hia
 iKf
-wEK
-iKf
 qES
 uhb
 qES
+qES
 kVN
+qES
 qES
 qES
 egf
@@ -99961,11 +100013,11 @@ iKf
 iKf
 iKf
 iKf
-tiN
-wEK
 qES
 qES
 uhb
+qES
+qES
 qES
 qES
 qES
@@ -100218,13 +100270,13 @@ tiN
 iKf
 iKf
 iKf
-iKf
-tiN
 qES
 qES
 eVJ
 qES
+qES
 yky
+qES
 qES
 iKf
 qES
@@ -100475,8 +100527,8 @@ iKf
 rQm
 tiN
 iKf
-tiN
-iKf
+qES
+qES
 qES
 qES
 qES
@@ -100733,12 +100785,12 @@ tDc
 iKf
 iKf
 iKf
+qES
+qES
+qES
+qES
+qES
 iKf
-iKf
-qES
-qES
-qES
-qES
 dua
 iKf
 qES
@@ -100989,15 +101041,15 @@ wEK
 iKf
 tiN
 iKf
-iKf
-iKf
 tiN
-qKY
 qES
 qES
+qES
+qES
+iKf
 iKf
 dSf
-iKf
+xwj
 qES
 iKf
 iKf
@@ -101245,16 +101297,16 @@ bGx
 iKf
 iKf
 iKf
-iKf
-iKf
-iKf
-iKf
-qES
-qES
-qES
-tiN
-iKV
-iKf
+aLl
+aLl
+vtp
+vtp
+vtp
+cYp
+lFI
+lFI
+dSf
+dSf
 qES
 iKf
 iKf
@@ -101502,18 +101554,18 @@ iKf
 iKf
 iKf
 iKf
-lmY
-iKf
-aLl
-aLl
-aLl
-dOr
-qES
-okQ
-frr
+wjn
+taA
 wjs
-qES
-iKf
+wjs
+wjs
+uWA
+eJW
+qsc
+eFz
+lVQ
+sOU
+dOr
 iKf
 iKf
 iKf
@@ -101759,18 +101811,18 @@ iKf
 iKf
 iKf
 iKf
-iKf
-iKf
-xRG
+lFI
+eJW
+azf
 sdR
-sdR
-aLl
-lqe
-hip
+azf
+eJW
+eJW
+lmR
+eJW
+eJW
+eJW
 eFz
-lVQ
-sOU
-dOr
 aLl
 lFI
 oLK
@@ -102016,17 +102068,17 @@ iKf
 iKf
 iKf
 iKf
-lmY
-iKf
+lFI
+mzv
 xRG
 ngB
-nSg
-eey
-nSg
-iyT
-taA
-eey
-nSg
+iKV
+azf
+eJW
+lmR
+eJW
+eJW
+eJW
 asF
 nSg
 jCe
@@ -102273,17 +102325,17 @@ iKf
 tiN
 tiN
 iKf
-wEK
-lmY
-xRG
+lFI
+eJW
+azf
 oDo
-fqZ
-nSg
-nSg
-iyT
-emA
-nSg
-nSg
+azf
+eJW
+eJW
+lmR
+eJW
+eJW
+eJW
 eFz
 xOE
 brf
@@ -102530,17 +102582,17 @@ iKf
 iKf
 cqd
 cqd
-iKf
-iKf
-mMg
-vse
-nSg
+lFI
+fde
+eJW
+eJW
+okQ
 lWl
-nSg
-vtp
-nSg
-hze
-nSg
+eJW
+qsc
+eJW
+eJW
+eJW
 cYp
 mcC
 eGK
@@ -102787,25 +102839,25 @@ tiN
 wEK
 tiN
 iKf
-iKf
-iKf
-dOr
+tej
+tej
 aLl
 aLl
 qsc
 qsc
 kHJ
 qsc
-qsc
-vtp
+plJ
+eJW
+eJW
 tIi
 qsc
 qsc
 kQO
 eFz
+eFz
+eFz
 gRn
-gRn
-wWK
 eHB
 wWK
 eHB
@@ -103052,16 +103104,16 @@ sHR
 iXF
 rVB
 lmR
-wjn
-uKL
+eJW
+eJW
 eJW
 qsc
-eZH
-oPM
+uKL
 nSg
-tIi
-gRn
-gRn
+emA
+emA
+nSg
+eFz
 gRn
 wWK
 wWK
@@ -103313,12 +103365,12 @@ eJW
 eJW
 eJW
 qsc
-mYK
-lzn
-nSg
+eey
+emA
+rhU
+rhU
+emA
 eFz
-gRn
-gRn
 gRn
 iRq
 wWK
@@ -103572,12 +103624,12 @@ eJW
 asF
 nSg
 nSg
-nSg
-xRG
+emA
+emA
+vjt
+eFz
 gRn
 gRn
-wWK
-wWK
 gRn
 gRn
 gRn
@@ -103827,17 +103879,17 @@ eUV
 eJW
 twt
 qsc
-uIX
+nSg
 uTQ
 nSg
-xRG
-gRn
-gRn
-wWK
-tCq
-wWK
-gRn
-gRn
+nSg
+nSg
+eFz
+eFz
+eFz
+eFz
+eFz
+eFz
 gRn
 gRn
 gMW
@@ -104086,15 +104138,15 @@ fYC
 qsc
 sZy
 qsc
+qsc
 pfv
-cYp
-gRn
-gRn
-gRn
-wWK
-eHB
-wWK
-gRn
+qsc
+eFz
+eZH
+oPM
+nSg
+nzE
+eFz
 gRn
 gRn
 wWK
@@ -104344,14 +104396,14 @@ bJD
 xeQ
 rhU
 nSg
+nSg
+nSg
 lFI
-gRn
-gRn
-gRn
-wWK
-eHB
-wWK
-gRn
+mYK
+lzn
+nSg
+mMg
+eFz
 gRn
 gRn
 wWK
@@ -104594,21 +104646,21 @@ maJ
 jLU
 fOH
 lmR
-xwj
+eJW
 eJW
 azf
 xPe
 vqc
 rhU
 nSg
-fde
-gRn
-gRn
-gRn
-wWK
-iRq
-gRn
-gRn
+nSg
+nSg
+pfv
+nSg
+nSg
+nSg
+nSg
+eFz
 gRn
 gRn
 wWK
@@ -104857,15 +104909,15 @@ azf
 bJD
 rhU
 rhU
+nSg
+nSg
 iAq
 yjb
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+qKY
+uoY
+uIX
+xOy
+eFz
 gRn
 gRn
 wWK
@@ -105113,18 +105165,18 @@ eJW
 cur
 qsc
 biI
-sZy
+biI
+qsc
 rzY
+qsc
 xYV
 eFz
 fHz
 cYp
 wyI
-lFI
+eFz
 gRn
 gRn
-gRn
-wWK
 wWK
 wWK
 wWK
@@ -105372,6 +105424,7 @@ ryS
 atp
 srD
 vYO
+vYO
 cYp
 jPB
 jSc
@@ -105379,8 +105432,7 @@ epr
 ndB
 bdy
 gRn
-wWK
-wWK
+gRn
 wWK
 wWK
 gMW
@@ -105629,6 +105681,7 @@ ryS
 vYO
 vYO
 vYO
+vYO
 cYp
 nSg
 nSg
@@ -105636,10 +105689,9 @@ nSg
 nSg
 vDB
 gRn
+gRn
 wWK
 wWK
-wWK
-gMW
 gMW
 gMW
 wWK
@@ -105885,6 +105937,7 @@ wuW
 ryS
 vYO
 vYO
+vYO
 vvk
 tpy
 wnb
@@ -105895,7 +105948,6 @@ tej
 gRn
 wWK
 wWK
-gMW
 gMW
 gMW
 gMW
@@ -106143,13 +106195,13 @@ ryS
 vYO
 vYO
 vYO
+vYO
 rzY
 nSg
 nSg
 nSg
 cUP
 tej
-gRn
 gRn
 wWK
 gMW
@@ -106400,13 +106452,13 @@ ryS
 dOB
 ryS
 ryS
+hip
 lFI
 sHS
 nMG
 kew
 ezM
 eFz
-gRn
 gRn
 wWK
 gMW
@@ -106649,7 +106701,7 @@ euo
 euo
 euo
 gRn
-gRn
+hze
 eFz
 eJW
 nSg
@@ -106657,13 +106709,13 @@ iFh
 iFh
 iFh
 iFh
+lFI
 hip
 fHz
 fHz
 cYp
 eFz
 eFz
-gRn
 gRn
 wWK
 gMW
@@ -106906,8 +106958,8 @@ jZn
 gRn
 gRn
 gRn
-gRn
 cYp
+lqe
 eJW
 eJW
 eJW
@@ -106921,7 +106973,7 @@ gRn
 gRn
 gRn
 gRn
-wWK
+gRn
 wWK
 gRn
 kOR
@@ -107163,8 +107215,8 @@ gRn
 gRn
 gRn
 gRn
-gRn
 fHz
+iyT
 eJW
 huC
 eJW
@@ -107179,7 +107231,7 @@ gRn
 wWK
 wWK
 wWK
-gRn
+wWK
 gRn
 nsO
 xnv
@@ -107420,9 +107472,9 @@ gRn
 gRn
 gRn
 gRn
-gRn
 aLl
-nzE
+fqZ
+eJW
 ibV
 eJW
 sAa
@@ -107436,7 +107488,7 @@ gRn
 wWK
 gRn
 gRn
-gRn
+wWK
 gRn
 kOR
 eft
@@ -107677,9 +107729,9 @@ gRn
 gRn
 gRn
 gRn
-gRn
+lFI
 fHz
-cYp
+fHz
 eFz
 tvk
 cYp
@@ -109215,7 +109267,7 @@ gMW
 gMW
 gMW
 gMW
-gMW
+gRn
 gRn
 gRn
 gRn
@@ -109472,17 +109524,17 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
 gMW
 gMW
 gMW
@@ -109729,17 +109781,17 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
 gMW
 gMW
 gMW
@@ -109986,17 +110038,17 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
 gMW
 gMW
 gMW
@@ -110243,17 +110295,17 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
 gMW
 gMW
 gMW
@@ -110500,17 +110552,17 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
+gRn
 gMW
 gMW
 gMW

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -4718,6 +4718,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/city)
+"cCh" = (
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "cCB" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -7833,8 +7839,7 @@
 	},
 /area/f13/building)
 "eey" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/cups,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eeA" = (
@@ -9604,16 +9609,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fde" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/jet,
-/obj/item/reagent_containers/pill/patch/jet{
-	pixel_x = -5;
-	pixel_y = 18
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars{
+	max_integrity = 800;
+	name = "strong metal bars";
+	obj_integrity = 800
 	},
-/obj/item/reagent_containers/hypospray/medipen/medx,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "fdv" = (
 /obj/structure/flora/small_bush,
@@ -10209,11 +10211,10 @@
 	},
 /area/f13/wasteland)
 "fqZ" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/flora/small_bush,
+/obj/structure/flora/grass/jungle,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "frh" = (
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -14164,8 +14165,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hze" = (
-/turf/closed/wall/f13/wood/house,
-/area/f13/caves)
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "hzq" = (
 /obj/structure/closet,
 /obj/item/clothing/under/f13/relaxedwear{
@@ -16092,7 +16102,13 @@
 	},
 /area/f13/wasteland)
 "iyT" = (
-/obj/machinery/vending/cola/random,
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/hypospray/medipen/medx,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -16624,10 +16640,9 @@
 	},
 /area/f13/building)
 "iKV" = (
-/obj/structure/table/wood/poker{
-	name = "felt table"
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/obj/item/storage/box/dice,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -21646,11 +21661,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "lqe" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/tires,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lqm" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine,
@@ -23660,18 +23673,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/city)
-"mzv" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "mzH" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -24133,9 +24134,13 @@
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
 "mMg" = (
-/obj/structure/table/wood/settler,
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/structure/closet/cabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "mMo" = (
@@ -25569,7 +25574,8 @@
 	},
 /area/f13/building/abandoned)
 "nzE" = (
-/obj/structure/dresser,
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "nzP" = (
@@ -26801,9 +26807,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "okQ" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_x = 32
-	},
+/obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -26954,6 +26958,14 @@
 	dir = 10
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"opl" = (
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_x = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "ops" = (
 /obj/structure/flora/grass/wasteland{
@@ -31423,11 +31435,13 @@
 	},
 /area/f13/wasteland)
 "qKY" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain{
+	color = "#363636";
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "qLB" = (
 /obj/structure/barricade/sandbags,
@@ -35710,10 +35724,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "taA" = (
-/obj/machinery/vending/games,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/dresser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "taE" = (
 /obj/item/stack/ore/slag,
@@ -36924,11 +36936,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned)
-"tGA" = (
-/obj/structure/flora/small_bush,
-/obj/structure/flora/grass/jungle,
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "tGM" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38300,19 +38307,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
-"uoY" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/clothing/under/misc/gear_harness,
-/obj/item/clothing/under/misc/gear_harness,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "upg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -38600,6 +38594,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"uwX" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "uwY" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden/planks{
@@ -38761,6 +38761,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"uCG" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "uCV" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks,
@@ -38990,13 +38996,10 @@
 	},
 /area/f13/wasteland)
 "uIX" = (
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/mankini,
-/obj/item/clothing/under/misc/stripper/mankini,
 /obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uJq" = (
@@ -39057,8 +39060,13 @@
 	},
 /area/f13/wasteland)
 "uKL" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/wood/poker{
+	name = "felt table"
+	},
+/obj/item/storage/box/dice,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "uKM" = (
 /obj/machinery/light/lampost,
@@ -39462,14 +39470,6 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/savannah/edgesnew,
 /area/f13/wasteland)
-"uWA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "uXa" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
@@ -40241,8 +40241,8 @@
 	},
 /area/f13/building/abandoned)
 "vtp" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -41583,13 +41583,8 @@
 	},
 /area/f13/wasteland)
 "wjn" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/turf/closed/wall/f13/wood/house,
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wjo" = (
 /obj/structure/flora/grass/wasteland{
@@ -41602,13 +41597,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wjs" = (
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/table/wood/settler,
+/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wjt" = (
 /obj/structure/flora/tree/tall{
@@ -43861,9 +43853,18 @@
 	},
 /area/f13/wasteland)
 "xwj" = (
-/obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/gear_harness,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xws" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -44521,10 +44522,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"xOy" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "xOE" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -99504,7 +99501,7 @@ lmY
 frx
 frx
 iKf
-tGA
+fqZ
 eQD
 qES
 qES
@@ -101049,7 +101046,7 @@ qES
 iKf
 iKf
 dSf
-xwj
+lqe
 qES
 iKf
 iKf
@@ -101299,9 +101296,9 @@ iKf
 iKf
 aLl
 aLl
-vtp
-vtp
-vtp
+iKV
+iKV
+iKV
 cYp
 lFI
 lFI
@@ -101554,12 +101551,12 @@ iKf
 iKf
 iKf
 iKf
-wjn
-taA
-wjs
-wjs
-wjs
-uWA
+fde
+cCh
+qKY
+qKY
+qKY
+vtp
 eJW
 qsc
 eFz
@@ -102069,10 +102066,10 @@ iKf
 iKf
 iKf
 lFI
-mzv
+hze
 xRG
 ngB
-iKV
+uKL
 azf
 eJW
 lmR
@@ -102583,10 +102580,10 @@ iKf
 cqd
 cqd
 lFI
-fde
+iyT
 eJW
 eJW
-okQ
+opl
 lWl
 eJW
 qsc
@@ -103108,7 +103105,7 @@ eJW
 eJW
 eJW
 qsc
-uKL
+eey
 nSg
 emA
 emA
@@ -103365,7 +103362,7 @@ eJW
 eJW
 eJW
 qsc
-eey
+nzE
 emA
 rhU
 rhU
@@ -104145,7 +104142,7 @@ eFz
 eZH
 oPM
 nSg
-nzE
+taA
 eFz
 gRn
 gRn
@@ -104402,7 +104399,7 @@ lFI
 mYK
 lzn
 nSg
-mMg
+wjs
 eFz
 gRn
 gRn
@@ -104913,10 +104910,10 @@ nSg
 nSg
 iAq
 yjb
-qKY
-uoY
 uIX
-xOy
+xwj
+mMg
+wjn
 eFz
 gRn
 gRn
@@ -106701,7 +106698,7 @@ euo
 euo
 euo
 gRn
-hze
+eFz
 eFz
 eJW
 nSg
@@ -106959,7 +106956,7 @@ gRn
 gRn
 gRn
 cYp
-lqe
+uCG
 eJW
 eJW
 eJW
@@ -107216,7 +107213,7 @@ gRn
 gRn
 gRn
 fHz
-iyT
+uwX
 eJW
 huC
 eJW
@@ -107473,7 +107470,7 @@ gRn
 gRn
 gRn
 aLl
-fqZ
+okQ
 eJW
 ibV
 eJW


### PR DESCRIPTION
## About The Pull Request
Gives Ashdown bar a facelift, adds a small poker room, break room, and re-adjusts the dressing room so not everyone has to walk through it to get to the bar.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: New poker room, outfits, autodrobe, staff lounge
del: Old workshop room by entrance
tweak: Cleaned the bathroom
/:cl:
Revamped bar image: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/fb017448-ad92-4a16-be0b-3e88b2623fa2)

