### PR TITLE
Renames Ashdown Waster to Citizen

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -806,7 +806,7 @@ obj/effect/landmark/start/f13/ncrlogisticsofficer
 	icon_state = "Wastelander"
 
 /obj/effect/landmark/start/f13/wastelander/ashdown
-	name = "Ashdown Wastelander"
+	name = "Ashdown Citizen"
 	icon_state = "Wastelander"
 
 /obj/effect/landmark/start/f13/raider

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -1314,7 +1314,7 @@ Raider
 */
 
 /datum/job/wasteland/f13wastelander/ashdown
-	title = "Ashdown Wastelander"
+	title = "Ashdown Citizen"
 	total_positions = 25
 	spawn_positions = 25
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -293,7 +293,7 @@ GLOBAL_LIST_INIT(tribal_positions, list(
 GLOBAL_LIST_INIT(biker_positions, list(
 	"Overbiker",
 	"Hells Nomad",
-	"Ashdown Wastelander",
+	"Ashdown Citizen",
 ))
 //bikrs
 GLOBAL_LIST_INIT(debug_positions, list(


### PR DESCRIPTION
To proper show what they are, citizens of the town of Ashdown.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
