### PR TITLE
adds new speed for refurbished armor + nerfs powered scrap armor

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -951,14 +951,6 @@ GLOBAL_LIST_INIT(armor_token_operation_legend, list(
 */
 #define ARMOR_SLOWDOWN_SALVAGE 2
 
-
-/*
- * Refurbished Power Armor
- * Basically driving a crappy car
-*/
-#define ARMOR_SLOWDOWN_REPA 1.2
-
-
 /*
  * Refurbished Power Armor
  * Basically driving a crappy car

--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -951,6 +951,14 @@ GLOBAL_LIST_INIT(armor_token_operation_legend, list(
 */
 #define ARMOR_SLOWDOWN_SALVAGE 2
 
+
+/*
+ * Refurbished Power Armor
+ * Basically driving a crappy car
+*/
+#define ARMOR_SLOWDOWN_REPA 1.2
+
+
 /*
  * Power Armor
  * Basically driving a car

--- a/code/modules/clothing/head/f13heavy_helmets.dm
+++ b/code/modules/clothing/head/f13heavy_helmets.dm
@@ -20,7 +20,8 @@
 	desc = "a raider's attempt to duplicate a power armor helmet. The result is a fuzed mass of metal and ceramic that nonetheless provides protection"
 	icon_state = "raiderpa_helm"
 	item_state = "raiderpa_helm"
-
+	armor = ARMOR_VALUE_SALVAGE
+	slowdown =  ARMOR_SLOWDOWN_REPA * ARMOR_SLOWDOWN_GLOBAL_MULT
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45b/ncr
 	name = "ncr salvaged T-45b helmet"
 	desc = "It's an NCR salvaged T-45b power armor helmet, better repaired than regular salvaged PA, and decorated with the NCR flag and other markings for an NCR Heavy Trooper."

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -3399,7 +3399,7 @@
 	icon_state = "t45bpowerarmor"
 	item_state = "t45bpowerarmor"
 	armor = ARMOR_VALUE_SALVAGE
-	slowdown = ARMOR_SLOWDOWN_SALVAGE * ARMOR_SLOWDOWN_GLOBAL_MULT
+	slowdown =  ARMOR_SLOWDOWN_REPA * ARMOR_SLOWDOWN_GLOBAL_MULT
 	salvaged_type = /obj/item/clothing/suit/armor/heavy/salvaged_pa/t45b
 
 /obj/item/clothing/suit/armor/power_armor/t45b/raider
@@ -3407,6 +3407,8 @@
 	desc = "A monumentously heavy suit of rusty metal and car parts. Either an actual power armor exoskeleton or some home-built substitute sits embedded under all that rust. Is this some attempt at power armor???"
 	icon_state = "raiderpa"
 	item_state = "raiderpa"
+	armor = ARMOR_VALUE_SALVAGE
+	slowdown =  ARMOR_SLOWDOWN_REPA * ARMOR_SLOWDOWN_GLOBAL_MULT
 	mutantrace_variation = STYLE_DIGITIGRADE
 	salvaged_type = /obj/item/clothing/suit/armor/medium/raider/raidermetal
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
adds a new armor speed category for refurbished power armor, so it's slightly slower than regular PA, (regular PA being a value of 1, same as heavy armor, while the refurbished armor will get a value of 1.2) and also nerfs the powered scrap armor, which turns out, is just identical to regular T45b with just a different sprite, it gives it a salvaged power armor value instead alongside the speed changes.
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
RinPin :cl:
add: New speed for refurbished power armor
balance: powered scrap armor is no longer free regular T45b, it's instead now salvaged tier.

/:cl:

