### PR TITLE
Nash clinic content pass, Ashdown curtain fix

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -1050,10 +1050,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic)
 "kF" = (
-/obj/structure/table,
-/obj/item/toy/plush/beeplushie,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/hospital/clinic)
 "kH" = (
 /turf/open/floor/wood_wide{
@@ -1961,6 +1959,12 @@
 	color = "#779999"
 	},
 /area/f13/building/abandoned)
+"tt" = (
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/wasteland)
 "tA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -3185,8 +3189,8 @@
 /area/f13/wasteland)
 "ES" = (
 /obj/structure/table,
-/obj/item/toy/plush/lizardplushie,
 /obj/machinery/light,
+/obj/effect/spawner/lootdrop/plush,
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic)
 "ET" = (
@@ -9203,7 +9207,7 @@ FS
 dA
 HN
 hL
-kF
+ES
 FS
 dA
 HN
@@ -9711,8 +9715,8 @@ Wr
 Wr
 Wr
 Wr
-Wr
-Xv
+SR
+Wg
 FS
 FS
 FS
@@ -9968,8 +9972,8 @@ Wr
 Wr
 Wr
 Wr
-SR
-Fg
+Xv
+tt
 FS
 Dc
 Gi
@@ -10227,7 +10231,7 @@ Wr
 Wr
 Xv
 FS
-FS
+kF
 VU
 VU
 VU

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -1050,8 +1050,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic)
 "kF" = (
-/obj/machinery/mineral/wasteland_vendor/medical,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/plush,
+/turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic)
 "kH" = (
 /turf/open/floor/wood_wide{
@@ -1959,12 +1961,6 @@
 	color = "#779999"
 	},
 /area/f13/building/abandoned)
-"tt" = (
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
-	},
-/area/f13/wasteland)
 "tA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -3188,10 +3184,8 @@
 	},
 /area/f13/wasteland)
 "ES" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/plush,
-/turf/open/floor/f13/wood,
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/hospital/clinic)
 "ET" = (
 /obj/structure/bed/dogbed,
@@ -9207,12 +9201,12 @@ FS
 dA
 HN
 hL
-ES
+kF
 FS
 dA
 HN
 hL
-ES
+kF
 FS
 SP
 qt
@@ -9973,7 +9967,7 @@ Wr
 Wr
 Wr
 Xv
-tt
+FS
 FS
 Dc
 Gi
@@ -10231,7 +10225,7 @@ Wr
 Wr
 Xv
 FS
-kF
+ES
 VU
 VU
 VU

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -22495,11 +22495,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "uHi" = (
-/obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
+/obj/machinery/ore_silo,
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess,
 /area/f13/building/hospital/clinic)
 "uHj" = (

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -63608,10 +63608,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/vault,
 /area/f13/ruins)
-"lTP" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/f13/wood,
-/area/f13/building/hospital/clinic)
 "lTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -72088,7 +72084,9 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/machinery/vending/medical/nash,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic)
 "nTt" = (
@@ -97469,7 +97467,8 @@
 	layer = 5;
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
+/obj/machinery/vending/medical/nash,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building/hospital/clinic)
 "ugG" = (
 /obj/effect/spawner/lootdrop/f13/common,
@@ -120018,7 +120017,7 @@ wTy
 wTy
 wTy
 xix
-lTP
+bGz
 bGz
 bGz
 bGz

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -16628,6 +16628,9 @@
 /obj/structure/window/fulltile/house{
 	dir = 2
 	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -31414,15 +31417,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"qKY" = (
-/obj/structure/curtain{
-	color = "#363636";
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
 "qLB" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13{
@@ -101537,9 +101531,9 @@ iKf
 iKf
 fde
 cCh
-qKY
-qKY
-qKY
+eJW
+eJW
+eJW
 vtp
 eJW
 qsc


### PR DESCRIPTION

## About The Pull Request
Gives Nash clinic an ore silo and the medical book vendor inside instead of outside to incentivize people actually using the custom vendor. Moves the resupply vendor inside so people don't just empty it out in the lobby.

Puts Ashdown's bar curtains on the windows themselves instead of inside and pixel-shifted, which is dumb, but density=1 closed curtains are too.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Ore silo, med vendor to Nash clinic
fix: Ashdown bar curtains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
