### PR TITLE
Ashdown Bar Nightification

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -143,6 +143,10 @@
 	color = "#777777"
 	},
 /area/f13/caves)
+"bN" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "bQ" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -230,6 +234,14 @@
 /obj/structure/flora/burnedtree1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"dA" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/tree/med_pine,
@@ -355,6 +367,16 @@
 /obj/structure/flora/grass/coyote/twentyeight,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"eE" = (
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eF" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -552,6 +574,13 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"gT" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hb" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/grass,
@@ -650,6 +679,10 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"hK" = (
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hL" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -754,10 +787,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iC" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/chair/stool/retro,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iD" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -810,6 +842,16 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"jo" = (
+/obj/structure/sign/poster/prewar/poster60{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jq" = (
 /obj/structure/flora/burnedtree3,
 /turf/open/indestructible/ground/outside/desert,
@@ -818,6 +860,12 @@
 /obj/structure/flora/tree_stump,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jy" = (
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jz" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
@@ -856,8 +904,26 @@
 "jT" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"jU" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"jV" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "jZ" = (
 /obj/structure/bed/mattress,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"ka" = (
+/obj/structure/chair/right{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kb" = (
@@ -878,7 +944,11 @@
 /obj/structure/chair/stool/retro/black,
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
+"kh" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "kj" = (
 /obj/structure/flora/burnedtree5,
 /turf/open/indestructible/ground/outside/desert,
@@ -1116,6 +1186,15 @@
 "mt" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"my" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "mz" = (
 /obj/item/cultivator/rake,
 /obj/effect/decal/cleanable/dirt,
@@ -1161,6 +1240,12 @@
 "mH" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"mJ" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mR" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1333,6 +1418,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
+"oZ" = (
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pg" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1440,10 +1529,20 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"qn" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qo" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/caves)
+"qy" = (
+/obj/structure/sign/poster/prewar/poster93{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qH" = (
 /obj/structure/fence/wooden{
 	pixel_x = -14
@@ -1619,6 +1718,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sj" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "ss" = (
 /obj/structure/closet/crate/large{
 	pixel_y = 8;
@@ -1641,6 +1746,11 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"sx" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sy" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -1708,6 +1818,10 @@
 	name = "felt table"
 	},
 /turf/open/floor/carpet/black,
+/area/f13/building)
+"ty" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tC" = (
 /obj/structure/barricade/wooden,
@@ -1780,7 +1894,8 @@
 /obj/structure/nightstand/small{
 	pixel_x = 2;
 	pixel_y = 22;
-	density = 0
+	density = 0;
+	opacity = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -1831,6 +1946,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"uB" = (
+/obj/structure/table/wood,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uF" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/hay/ten,
@@ -1918,9 +2038,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vu" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vv" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/grass/wasteland{
@@ -1954,6 +2077,12 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"vy" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vE" = (
 /obj/structure/barricade/wooden,
@@ -2058,6 +2187,13 @@
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
+/area/f13/building)
+"wp" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "wr" = (
 /obj/structure/table,
@@ -2180,6 +2316,15 @@
 	},
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
+"xp" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "xr" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/grass/wasteland{
@@ -2202,6 +2347,16 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
+/area/f13/building)
+"xE" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
+"xO" = (
+/obj/structure/chair/booth,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "xU" = (
 /obj/structure/barricade/tentclothedge{
@@ -2244,6 +2399,10 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"ye" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "yf" = (
 /obj/structure/car/rubbish2,
@@ -2452,6 +2611,12 @@
 	color = "#777777"
 	},
 /area/f13/building)
+"zQ" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "zZ" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -2638,6 +2803,23 @@
 	color = "#777777"
 	},
 /area/f13/caves)
+"Bx" = (
+/obj/structure/sink/greyscale{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "BD" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -2745,10 +2927,16 @@
 /obj/structure/chair/stool/retro/black,
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "CL" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/tentflap_cloth,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"CY" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "CZ" = (
@@ -2848,6 +3036,13 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"Ef" = (
+/obj/structure/chair/sofa/right{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "Eg" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -2912,6 +3107,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"EH" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "EJ" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3115,6 +3318,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Gi" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Gk" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -3139,6 +3348,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Gt" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Gw" = (
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
@@ -3148,6 +3364,16 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"Gy" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Gz" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -3160,6 +3386,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"GH" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "GK" = (
 /obj/structure/flora/tallgrass4,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3191,6 +3421,12 @@
 	color = "#777777"
 	},
 /area/f13/caves)
+"Hd" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "Hi" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/machinery/recycler,
@@ -3298,6 +3534,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"Ic" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "Ie" = (
 /obj/item/bedsheet/gondola,
 /turf/open/indestructible/ground/outside/desert,
@@ -3335,6 +3575,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"Io" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Ip" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3560,6 +3807,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"JX" = (
+/obj/structure/chair/left,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "JZ" = (
 /obj/structure/reagent_dispensers/compostbin,
 /obj/effect/turf_decal/weather/dirt{
@@ -3596,6 +3847,12 @@
 /obj/structure/flora/jungle2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Kr" = (
+/obj/structure/chair/left{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Kw" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
@@ -3609,17 +3866,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "KK" = (
-/obj/structure/fence/wooden{
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/machinery/light{
 	dir = 1;
-	pixel_y = 9
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	pixel_y = 14;
-	pixel_x = -18
+	light_color = "#cca741"
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "KM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3649,6 +3903,10 @@
 /area/f13/wasteland)
 "KZ" = (
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Lh" = (
+/obj/structure/chair/right,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ln" = (
@@ -3715,6 +3973,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"LX" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "LY" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/cobble{
@@ -3779,6 +4042,12 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"Mw" = (
+/obj/structure/chair/booth{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Mx" = (
 /mob/living/simple_animal/cow/brahmin,
@@ -3871,6 +4140,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"NV" = (
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "NZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -3942,6 +4214,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"OA" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "OB" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag,
@@ -4237,6 +4517,13 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"RF" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "RG" = (
 /obj/structure/flora/grass/coyote/twentytwo,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4283,6 +4570,15 @@
 	dir = 4;
 	pixel_y = 14;
 	pixel_x = -18
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"RY" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -4399,12 +4695,24 @@
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"SH" = (
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "SJ" = (
 /obj/structure/table,
 /obj/structure/rug/big/rug_red{
 	layer = 1
 	},
 /obj/item/storage/box/dice,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"SK" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "SL" = (
@@ -4417,10 +4725,13 @@
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"Ta" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Tg" = (
-/obj/structure/campfire/barrel,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "Ti" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -4514,6 +4825,12 @@
 	color = "#777777"
 	},
 /area/f13/building)
+"Ua" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Ud" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/grass/wasteland{
@@ -4571,6 +4888,14 @@
 	color = "#777777"
 	},
 /area/f13/caves)
+"UJ" = (
+/obj/machinery/computer/arcade/battle,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "UO" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -4685,6 +5010,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"VG" = (
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "VH" = (
 /obj/structure/bed/mattress{
@@ -4866,6 +5194,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"WQ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "WS" = (
 /obj/machinery/microwave/stove,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4891,6 +5226,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
 	sunlight_state = 1
+	},
+/area/f13/building)
+"Xy" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
+"XH" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "XJ" = (
@@ -4953,6 +5303,15 @@
 /obj/structure/flora/grass/coyote/sixteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Yd" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Ye" = (
 /obj/structure/rug/big/rug_blue_shag{
 	layer = 1
@@ -5172,6 +5531,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"ZM" = (
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_y = 30
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ZR" = (
 /turf/open/indestructible/cobble{
@@ -63404,13 +63770,13 @@ Hw
 Hw
 Hw
 Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+WQ
+dA
+dA
+dA
+dA
+dA
+gT
 Hw
 Hw
 Hw
@@ -63660,15 +64026,15 @@ Hw
 Hw
 Hw
 Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+WQ
+RV
+nR
+Lh
+hK
+Kr
+nR
+RV
+gT
 Hw
 Hw
 Hw
@@ -63917,15 +64283,15 @@ wj
 wj
 Hw
 Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+RF
+nR
+nR
+JX
+hK
+ka
+nR
+nR
+UR
 Hw
 Hw
 Hw
@@ -64174,21 +64540,21 @@ eN
 wj
 Hw
 Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+RF
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+Gz
+Gz
+cw
+cw
+cw
+dK
+dK
 Hw
 Hw
 Hw
@@ -64431,21 +64797,21 @@ wj
 wj
 wj
 Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+RF
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+vc
+Gy
+NV
+LX
+nR
+RY
+dK
 Hw
 Hw
 Hw
@@ -64688,33 +65054,33 @@ wj
 wj
 wj
 wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+RF
+nR
+nR
+Lh
+hK
+Kr
+nR
+nR
+vc
+bN
+NV
+NV
+nR
+Ta
+Gz
+Gz
+Gz
+vE
+dK
+dK
+dK
+cw
+cw
+cw
+vc
+vc
+Gz
 Hw
 Hw
 Hw
@@ -64945,33 +65311,33 @@ wj
 wj
 wj
 wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+RF
+RV
+nR
+JX
+hK
+ka
+nR
+nR
+dK
+Ua
+NV
+NV
+nR
+nR
+vc
+Bx
+yc
+XH
+nR
+nR
+jo
+xO
+hK
+Mw
+Gt
+nR
+Gz
 Hw
 Hw
 Hw
@@ -65203,32 +65569,32 @@ wj
 wj
 wj
 wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
+Gz
+Gz
+dK
+dK
+dK
+dK
+jy
+dK
+NV
+NV
+NV
+nR
+ty
+Gz
+EH
+yc
+dK
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+vy
+cw
 Hw
 Hw
 Hw
@@ -65460,32 +65826,32 @@ wj
 wj
 wj
 Av
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-Hw
-Hw
-qm
+Gz
+OA
+bN
+zQ
+NV
+vE
+nR
+dK
+vE
+Xm
+dK
+dK
+dK
+vE
+dK
+dK
+dK
+ZM
+nR
+iC
+iC
+nR
+nR
+nR
+hK
+cw
 jG
 jG
 jG
@@ -65717,40 +66083,40 @@ wj
 wj
 wj
 eN
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-Hw
-Hw
-ti
-mH
-mH
-mH
+vc
+NV
+NV
+NV
+NV
+Xm
+nR
+nR
+nR
+nR
+SH
+dK
+Yd
+uB
+hz
+wp
+dK
+ye
+VG
+ye
+ye
+iC
+nR
+nR
+CY
+cw
+nR
+nR
+nR
 CC
-mH
-mH
+nR
+nR
 CC
-mH
+nR
 Jl
 Hw
 Hw
@@ -65974,40 +66340,40 @@ wj
 wj
 wj
 wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-uK
-ti
-Hw
-Hw
-ti
-ti
-mH
-mH
-mH
-mH
-mH
-mH
-mH
+PG
+LX
+NV
+NV
+NV
+dK
+nR
+nR
+nR
+nR
+jU
+vE
+vu
+nR
+nR
+nR
+dK
+my
+VG
+VG
+ye
+iC
+nR
+nR
+qy
+dK
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
 YU
 Tz
 Hw
@@ -66231,40 +66597,40 @@ wj
 wj
 wj
 wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-uK
-ti
-ti
-Hw
-ti
-ti
-ti
-mH
-mH
-mH
-mH
-mH
-mH
+dK
+Ta
+nR
+nR
+nR
+cw
+nR
+nR
+RV
+nR
+nR
+Gz
+sx
+nR
+nR
+nR
+Xm
+VG
+VG
+VG
+ye
+iC
+nR
+nR
+nR
+Xm
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
 kg
 Jl
 Hw
@@ -66488,41 +66854,41 @@ wj
 wj
 wj
 wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-uK
-ti
-ti
-ti
-ti
-ti
-vu
-IP
-ti
-mH
-mH
-mH
-mH
-mH
-mH
+dK
+KK
+nR
+nR
+ty
+cw
+nR
+nR
+nR
+nR
+mJ
+Gz
+vs
+nR
+nR
+nR
+dK
+xp
+VG
+VG
+ye
+iC
+nR
+nR
+nR
+vE
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
 Jl
 Hw
 Hw
@@ -66745,41 +67111,41 @@ wj
 wj
 wj
 wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-ti
-uK
-ti
-ti
-ti
-ti
-vu
-Tg
+dK
+dK
+dK
+dK
+dK
+dK
+nR
+nR
+nR
+nR
+qn
+vc
+SK
+nR
+oZ
+GH
+dK
+Xy
+ye
+ye
+ye
 iC
-IP
-mH
-mH
-mH
-KK
-mH
-Yf
+nR
+nR
+vy
+cw
+nR
+nR
+nR
+nR
+nR
+nR
+RV
+nR
+dK
 uA
 Hw
 qm
@@ -67002,41 +67368,41 @@ wj
 wj
 wj
 wj
-wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-uK
-ti
-ti
-ti
-ti
-ti
-ti
-IP
-vu
-IP
-mH
-mH
-mH
-mH
-mH
-mH
-Yf
+Gz
+UJ
+Ic
+Tg
+Tg
+Tg
+nR
+nR
+nR
+nR
+Gi
+Gz
+Gz
+vc
+dK
+dK
+dK
+nR
+iC
+iC
+iC
+nR
+nR
+nR
+hK
+cw
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+dK
 jG
 jG
 mR
@@ -67259,41 +67625,41 @@ uK
 wj
 wj
 wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-uK
-uK
-uK
-uK
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-IP
-mH
-KK
-mH
-mH
-mH
-mH
-mH
-Yf
+dR
+Tg
+Tg
+Tg
+Tg
+Tg
+nR
+nR
+RV
+nR
+nR
+Gt
+nR
+nR
+nR
+nR
+Gt
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+CY
+cw
+nR
+nR
+RV
+nR
+nR
+nR
+nR
+nR
+dK
 OI
 Mp
 zJ
@@ -67516,37 +67882,37 @@ uK
 wj
 wj
 eN
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-uK
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-ti
-mH
-mH
-mH
+vc
+kh
+Ic
+Tg
+Tg
+Tg
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+nR
+Io
+xO
+hK
+Mw
+eE
+nR
+dK
+nR
+nR
+nR
+nR
+nR
 py
 py
 Ya
@@ -67773,32 +68139,32 @@ uK
 wj
 wj
 wj
-wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-uK
-ti
-ti
-uK
-uK
-ti
-ti
-ti
-uK
-ti
-ti
-ti
-ti
-ti
-ti
-ti
+Gz
+Tg
+Tg
+Tg
+Tg
+Tg
+nR
+nR
+ye
+ye
+sj
+vc
+Gz
+cw
+cw
+cw
+Gz
+vc
+Gz
+dK
+cw
+cw
+cw
+dK
+vE
+dK
 ti
 ti
 Yf
@@ -68030,27 +68396,27 @@ wj
 wj
 wj
 wj
-wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-ti
-uK
+vc
+jV
+Ic
+Tg
+Tg
+Tg
+nR
+nR
+Ef
+Hd
+xE
+dK
+IP
+IP
 Yz
 IP
-ti
-ti
+IP
+IP
 AI
-uK
-ti
+IP
+IP
 Yz
 IP
 eo
@@ -68287,23 +68653,23 @@ wj
 wj
 wj
 wj
-wj
-wj
-Hw
-Hw
-Hw
-Hw
-Hw
-Hw
-ti
-ti
-ti
-ti
-uK
-uK
+Gz
+dK
+dK
+dK
+dK
+dK
+dK
+PG
+vE
+PG
+dK
+dK
 IP
 IP
-ti
+IP
+IP
+IP
 IP
 IP
 IP
@@ -68555,12 +68921,12 @@ ti
 ti
 ti
 ti
-ti
-uK
 IP
 IP
-ti
-ti
+IP
+IP
+IP
+IP
 IP
 IP
 IP
@@ -68812,11 +69178,11 @@ ti
 uK
 ti
 ti
-ti
-ti
 IP
-ti
-ti
+IP
+IP
+IP
+IP
 IP
 IP
 IP
@@ -69070,10 +69436,10 @@ uK
 uK
 gk
 ti
-ti
-ti
-uK
-uK
+IP
+IP
+IP
+IP
 uK
 IP
 gk
@@ -69327,10 +69693,10 @@ ti
 uK
 uK
 ti
-ti
-ti
-ti
-ti
+IP
+IP
+IP
+IP
 ti
 ti
 ti
@@ -69587,7 +69953,7 @@ uK
 uK
 ti
 ti
-ti
+IP
 ti
 ti
 ti

--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -127,6 +127,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bF" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -971,6 +972,7 @@
 /obj/structure/curtain{
 	color = "#845f58"
 	},
+/obj/structure/simple_door/interior,
 /turf/open/indestructible/cobble{
 	light_color = null;
 	color = "#777777"
@@ -1363,8 +1365,10 @@
 	},
 /area/f13/building)
 "px" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
+/obj/structure/simple_door/interior,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "py" = (
@@ -1404,10 +1408,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pT" = (
-/obj/structure/simple_door/interior,
-/obj/effect/step_trigger/player_choice_log{
-	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
-	},
+/obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pU" = (
@@ -61392,9 +61393,9 @@ nL
 nR
 KZ
 nR
-bF
+pT
 nR
-bF
+pT
 PG
 gh
 gh
@@ -61649,9 +61650,9 @@ nR
 nR
 nR
 nR
-bF
+pT
 nR
-bF
+pT
 PG
 uF
 ia
@@ -61906,9 +61907,9 @@ We
 nR
 nR
 KZ
-bF
+pT
 nR
-bF
+pT
 PG
 vs
 nR
@@ -62163,9 +62164,9 @@ nL
 nR
 nR
 nR
-bF
+pT
 nR
-bF
+pT
 PG
 nR
 nR
@@ -62420,9 +62421,9 @@ nR
 nR
 nR
 nR
-bF
+pT
 KZ
-px
+bF
 PG
 nR
 nR
@@ -66274,7 +66275,7 @@ nR
 nR
 nR
 dK
-pT
+px
 ft
 iX
 nR

--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -127,8 +127,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bF" = (
-/obj/structure/rug/carpet,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bG" = (
@@ -1364,10 +1363,8 @@
 	},
 /area/f13/building)
 "px" = (
-/obj/structure/rug/mat{
-	color = "#EE5555"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "py" = (
@@ -1407,8 +1404,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pT" = (
-/obj/structure/chair/stool/retro/black,
-/obj/item/binoculars,
+/obj/structure/simple_door/interior,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pU" = (
@@ -60876,13 +60875,13 @@ uU
 uU
 uU
 uU
+Tz
+Hw
+qm
 uU
 uU
 uU
 ks
-Hw
-Hw
-Hw
 Hw
 Hw
 wj
@@ -61128,18 +61127,18 @@ Hw
 Hw
 Hw
 EF
-pT
 nR
 nR
 nR
 nR
-PG
 nR
 nR
-YU
-uU
-uU
-ks
+nR
+nR
+RV
+nR
+nR
+Jl
 Hw
 Hw
 wj
@@ -61387,15 +61386,15 @@ Hw
 EF
 nR
 nR
+nL
+We
+nL
 nR
-nR
-nR
-PG
 KZ
 nR
+bF
 nR
-nR
-nR
+bF
 PG
 gh
 gh
@@ -61643,16 +61642,16 @@ Hw
 Hw
 EF
 nR
-nR
-nR
 RV
 nR
-PG
+EP
 nR
 nR
 nR
 nR
+bF
 nR
+bF
 PG
 uF
 ia
@@ -61900,16 +61899,16 @@ Hw
 Hw
 EF
 nR
+uf
+We
+EP
+We
 nR
-nR
-nR
-nR
-JS
 nR
 KZ
-RV
+bF
 nR
-nR
+bF
 PG
 vs
 nR
@@ -62157,16 +62156,16 @@ Hw
 Hw
 EF
 nR
-nR
-nR
 RV
-nR
-Xm
-nR
-nR
-nR
+nL
+EP
+nL
 nR
 nR
+nR
+bF
+nR
+bF
 PG
 nR
 nR
@@ -62416,14 +62415,14 @@ EF
 nR
 nR
 nR
-nR
-zm
-JS
-nR
-nL
 We
+nR
+nR
+nR
+nR
 bF
 KZ
+px
 PG
 nR
 nR
@@ -62670,15 +62669,15 @@ Hw
 Hw
 Hw
 EF
-pT
-nR
-dK
-dK
-dK
-PG
 nR
 nR
-EP
+nR
+nR
+nR
+nR
+nR
+nR
+RV
 nR
 KZ
 iD
@@ -62933,10 +62932,10 @@ Cf
 Jq
 nR
 nR
-uf
-px
-EP
-px
+nR
+KZ
+nR
+KZ
 KZ
 PG
 bx
@@ -63191,9 +63190,9 @@ nR
 nR
 nR
 nR
-nL
-EP
-nL
+nR
+nR
+nR
 nR
 PG
 dK
@@ -63449,7 +63448,7 @@ nR
 nR
 KZ
 nR
-px
+KZ
 nR
 nR
 Ay
@@ -66275,7 +66274,7 @@ nR
 nR
 nR
 dK
-Xm
+pT
 ft
 iX
 nR

--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -1351,6 +1351,22 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nh" = (
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = 14;
+	pixel_x = -18
+	},
+/obj/structure/railing/corner{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "nn" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -2239,6 +2255,22 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"wg" = (
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = 14;
+	pixel_x = -18
+	},
+/obj/structure/railing/corner{
+	dir = 4;
+	color = "#A47449"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wh" = (
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table/wood,
@@ -64052,13 +64084,13 @@ Hw
 Hw
 Hw
 eS
-RV
+wg
 nR
 Hh
 VK
 KK
 nR
-RV
+nh
 uS
 Hw
 Hw

--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -20,6 +20,14 @@
 /obj/structure/flora/grass/coyote/eighteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"af" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "an" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
@@ -38,6 +46,14 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"az" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aB" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -93,12 +109,26 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"bg" = (
+/obj/structure/chair/sofa/right{
+	dir = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "bi" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"bo" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bs" = (
@@ -126,6 +156,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bC" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/bench,
@@ -143,10 +182,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"bN" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "bQ" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -164,6 +199,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ch" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "ci" = (
 /obj/structure/flora/tree/african_acacia_alt{
 	color = "#d9b51c"
@@ -189,6 +230,23 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"cB" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"cS" = (
+/obj/structure/sign/poster/prewar/poster60{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "da" = (
 /obj/structure/flora/tallgrass8,
 /turf/open/indestructible/ground/outside/dirt,
@@ -222,6 +280,12 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"ds" = (
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dt" = (
 /obj/structure/flora/jungle1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -234,14 +298,6 @@
 /obj/structure/flora/burnedtree1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"dA" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/tree/med_pine,
@@ -327,6 +383,19 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
+"ek" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
+"el" = (
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "em" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -363,20 +432,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"ev" = (
+/obj/structure/sign/poster/prewar/poster81{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "eB" = (
 /obj/structure/flora/grass/coyote/twentyeight,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"eE" = (
-/obj/structure/sign/poster/prewar/poster79{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "eF" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -402,6 +467,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"eS" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eV" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -429,6 +501,14 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/wood/house,
+/area/f13/building)
+"fh" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "fi" = (
 /obj/structure/flora/grass/coyote/seventeen,
@@ -462,6 +542,9 @@
 /obj/structure/flora/jungle6,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"fC" = (
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "fP" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -491,6 +574,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"gb" = (
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "gc" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -531,6 +620,12 @@
 	name = "metal plating";
 	sunlight_state = 1
 	},
+/area/f13/building)
+"gr" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gs" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -573,13 +668,6 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
-/area/f13/building)
-"gT" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 10
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "hb" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -634,6 +722,15 @@
 	color = "#777777"
 	},
 /area/f13/caves)
+"hv" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "hz" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -679,10 +776,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"hK" = (
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hL" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -787,7 +880,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iC" = (
-/obj/structure/chair/stool/retro,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iD" = (
@@ -821,6 +919,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"ja" = (
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "jc" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -842,16 +943,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jo" = (
-/obj/structure/sign/poster/prewar/poster60{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "jq" = (
 /obj/structure/flora/burnedtree3,
 /turf/open/indestructible/ground/outside/desert,
@@ -860,9 +951,9 @@
 /obj/structure/flora/tree_stump,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"jy" = (
-/obj/structure/curtain{
-	color = "#845f58"
+"jx" = (
+/obj/structure/sign/poster/prewar/poster93{
+	pixel_y = -32
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -895,6 +986,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"jL" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "jP" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -904,26 +1001,8 @@
 "jT" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"jU" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"jV" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "jZ" = (
 /obj/structure/bed/mattress,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"ka" = (
-/obj/structure/chair/right{
-	dir = 1
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kb" = (
@@ -945,10 +1024,6 @@
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kh" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "kj" = (
 /obj/structure/flora/burnedtree5,
 /turf/open/indestructible/ground/outside/desert,
@@ -964,6 +1039,15 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ko" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "kq" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -1108,6 +1192,15 @@
 /obj/structure/flora/grass/coyote/eleven,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lC" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lD" = (
 /obj/item/storage/trash_stack,
 /obj/effect/turf_decal/weather/dirt{
@@ -1123,6 +1216,16 @@
 	dir = 4;
 	pixel_y = 5;
 	pixel_x = -18
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"lM" = (
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#cca741"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -1186,15 +1289,6 @@
 "mt" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
-"my" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "mz" = (
 /obj/item/cultivator/rake,
 /obj/effect/decal/cleanable/dirt,
@@ -1240,12 +1334,6 @@
 "mH" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"mJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "mR" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1325,6 +1413,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/wasteland)
+"oq" = (
+/obj/structure/sign/poster/prewar/poster69{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "ou" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -1418,10 +1512,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
-"oZ" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "pg" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1437,6 +1527,12 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"pn" = (
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -1523,26 +1619,20 @@
 /obj/structure/flora/tallgrass5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qh" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "qm" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"qn" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qo" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/caves)
-"qy" = (
-/obj/structure/sign/poster/prewar/poster93{
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "qH" = (
 /obj/structure/fence/wooden{
 	pixel_x = -14
@@ -1718,11 +1808,13 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sj" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+"sg" = (
+/obj/machinery/computer/arcade/battle,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/carpet/arcade,
 /area/f13/building)
 "ss" = (
 /obj/structure/closet/crate/large{
@@ -1746,11 +1838,6 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"sx" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sy" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -1765,6 +1852,10 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sJ" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sK" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -1818,10 +1909,6 @@
 	name = "felt table"
 	},
 /turf/open/floor/carpet/black,
-/area/f13/building)
-"ty" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "tC" = (
 /obj/structure/barricade/wooden,
@@ -1946,11 +2033,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"uB" = (
-/obj/structure/table/wood,
-/obj/machinery/processor/chopping_block,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uF" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/hay/ten,
@@ -1991,6 +2073,13 @@
 	},
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood,
+/area/f13/building)
+"uS" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "uU" = (
 /obj/structure/railing{
@@ -2038,11 +2127,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vu" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13/wood,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
 /area/f13/building)
 "vv" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -2077,12 +2165,6 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/building)
-"vy" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "vE" = (
 /obj/structure/barricade/wooden,
@@ -2188,13 +2270,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/building)
-"wp" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -13
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wr" = (
 /obj/structure/table,
 /obj/machinery/chem_master{
@@ -2247,6 +2322,10 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
+/area/f13/building)
+"wZ" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/carpet/arcade,
 /area/f13/building)
 "xb" = (
 /obj/structure/flora/chomp/bush3{
@@ -2316,15 +2395,6 @@
 	},
 /turf/open/indestructible/ground/outside/wood,
 /area/f13/building)
-"xp" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "xr" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/grass/wasteland{
@@ -2347,16 +2417,6 @@
 /turf/open/floor/f13{
 	icon_state = "floordirty"
 	},
-/area/f13/building)
-"xE" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
-"xO" = (
-/obj/structure/chair/booth,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "xU" = (
 /obj/structure/barricade/tentclothedge{
@@ -2399,10 +2459,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"ye" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "yf" = (
 /obj/structure/car/rubbish2,
@@ -2611,12 +2667,6 @@
 	color = "#777777"
 	},
 /area/f13/building)
-"zQ" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "zZ" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt,
@@ -2803,23 +2853,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"Bx" = (
-/obj/structure/sink/greyscale{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "BD" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -2933,12 +2966,6 @@
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"CY" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "CZ" = (
 /obj/structure/flora/tree/african_acacia,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3005,6 +3032,15 @@
 	color = "#777777"
 	},
 /area/f13/building)
+"DI" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/sign/poster/prewar/poster70{
+	pixel_y = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "DN" = (
 /obj/structure/flora/tallgrass1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3036,13 +3072,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"Ef" = (
-/obj/structure/chair/sofa/right{
-	dir = 8;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "Eg" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -3089,6 +3118,10 @@
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Ez" = (
+/obj/structure/chair/booth,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ED" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3107,14 +3140,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"EH" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "EJ" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3318,12 +3343,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"Gi" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Gk" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -3348,13 +3367,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Gt" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Gw" = (
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
@@ -3364,16 +3376,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"Gy" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "Gz" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
@@ -3386,14 +3388,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"GH" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "GK" = (
 /obj/structure/flora/tallgrass4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"GM" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "GN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -3421,11 +3423,9 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"Hd" = (
-/obj/structure/chair/sofa{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
+"Hh" = (
+/obj/structure/chair/right,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Hi" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -3534,10 +3534,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"Ic" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "Ie" = (
 /obj/item/bedsheet/gondola,
 /turf/open/indestructible/ground/outside/desert,
@@ -3575,13 +3571,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"Io" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Ip" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3641,6 +3630,10 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"IE" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "IL" = (
 /obj/structure/flora/tree/cactus_alt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3669,6 +3662,17 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"IY" = (
+/obj/structure/chair/stool/retro,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Jb" = (
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_y = 30
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Jl" = (
 /obj/structure/railing{
@@ -3735,6 +3739,11 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
+/area/f13/building)
+"JC" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "JF" = (
 /obj/structure/rug/big/rug_red{
@@ -3807,10 +3816,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"JX" = (
-/obj/structure/chair/left,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "JZ" = (
 /obj/structure/reagent_dispensers/compostbin,
 /obj/effect/turf_decal/weather/dirt{
@@ -3847,12 +3852,6 @@
 /obj/structure/flora/jungle2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"Kr" = (
-/obj/structure/chair/left{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Kw" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building)
@@ -3866,11 +3865,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "KK" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/brown,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
+/obj/structure/chair/left{
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -3892,6 +3888,13 @@
 /obj/structure/flora/grass/coyote/thirteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"KW" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "KX" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3905,8 +3908,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Lg" = (
+/obj/machinery/smartfridge/bottlerack,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Lh" = (
-/obj/structure/chair/right,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ln" = (
@@ -3973,11 +3980,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"LX" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "LY" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/cobble{
@@ -4036,6 +4038,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"Mq" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/building)
 "Mt" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/interior,
@@ -4043,16 +4053,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"Mw" = (
-/obj/structure/chair/booth{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Mx" = (
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"MC" = (
+/obj/structure/table/wood,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "MG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library{
@@ -4087,6 +4096,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"MQ" = (
+/obj/structure/chair/booth{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "MT" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -4107,6 +4122,10 @@
 /obj/structure/flora/burnedtree4,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"Nj" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "NC" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -4120,6 +4139,11 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"NI" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "NM" = (
 /obj/structure/closet/crate/wicker,
 /obj/effect/turf_decal/weather/dirt,
@@ -4140,14 +4164,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"NV" = (
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "NZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"Of" = (
+/obj/structure/sign/poster/prewar/poster72{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/arcade,
 /area/f13/building)
 "Oi" = (
 /obj/structure/flora/rock/pile/largejungle{
@@ -4206,6 +4233,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"Ox" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Oz" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -4214,14 +4248,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"OA" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "OB" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag,
@@ -4441,6 +4467,12 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"QQ" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "QT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -4451,10 +4483,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"QV" = (
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Ra" = (
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"Rg" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Ri" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -4517,13 +4559,6 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"RF" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "RG" = (
 /obj/structure/flora/grass/coyote/twentytwo,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4573,15 +4608,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"RY" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/brown,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Sa" = (
 /obj/structure/flora/tree_timber,
 /turf/open/indestructible/ground/outside/desert,
@@ -4619,6 +4645,23 @@
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"Si" = (
+/obj/structure/sink/greyscale{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "Sl" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -4695,24 +4738,12 @@
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"SH" = (
-/obj/machinery/vending/games,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "SJ" = (
 /obj/structure/table,
 /obj/structure/rug/big/rug_red{
 	layer = 1
 	},
 /obj/item/storage/box/dice,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"SK" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "SL" = (
@@ -4725,12 +4756,15 @@
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"Ta" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
+"SX" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "Tg" = (
-/turf/open/floor/carpet/arcade,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "Ti" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4826,10 +4860,8 @@
 	},
 /area/f13/building)
 "Ua" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/chair/left,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Ud" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -4888,14 +4920,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"UJ" = (
-/obj/machinery/computer/arcade/battle,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "UO" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -4934,6 +4958,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Va" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "Vg" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5011,8 +5043,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"VG" = (
-/turf/open/floor/carpet/royalblack,
+"VF" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "VH" = (
 /obj/structure/bed/mattress{
@@ -5025,6 +5058,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"VK" = (
+/obj/structure/table/booth,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "VL" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -5194,13 +5231,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"WQ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 9
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "WS" = (
 /obj/machinery/microwave/stove,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -5221,26 +5251,21 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Xn" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#cca741"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Xr" = (
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "Xx" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating";
 	sunlight_state = 1
-	},
-/area/f13/building)
-"Xy" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
-"XH" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
 	},
 /area/f13/building)
 "XJ" = (
@@ -5303,15 +5328,6 @@
 /obj/structure/flora/grass/coyote/sixteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"Yd" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Ye" = (
 /obj/structure/rug/big/rug_blue_shag{
 	layer = 1
@@ -5488,6 +5504,12 @@
 /obj/structure/flora/burnedbush3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ZC" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "ZD" = (
 /obj/structure/decoration/rag,
 /obj/structure/spacevine,
@@ -5532,12 +5554,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ZM" = (
-/obj/structure/sign/poster/prewar/poster61{
-	pixel_y = 30
+"ZO" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/obj/machinery/jukebox,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#cca741"
+	},
+/turf/open/floor/carpet/red,
 /area/f13/building)
 "ZR" = (
 /turf/open/indestructible/cobble{
@@ -63770,13 +63795,13 @@ Hw
 Hw
 Hw
 Hw
-WQ
-dA
-dA
-dA
-dA
-dA
-gT
+eS
+az
+az
+az
+az
+az
+uS
 Hw
 Hw
 Hw
@@ -64026,15 +64051,15 @@ Hw
 Hw
 Hw
 Hw
-WQ
+eS
 RV
 nR
-Lh
-hK
-Kr
+Hh
+VK
+KK
 nR
 RV
-gT
+uS
 Hw
 Hw
 Hw
@@ -64283,12 +64308,12 @@ wj
 wj
 Hw
 Hw
-RF
+Ox
 nR
 nR
-JX
-hK
-ka
+Ua
+VK
+gb
 nR
 nR
 UR
@@ -64540,7 +64565,7 @@ eN
 wj
 Hw
 Hw
-RF
+Ox
 nR
 nR
 nR
@@ -64797,7 +64822,7 @@ wj
 wj
 wj
 Hw
-RF
+Ox
 nR
 nR
 nR
@@ -64806,11 +64831,11 @@ nR
 nR
 nR
 vc
-Gy
-NV
-LX
+ZO
+fC
+NI
 nR
-RY
+iC
 dK
 Hw
 Hw
@@ -65054,20 +65079,20 @@ wj
 wj
 wj
 wj
-RF
+Ox
 nR
 nR
-Lh
-hK
-Kr
+Hh
+VK
+KK
 nR
 nR
 vc
-bN
-NV
-NV
+IE
+fC
+fC
 nR
-Ta
+QV
 Gz
 Gz
 Gz
@@ -65311,31 +65336,31 @@ wj
 wj
 wj
 wj
-RF
+Ox
 RV
 nR
-JX
-hK
-ka
+Ua
+VK
+gb
 nR
 nR
 dK
-Ua
-NV
-NV
+Rg
+fC
+fC
 nR
 nR
 vc
-Bx
+Si
 yc
-XH
+jL
 nR
 nR
-jo
-xO
-hK
-Mw
-Gt
+cS
+Ez
+VK
+MQ
+KW
 nR
 Gz
 Hw
@@ -65575,15 +65600,15 @@ dK
 dK
 dK
 dK
-jy
+ds
 dK
-NV
-NV
-NV
+fC
+fC
+fC
 nR
-ty
+sJ
 Gz
-EH
+Va
 yc
 dK
 nR
@@ -65593,7 +65618,7 @@ nR
 nR
 nR
 nR
-vy
+gr
 cw
 Hw
 Hw
@@ -65827,10 +65852,10 @@ wj
 wj
 Av
 Gz
-OA
-bN
-zQ
-NV
+af
+IE
+vu
+fC
 vE
 nR
 dK
@@ -65843,14 +65868,14 @@ vE
 dK
 dK
 dK
-ZM
+Jb
 nR
-iC
-iC
+IY
+IY
 nR
 nR
 nR
-hK
+VK
 cw
 jG
 jG
@@ -66084,30 +66109,30 @@ wj
 wj
 eN
 vc
-NV
-NV
-NV
-NV
+fC
+fC
+fC
+fC
 Xm
 nR
 nR
 nR
 nR
-SH
+el
 dK
-Yd
-uB
+bC
+MC
 hz
-wp
+bo
 dK
-ye
-VG
-ye
-ye
-iC
+Tg
+Xr
+Tg
+Tg
+IY
 nR
 nR
-CY
+pn
 cw
 nR
 nR
@@ -66341,30 +66366,30 @@ wj
 wj
 wj
 PG
-LX
-NV
-NV
-NV
+NI
+fC
+fC
+fC
 dK
 nR
 nR
 nR
 nR
-jU
+Lh
 vE
-vu
+cB
 nR
 nR
 nR
 dK
-my
-VG
-VG
-ye
-iC
+hv
+Xr
+Xr
+Tg
+IY
 nR
 nR
-qy
+jx
 dK
 nR
 nR
@@ -66598,7 +66623,7 @@ wj
 wj
 wj
 dK
-Ta
+QV
 nR
 nR
 nR
@@ -66609,16 +66634,16 @@ RV
 nR
 nR
 Gz
-sx
+JC
 nR
 nR
 nR
 Xm
-VG
-VG
-VG
-ye
-iC
+Xr
+Xr
+Xr
+Tg
+IY
 nR
 nR
 nR
@@ -66855,27 +66880,27 @@ wj
 wj
 wj
 dK
-KK
+lC
 nR
 nR
-ty
+sJ
 cw
 nR
 nR
 nR
 nR
-mJ
+DI
 Gz
 vs
 nR
 nR
 nR
 dK
-xp
-VG
-VG
-ye
-iC
+ek
+Xr
+Xr
+Tg
+IY
 nR
 nR
 nR
@@ -67121,21 +67146,21 @@ nR
 nR
 nR
 nR
-qn
+VF
 vc
-SK
+fh
 nR
-oZ
-GH
+Lg
+Nj
 dK
-Xy
-ye
-ye
-ye
-iC
+ko
+Tg
+Tg
+Tg
+IY
 nR
 nR
-vy
+gr
 cw
 nR
 nR
@@ -67369,16 +67394,16 @@ wj
 wj
 wj
 Gz
-UJ
-Ic
-Tg
-Tg
-Tg
+sg
+GM
+ja
+ev
+ja
 nR
 nR
 nR
 nR
-Gi
+QQ
 Gz
 Gz
 vc
@@ -67386,13 +67411,13 @@ dK
 dK
 dK
 nR
-iC
-iC
-iC
+IY
+IY
+IY
 nR
 nR
 nR
-hK
+VK
 cw
 nR
 nR
@@ -67625,23 +67650,23 @@ uK
 wj
 wj
 wj
-dR
-Tg
-Tg
-Tg
-Tg
-Tg
+Gz
+Of
+ja
+ja
+ja
+ja
 nR
 nR
 RV
 nR
 nR
-Gt
+KW
 nR
 nR
 nR
 nR
-Gt
+KW
 nR
 nR
 nR
@@ -67649,7 +67674,7 @@ nR
 nR
 nR
 nR
-CY
+pn
 cw
 nR
 nR
@@ -67883,11 +67908,11 @@ wj
 wj
 eN
 vc
-kh
-Ic
-Tg
-Tg
-Tg
+wZ
+GM
+ja
+ja
+ja
 nR
 nR
 nR
@@ -67901,11 +67926,11 @@ nR
 nR
 nR
 nR
-Io
-xO
-hK
-Mw
-eE
+Xn
+Ez
+VK
+MQ
+lM
 nR
 dK
 nR
@@ -68140,16 +68165,16 @@ wj
 wj
 wj
 Gz
-Tg
-Tg
-Tg
-Tg
-Tg
+ja
+ja
+ja
+ja
+ja
 nR
 nR
-ye
-ye
-sj
+Tg
+Tg
+ch
 vc
 Gz
 cw
@@ -68397,16 +68422,16 @@ wj
 wj
 wj
 vc
-jV
-Ic
-Tg
-Tg
-Tg
+Mq
+GM
+oq
+ja
+qh
 nR
 nR
-Ef
-Hd
-xE
+bg
+ZC
+SX
 dK
 IP
 IP

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -2578,15 +2578,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
-"buu" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
 "buG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16094,16 +16085,6 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
-"iyK" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	dir = 1;
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "iyT" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -16642,10 +16623,22 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"iKR" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "iKV" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "iKY" = (
 /obj/effect/decal/waste{
@@ -16747,15 +16740,6 @@
 /obj/structure/closet/crate/footchest,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
-"iPr" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "iPs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -17473,6 +17457,11 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building/abandoned)
+"jjI" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "jjP" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -29416,6 +29405,16 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
 	},
+/area/f13/wasteland)
+"pBW" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	dir = 1;
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "pCC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41752,12 +41751,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"wnO" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "wnP" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_8"
@@ -43780,6 +43773,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
+"xsT" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "xtq" = (
 /obj/structure/wreck/trash/engine,
 /obj/structure/car/rubbish1,
@@ -101050,9 +101052,9 @@ iKf
 iKf
 qES
 yky
-iyK
-wnO
-iPr
+pBW
+iKR
+xsT
 qES
 lqe
 qES
@@ -101304,8 +101306,8 @@ iKf
 iKf
 aLl
 aLl
-iKV
-iKV
+jjI
+jjI
 lFI
 cYp
 lFI
@@ -101816,7 +101818,7 @@ iKf
 iKf
 iKf
 iKf
-buu
+iKV
 eJW
 azf
 sdR
@@ -102073,7 +102075,7 @@ iKf
 iKf
 iKf
 iKf
-buu
+iKV
 hze
 xRG
 ngB
@@ -102330,7 +102332,7 @@ iKf
 tiN
 tiN
 iKf
-buu
+iKV
 eJW
 azf
 oDo

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -9325,6 +9325,11 @@
 "eVO" = (
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/building/abandoned)
+"eVV" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "eWc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/cultist/ranged/smg,
@@ -10055,8 +10060,12 @@
 	},
 /area/f13/building/abandoned)
 "fnh" = (
-/obj/structure/barricade/sandbags{
-	pixel_x = 7
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	dir = 1;
+	color = "#A47449"
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
@@ -11716,6 +11725,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"gfO" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "gge" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -16623,12 +16643,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"iKR" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "iKV" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -17457,11 +17471,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building/abandoned)
-"jjI" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "jjP" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -24586,6 +24595,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mZZ" = (
+/obj/structure/barricade/sandbags{
+	pixel_x = 7
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "nam" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/fence/wooden,
@@ -29406,16 +29421,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"pBW" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	dir = 1;
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "pCC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblue,
@@ -32418,6 +32423,12 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/city)
+"rqG" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "rqJ" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -43773,15 +43784,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
-"xsT" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
 "xtq" = (
 /obj/structure/wreck/trash/engine,
 /obj/structure/car/rubbish1,
@@ -44897,6 +44899,15 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter - W"
 	},
+/area/f13/wasteland)
+"xXa" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "xXu" = (
 /obj/structure/spacevine,
@@ -101052,9 +101063,9 @@ iKf
 iKf
 qES
 yky
-pBW
-iKR
-xsT
+fnh
+rqG
+xXa
 qES
 lqe
 qES
@@ -101306,13 +101317,13 @@ iKf
 iKf
 aLl
 aLl
-jjI
-jjI
+eVV
+eVV
 lFI
 cYp
 lFI
 lFI
-fnh
+mZZ
 dSf
 qES
 iKf
@@ -101818,7 +101829,7 @@ iKf
 iKf
 iKf
 iKf
-iKV
+gfO
 eJW
 azf
 sdR

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -2578,6 +2578,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
+"buu" = (
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/building)
 "buG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6334,7 +6343,7 @@
 "dua" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/tires,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "due" = (
 /turf/open/indestructible/ground/outside/sidewalk_s,
@@ -10055,8 +10064,10 @@
 	},
 /area/f13/building/abandoned)
 "fnh" = (
-/obj/structure/nest/cazador,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/barricade/sandbags{
+	pixel_x = 7
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "fnu" = (
 /obj/structure/closet/crate,
@@ -14154,9 +14165,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -16086,6 +16094,16 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"iyK" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	dir = 1;
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "iyT" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -16625,15 +16643,9 @@
 	},
 /area/f13/building)
 "iKV" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "iKY" = (
 /obj/effect/decal/waste{
@@ -16735,6 +16747,15 @@
 /obj/structure/closet/crate/footchest,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
+"iPr" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/obj/structure/fluff/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "iPs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -35225,6 +35246,9 @@
 /area/f13/wasteland)
 "sOU" = (
 /obj/structure/simple_door/glass,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "sOX" = (
@@ -41727,6 +41751,12 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
+/area/f13/wasteland)
+"wnO" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "wnP" = (
 /obj/structure/flora/grass/wasteland{
@@ -98959,9 +98989,9 @@ iKf
 iKf
 iKf
 iKf
-iKf
-iKf
-iKf
+qES
+qES
+qES
 whc
 iKf
 iKf
@@ -99215,11 +99245,11 @@ fJi
 iKf
 iKf
 iKf
-iKf
-iKf
-iKf
-iKf
-iKf
+qES
+qES
+uhb
+qES
+qES
 iKf
 iKf
 tiN
@@ -99472,11 +99502,11 @@ qZY
 iKf
 iKf
 iKf
-tiN
-hia
-lmY
-lmY
-frx
+yky
+qES
+uhb
+qES
+qES
 frx
 iKf
 fqZ
@@ -99728,12 +99758,12 @@ hRF
 tiN
 gEj
 iKf
-tiN
-pkw
-hia
-iKf
+yky
+kVN
 qES
-uhb
+eVJ
+qES
+qES
 qES
 qES
 kVN
@@ -99985,12 +100015,12 @@ tiN
 iKf
 tiN
 iKf
-iKf
-iKf
-iKf
 qES
 qES
-uhb
+qES
+qES
+qES
+qES
 qES
 qES
 qES
@@ -100243,11 +100273,11 @@ iKf
 iKf
 tiN
 iKf
-iKf
-iKf
 qES
 qES
-eVJ
+qES
+qES
+qES
 qES
 qES
 yky
@@ -100500,8 +100530,7 @@ iKf
 tiN
 iKf
 rQm
-tiN
-iKf
+yky
 qES
 qES
 qES
@@ -100510,7 +100539,8 @@ qES
 qES
 qES
 qES
-iKf
+qES
+qES
 egf
 qES
 yky
@@ -100758,16 +100788,16 @@ iKf
 wEK
 tDc
 iKf
-iKf
-iKf
 qES
 qES
 qES
 qES
 qES
-iKf
+qES
+qES
+qES
 dua
-iKf
+qES
 qES
 qES
 iKf
@@ -101016,14 +101046,14 @@ wEK
 iKf
 tiN
 iKf
-tiN
-qES
-qES
-qES
-qES
 iKf
 iKf
-dSf
+qES
+yky
+iyK
+wnO
+iPr
+qES
 lqe
 qES
 iKf
@@ -101276,11 +101306,11 @@ aLl
 aLl
 iKV
 iKV
-iKV
+lFI
 cYp
 lFI
 lFI
-dSf
+fnh
 dSf
 qES
 iKf
@@ -101786,7 +101816,7 @@ iKf
 iKf
 iKf
 iKf
-lFI
+buu
 eJW
 azf
 sdR
@@ -102043,7 +102073,7 @@ iKf
 iKf
 iKf
 iKf
-lFI
+buu
 hze
 xRG
 ngB
@@ -102300,7 +102330,7 @@ iKf
 tiN
 tiN
 iKf
-lFI
+buu
 eJW
 azf
 oDo
@@ -102548,15 +102578,15 @@ egf
 iKf
 iKf
 iKf
-fnh
+iKf
 iKf
 iKf
 iKf
 pkw
 iKf
 iKf
-cqd
-cqd
+lmY
+lmY
 lFI
 iyT
 eJW
@@ -102811,7 +102841,7 @@ iKf
 iKf
 tiN
 tiN
-wEK
+iKf
 tiN
 iKf
 tej


### PR DESCRIPTION


## About The Pull Request
Due to a _Fun_ incident in-game today, turns the bar, with stripper poles, adult content, and a slew of outfits around it making it as obvious as it possibly can be that they're for sexual content, into something that- actually works to that design

Adds an alternative entrance/exit to Ashdown on the side of the bar without going directly through it and remaps the 'meeting hall' area to have proper seating. Also adds the Heaven's Night style pop-up warnings to avoid rule-based complaints.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Heaven's Night warning to Ashdown bar (With different text, ofc.)
tweak: Shimmies around the Ashdown meeting hall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
Lower Floor:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/24967284-2fed-48c6-97eb-11943fd9e1e3)
Upper Floor:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/175cc628-13d0-447e-9f2b-95d3def5a79a)
