### PR TITLE
Hotrod Refurbished + Recipe

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -952,6 +952,12 @@ GLOBAL_LIST_INIT(armor_token_operation_legend, list(
 #define ARMOR_SLOWDOWN_SALVAGE 2
 
 /*
+ * Refurbished Power Armor
+ * Basically driving a crappy car
+*/
+#define ARMOR_SLOWDOWN_REPA 1.2
+
+/*
  * Power Armor
  * Basically driving a car
 */

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -675,6 +675,31 @@
 	subcategory = CAT_SCAVENGING
 	always_available = FALSE
 
+/datum/crafting_recipe/repair_t45/hotrod
+	name = "Refurbished T-45b Hotrod Power Armor"
+	result = /obj/item/clothing/suit/armor/power_armor/t45b/hotrod
+	reqs = list(/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/hotrod = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/crafting/electronicparts = 5,
+				/obj/item/stock_parts/manipulator/pico = 1,
+				/obj/item/stock_parts/cell/ammo/mfc = 1)
+	time = 35
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+/datum/crafting_recipe/repair_t45_helm/hotrod
+	name = "Refurbished T-45b Hotrod Power Armor Helmet"
+	result = /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
+	reqs = list(/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/hotrod = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/crafting/electronicparts = 2)
+	time = 25
+	category = CAT_CRAFTING
+	subcategory = CAT_SCAVENGING
+	always_available = FALSE
+
+
 /datum/crafting_recipe/teachboy
 	name = "Refurbish Educational Pip-Boy 2000"
 	result = /obj/item/pda/teachboy

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -95,7 +95,10 @@ GLOBAL_LIST_INIT(pa_repair, list(
 	/datum/crafting_recipe/repair_t45,
 	/datum/crafting_recipe/repair_t45_helm,
 	/datum/crafting_recipe/scrap_pa,
-	/datum/crafting_recipe/scrap_pa_helm))
+	/datum/crafting_recipe/scrap_pa_helm,
+	/datum/crafting_recipe/repair_t45/hotrod,
+	/datum/crafting_recipe/repair_t45_helm/hotrod))
+
 
 GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	/datum/crafting_recipe/policepistol,

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -22,6 +22,17 @@
 	item_state = "raiderpa_helm"
 	armor = ARMOR_VALUE_SALVAGE
 
+ /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
+	name = "Refurbished T-45b Hotrod helmet"
+	desc = "This power armor helmet was restored and modified to protect against flames and high intensity lasers at the cost of some protection against blunt trauma."
+	icon_state = "t45hotrod_helm"
+	item_state = "t45hotrod_helm"
+	armor = ARMOR_VALUE_SALVAGE
+	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/hotrod
+	armor_tokens = list( ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3,)
+
+
+
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/ncr
 	name = "ncr salvaged T-45b helmet"
 	desc = "It's an NCR salvaged T-45b power armor helmet, better repaired than regular salvaged PA, and decorated with the NCR flag and other markings for an NCR Heavy Trooper."

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -24,7 +24,7 @@
 
  /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
 	name = "Refurbished T-45b Hotrod helmet"
-	desc = "This power armor helmet was restored and modified to protect against flames and high intensity lasers at the cost of some protection against blunt trauma."
+	desc = "This power armor helmet was restored and modified to protect against fire and high intensity lasers at the cost of some protection against blunt trauma."
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
 	armor = ARMOR_VALUE_SALVAGE

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -30,8 +30,6 @@
 	armor = ARMOR_VALUE_SALVAGE
 	armor_tokens = list( ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3,)
 
-
-
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/ncr
 	name = "ncr salvaged T-45b helmet"
 	desc = "It's an NCR salvaged T-45b power armor helmet, better repaired than regular salvaged PA, and decorated with the NCR flag and other markings for an NCR Heavy Trooper."

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -34,6 +34,15 @@
 	item_state = "t45hotrod_helm"
 	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3)
 
