### PR TITLE
[DNM] Re-adds gangs, gang-tool for wasters.

### DIFF
--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -79,13 +79,13 @@
 /datum/gang_item/clothing/glasses/sunglasses
 	name = "Sunglasses"
 	id = "sunglasses"
-	cost = 20
+	cost = 30
 	item_path = /obj/item/clothing/glasses/sunglasses
 
 /datum/gang_item/clothing/raider_uniform
 	name = "Raider uniform"
 	id = "raider_uniform"
-	cost = 20
+	cost = 10
 	item_path = /obj/item/clothing/under/f13/raider_leather
 
 /datum/gang_item/clothing/jester_uniform
@@ -103,19 +103,19 @@
 /datum/gang_item/clothing/scarecrow_uniform
 	name = "Scarecrow uniform"
 	id = "scarecrow_uniform"
-	cost = 20
+	cost = 10
 	item_path = /obj/item/clothing/under/scarecrow
 
 /datum/gang_item/clothing/soviet_uniform
 	name = "Soviet uniform"
 	id = "soviet_uniform"
-	cost = 20
+	cost = 10
 	item_path = /obj/item/clothing/under/soviet
 
 /datum/gang_item/clothing/chairmen_uniform
 	name = "Chairmen uniform"
 	id = "chairmen_uniform"
-	cost = 20
+	cost = 10
 	item_path = /obj/item/clothing/under/f13/bennys/gang
 
 /obj/item/clothing/under/f13/bennys/gang
@@ -137,7 +137,7 @@
 /datum/gang_item/weapon/shuriken
 	name = "Shuriken"
 	id = "shuriken"
-	cost = 30
+	cost = 10
 	item_path = /obj/item/throwing_star
 
 /datum/gang_item/weapon/switchblade
@@ -167,13 +167,13 @@
 /datum/gang_item/weapon/sappers
 	name = "Sappers"
 	id = "sappers"
-	cost = 75
+	cost = 35
 	item_path = /obj/item/melee/unarmed/sappers
 
 /datum/gang_item/weapon/greasegun
 	name = "Grease Gun"
 	id = "greasegun"
-	cost = 300
+	cost = 120
 	item_path = /obj/item/gun/ballistic/automatic/smg/greasegun
 
 /datum/gang_item/weapon/uzi
@@ -191,7 +191,7 @@
 /datum/gang_item/weapon/type93
 	name = "Worn Type 93"
 	id = "worntype93"
-	cost = 500
+	cost = 250
 	item_path = /obj/item/gun/ballistic/automatic/type93/worn
 
 
@@ -205,47 +205,47 @@
 /datum/gang_item/equipment/spraycan
 	name = "Spraycan"
 	id = "spraycan"
-	cost = 10
+	cost = 5
 	item_path = /obj/item/toy/crayon/spraycan
 
 /datum/gang_item/equipment/mentats
 	name = "Mentats"
 	id = "mentats"
-	cost = 30
+	cost = 90
 	item_path = /obj/item/storage/pill_bottle/chem_tin/mentats
 
 /datum/gang_item/equipment/fixer
 	name = "Fixer"
 	id = "fixer"
-	cost = 30
+	cost = 90
 	item_path = /obj/item/storage/pill_bottle/chem_tin/fixer
 
 /datum/gang_item/equipment/emp
 	name = "EMP Grenade"
 	id = "EMP"
-	cost = 95
+	cost = 135
 	item_path = /obj/item/grenade/empgrenade
 
 /datum/gang_item/equipment/necklace
 	name = "Gold Necklace"
 	id = "necklace"
-	cost = 150
+	cost = 70
 	item_path = /obj/item/clothing/neck/necklace/dope
 
 /datum/gang_item/equipment/c4
 	name = "C4 Explosive"
 	id = "c4"
-	cost = 100
+	cost = 150
 	item_path = /obj/item/grenade/plastic/c4
 
 /datum/gang_item/equipment/stinger
 	name = "Stinger"
-	cost = 75
+	cost = 100
 	item_path = /obj/item/grenade/f13/stinger
 
 /datum/gang_item/equipment/he
 	name = "High Explosive Grenade"
-	cost = 100
+	cost = 150
 	item_path = /datum/crafting_recipe/concussion
 
 
@@ -261,7 +261,7 @@
 /datum/gang_item/equipment/bundledenboss
 	name = "Drug Lord Bundle"
 	id = "bundledenboss"
-	cost = 850
+	cost = 420
 	item_path = /obj/item/storage/box/bundledenboss
 
 /obj/item/storage/box/bundledenboss
@@ -296,10 +296,29 @@
 	new /obj/item/grenade/syndieminibomb/concussion(src)
 	new /obj/item/clothing/suit/bomb_suit(src)
 
+/datum/gang_item/equipment/bundleboss
+	name = "Big Boss"
+	id = "bundleboss"
+	cost = 1200
+	item_path = /obj/item/storage/box/bundleboss
+
+/obj/item/storage/box/bundleboss
+	name = "Big Boss"
+	desc = "For the Biggest Outlaw around"
+	
+/obj/item/storage/box/bundleanarchist/PopulateContents()
+	new /obj/item/reagent_containers/hypospray/medipen/medx(src)
+	new /obj/item/reagent_containers/hypospray/medipen/psycho(src)
+	new /obj/item/clothing/suit/armor/power_armor/t45b/raider(src)
+	new /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller(src)
+	new /obj/item/clothing/head/helmet/f13/power_armor/t45b/raider(src)
+	new /obj/item/ammo_box/shotgun/slug(src)
+
+
 /datum/gang_item/equipment/bundlegunner
 	name = "Old Soldier Bundle"
 	id = "bundlegunner"
-	cost = 400
+	cost = 350
 	item_path = /obj/item/storage/box/bundlegunner
 
 /obj/item/storage/box/bundlegunner
@@ -310,7 +329,7 @@
 	new /obj/item/gun/ballistic/automatic/smg/greasegun(src)
 	new /obj/item/ammo_box/magazine/greasegun(src)
 	new /obj/item/clothing/head/helmet/armyhelmet(src)
-	new /obj/item/storage/belt/fannypack(src)
+	new /obj/item/storage/belt(src)
 	new /obj/item/clothing/under/f13/army(src)
 	new /obj/item/gun/ballistic/automatic/pistol/m1911(src)
 	new /obj/item/grenade/frag(src)
@@ -318,7 +337,7 @@
 /datum/gang_item/equipment/bundleelguapo
 	name = "Bandito Bundle"
 	id = "bundleelguapo"
-	cost = 300
+	cost = 350
 	item_path = /obj/item/storage/box/bundleelguapo
 
 /obj/item/storage/box/bundleelguapo
@@ -330,4 +349,4 @@
 	new /obj/item/ammo_box/a357box/ricochet(src)
 	new /obj/item/gun/ballistic/revolver/colt357(src)
 	new /obj/item/clothing/head/f13/ranger_hat(src)
-	new /obj/item/clothing/suit/armor/light/leather/leathercoat(src)
+	new /obj/item/clothing/suit/armor/medium/raider/combatduster(src)

--- a/code/modules/fallout/misc/gangs.dm
+++ b/code/modules/fallout/misc/gangs.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_INIT(gang_names, list ( \
 ))
 
 //Which social factions are allowed to join gangs?
-GLOBAL_LIST_INIT(allowed_gang_factions, list (FACTION_RAIDERS, FACTION_TRIBE))
+GLOBAL_LIST_INIT(allowed_gang_factions, list (FACTION_RAIDERS, FACTION_TRIBE, FACTION_WASTELAND))
 
 // List of all existing gangs
 GLOBAL_LIST_EMPTY(all_gangs)
@@ -60,6 +60,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 		/datum/gang_item/equipment/bundleanarchist,
 		/datum/gang_item/equipment/bundlegunner,
 		/datum/gang_item/equipment/bundledenboss,
