### PR TITLE
Revert "Merge pull request #2554 from jinxynii/master" and nerfs 'Stimulants' reagent instead

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -33,7 +33,7 @@
 /obj/item/implant/adrenalin/activate()
 	. = ..()
 	uses--
-	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/medicine/regen_jelly = 1, /datum/reagent/medicine/stimulants = 1, /datum/reagent/drug/jet = 3), span_boldnotice("You feel a sudden surge of energy!"))
+	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list(/datum/reagent/medicine/inaprovaline = 3, /datum/reagent/medicine/synaptizine = 5, /datum/reagent/medicine/regen_jelly = 5, /datum/reagent/medicine/stimulants = 5), span_boldnotice("You feel a sudden surge of energy!"))
 	to_chat(imp_in, span_notice("You feel a sudden surge of energy!"))
 	if(!uses)
 		qdel(src)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1166,7 +1166,7 @@
 		M.adjustFireLoss(-1*REM, FALSE)
 	M.AdjustAllImmobility(-60, FALSE)
 	M.AdjustUnconscious(-60, FALSE)
-	M.adjustStaminaLoss(-20*REM, FALSE)
+	M.adjustStaminaLoss(-7.5*REM, FALSE)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
This reverts commit 165e28f89019f2ccf6fb02b7fb2a31acfdba4223, reversing changes made to 31697d20c72bbfd1b5ff9dfdf4f79f1cd5292711 on the grounds that it is a salt PR that was merged without proper consideration of balance, explanation of why it is needed, exploration of alternative solutions, or even an honest to god review of the mechanics behind the changes.

Adrenaline implants are presumably altered because one of the chemicals it contained has a stamina restoration effect, which is the reason why a clean veins trait is forced on all martial arts -- to prevent the abuse of jet with sleeping carp for infinite stamina. This is handled in relevant chemicals with a `M.adjustStaminaLoss()` proc. 

One of the problems I have with this PR, however, is that Jet is far and away **far** easier to obtain than the implant itself and, like the implant itself, it is single use. To my knowledge, there is no way outside of this implant to obtain the specific chemical providing the original effect, which is stimulants. If having as much stamina regen as jet for no other downsides than mild toxin damage is such a deal-breaker, then couldn't jinx just as easily nerfed the regeneration effect instead of precluding the use of a pre-war tech, which has no business containing post-war drugs to begin with, from use by people with certain traits by replacing the prewar drug made specifically for it with street drugs? In fact, I have included a nerf to stimulants, taking the stamina regen from -20*REM (the same as Jet) to -7.5*REM, which is less than half the original. This value can be adjusted further on review if needed, but ideally it will be weak enough to not provide infinite stamina while blocking projectiles with Sleeping Carp, but still provides the other anti-stun and anti stam-crit properties of the implant, which is the use for which it was intended when it was added as an antag item in the first place.

## Pre-Merge Checklist
- [ x] You tested this on a local server.
- [ x] This code did not runtime during testing.
- [ x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: stamina regen effect of stimulants decreased from -20*REM to 7.5*REM
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
