### PR TITLE
Slight refurbished power armor tweak

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -951,6 +951,14 @@ GLOBAL_LIST_INIT(armor_token_operation_legend, list(
 */
 #define ARMOR_SLOWDOWN_SALVAGE 2
 
+
+/*
+ * Refurbished Power Armor
+ * Basically driving a crappy car
+*/
+#define ARMOR_SLOWDOWN_REPA 1.2
+
+
 /*
  * Power Armor
  * Basically driving a car

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3399,7 +3399,7 @@
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
 	armor = ARMOR_VALUE_SALVAGE
-	slowdown = ARMOR_SLOWDOWN_SALVAGE * ARMOR_SLOWDOWN_GLOBAL_MULT
+	slowdown = ARMOR_SLOWDOWN_PA * ARMOR_SLOWDOWN_GLOBAL_MULT
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3399,7 +3399,7 @@
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
 	armor = ARMOR_VALUE_SALVAGE
-	slowdown = ARMOR_SLOWDOWN_PA * ARMOR_SLOWDOWN_GLOBAL_MULT
+	slowdown = ARMOR_SLOWDOWN_REPA * ARMOR_SLOWDOWN_GLOBAL_MULT
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Makes the refurbished power armor have a speed that is slightly slower than regular PA, at 1.2 instead of 1, since at the moment, it's just as slow and bad as  salvaged despite all the trouble it takes to get the servos restored + the training to wear it, while still keeping the salvaged armor values.
## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
RinPin :cl:
tweak: refurbished PA now moves at slightly slower than PA speed

/:cl: