### PR TITLE
Adds a Loadout for Dumbdumn5

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -401,7 +401,17 @@
 /obj/item/storage/box/large/custom_kit/Delta_Dav/PopulateContents()
     new /obj/item/clothing/head/f13/ncr/steelpot_mp(src)
     new /obj/item/clothing/under/f13/ncr/ncr_dress(src)
-    new /obj/item/clothing/accessory/armband/black(src)	
+    new /obj/item/clothing/accessory/armband/black(src)
+
+/datum/gear/donator/kits/dumbdumn5
+	name = "Requisitioned IC Printer"
+	path = /obj/item/storage/box/large/custom_kit/dumbdumn5
+	ckeywhitelist = list("dumbdumn5")
+
+/obj/item/storage/box/large/custom_kit/dumbdumn5/PopulateContents()
+	/obj/item/integrated_circuit_printer
+	/obj/item/disk/integrated_circuit/upgrade/advanced
+	/obj/item/disk/integrated_circuit/upgrade/clone
 
 // E
 


### PR DESCRIPTION

## About The Pull Request
Adds a circuit-printer loadout for my Senior Scribe dweeb to tinker with machines. (I am already aware of farming robots, please understand I will not be making them as they fucking crash the server.)

This is a very powerful, highly customizable tool reliant on power cells, metal, and knowledge to use, hopefully I can be trusted to not d e m o l i s h the thing given Nash's clinic can print it, but I don't see these ever really 'used' and I'd be interested in changing that.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Loadout kit for Dumbdumn5's Scribe goblin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
