### PR TITLE
Ashdown - Reverse Course

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -20,14 +20,6 @@
 /obj/structure/flora/grass/coyote/eighteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"af" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "an" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
@@ -46,14 +38,6 @@
 	dir = 4
 	},
 /turf/closed/wall/f13/wood,
-/area/f13/building)
-"az" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "aB" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -109,26 +93,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"bg" = (
-/obj/structure/chair/sofa/right{
-	dir = 8;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "bi" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"bo" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -13
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bs" = (
@@ -153,15 +123,6 @@
 	},
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
 	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"bC" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -199,12 +160,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ch" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "ci" = (
 /obj/structure/flora/tree/african_acacia_alt{
 	color = "#d9b51c"
@@ -230,23 +185,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"cB" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"cS" = (
-/obj/structure/sign/poster/prewar/poster60{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "da" = (
 /obj/structure/flora/tallgrass8,
 /turf/open/indestructible/ground/outside/dirt,
@@ -280,12 +218,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"ds" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dt" = (
 /obj/structure/flora/jungle1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -383,19 +315,6 @@
 	sunlight_state = 1
 	},
 /area/f13/building)
-"ek" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
-"el" = (
-/obj/machinery/vending/games,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "em" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -432,12 +351,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"ev" = (
-/obj/structure/sign/poster/prewar/poster81{
-	pixel_x = -32
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "eB" = (
 /obj/structure/flora/grass/coyote/twentyeight,
 /turf/open/indestructible/ground/outside/dirt,
@@ -467,13 +380,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"eS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 9
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "eV" = (
 /obj/structure/table,
 /obj/item/kitchen/knife/butcher,
@@ -501,14 +407,6 @@
 	pixel_y = 2
 	},
 /turf/closed/wall/f13/wood/house,
-/area/f13/building)
-"fh" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "fi" = (
 /obj/structure/flora/grass/coyote/seventeen,
@@ -542,9 +440,6 @@
 /obj/structure/flora/jungle6,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"fC" = (
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "fP" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/indestructible/ground/outside/dirt,
@@ -574,12 +469,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"gb" = (
-/obj/structure/chair/right{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "gc" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -620,12 +509,6 @@
 	name = "metal plating";
 	sunlight_state = 1
 	},
-/area/f13/building)
-"gr" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "gs" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -722,15 +605,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"hv" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "hz" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -879,15 +753,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"iC" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/brown,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iD" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -919,9 +784,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"ja" = (
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "jc" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -952,10 +814,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jx" = (
-/obj/structure/sign/poster/prewar/poster93{
-	pixel_y = -32
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
 	},
-/turf/open/floor/f13/wood,
+/turf/closed/wall/f13/wood,
 /area/f13/building)
 "jz" = (
 /obj/structure/chair/stool,
@@ -986,12 +850,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"jL" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "jP" = (
 /turf/closed/wall/f13/store{
 	desc = "A pre-War wall made of solid concrete.";
@@ -1039,15 +897,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ko" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "kq" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -1193,11 +1042,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "lC" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/brown,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
+/obj/structure/nightstand/small{
+	pixel_x = 2;
+	pixel_y = 22;
+	density = 0;
+	opacity = 0
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -1216,16 +1065,6 @@
 	dir = 4;
 	pixel_y = 5;
 	pixel_x = -18
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"lM" = (
-/obj/structure/sign/poster/prewar/poster79{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#cca741"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -1351,22 +1190,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nh" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 9
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	pixel_y = 14;
-	pixel_x = -18
-	},
-/obj/structure/railing/corner{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "nn" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -1429,12 +1252,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/wasteland)
-"oq" = (
-/obj/structure/sign/poster/prewar/poster69{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "ou" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -1543,12 +1360,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"pn" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "pp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -1564,13 +1375,6 @@
 	light_color = null;
 	color = "#777777"
 	},
-/area/f13/building)
-"px" = (
-/obj/structure/simple_door/interior,
-/obj/effect/step_trigger/player_choice_log{
-	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "py" = (
 /turf/open/indestructible/cobble{
@@ -1635,10 +1439,6 @@
 /obj/structure/flora/tallgrass5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qh" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "qm" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -1824,14 +1624,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sg" = (
-/obj/machinery/computer/arcade/battle,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "ss" = (
 /obj/structure/closet/crate/large{
 	pixel_y = 8;
@@ -1868,10 +1660,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sJ" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sK" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -2090,13 +1878,6 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"uS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 10
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uU" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -2141,12 +1922,6 @@
 "vt" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"vu" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "vv" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -2255,22 +2030,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wg" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 9
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	pixel_y = 14;
-	pixel_x = -18
-	},
-/obj/structure/railing/corner{
-	dir = 4;
-	color = "#A47449"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "wh" = (
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table/wood,
@@ -2354,10 +2113,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
 	},
-/area/f13/building)
-"wZ" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/carpet/arcade,
 /area/f13/building)
 "xb" = (
 /obj/structure/flora/chomp/bush3{
@@ -2725,11 +2480,6 @@
 "Au" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"Av" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
 "Ay" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -3064,15 +2814,6 @@
 	color = "#777777"
 	},
 /area/f13/building)
-"DI" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/structure/sign/poster/prewar/poster70{
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "DN" = (
 /obj/structure/flora/tallgrass1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3148,10 +2889,6 @@
 /area/f13/building)
 "Ex" = (
 /obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Ez" = (
-/obj/structure/chair/booth,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ED" = (
@@ -3424,10 +3161,6 @@
 /obj/structure/flora/tallgrass4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"GM" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "GN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -3455,10 +3188,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"Hh" = (
-/obj/structure/chair/right,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Hi" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/machinery/recycler,
@@ -3663,8 +3392,8 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "IE" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
+/obj/structure/table,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "IL" = (
 /obj/structure/flora/tree/cactus_alt,
@@ -3694,17 +3423,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/building)
-"IY" = (
-/obj/structure/chair/stool/retro,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Jb" = (
-/obj/structure/sign/poster/prewar/poster61{
-	pixel_y = 30
-	},
-/obj/machinery/jukebox,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "Jl" = (
 /obj/structure/railing{
@@ -3771,11 +3489,6 @@
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/black,
-/area/f13/building)
-"JC" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "JF" = (
 /obj/structure/rug/big/rug_red{
@@ -3896,12 +3609,6 @@
 /obj/structure/flora/brushwoodalt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"KK" = (
-/obj/structure/chair/left{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "KM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3920,13 +3627,6 @@
 /obj/structure/flora/grass/coyote/thirteen,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"KW" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "KX" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3938,14 +3638,6 @@
 /area/f13/wasteland)
 "KZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Lg" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Lh" = (
-/obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ln" = (
@@ -4070,14 +3762,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"Mq" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/building)
 "Mt" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/interior,
@@ -4089,11 +3773,6 @@
 /mob/living/simple_animal/cow/brahmin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"MC" = (
-/obj/structure/table/wood,
-/obj/machinery/processor/chopping_block,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "MG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library{
@@ -4128,12 +3807,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"MQ" = (
-/obj/structure/chair/booth{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "MT" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -4154,10 +3827,6 @@
 /obj/structure/flora/burnedtree4,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"Nj" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "NC" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -4171,11 +3840,6 @@
 /obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"NI" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "NM" = (
 /obj/structure/closet/crate/wicker,
 /obj/effect/turf_decal/weather/dirt,
@@ -4201,12 +3865,6 @@
 /obj/machinery/reagentgrinder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"Of" = (
-/obj/structure/sign/poster/prewar/poster72{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/arcade,
 /area/f13/building)
 "Oi" = (
 /obj/structure/flora/rock/pile/largejungle{
@@ -4264,13 +3922,6 @@
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/closed/wall/f13/wood/house,
-/area/f13/building)
-"Ox" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "Oz" = (
 /obj/structure/fence/wooden{
@@ -4499,12 +4150,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"QQ" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "QT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -4515,20 +4160,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"QV" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Ra" = (
 /obj/structure/nest/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"Rg" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "Ri" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -4677,23 +4312,6 @@
 /obj/item/storage/bag/ore,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"Si" = (
-/obj/structure/sink/greyscale{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "Sl" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -4788,15 +4406,10 @@
 /obj/structure/closet/cabinet,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"SX" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "Tg" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table,
+/obj/item/storage/box/dice,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Ti" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4890,10 +4503,6 @@
 	light_color = null;
 	color = "#777777"
 	},
-/area/f13/building)
-"Ua" = (
-/obj/structure/chair/left,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "Ud" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -4990,14 +4599,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"Va" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "Vg" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5075,10 +4676,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"VF" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "VH" = (
 /obj/structure/bed/mattress{
 	pixel_y = 4
@@ -5090,10 +4687,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"VK" = (
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "VL" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -5283,15 +4876,9 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Xn" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#cca741"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Xr" = (
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/sofa,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Xx" = (
 /obj/structure/chair/stool/retro/black,
@@ -5536,12 +5123,6 @@
 /obj/structure/flora/burnedbush3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"ZC" = (
-/obj/structure/chair/sofa{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building)
 "ZD" = (
 /obj/structure/decoration/rag,
 /obj/structure/spacevine,
@@ -5585,16 +5166,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"ZO" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#cca741"
-	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "ZR" = (
 /turf/open/indestructible/cobble{
@@ -61293,15 +60864,15 @@ Hw
 Hw
 Hw
 Hw
-qm
-uU
-uU
-uU
-uU
-uU
-Tz
 Hw
 qm
+uU
+uU
+uU
+uU
+uU
+uU
+uU
 uU
 uU
 uU
@@ -61550,8 +61121,8 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
-nR
 nR
 nR
 nR
@@ -61807,6 +61378,7 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 nR
@@ -61814,7 +61386,6 @@ nL
 We
 nL
 nR
-KZ
 nR
 pT
 nR
@@ -62064,12 +61635,12 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 RV
 nR
 EP
-nR
 nR
 nR
 nR
@@ -62321,13 +61892,13 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 uf
 We
 EP
 We
-nR
 nR
 KZ
 pT
@@ -62578,13 +62149,13 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 RV
 nL
 EP
 nL
-nR
 nR
 nR
 pT
@@ -62835,12 +62406,12 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 nR
 nR
 We
-nR
 nR
 nR
 nR
@@ -63092,8 +62663,8 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
-nR
 nR
 nR
 nR
@@ -63349,12 +62920,12 @@ Hw
 Hw
 Hw
 Hw
+Hw
 SE
 vg
 vg
 Cf
 Jq
-nR
 nR
 nR
 KZ
@@ -63609,8 +63180,8 @@ Hw
 Hw
 Hw
 Hw
+Hw
 EF
-nR
 nR
 nR
 nR
@@ -63827,13 +63398,14 @@ Hw
 Hw
 Hw
 Hw
-eS
-az
-az
-az
-az
-az
-uS
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -63868,7 +63440,6 @@ Hw
 Hw
 EF
 RV
-nR
 nR
 KZ
 nR
@@ -64083,15 +63654,16 @@ Hw
 Hw
 Hw
 Hw
-eS
-wg
-nR
-Hh
-VK
-KK
-nR
-nh
-uS
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -64125,7 +63697,6 @@ Hw
 Hw
 EF
 Jq
-nR
 KZ
 nR
 nR
@@ -64340,15 +63911,16 @@ wj
 wj
 Hw
 Hw
-Ox
-nR
-nR
-Ua
-VK
-gb
-nR
-nR
-UR
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -64382,7 +63954,6 @@ Hw
 Hw
 zk
 zf
-dK
 dK
 dR
 lJ
@@ -64597,21 +64168,22 @@ eN
 wj
 Hw
 Hw
-Ox
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-Gz
-Gz
-cw
-cw
-cw
-dK
-dK
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -64639,7 +64211,6 @@ Hw
 Hw
 zk
 zc
-Vs
 Bb
 UO
 Gz
@@ -64854,21 +64425,22 @@ wj
 wj
 wj
 Hw
-Ox
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-vc
-ZO
-fC
-NI
-nR
-iC
-dK
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -64896,7 +64468,6 @@ Hw
 Hw
 zk
 HQ
-Vs
 AQ
 JS
 wB
@@ -65111,33 +64682,34 @@ wj
 wj
 wj
 wj
-Ox
-nR
-nR
-Hh
-VK
-KK
-nR
-nR
-vc
-IE
-fC
-fC
-nR
-QV
-Gz
-Gz
-Gz
-vE
-dK
-dK
-dK
-cw
-cw
-cw
-vc
-vc
-Gz
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -65153,7 +64725,6 @@ Hw
 Hw
 zk
 Xx
-Vs
 AQ
 zj
 Yj
@@ -65368,33 +64939,34 @@ wj
 wj
 wj
 wj
-Ox
-RV
-nR
-Ua
-VK
-gb
-nR
-nR
-dK
-Rg
-fC
-fC
-nR
-nR
-vc
-Si
-yc
-jL
-nR
-nR
-cS
-Ez
-VK
-MQ
-KW
-nR
-Gz
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -65410,7 +64982,6 @@ Hw
 Hw
 zk
 PJ
-Vs
 AQ
 tK
 Yj
@@ -65626,32 +65197,33 @@ wj
 wj
 wj
 wj
-Gz
-Gz
-dK
-dK
-dK
-dK
-ds
-dK
-fC
-fC
-fC
-nR
-sJ
-Gz
-Va
-yc
-dK
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-gr
-cw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 Hw
 Hw
 Hw
@@ -65667,7 +65239,6 @@ Hw
 Hw
 zk
 kx
-Vs
 iU
 zj
 Yj
@@ -65882,33 +65453,33 @@ wj
 wj
 wj
 wj
-Av
-Gz
-af
-IE
-vu
-fC
-vE
-nR
-dK
-vE
-Xm
-dK
-dK
-dK
-vE
-dK
-dK
-dK
-Jb
-nR
-IY
-IY
-nR
-nR
-nR
-VK
-cw
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+kP
+kP
+kP
+kP
+kP
+Hw
+qm
+jG
 jG
 jG
 jG
@@ -65922,9 +65493,9 @@ Hw
 Hw
 Hw
 Hw
+Hw
 zk
 HQ
-Vs
 gm
 wx
 ZX
@@ -66139,33 +65710,33 @@ wj
 wj
 wj
 wj
-eN
-vc
-fC
-fC
-fC
-fC
-Xm
-nR
-nR
-nR
-nR
-el
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
 dK
-bC
-MC
-hz
-bo
-dK
-Tg
-Xr
-Tg
-Tg
-IY
-nR
-nR
-pn
 cw
+cw
+cw
+dK
+dK
+jx
+nR
 nR
 nR
 nR
@@ -66179,9 +65750,9 @@ Hw
 Hw
 Hw
 Hw
+Hw
 zk
 ef
-Vs
 Vs
 Xm
 UR
@@ -66397,32 +65968,32 @@ wj
 wj
 wj
 wj
-PG
-NI
-fC
-fC
-fC
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
 dK
-nR
-nR
-nR
-nR
-Lh
-vE
-cB
-nR
-nR
-nR
-dK
-hv
-Xr
-Xr
+Hs
 Tg
-IY
 nR
-nR
+zs
+NZ
 jx
-dK
+nR
 nR
 nR
 nR
@@ -66436,9 +66007,9 @@ Tz
 Hw
 Hw
 Hw
+Hw
 zk
 mF
-dK
 dR
 ac
 nR
@@ -66654,32 +66225,32 @@ wj
 wj
 wj
 wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
 dK
-QV
-nR
-nR
-nR
-cw
-nR
-nR
-RV
-nR
-nR
-Gz
-JC
-nR
-nR
-nR
-Xm
 Xr
-Xr
-Xr
-Tg
-IY
+IE
 nR
 nR
+hX
+jx
 nR
-Xm
 nR
 nR
 nR
@@ -66693,12 +66264,12 @@ Jl
 Hw
 Hw
 Hw
+Hw
 EF
 nR
 nR
-nR
 dK
-px
+Xm
 ft
 iX
 nR
@@ -66911,32 +66482,32 @@ wj
 wj
 wj
 wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
 dK
-lC
+yD
+IE
 nR
 nR
-sJ
-cw
-nR
-nR
-nR
-nR
-DI
-Gz
-vs
-nR
-nR
-nR
+hz
 dK
-ek
-Xr
-Xr
-Tg
-IY
 nR
-nR
-nR
-vE
 nR
 nR
 nR
@@ -66950,8 +66521,8 @@ Jl
 Hw
 Hw
 Hw
+Hw
 EF
-nR
 nR
 nR
 nR
@@ -67168,32 +66739,32 @@ wj
 wj
 wj
 wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
+ti
+ti
 dK
-dK
-dK
-dK
-dK
-dK
+lC
 nR
 nR
 nR
-nR
-VF
-vc
-fh
-nR
-Lg
-Nj
+QI
 dK
-ko
-Tg
-Tg
-Tg
-IY
 nR
-nR
-gr
-cw
 nR
 nR
 nR
@@ -67207,9 +66778,9 @@ uA
 Hw
 qm
 jG
+jG
 mR
 RV
-nR
 nR
 nR
 nR
@@ -67425,32 +66996,32 @@ wj
 wj
 wj
 wj
-Gz
-sg
-GM
-ja
-ev
-ja
-nR
-nR
-nR
-nR
-QQ
-Gz
-Gz
-vc
+wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+uK
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
 dK
-dK
-dK
-nR
-IY
-IY
-IY
+qI
 nR
 nR
 nR
-VK
-cw
+nR
+Xm
+nR
 nR
 nR
 nR
@@ -67682,32 +67253,32 @@ uK
 wj
 wj
 wj
-Gz
-Of
-ja
-ja
-ja
-ja
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+uK
+uK
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+dK
+dK
+dK
+dK
+dK
+dK
+dK
 nR
-nR
-RV
-nR
-nR
-KW
-nR
-nR
-nR
-nR
-KW
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-pn
-cw
 nR
 nR
 RV
@@ -67938,33 +67509,33 @@ wj
 uK
 wj
 wj
-eN
-vc
-wZ
-GM
-ja
-ja
-ja
+wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
+uK
+ti
+uK
+uK
+uK
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
 nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-nR
-Xn
-Ez
-VK
-MQ
-lM
-nR
-dK
 nR
 nR
 nR
@@ -68196,32 +67767,32 @@ uK
 wj
 wj
 wj
-Gz
-ja
-ja
-ja
-ja
-ja
-nR
-nR
-Tg
-Tg
-ch
-vc
-Gz
-cw
-cw
-cw
-Gz
-vc
-Gz
-dK
-cw
-cw
-cw
-dK
-vE
-dK
+wj
+wj
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+uK
+uK
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
+ti
 ti
 ti
 Yf
@@ -68453,26 +68024,26 @@ wj
 wj
 wj
 wj
-vc
-Mq
-GM
-oq
-ja
-qh
-nR
-nR
-bg
-ZC
-SX
-dK
+ti
+ti
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
+ti
+ti
 IP
 IP
 Yz
-IP
-IP
-IP
+ti
+ti
+ti
+ti
 AI
-IP
 IP
 Yz
 IP
@@ -68710,25 +68281,25 @@ wj
 wj
 wj
 wj
-Gz
-dK
-dK
-dK
-dK
-dK
-dK
-PG
-vE
-PG
-dK
-dK
+ti
+ti
+Hw
+Hw
+Hw
+Hw
+Hw
+Hw
+ti
+ti
+ti
+ti
 IP
 IP
 IP
 IP
-IP
-IP
-IP
+ti
+ti
+AI
 IP
 IP
 Sh

--- a/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver-Upper.dmm
@@ -598,7 +598,7 @@
 /area/f13/caves)
 "hp" = (
 /obj/machinery/conveyor/auto{
-	dir = 8
+	dir = 4
 	},
 /turf/open/indestructible/cobble{
 	light_color = null;
@@ -4554,7 +4554,7 @@
 "UG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor/auto{
-	dir = 8
+	dir = 4
 	},
 /turf/open/indestructible/cobble{
 	light_color = null;

--- a/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RedRiver.dmm
@@ -1318,13 +1318,8 @@
 	},
 /area/f13/wasteland)
 "aKf" = (
-/obj/structure/closet/crate/footchest{
-	pixel_x = -8
-	},
-/obj/item/ingot/gold,
-/obj/item/ingot/gold,
-/obj/item/coin/gold,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aKy" = (
 /turf/open/indestructible/ground/outside/road{
@@ -1957,7 +1952,8 @@
 /area/f13/building/abandoned)
 "bdy" = (
 /obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood,
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "bdG" = (
 /obj/structure/window/fulltile/house{
@@ -5499,11 +5495,13 @@
 	},
 /area/f13/building/abandoned)
 "cUP" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "cUY" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -6352,19 +6350,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "duw" = (
-/obj/structure/fence/pole_b{
-	pixel_y = 15
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
 	},
-/obj/structure/fence/pole_b{
-	pixel_y = 37;
-	layer = 5
-	},
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/obj/structure/bedsheetbin/towel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "duz" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -7325,17 +7317,10 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "dRm" = (
-/obj/structure/fence/pole_b{
-	pixel_y = 15
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
 	},
-/obj/structure/fence/pole_b{
-	pixel_y = 37;
-	layer = 5
-	},
-/obj/structure/table/booth,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "dRn" = (
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
@@ -7406,11 +7391,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "dSf" = (
-/obj/structure/barricade/sandbags{
-	pixel_x = 7
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_y = 30
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/building)
 "dSR" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -7859,9 +7846,16 @@
 	},
 /area/f13/wasteland)
 "eft" = (
-/obj/structure/chair/stool/retro,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_x = 32
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "efw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8432,6 +8426,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
+"evH" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#a83131";
+	name = "light tube"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "ewn" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/wooden/planks{
@@ -8812,9 +8818,6 @@
 /obj/item/reagent_containers/glass/bucket{
 	desc = "It smells awful.";
 	name = "waste bucket"
-	},
-/obj/structure/sign/poster/contraband/pinup_pink{
-	pixel_x = 32
 	},
 /obj/structure/sign/poster/contraband/free_tonto{
 	pixel_y = -32
@@ -9291,8 +9294,8 @@
 	},
 /area/f13/building)
 "eUV" = (
-/obj/structure/sign/poster/prewar/poster73{
-	pixel_y = 32
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -9326,9 +9329,8 @@
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/building/abandoned)
 "eVV" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eWc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9614,13 +9616,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fde" = (
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/structure/sign/poster/prewar/poster70{
+	pixel_y = -32
 	},
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "fdv" = (
 /obj/structure/flora/small_bush,
@@ -10060,15 +10061,9 @@
 	},
 /area/f13/building/abandoned)
 "fnh" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	dir = 1;
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/obj/structure/flora/rock/jungle,
+/turf/open/water,
+/area/f13/caves)
 "fnu" = (
 /obj/structure/closet/crate,
 /obj/item/toy/plush/beeplushie,
@@ -11077,8 +11072,12 @@
 	},
 /area/f13/wasteland)
 "fOH" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
+/obj/structure/sign/poster/contraband/rebels_unite{
+	pixel_x = 32
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 4;
+	light_color = "#a83131"
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -11462,15 +11461,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "fYC" = (
-/obj/machinery/light/fo13colored/Red{
-	light_color = "#a83131"
-	},
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_y = -32
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "fYE" = (
 /obj/effect/spawner/lootdrop/f13/medical,
@@ -11726,14 +11717,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gfO" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/obj/structure/curtain{
-	color = "#363636"
+/obj/structure/chair/booth{
+	icon_state = "booth_north_east"
 	},
 /turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
+	icon_state = "housewood2"
 	},
 /area/f13/building)
 "gge" = (
@@ -13871,6 +13859,16 @@
 	icon_state = "topshadowright"
 	},
 /area/f13/wasteland/city)
+"hpc" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "hpd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
@@ -14044,13 +14042,9 @@
 	},
 /area/f13/wasteland)
 "huC" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/water,
+/area/f13/caves)
 "huY" = (
 /obj/structure/fence{
 	pixel_x = 1
@@ -14172,13 +14166,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hze" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "hzq" = (
 /obj/structure/closet,
@@ -15180,17 +15171,14 @@
 	},
 /area/f13/wasteland/city)
 "ibV" = (
-/obj/structure/sign/poster/contraband/rebels_unite{
-	pixel_x = 32
-	},
-/obj/machinery/computer/slot_machine,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4;
-	light_color = "#a83131"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/stripeddress,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "icp" = (
 /obj/structure/fence{
@@ -15685,15 +15673,11 @@
 	},
 /area/f13/building/abandoned)
 "inU" = (
-/obj/structure/table/booth,
-/obj/machinery/light/fo13colored/Red{
-	dir = 1;
-	pixel_y = 15;
-	light_color = "#a83131"
+/obj/structure/simple_door/room,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "inY" = (
 /obj/structure/flora/grass/wasteland{
@@ -16106,17 +16090,17 @@
 	},
 /area/f13/wasteland)
 "iyT" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/jet,
-/obj/item/reagent_containers/pill/patch/jet{
-	pixel_x = -5;
-	pixel_y = 18
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9
 	},
-/obj/item/reagent_containers/hypospray/medipen/medx,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = 14;
+	pixel_x = -18
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "iyW" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -16426,12 +16410,12 @@
 	},
 /area/f13/building)
 "iFJ" = (
-/obj/structure/decoration/rag,
-/turf/closed/mineral/random/low_chance{
-	mineralAmt = 6;
-	mineralChance = 10
+/obj/structure/barricade/wooden,
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/area/f13/caves)
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "iFQ" = (
 /turf/open/indestructible/ground/outside/graveldirt{
 	dir = 1
@@ -16644,11 +16628,9 @@
 	},
 /area/f13/building)
 "iKV" = (
-/obj/structure/window/fulltile/house{
-	dir = 2
-	},
-/obj/structure/curtain{
-	color = "#363636"
+/obj/machinery/computer/arcade/orion_trail,
+/obj/structure/sign/poster/prewar/poster81{
+	pixel_y = 30
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -17077,7 +17059,7 @@
 /area/f13/building)
 "iXF" = (
 /obj/structure/chair/booth{
-	icon_state = "booth_east_north"
+	icon_state = "booth_south_west"
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -17387,10 +17369,14 @@
 	},
 /area/f13/wasteland)
 "jgM" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/mask/bandana/legion/legrecruit,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/chair/stool/bar,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "jhh" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -18529,6 +18515,10 @@
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
+"jIp" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jIx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18647,8 +18637,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jLU" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
+/obj/structure/sign/poster/prewar/poster65{
+	pixel_y = 32
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -20188,12 +20178,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
 "kDx" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/chair/stool/bar,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
 	},
-/area/f13/building)
+/turf/open/water,
+/area/f13/caves)
 "kDA" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 9;
@@ -20383,13 +20373,9 @@
 	},
 /area/f13/wasteland)
 "kHJ" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+/obj/structure/glowshroom/single,
+/turf/open/water,
+/area/f13/caves)
 "kHN" = (
 /obj/structure/sink{
 	dir = 4;
@@ -22596,13 +22582,9 @@
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
 "lWl" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "lWn" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -22822,21 +22804,20 @@
 	},
 /area/f13/wasteland)
 "maJ" = (
-/obj/structure/barricade/wooden,
-/obj/structure/window/fulltile/house{
-	dir = 2
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplain/nun,
+/obj/item/clothing/under/maid,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
-	},
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "maN" = (
 /obj/structure/barricade/wooden,
@@ -22878,9 +22859,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mcC" = (
-/obj/structure/sign/poster/prewar/poster79{
-	pixel_x = 32
-	},
 /obj/structure/decoration/vent/rusty{
 	desc = "It's very old and rusty.";
 	name = "rusty grate";
@@ -24037,15 +24015,8 @@
 	},
 /area/f13/building/abandoned)
 "mJr" = (
-/obj/structure/table/booth,
-/obj/machinery/light/fo13colored/Red{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/machinery/light/fo13colored/Red{
-	dir = 1;
-	pixel_y = 15;
-	light_color = "#a83131"
+/obj/structure/chair/booth{
+	icon_state = "booth_south_east"
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -24145,15 +24116,11 @@
 /turf/open/indestructible/ground/outside/savannah/topleft,
 /area/f13/wasteland)
 "mMg" = (
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/mankini,
-/obj/item/clothing/under/misc/stripper/mankini,
-/obj/structure/closet/cabinet,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/water,
+/area/f13/caves)
 "mMo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -24596,9 +24563,7 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mZZ" = (
-/obj/structure/barricade/sandbags{
-	pixel_x = 7
-	},
+/obj/machinery/grill,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "nam" = (
@@ -25367,12 +25332,13 @@
 	},
 /area/f13/building/abandoned)
 "nsO" = (
-/mob/living/simple_animal/hostile/mirelurk/baby{
-	faction = list("hostile","neutral");
-	name = "captain harpe"
+/obj/structure/sign/poster/prewar/poster69{
+	pixel_y = -32
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "ntL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26968,8 +26934,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "opl" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_x = 32
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/hypospray/medipen/medx,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet{
+	pixel_x = -5;
+	pixel_y = 18
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -27475,20 +27445,9 @@
 	},
 /area/f13/building/abandoned)
 "oDo" = (
-/mob/living/simple_animal/hostile/wolf/alpha{
-	desc = "Sheepdogs are known for their intelligence and have worked alongside humans for thousands of years. This one has a dopey smile and smells of barbecue sauce.";
-	faction = list("neutral");
-	health = 200;
-	icon_dead = "tippen_dead";
-	icon_living = "tippen";
-	icon_state = "tippen";
-	name = "Dreams-of-Moonlight"
-	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "oDp" = (
 /obj/structure/statue_fal,
 /turf/open/indestructible/ground/outside/dirt,
@@ -27967,11 +27926,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oPM" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oPO" = (
 /turf/closed/mineral/random/low_chance,
@@ -30848,9 +30806,14 @@
 	},
 /area/f13/building/abandoned)
 "qtd" = (
-/obj/item/paper/crumpled,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/simple_door/room,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
+/area/f13/building)
 "qtM" = (
 /obj/machinery/light{
 	dir = 1
@@ -32424,11 +32387,13 @@
 	},
 /area/f13/wasteland/city)
 "rqG" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/obj/structure/fence/wooden{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "rqJ" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -33544,20 +33509,19 @@
 	},
 /area/f13/building)
 "rVB" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
+/obj/structure/table/booth,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
 "rVG" = (
-/obj/machinery/light/fo13colored/Red{
-	dir = 1;
-	light_color = "#a83131"
+/obj/structure/table/booth,
+/obj/structure/fence/pole_b{
+	pixel_y = 15
 	},
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_y = 32
+/obj/structure/fence/pole_b{
+	pixel_y = 37;
+	layer = 5
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -33830,19 +33794,10 @@
 	},
 /area/f13/building/abandoned)
 "sdR" = (
-/mob/living/simple_animal/hostile/wolf{
-	desc = "The dogs that survived the Great War are a larger, and tougher breed, size of a wolf.<br>This one looks mangy, with mud stuck to his hair and flies buzzing around him.";
-	faction = list("neutral");
-	health = 200;
-	maxHealth = 200;
-	name = "Guerrilla";
-	tame = 1
-	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sen" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -35255,11 +35210,15 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "sOU" = (
-/obj/structure/simple_door/glass,
-/obj/effect/step_trigger/player_choice_log{
-	question = "Welcome to Ashdown's Bar, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_x = 32
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "sOX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36028,10 +35987,8 @@
 /area/f13/building)
 "thf" = (
 /obj/machinery/light/fo13colored/Red{
-	dir = 4;
-	light_color = "#a83131"
+	dir = 8
 	},
-/obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -36533,8 +36490,8 @@
 	},
 /area/f13/building)
 "twt" = (
-/obj/structure/sign/poster/contraband/power{
-	pixel_y = -32
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -37155,7 +37112,10 @@
 /area/f13/building)
 "tLb" = (
 /obj/machinery/light,
-/obj/structure/closet/crate/bin/trashbin,
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "tLr" = (
@@ -39006,11 +38966,13 @@
 	},
 /area/f13/wasteland)
 "uIX" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/stripeddress,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/head/maid,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4;
+	light_color = "#a83131"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "uJq" = (
 /obj/structure/lattice/catwalk,
@@ -39070,14 +39032,9 @@
 	},
 /area/f13/wasteland)
 "uKL" = (
-/obj/structure/table/wood/poker{
-	name = "felt table"
-	},
-/obj/item/storage/box/dice,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
 "uKM" = (
 /obj/machinery/light/lampost,
 /obj/effect/decal/cleanable/dirt,
@@ -40252,12 +40209,16 @@
 	},
 /area/f13/building/abandoned)
 "vtp" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = 14;
+	pixel_x = -18
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vtu" = (
 /obj/structure/sink/greyscale{
@@ -40488,10 +40449,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vDB" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/sign/poster/prewar/poster81{
+	pixel_y = 30
 	},
-/turf/closed/wall/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "vDK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41272,12 +41235,11 @@
 	},
 /area/f13/wasteland/city)
 "waZ" = (
+/obj/structure/table/booth,
 /obj/machinery/light/fo13colored/Red{
-	dir = 1;
-	pixel_y = 15;
+	dir = 4;
 	light_color = "#a83131"
 	},
-/obj/structure/table/booth,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -42539,9 +42501,10 @@
 	},
 /area/f13/radiation)
 "wJX" = (
-/obj/effect/validball_spawner,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/caves)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/closed/wall/f13/wood/interior,
+/area/f13/building)
 "wKd" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -43556,8 +43519,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "xnv" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/water,
 /area/f13/caves)
 "xnD" = (
 /obj/structure/table/reinforced{
@@ -43864,17 +43826,12 @@
 	},
 /area/f13/wasteland)
 "xwj" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/redeveninggown,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplain/nun,
-/obj/item/clothing/under/maid,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/chair/booth{
+	icon_state = "booth_north_west"
 	},
-/obj/item/clothing/under/misc/gear_harness,
-/obj/item/clothing/under/misc/gear_harness,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2"
+	},
 /area/f13/building)
 "xws" = (
 /obj/structure/table/wood,
@@ -44658,10 +44615,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "xRG" = (
-/obj/structure/table/wood/poker{
-	name = "felt table"
+/obj/machinery/light/fo13colored/Red{
+	dir = 1;
+	pixel_y = 15;
+	light_color = "#a83131"
 	},
-/obj/item/toy/cards/deck,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -44901,14 +44859,9 @@
 	},
 /area/f13/wasteland)
 "xXa" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
-/obj/structure/fluff/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/outside/graveldirt,
-/area/f13/wasteland)
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xXu" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/road{
@@ -101060,12 +101013,12 @@ iKf
 tiN
 iKf
 iKf
-iKf
+qES
 qES
 yky
-fnh
-rqG
-xXa
+qES
+qES
+qES
 qES
 lqe
 qES
@@ -101315,18 +101268,18 @@ bGx
 iKf
 iKf
 iKf
-aLl
-aLl
-eVV
-eVV
-lFI
-cYp
-lFI
-lFI
-mZZ
-dSf
-qES
 iKf
+iyT
+qES
+qES
+qES
+lWl
+eFz
+eFz
+eFz
+lVQ
+eVV
+dOr
 iKf
 iKf
 iKf
@@ -101572,18 +101525,18 @@ iKf
 iKf
 iKf
 iKf
-fde
-cCh
+iKf
+mZZ
+qES
+qES
+qES
+qES
+aLl
+evH
+eUV
 eJW
 eJW
-eJW
-vtp
-eJW
-qsc
 eFz
-lVQ
-sOU
-dOr
 iKf
 iKf
 iKf
@@ -101829,17 +101782,17 @@ iKf
 iKf
 iKf
 iKf
-gfO
-eJW
-azf
-sdR
-azf
-eJW
-eJW
-lmR
-eJW
+iKf
+qES
+qES
+qES
+qES
+qES
+guz
 eJW
 eJW
+eJW
+fde
 eFz
 aLl
 lFI
@@ -102086,15 +102039,15 @@ iKf
 iKf
 iKf
 iKf
-iKV
-hze
-xRG
-ngB
+iKf
+qES
 uKL
-azf
-eJW
-lmR
-eJW
+oDo
+uKL
+qES
+guz
+sAa
+eUV
 eJW
 eJW
 asF
@@ -102343,14 +102296,14 @@ iKf
 tiN
 tiN
 iKf
-iKV
-eJW
-azf
+iKf
+qES
+uKL
 oDo
-azf
+uKL
+qES
+cUP
 eJW
-eJW
-lmR
 eJW
 eJW
 eJW
@@ -102600,15 +102553,15 @@ iKf
 iKf
 lmY
 lmY
-lFI
+iKf
 iyT
-eJW
-eJW
-opl
+qES
+qES
+qES
 lWl
-eJW
-qsc
-eJW
+aLl
+iKV
+eUV
 eJW
 eJW
 cYp
@@ -102857,25 +102810,25 @@ tiN
 iKf
 tiN
 iKf
-tej
-tej
-aLl
-aLl
-qsc
-qsc
-kHJ
-qsc
-plJ
+iKf
+iKf
+qES
+qES
+bdy
+cYp
+tNo
+xRG
 eJW
 eJW
-tIi
+oPM
 qsc
 qsc
-kQO
+qsc
 eFz
 eFz
 eFz
-gRn
+eFz
+eFz
 eHB
 wWK
 eHB
@@ -103119,20 +103072,20 @@ qES
 euo
 euo
 sHR
-iXF
-rVB
-lmR
+uCG
 eJW
 eJW
 eJW
-qsc
-eey
-nSg
-emA
-emA
-nSg
+eJW
+eJW
+eJW
+eJW
+eJW
+vtp
+eJW
+eJW
+oPM
 eFz
-gRn
 wWK
 wWK
 wWK
@@ -103376,20 +103329,20 @@ iKf
 faV
 tfU
 dmM
-waZ
-dRm
-lmR
+uwX
 eJW
 eJW
 eJW
-qsc
-nzE
-emA
-rhU
-rhU
-emA
+eJW
+eJW
+iXF
+rVB
+xwj
+eJW
+iXF
+rVB
+xwj
 eFz
-gRn
 iRq
 wWK
 gRn
@@ -103633,20 +103586,20 @@ mGg
 xNc
 eSK
 aLl
-jLU
-fOH
-lmR
+okQ
 eJW
 eJW
 eJW
-asF
-nSg
-nSg
-emA
-emA
-vjt
+eJW
+eJW
+mJr
+rVB
+gfO
+eJW
+mJr
+rVB
+gfO
 eFz
-gRn
 gRn
 gRn
 gRn
@@ -103890,24 +103843,24 @@ ctM
 xNc
 eSK
 tNo
-qsc
-qsc
-qsc
-eUV
+xRG
 eJW
-twt
-qsc
-nSg
-uTQ
-nSg
-nSg
-nSg
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+vtp
+eJW
+eJW
+nsO
 eFz
-eFz
-eFz
-eFz
-eFz
-eFz
+gRn
+gRn
+gRn
+gRn
 gRn
 gRn
 gMW
@@ -104149,22 +104102,22 @@ eSK
 guz
 iXF
 rVB
-lmR
+xwj
 eJW
 eJW
-fYC
-qsc
-sZy
-qsc
-qsc
-pfv
-qsc
+eJW
+iXF
+rVB
+xwj
+eJW
+iXF
+rVB
+xwj
 eFz
-eZH
-oPM
-nSg
-taA
-eFz
+gRn
+gRn
+gRn
+gRn
 gRn
 gRn
 wWK
@@ -104403,25 +104356,25 @@ iKf
 mGg
 flw
 eSK
-aLl
+cUP
 mJr
-duw
-lmR
+rVB
+gfO
 eJW
 eJW
-kDx
-bJD
-xeQ
-rhU
-nSg
-nSg
-nSg
-lFI
-mYK
-lzn
-nSg
-wjs
+eJW
+mJr
+rVB
+gfO
+eJW
+mJr
+rVB
+gfO
 eFz
+gRn
+gRn
+gRn
+gRn
 gRn
 gRn
 wWK
@@ -104660,25 +104613,25 @@ iKf
 mGg
 flw
 eSK
-maJ
+dOr
 jLU
-fOH
-lmR
 eJW
 eJW
-azf
-xPe
-vqc
-rhU
-nSg
-nSg
-nSg
-pfv
-nSg
-nSg
-nSg
-nSg
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+oPM
 eFz
+gRn
+gRn
+gRn
+gRn
 gRn
 gRn
 wWK
@@ -104918,24 +104871,24 @@ mGg
 flw
 eSK
 grq
-qsc
-qsc
-qsc
-rVG
+xRG
 eJW
-azf
-bJD
-rhU
-rhU
-nSg
-nSg
-iAq
-yjb
-uIX
-xwj
-mMg
-wjn
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
 eFz
+gRn
+gRn
+gRn
+gRn
 gRn
 gRn
 wWK
@@ -105174,10 +105127,10 @@ iKf
 mGg
 flw
 eSK
-maJ
+guz
 iXF
 rVB
-lmR
+xwj
 eJW
 eJW
 cur
@@ -105186,18 +105139,18 @@ biI
 biI
 qsc
 rzY
+eFz
+lFI
+lFI
+lFI
+eFz
+eFz
 qsc
-xYV
+qsc
+kQO
 eFz
-fHz
-cYp
-wyI
 eFz
-gRn
-gRn
-wWK
-wWK
-wWK
+eFz
 wWK
 wWK
 wWK
@@ -105431,10 +105384,10 @@ iKf
 mGg
 flw
 eSK
-aLl
-inU
-duw
-lmR
+cUP
+mJr
+rVB
+gfO
 eJW
 eJW
 wuW
@@ -105448,13 +105401,13 @@ jPB
 jSc
 epr
 ndB
-bdy
-gRn
-gRn
-wWK
-wWK
-gMW
-wWK
+tIi
+nSg
+nSg
+nSg
+nSg
+nSg
+eFz
 wWK
 wWK
 wWK
@@ -105688,10 +105641,10 @@ wEK
 mGg
 flw
 eSK
-maJ
-jLU
-fOH
-lmR
+aLl
+eJW
+eJW
+eJW
 eJW
 eJW
 wuW
@@ -105704,14 +105657,14 @@ cYp
 nSg
 nSg
 nSg
+sHS
+qsc
+eey
 nSg
-vDB
-gRn
-gRn
-wWK
-wWK
-gMW
-gMW
+emA
+emA
+nSg
+eFz
 wWK
 wWK
 wWK
@@ -105962,13 +105915,13 @@ wnb
 nSg
 nSg
 tLb
-tej
-gRn
-wWK
-wWK
-gMW
-gMW
-gMW
+qsc
+nzE
+emA
+rhU
+rhU
+emA
+eFz
 gMW
 wWK
 wWK
@@ -106218,14 +106171,14 @@ rzY
 nSg
 nSg
 nSg
-cUP
-tej
-gRn
-wWK
-gMW
-gMW
-gMW
-gMW
+nSg
+pfv
+nSg
+nSg
+emA
+emA
+vjt
+eFz
 gMW
 wWK
 iXj
@@ -106472,17 +106425,17 @@ ryS
 ryS
 hip
 lFI
-sHS
+nSg
 nMG
 kew
 ezM
+qsc
+nSg
+uTQ
+nSg
+nSg
+nSg
 eFz
-gRn
-wWK
-gMW
-gMW
-gMW
-gMW
 gMW
 gMW
 tNF
@@ -106719,7 +106672,7 @@ euo
 euo
 euo
 gRn
-eFz
+rYb
 eFz
 eJW
 nSg
@@ -106729,18 +106682,18 @@ iFh
 iFh
 lFI
 hip
-fHz
+inU
 fHz
 cYp
 eFz
 eFz
-gRn
-wWK
-gMW
-gMW
-wJX
-aKf
-gMW
+eFz
+eFz
+eFz
+inU
+eFz
+eFz
+eFz
 gMW
 kOR
 kOR
@@ -106973,31 +106926,31 @@ iKf
 tzZ
 sWE
 jZn
-gRn
-gRn
-gRn
+rYb
+rYb
+rYb
+rYb
 cYp
-uCG
+eJW
+fOH
 eJW
 eJW
 eJW
+uIX
+cYp
+eFz
+vYO
+atp
+srD
+dOB
+dRm
 eJW
-eJW
-eJW
-fHz
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-wWK
-gRn
-kOR
-eft
-kOR
-kOR
+eFz
+eZH
+emA
+nSg
+taA
+eFz
 gMW
 kOR
 kOR
@@ -107227,35 +107180,35 @@ iKf
 tfn
 iKf
 iKf
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
 fHz
-uwX
+qtd
+eFz
+tvk
+cYp
+hip
+lFI
+eFz
+eFz
+dSf
+vYO
+vYO
+ryS
+dRm
 eJW
-huC
-eJW
-huC
-eJW
-huC
-wyI
-gRn
-gRn
-gRn
-gRn
-wWK
-wWK
-wWK
-wWK
-gRn
-nsO
-xnv
-jgM
-kOR
-kOR
+eFz
+mYK
+lzn
+nSg
+wjs
+eFz
+gMW
 kOR
 kOR
 gMW
@@ -107483,36 +107436,36 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+rYb
+rYb
+rYb
+sdR
+duw
+rYb
 aLl
-okQ
 eJW
-ibV
 eJW
-sAa
+eJW
+eJW
 eJW
 thf
-cYp
-gRn
-gRn
-gRn
-gRn
-wWK
-gRn
-gRn
-wWK
-gRn
-kOR
-eft
-kOR
-qtd
-kOR
+wuW
+ryS
+vYO
+vYO
+vYO
+ryS
+dRm
+eJW
+pfv
+nSg
+nSg
+nSg
+wjn
+eFz
+gMW
 sKh
 kOR
 gMW
@@ -107739,37 +107692,37 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+rYb
+xXa
+aKf
+aKf
+wWK
+wWK
+wWK
 lFI
-fHz
-fHz
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+wuW
+ryS
+ryS
+ryS
+ryS
+ryS
+dRm
+eJW
+bdy
+ibV
+maJ
+nSg
+nSg
 eFz
-tvk
-cYp
-hip
-lFI
-eFz
-gRn
-wWK
-wWK
-wWK
-wWK
-wWK
-gRn
-gRn
-gRn
-gRn
-kOR
-kOR
-kOR
-kOR
+gMW
 kOR
 gMW
 gMW
@@ -107995,38 +107948,38 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+rYb
+rYb
 wWK
-tCq
-iRq
+fnh
 wWK
 wWK
-iFJ
-gRn
-gRn
+wWK
+wWK
+hze
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+nSg
+iFh
+iFh
+iFh
+iFh
+iFh
+nSg
+oPM
+qsc
+sZy
+qsc
+wJX
+pfv
+eFz
 gMW
-kOR
-kOR
-kOR
 gMW
 gMW
 gMW
@@ -108252,37 +108205,37 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-iRq
-tCq
+rYb
+rYb
+rYb
+xnv
+xnv
+xnv
+qAV
 wWK
-eHB
 wWK
-gRn
-gRn
-gRn
-gMW
-kOR
-gMW
+wWK
+hze
+fYC
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+azf
+bJD
+xeQ
+rhU
+nSg
+nSg
+lFI
 gMW
 gMW
 gMW
@@ -108509,37 +108462,37 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+fnh
+xnv
+xnv
+xnv
+qAV
 wWK
 wWK
 wWK
-wWK
-gRn
-gRn
-gRn
-gRn
-gMW
-gMW
-gMW
+hze
+fYC
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+eJW
+azf
+xPe
+vqc
+rhU
+nSg
+nSg
+lFI
 gMW
 gMW
 gMW
@@ -108766,37 +108719,37 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+rYb
+rYb
+kDx
+xnv
+xnv
+xnv
+xnv
+qAV
 wWK
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
-gMW
-gMW
+jIp
+lFI
+fYC
+eJW
+eJW
+eJW
+eJW
+eft
+eJW
+eJW
+eJW
+sOU
+eJW
+eJW
+eJW
+hpc
+bJD
+rhU
+rhU
+nSg
+iAq
+yjb
 gMW
 gMW
 gMW
@@ -109023,37 +108976,37 @@ gRn
 gRn
 gRn
 gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
-gMW
-gMW
+rYb
+rYb
+kHJ
+xnv
+xnv
+huC
+xnv
+qAV
+xXa
+rYb
+lFI
+lFI
+lmR
+lmR
+lmR
+qsc
+qsc
+lmR
+lmR
+lmR
+qsc
+lmR
+lmR
+lmR
+eFz
+tej
+lFI
+lFI
+lFI
+lFI
+xYV
 gMW
 gMW
 gMW
@@ -109280,37 +109233,37 @@ gRn
 gRn
 gRn
 gMW
+rYb
+rYb
+wWK
+xnv
+xnv
+xnv
+xnv
+xnv
+wWK
+rYb
+rqG
+eJW
+eJW
+eJW
+eJW
+eJW
+qsc
+iXF
+rVG
+xwj
+qsc
+iXF
+rVG
+xwj
+eFz
 gMW
 gMW
 gMW
 gMW
 gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
+gMW
 gMW
 gMW
 gMW
@@ -109537,33 +109490,33 @@ gMW
 gMW
 gMW
 gMW
+rYb
+rYb
+wWK
+wWK
+fnh
+xnv
+xnv
+xnv
+fnh
+rYb
+lFI
+vDB
+eJW
+azf
+eJW
+eJW
+hll
+mJr
+waZ
+gfO
+qsc
+mJr
+waZ
+gfO
+tIi
+gRn
 gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
 gRn
 gRn
 gRn
@@ -109794,32 +109747,32 @@ gMW
 gMW
 gMW
 gMW
+rYb
+rYb
+rYb
+wWK
+wWK
+xnv
+mMg
+xnv
+rYb
+rYb
+lFI
+eJW
+azf
+ngB
+azf
+nsO
+qsc
+lFI
+lFI
+lFI
+lFI
+lFI
+rqG
+iFJ
+lFI
 gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
 gRn
 gRn
 gRn
@@ -110051,23 +110004,23 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
+rYb
+rYb
+rYb
+rYb
+wWK
+wWK
+rYb
+wWK
+rYb
+rYb
+rqG
+twt
+azf
+ngB
+azf
+oPM
+wJX
 gMW
 gMW
 gMW
@@ -110308,23 +110261,23 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+tej
+eJW
+azf
+ngB
+azf
+eJW
+qsc
 gMW
 gMW
 gMW
@@ -110565,23 +110518,23 @@ gMW
 gMW
 gMW
 gMW
-gMW
-gMW
-gMW
-gMW
-gMW
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gRn
-gMW
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+rYb
+lFI
+cCh
+eJW
+jgM
+eJW
+opl
+wyI
 gMW
 gMW
 gMW
@@ -110832,13 +110785,13 @@ rYb
 rYb
 rYb
 rYb
-rYb
-rYb
-rYb
-rYb
-rYb
-rYb
-rYb
+nmX
+nmX
+nmX
+nmX
+nmX
+nmX
+nmX
 rYb
 rYb
 rYb


### PR DESCRIPTION
## About The Pull Request
Reverses the idea of a second Ashdown bar and, instead, takes option 2. Gives Ashdown's main bar an adult segment that's a bit more condensed while turning the *main* section into a 'family friendly' zone.

Note: May need a few more passes, but this _should_ be good.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: An additional top-side house
del: Second Bar in Ashdown I'd made and the alternate path up.
tweak: Drastically adjusts the Ashdown bar's Aesthetics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
Bar in question: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/c810abbb-e322-4bf3-9f73-f11af07c5c7d)
House: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/0113bb82-3b73-4e37-b475-d8247c606e87)