+		/datum/gang_item/equipment/bundleboss,
 	)
 
 //Round-start gangs
@@ -128,7 +129,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	if(!round_start)
 		add_verb(new_leader,/mob/living/proc/setcolor)
 	add_verb(new_leader,/mob/living/proc/leavegang)
-	to_chat(new_leader, span_notice("You have become a new leader of the [name]! You can now invite and remove members at will. You have also received a Gangtool device that allows you to buy a special gear for you and your gang."))
+	to_chat(new_leader, "<span class='notice'>You have become a new leader of the [name]! You can now invite and remove members at will. You have also received a Gangtool device that allows you to buy a special gear for you and your gang.</span>")
 
 	var/obj/item/device/gangtool/gangtool = new(new_leader)
 	gangtool.gang = new_leader.gang
@@ -157,9 +158,9 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	if(!round_start)
 		remove_verb(old_leader,/mob/living/proc/setcolor)
 	add_verb(old_leader,/mob/living/proc/assumeleader)
-	to_chat(old_leader, span_warning("You are no longer the leader of the [name]!"))
+	to_chat(old_leader, "<span class='warning'>You are no longer the leader of the [name]!</span>")
 	if(assigned_tool)
-		assigned_tool.audible_message(span_warning("With a change of the [name] leadership, [assigned_tool] ceases to function and self-destructs!"))
+		assigned_tool.audible_message("<span class='warning'>With a change of the [name] leadership, [assigned_tool] ceases to function and self-destructs!</span>")
 		qdel(assigned_tool)
 
 /datum/gang/proc/add_member(mob/living/carbon/new_member)
@@ -170,7 +171,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	add_verb(new_member,/mob/living/proc/leavegang)
 
 	add_verb(new_member,/mob/living/proc/assumeleader)
-	to_chat(new_member, span_notice("You are now a member of the [name]! Everyone can recognize your gang membership now."))
+	to_chat(new_member, "<span class='notice'>You are now a member of the [name]! Everyone can recognize your gang membership now.</span>")
 	if(welcome_text)
 		to_chat(new_member, "<span class='notice'>Welcome text: </span><span class='purple'>[welcome_text]</span>")
 
@@ -181,7 +182,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	add_verb(member,/mob/living/proc/creategang)
 	remove_verb(member,/mob/living/proc/leavegang)
 	remove_verb(member,/mob/living/proc/assumeleader)
-	to_chat(member, span_warning("You are no longer a member of the [name]!"))
+	to_chat(member, "<span class='warning'>You are no longer a member of the [name]!</span>")
 
 	if(!members.len && !round_start)
 		GLOB.gang_names -= lowertext(name)
@@ -232,7 +233,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 		return
 	input = copytext(sanitize(input), 1, 30)
 	if(lowertext(input) in GLOB.gang_names)
-		to_chat(src, span_notice("This gang name is already taken!"))
+		to_chat(src, "<span class='notice'>This gang name is already taken!</span>")
 		return
 	GLOB.gang_names |= lowertext(input)
 
@@ -240,7 +241,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	G.name = input
 	GLOB.all_gangs |= G
 	gang = G
-	to_chat(src, span_notice("You have created [G.name]!"))
+	to_chat(src, "<span class='notice'>You have created [G.name]!</span>")
 
 	G.add_member(src)
 	G.add_leader(src)
@@ -269,7 +270,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	if(G && G.leader)
 		var/mob/living/L = G.leader
 		if(L.stat != DEAD && L.client)
-			to_chat(src, span_warning("Gang leader is still alive and well!"))
+			to_chat(src, "<span class='warning'>Gang leader is still alive and well!</span>")
 			return
 		else
 			G.remove_leader(L)
@@ -300,8 +301,8 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 		if(!new_leader || new_leader == src)
 			return
 		var/mob/living/H = new_leader