+/obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
+	name = "Refurbished T-45b Hotrod helmet"
+	desc = "This power armor helmet was restored and modified to protect against flames and high intensity lasers at the cost of some protection against blunt trauma."
+	icon_state = "t45hotrod_helm"
+	item_state = "t45hotrod_helm"
+	armor = ARMOR_VALUE_SALVAGE
+	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/hotrod
+	armor_tokens = list( ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3,)
+
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/tribal
 	name = "tribal t-45b headdress"
 	desc = "A salvaged T-45b powered armor, with the servos removed and a feathered headdress. Certain bits of plating have been stripped out to retain more freedom of movement."

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -28,7 +28,6 @@
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
 	armor = ARMOR_VALUE_SALVAGE
-	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/hotrod
 	armor_tokens = list( ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3,)
 
 

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -22,9 +22,9 @@
 	item_state = "raiderpa_helm"
 	armor = ARMOR_VALUE_SALVAGE
 
- /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
+/obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
 	name = "Refurbished T-45b Hotrod helmet"
-	desc = "This power armor helmet was restored and modified to protect against fire and high intensity lasers at the cost of some protection against blunt trauma."
+	desc = "This power armor helmet was restored and modified to protect against flames and high intensity lasers at the cost of some protection against blunt trauma."
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
 	armor = ARMOR_VALUE_SALVAGE

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -20,6 +20,7 @@
 	desc = "a raider's attempt to duplicate a power armor helmet. The result is a fuzed mass of metal and ceramic that nonetheless provides protection"
 	icon_state = "raiderpa_helm"
 	item_state = "raiderpa_helm"
+	armor = ARMOR_VALUE_SALVAGE
 
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/ncr
 	name = "ncr salvaged T-45b helmet"
@@ -33,15 +34,6 @@
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
 	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3)
-
-/obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
-	name = "Refurbished T-45b Hotrod helmet"
-	desc = "This power armor helmet was restored and modified to protect against flames and high intensity lasers at the cost of some protection against blunt trauma."
-	icon_state = "t45hotrod_helm"
-	item_state = "t45hotrod_helm"
-	armor = ARMOR_VALUE_SALVAGE
-	salvaged_type = /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/hotrod
-	armor_tokens = list( ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3,)
 
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/tribal
 	name = "tribal t-45b headdress"

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3463,6 +3463,17 @@
 	icon_state = "t51bpowerarmor_bos"
 	item_state = "t51bpowerarmor_bos"
 
+/obj/item/clothing/suit/armor/power_armor/t45b/hotrod
+	name = "Refurbished T-45b Hotrod power armor"
+	desc = "It's a set of T-45b power armor with a with some of its plating replaced by ablative, fire resistant armor. This set has exhaust pipes piped to the pauldrons, flames erupting from them."
+	icon_state = "t45hotrod"
+	item_state = "t45hotrod"
+	armor = ARMOR_VALUE_SALVAGE
+	slowdown = ARMOR_SLOWDOWN_PA * ARMOR_SLOWDOWN_GLOBAL_MULT
+	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/hotrod
+	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3, )
+
+
 /obj/item/clothing/suit/armor/power_armor/excavator
 	name = "excavator power armor"
 	desc = "Developed by Garrahan Mining Co. in collaboration with West Tek, the Excavator-class power armor was designed to protect miners from rockfalls and airborne contaminants while increasing the speed at which they could work. "

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3469,7 +3469,7 @@
 	icon_state = "t45hotrod"
 	item_state = "t45hotrod"
 	armor = ARMOR_VALUE_SALVAGE
-	slowdown = ARMOR_SLOWDOWN_PA * ARMOR_SLOWDOWN_GLOBAL_MULT
+	slowdown = ARMOR_SLOWDOWN_REPA * ARMOR_SLOWDOWN_GLOBAL_MULT
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b/hotrod
 	armor_tokens = list(ARMOR_MODIFIER_UP_FIRE_T3, ARMOR_MODIFIER_DOWN_MELEE_T2, ARMOR_MODIFIER_UP_LASER_T3, )
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Adds a refurbished version of the hotrod armor + recipe locked behind technophreak, because the sprite is too awesome to be wasted in such terrible armor, it keeps the stats it had as salvaged, with just a slightly increase to DT, making it a laser focused counterpart to the regular refurbished, at the cost of melee
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
Rin Pin :cl:
add: Adds a refurbished version of the Hotrod PA + Recipe

/:cl:
