### PR TITLE
Sleeping Carp fix and "nerf"

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -143,7 +143,7 @@
 		return
 	ADD_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, SLEEPING_CARP_TRAIT)
+	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS ,SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod *= 0.5 //You take less stamina damage overall, but you do not reduce the damage from stun batons
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	//H.physiology.pressure_mod *= 0.3 //go hang out with carp
@@ -156,7 +156,7 @@
 	. = ..()
 	REMOVE_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	REMOVE_TRAIT(H, TRAIT_TASED_RESISTANCE, SLEEPING_CARP_TRAIT)
+	REMOVE_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS ,SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -143,7 +143,7 @@
 		return
 	ADD_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
+	ADD_TRAIT(H, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod *= 0.5 //You take less stamina damage overall, but you do not reduce the damage from stun batons
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	//H.physiology.pressure_mod *= 0.3 //go hang out with carp
@@ -156,7 +156,7 @@
 	. = ..()
 	REMOVE_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	REMOVE_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
+	REMOVE_TRAIT(H, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -143,7 +143,7 @@
 		return
 	ADD_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS ,SLEEPING_CARP_TRAIT)
+	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod *= 0.5 //You take less stamina damage overall, but you do not reduce the damage from stun batons
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	//H.physiology.pressure_mod *= 0.3 //go hang out with carp
@@ -156,7 +156,7 @@
 	. = ..()
 	REMOVE_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-	REMOVE_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS ,SLEEPING_CARP_TRAIT)
+	REMOVE_TRAIT(H, TRAIT_TASED_RESISTANCE, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -17,7 +17,7 @@
 	name = "adrenal implant"
 	desc = "Removes all stuns."
 	icon_state = "adrenal"
-	uses = 3
+	uses = 1
 
 /obj/item/implant/adrenalin/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -33,7 +33,7 @@
 /obj/item/implant/adrenalin/activate()
 	. = ..()
 	uses--
-	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list(/datum/reagent/medicine/inaprovaline = 3, /datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/regen_jelly = 10, /datum/reagent/medicine/stimulants = 10), span_boldnotice("You feel a sudden surge of energy!"))
+	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list(/datum/reagent/medicine/inaprovaline = 3, /datum/reagent/medicine/synaptizine = 5, /datum/reagent/medicine/regen_jelly = 5, /datum/reagent/medicine/stimulants = 5), span_boldnotice("You feel a sudden surge of energy!"))
 	to_chat(imp_in, span_notice("You feel a sudden surge of energy!"))
 	if(!uses)
 		qdel(src)


### PR DESCRIPTION
Gives the no drugs trait to sleeping carp, as it was intended from the getgo. Halves adrenaline implant's reagents while also giving it only 1 use. You don't need 3. The only reason this ever even gets used is for sleeping carp, to instantly regain all of your stamina back-- 3 times.

For the same reasons I removed the slime cores, this is being nerfed. If it continues to be a problem, I will hit it again.