-		to_chat(src, span_notice("You have transferred gang leadership of the [G.name] to [H.real_name]!"))
-		to_chat(H, span_notice("You have received gang leadership of the [G.name] from [src.real_name]!"))
+		to_chat(src, "<span class='notice'>You have transferred gang leadership of the [G.name] to [H.real_name]!</span>")
+		to_chat(H, "<span class='notice'>You have received gang leadership of the [G.name] from [src.real_name]!</span>")
 		G.remove_leader(src)
 		G.add_leader(H)
 
@@ -329,8 +330,8 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 			return
 
 		var/mob/living/H = kicked_member
-		to_chat(src, span_notice("You have removed [H.real_name] from the [G.name]!"))
-		to_chat(H, span_warning("You have been kicked from the [G.name] by [src.real_name]!"))
+		to_chat(src, "<span class='notice'>You have removed [H.real_name] from the [G.name]!</span>")
+		to_chat(H, "<span class='warning'>You have been kicked from the [G.name] by [src.real_name]!</span>")
 		G.remove_member(H)
 
 /mob/living/proc/setwelcome()
@@ -345,7 +346,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 	input = copytext(sanitize(input), 1, 300)
 	G.welcome_text = input
 
-	to_chat(src, span_notice("You have set a welcome text for a new gang members!"))
+	to_chat(src, "<span class='notice'>You have set a welcome text for a new gang members!</span>")
 
 /mob/living/proc/setcolor()
 	set name = "Choose Gang Color"
@@ -358,4 +359,5 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 		return
 	G.color = sanitize_color(picked_color)
 
-	to_chat(src, span_notice("You have chosen a new gang color!"))
+	to_chat(src, "<span class='notice'>You have chosen a new gang color!</span>")
+

--- a/code/modules/fallout/misc/tribes.dm
+++ b/code/modules/fallout/misc/tribes.dm
@@ -14,7 +14,7 @@
 	add_verb(new_leader,/mob/living/proc/set_tribe_welcome)
 	if(!round_start)
 		add_verb(new_leader,/mob/living/proc/set_tribe_color)
-	to_chat(new_leader, span_notice("You have become a new leader of the [name]! You can now invite and remove members at will."))
+	to_chat(new_leader, "<span class='notice'>You have become a new leader of the [name]! You can now invite and remove members at will.</span>")
 
 	var/obj/item/device/gangtool/gangtool = new(new_leader)
 	gangtool.gang = new_leader.gang
@@ -43,7 +43,7 @@
 	if(!round_start)
 		remove_verb(old_leader,/mob/living/proc/set_tribe_color)
 	add_verb(old_leader,/mob/living/proc/assume_tribe_leader)
-	to_chat(old_leader, span_warning("You are no longer the leader of the [name]!"))
+	to_chat(old_leader, "<span class='warning'>You are no longer the leader of the [name]!</span>")
 
 /datum/gang/tribe/add_member(mob/living/carbon/new_member)
 	members |= new_member
@@ -53,7 +53,7 @@
 	add_verb(new_member,/mob/living/proc/leave_tribe)
 
 	add_verb(new_member,/mob/living/proc/assume_tribe_leader)
-	to_chat(new_member, span_notice("You are now a member of the [name]! Everyone can recognize your tribe."))
+	to_chat(new_member, "<span class='notice'>You are now a member of the [name]! Everyone can recognize your tribe.</span>")
 	if(welcome_text)
 		to_chat(new_member, "<span class='notice'>Welcome text: </span><span class='purple'>[welcome_text]</span>")
 
@@ -64,7 +64,7 @@
 	add_verb(member,/mob/living/proc/create_tribe)
 	remove_verb(member,/mob/living/proc/leave_tribe)
 	remove_verb(member,/mob/living/proc/assume_tribe_leader)
-	to_chat(member, span_warning("You are no longer a member of the [name]!"))
+	to_chat(member, "<span class='warning'>You are no longer a member of the [name]!</span>")
 
 	if(!members.len && !round_start)
 		GLOB.gang_names -= lowertext(name)
@@ -115,7 +115,7 @@
 		return
 	input = copytext(sanitize(input), 1, 30)
 	if(lowertext(input) in GLOB.gang_names)
