### PR TITLE
Fixes cats being rats

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -377,7 +377,7 @@
 	name = "A cat!"
 	desc = "You identify as a cat! (Mostly to help identify your species mechanically)"
 	value = 0
-	mob_trait = TRAIT_RAT
+	mob_trait = TRAIT_CAT
 /datum/quirk/rat
 	name = "A rat!"
 	desc = "You identify as a rat! (Mostly to help identify your species mechanically)"


### PR DESCRIPTION
a mispelling in the code made everyone with the TRAIT_CAT in neutral quirks be actually TRAIT_RAT, this fixes that horrible crime.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
Rin Pin :cl:
fix: cats are no longer rats

/:cl:

