### PR TITLE
New boomerang weapon + "fixes" regarding boomerang code

### DIFF
--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -783,6 +783,12 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 /obj/item/storage/box/gun/melee/switchblade/PopulateContents()
 	new /obj/item/melee/onehanded/knife/switchblade(src)
 
+/datum/loadout_box/boomerang
+	entry_tag = "Boomerang"
+	entry_flags = LOADOUT_FLAG_WASTER | LOADOUT_FLAG_TRIBAL
+	entry_class = LOADOUT_CAT_MELEE_ONE
+	spawn_thing = /obj/item/melee/f13onehanded/boomerang
+
 /obj/item/storage/box/gun/melee/throwing
 	name = "throwing knife case"
 
@@ -2164,7 +2170,7 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	entry_flags = LOADOUT_FLAG_TRIBAL
 	entry_class = LOADOUT_CAT_MELEE_TWO
 	spawn_thing = /obj/item/storage/box/gun/tribal/bmprsword
-*/ 
+*/
 
 /datum/loadout_box/warmace
 	entry_tag = "Warmace"

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -646,8 +646,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "boomerang"
 	item_state = "boomerang"
 	force = 30
-	throwforce = 35 //so it can kill weak trash mobs in one throw
-	throw_speed = 3
+	throwforce = 18 //so it can kill weak trash mobs in one throw, a bug causes boomerang type weapons to deal double the intended damage, so this is  a bandaid fix meanwhile
+	throw_speed = 4
 	attack_verb = list("beat", "smacked", "clubbed", "clobbered")
 	sharpness = SHARP_NONE
 	attack_speed = CLICK_CD_MELEE
@@ -667,7 +667,7 @@ obj/item/melee/onehanded/knife/switchblade
 			throw_at(thrownby, throw_range+2, throw_speed, null, TRUE)
 	else if(!thrownby)
 		return
-	return ..()
+	return
 
 
 

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -640,6 +640,37 @@ obj/item/melee/onehanded/knife/switchblade
 	add_fingerprint(user)
 
 
+/obj/item/melee/f13onehanded/boomerang
+	name = "boomerang"
+	desc = "An ancient, primitive weapon used by hunters, able to return when thrown and surprisingly powerful for a piece of wood, this one seems to be equipped with non functioning electronics"
+	icon_state = "boomerang"
+	item_state = "boomerang"
+	force = 30
+	throwforce = 35 //so it can kill weak trash mobs in one throw
+	throw_speed = 3
+	attack_verb = list("beat", "smacked", "clubbed", "clobbered")
+	sharpness = SHARP_NONE
+	attack_speed = CLICK_CD_MELEE
+	var/throw_hit_chance = 99
+
+/obj/item/melee/f13onehanded/boomerang/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force)
+	if(ishuman(thrower))
+		var/mob/living/carbon/human/H = thrower
+		H.throw_mode_on() //so they can catch it on the return.
+	return ..()
+
+/obj/item/melee/f13onehanded/boomerang/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
+	if(thrownby && !caught)
+		sleep(1)
+		if(!QDELETED(src))
+			throw_at(thrownby, throw_range+2, throw_speed, null, TRUE)
+	else if(!thrownby)
+		return
+	return ..()
+
+
+
 // Slave whip
 /obj/item/melee/onehanded/slavewhip
 	name = "slave whip"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -265,7 +265,7 @@
 	icon_state = "garb"
 	item_state = "garb"
 	force = 23
-	throwforce = 23
+	throwforce = 12
 	throw_speed = 4
 	attack_verb = list("sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -306,7 +306,7 @@
 	icon_state = "gar"
 	item_state = "gar"
 	force = 23
-	throwforce = 23
+	throwforce = 12
 	throw_speed = 4
 	attack_verb = list("sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -337,7 +337,7 @@
 	icon_state = "supergar"
 	item_state = "gar"
 	force = 23
-	throwforce = 23
+	throwforce = 12
 	sharpness = SHARP_EDGED
 	glass_colour_type = /datum/client_colour/glass_colour/red
 	attack_speed = CLICK_CD_MELEE * 0.8


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Adds a new boomerang weapon to the weapon kit, a normal sized wooden boomerang that acts as a normal speed club while returning when thrown, it also "fixes" a current error in existing boomerang code which made it apply double damage to the target, this simply halves the throw damage in existing boomerang items it so now it should deal the damage it's meant to
## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
RinPin :cl:
add: Adds  new boomerang weapon to the kit choice
fix: halves existing boomerang weapon damage so it applies correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