-		to_chat(src, span_notice("This tribe name is already taken!"))
+		to_chat(src, "<span class='notice'>This tribe name is already taken!</span>")
 		return
 	GLOB.gang_names |= lowertext(input)
 
@@ -123,7 +123,7 @@
 	G.name = input
 	GLOB.all_gangs |= G
 	gang = G
-	to_chat(src, span_notice("You have created [G.name]!"))
+	to_chat(src, "<span class='notice'>You have created [G.name]!</span>")
 
 	G.add_member(src)
 	G.add_leader(src)
@@ -152,7 +152,7 @@
 	if(G && G.leader)
 		var/mob/living/L = G.leader
 		if(L.stat != DEAD && L.client)
-			to_chat(src, span_warning("Tribe leader is still alive and well!"))
+			to_chat(src, "<span class='warning'>Tribe leader is still alive and well!</span>")
 			return
 		else
 			G.remove_leader(L)
@@ -183,8 +183,8 @@
 		if(!new_leader || new_leader == src)
 			return
 		var/mob/living/H = new_leader
-		to_chat(src, span_notice("You have transferred tribe leadership of the [G.name] to [H.real_name]!"))
-		to_chat(H, span_notice("You have received tribe leadership of the [G.name] from [src.real_name]!"))
+		to_chat(src, "<span class='notice'>You have transferred tribe leadership of the [G.name] to [H.real_name]!</span>")
+		to_chat(H, "<span class='notice'>You have received tribe leadership of the [G.name] from [src.real_name]!</span>")
 		G.remove_leader(src)
 		G.add_leader(H)
 
@@ -212,8 +212,8 @@
 			return
 
 		var/mob/living/H = kicked_member
-		to_chat(src, span_notice("You have removed [H.real_name] from the [G.name]!"))
-		to_chat(H, span_warning("You have been kicked from the [G.name] by [src.real_name]!"))
+		to_chat(src, "<span class='notice'>You have removed [H.real_name] from the [G.name]!</span>")
+		to_chat(H, "<span class='warning'>You have been kicked from the [G.name] by [src.real_name]!</span>")
 		G.remove_member(H)
 
 /mob/living/proc/set_tribe_welcome()
@@ -228,7 +228,7 @@
 	input = copytext(sanitize(input), 1, 300)
 	G.welcome_text = input
 
-	to_chat(src, span_notice("You have set a welcome text for a new tribe members!"))
+	to_chat(src, "<span class='notice'>You have set a welcome text for a new tribe members!</span>")
 
 /mob/living/proc/set_tribe_color()
 	set name = "Choose Tribe Color"
@@ -241,4 +241,4 @@
 		return
 	G.color = sanitize_color(picked_color)
 
-	to_chat(src, span_notice("You have chosen a new tribe color!"))
+	to_chat(src, "<span class='notice'>You have chosen a new tribe color!</span>")

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -996,7 +996,8 @@ Raider
 		)
 
 /datum/outfit/job/wasteland/f13wastelander/pre_equip(mob/living/carbon/human/H)
-	..()
+	. = ..()
+	add_verb(H, /mob/living/proc/creategang)
 	uniform = pick(
 		/obj/item/clothing/under/f13/settler, \
 		/obj/item/clothing/under/f13/brahminm, \
@@ -1317,6 +1318,11 @@ Raider
 	title = "Ashdown Wastelander"
 	total_positions = 25
 	spawn_positions = 25
+	outfit = /datum/outfit/job/wasteland/f13wastelander/ashdown
+
+/datum/outfit/job/wasteland/f13wastelander/ashdown/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	add_verb(H, /mob/living/proc/creategang)
 
 /*/datum/job/wasteland/f13enforcer
 	title = "Den Mob Enforcer"


### PR DESCRIPTION
## About The Pull Request
WIP, works for Ashdown Waster and regular waster- just not really got proper kits or 'items' yet. Tool still uses 'caps, auereus, denari', so on.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Waster gang tool for ashdown and waster proper.
fix: Gang Tool works now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
