### PR TITLE
Add Ballistic Stun Taser to Sheriff and Deputy

### DIFF
--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -3,7 +3,7 @@ Town access doors
 Sheriff/Deputy, Gatehouse etc: 62 ACCESS_GATEWAY
 General access: 25 ACCESS_BAR
 Clinic surgery/storage: 68 ACCESS_CLONING
-Shopkeeper: 34 ACCESS_CARGO_BOT
+Shopkeeper: 34 ACCESS_CARGO_BOT / 31 ACCESS CARGO
 Barkeep : 28 ACCESS_KITCHEN - you jebronis made default bar for no reason bruh
 Prospector : 48 ACCESS_MINING
 Detective : 4 ACCESS_FORENSICS_LOCKERS
@@ -293,10 +293,11 @@ Mayor
 		/obj/item/storage/pill_bottle/chem_tin/radx,
 		/obj/item/storage/box/deputy_badges = 1,
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/melee/classic_baton = 1,
+		/obj/item/melee/baton/loaded = 1,
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/grenade/flashbang = 1,
-		/obj/item/storage/belt/army = 1
+		/obj/item/storage/belt/army = 1,
+		/obj/item/gun/energy/taser = 1
 		)
 
 /datum/outfit/loadout/thelaw
@@ -305,7 +306,7 @@ Mayor
 	head = /obj/item/clothing/head/f13/town/sheriff
 	uniform = /obj/item/clothing/under/f13/police/formal
 	neck = /obj/item/storage/belt/shoulderholster
-	r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
+	//r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
 	shoes = /obj/item/clothing/shoes/f13/military/plated
 
 	//backpack_contents = list(
@@ -412,7 +413,8 @@ Mayor
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		/obj/item/grenade/flashbang = 1,
 		/obj/item/flashlight/seclite = 1,
-		/obj/item/storage/belt/army/assault = 1
+		/obj/item/storage/belt/army/assault = 1,
+		/obj/item/gun/energy/taser = 1
 		)
 
 /datum/outfit/loadout/frontierjustice
@@ -1219,8 +1221,8 @@ Mayor
 	)
 
 	outfit = /datum/outfit/job/den/f13quartermaster
-	access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
-	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
 			/datum/job/oasis
@@ -1316,8 +1318,8 @@ Mayor
 	)
 
 	outfit = /datum/outfit/job/den/f13shopkeeper
-	access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
-	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT)
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
 			/datum/job/oasis


### PR DESCRIPTION
## About The Pull Request
Adds the stock ss13 hardstun taser to Nash Sheriff and Deputy as well as the stunbaton in replacement of the sheriff's telescoping baton.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Add /obj/item/gun/energy/taser to Sheriff and Deputy loadouts
add: Add /obj/item/melee/baton/loaded (stunbaton) to Sheriff loadout.
del: Removed /obj/item/melee/classic_baton from Sheriff loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
