### PR TITLE
Fixes a cargo exploit (if it passes checks, it's good to go)

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -155,7 +155,7 @@
 	export_types = list(/obj/item/stack/f13Cash/aureus)
 
 /datum/export/material/f13cash/scrip
-	cost = 15 // Texarkana Trade Union scrip. They like people using their money because economics or something
+	cost = 6 // Texarkana Trade Union scrip. They like people using their money because economics or something; 1 copper = 2 scrip; if abused again, set to 5
 	unit_name = "scrip"
 	export_types = list(/obj/item/stack/f13Cash/ncr)
 


### PR DESCRIPTION
## About The Pull Request
Trade Union Scrip (NCR cash) used to give way too much in the cargo train. It no longer does this.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Changed the sale value of Trade Union Scrip from 15 per scrip to 6 per scrip. Still more profitable than exporting coins to encourage its use, but just barely. Definitely less exploitable now.

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
