### PR TITLE
fixes reinforced hazard suits

### DIFF
--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3653,6 +3653,7 @@
 	name = "reinforced hazard suit"
 	desc = "A CBRN hazard suit that's been paired with a ballistic vest. Surprisingly lightweight for all of its bulk."
 	icon_state = "bio_security"
+	w_class = WEIGHT_CLASS_NORMAL
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENV_T4, ARMOR_MODIFIER_UP_DT_T3)
 
 //Janitor's biosuit, grey with purple arms


### PR DESCRIPTION
the craftable hazard suit was meant to be normal sized, but due to an error, it ended up taking the original bulk of the biosuit, considering it was meant to be the light version of the wanderer / seva suit, this fixes that.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
Rin Pin:cl:
fix: Reinforced Hazard Suit is now normal sized as it was meant to be.

/:cl:
