### PR TITLE
Fixes an infinite loot exploit with the metalworking bench (good to go if it passes checks)

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -468,15 +468,8 @@
 	disassembly_steps_remaining = WB_DISASSEMBLY_STEP_WELD | WB_DISASSEMBLY_STEP_SCREW | WB_DISASSEMBLY_STEP_CROWBAR | WB_DISASSEMBLY_STEP_CLUB
 	disassembly_start_step = WB_DISASSEMBLY_STEP_CUT
 	disassembly_loot = list(
-		/obj/item/salvage/low,
-		/obj/item/salvage/low,
-		/obj/item/salvage/low,
-		/obj/item/salvage/high,
-		/obj/item/salvage/high,
-		/obj/item/salvage/high,
-		/obj/item/blueprint/research,
-		/obj/item/blueprint/research,
-		/obj/item/stack/f13Cash/caps/fivezero,
+		/obj/item/stack/sheet/metal/twenty,
+		/obj/item/stack/sheet/plasteel/five,
 		)
 
 /obj/item/weaponcrafting/receiver


### PR DESCRIPTION
## About The Pull Request
Title

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Removed salvage loot from metalworking bench scrapping because it's craftable
- Replaced salvage loot with some metal/plasteel, though less than what you use to craft the bench

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
