### PR TITLE
Tweaks to the venoms

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -199,17 +199,30 @@ GLOBAL_LIST_INIT(blood_loss_messages, list(
  * knockdown_chance = chance for a knockdown to occur
  * knockdown_time = time they're knocked down for
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/mob/living/carbon/proc/apply_bloodloss_effects(oxy_loss_cap, stam_cap, dizzy, confusion, blurry, sprint_max, sprint_regen, sprint_cost, knockdown_chance, knockdown_time, slowdown)
+/mob/living/carbon/proc/apply_bloodloss_effects(
+	oxy_loss_cap,
+	stam_cap,
+	dizzy,
+	confusion,
+	blurry,
+	sprint_max,
+	sprint_regen,
+	sprint_cost,
+	knockdown_chance,
+	knockdown_time,
+	slowdown,
+)
+	var/stammoxy_dam = round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1)
 	if(oxy_loss_cap && getOxyLoss() < oxy_loss_cap)
-		adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+		adjustOxyLoss(stammoxy_dam)
 	if(stam_cap && getStaminaLoss() < stam_cap)
-		adjustStaminaLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
-	if(dizzy)
-		Dizzy(dizzy)
+		adjustStaminaLoss(stammoxy_dam)
+	if(dizzy && (dizziness < dizzy) && prob(50))
+		Dizzy(1)
 	if(confusion && confused < confusion)
 		confused = confusion
-	if(blurry && prob(35))
-		adjust_blurriness(blurry)
+	if(blurry && (eye_blurry < blurry) && prob(35))
+		adjust_blurriness(1)
 	if(knockdown_chance && prob(knockdown_chance))
 		to_chat(src, span_warning("You stumble over, dazed by your blood loss!"))
 		AdjustKnockdown(knockdown_time, TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/insects.dm
@@ -421,8 +421,8 @@
 	var/concentration = M.reagents.get_reagent_amount(/datum/reagent/toxin/cazador_venom)
 	M.damageoverlaytemp = concentration * 10
 	M.update_damage_hud()
-	if (M.eye_blurry < 20)
-		M.blur_eyes(3)
+	if (M.eye_blurry < 5)
+		M.adjust_blurriness(1)
 	if (M.confused < 20)
 		M.confused += 3
 	if(prob(10))
@@ -432,8 +432,8 @@
 
 /datum/reagent/toxin/cazador_venom/on_mob_life_synth(mob/living/M)
 	M.adjustStaminaLoss(10, 0)
-	if (M.eye_blurry < 20)
-		M.blur_eyes(3)
+	if (M.eye_blurry < 5)
+		M.adjust_blurriness(1)
 	if (M.confused < 20)
 		M.confused += 3
 	if(prob(5))

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -762,7 +762,7 @@
 	while(blood_i_lost > blood_loss_tier)
 		blood_i_lost -= blood_loss_tier
 		divisor *= bleed_tier_divisor
-	var/blood_to_lose = max(round(base_bleed / tobleed), 1)
+	var/blood_to_lose = max(round(base_bleed / max(divisor,1)), 1)
 	M.bleed(blood_to_lose)
 	var/concentration = M.reagents.get_reagent_amount(/datum/reagent/toxin/rattler_venom)
 	M.damageoverlaytemp = concentration * 10

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -752,9 +752,9 @@
 	toxpwr = 0.5
 	taste_description = "pain"
 	taste_mult = 1.3
-	var/base_bleed = 10
-	var/bleed_tier_divisor = 2 //increasing this number makes the effect weaker
-	var/blood_loss_tier = 200 // Losing a multiple of this much will stack on an extra divisor
+	var/base_bleed = 15
+	var/bleed_tier_divisor = 3 //increasing this number makes the effect weaker
+	var/blood_loss_tier = 250 // Losing a multiple of this much will stack on an extra divisor
 
 /datum/reagent/toxin/rattler_venom/on_mob_life(mob/living/carbon/M)
 	var/divisor = 1

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -762,7 +762,7 @@
 	while(blood_i_lost > blood_loss_tier)
 		blood_i_lost -= blood_loss_tier
 		divisor *= bleed_tier_divisor
-	var/blood_to_lose = max(round(base_bleed / tobleed)), 1)
+	var/blood_to_lose = max(round(base_bleed / tobleed), 1)
 	M.bleed(blood_to_lose)
 	var/concentration = M.reagents.get_reagent_amount(/datum/reagent/toxin/rattler_venom)
 	M.damageoverlaytemp = concentration * 10

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -752,16 +752,22 @@
 	toxpwr = 0.5
 	taste_description = "pain"
 	taste_mult = 1.3
-	var/bleed_strength = 20 //increasing this number makes the effect weaker
+	var/base_bleed = 10
+	var/bleed_tier_divisor = 3 //increasing this number makes the effect weaker
+	var/blood_loss_tier = 300 // Losing a multiple of this much will stack on an extra divisor
 
 /datum/reagent/toxin/rattler_venom/on_mob_life(mob/living/carbon/M)
-	if(M.get_blood() > 10)
-		M.blood_volume -= M.blood_volume/bleed_strength //starts out strong, then slows as you grow woozy. allows it to kick in quick but then not make you a empty juicebox
+	var/divisor = 1
+	var/blood_i_lost = clamp(BLOOD_VOLUME_NORMAL - M.get_blood(), 0, BLOOD_VOLUME_NORMAL)
+	while(blood_i_lost > blood_loss_tier)
+		blood_i_lost -= blood_loss_tier
+		divisor *= bleed_tier_divisor
+	M.bleed(base_bleed / tobleed)
 	var/concentration = M.reagents.get_reagent_amount(/datum/reagent/toxin/rattler_venom)
 	M.damageoverlaytemp = concentration * 10
 	M.update_damage_hud()
-	if (M.eye_blurry < 20)
-		M.blur_eyes(3)
+	if (M.eye_blurry < 5)
+		M.adjust_blurriness(1)
 	if (M.confused < 20)
 		M.confused += 3
 	if(prob(10))
@@ -771,8 +777,8 @@
 
 /datum/reagent/toxin/rattler_venom/on_mob_life_synth(mob/living/M)
 	M.adjustStaminaLoss(10, 0)
-	if (M.eye_blurry < 20)
-		M.blur_eyes(3)
+	if (M.eye_blurry < 5)
+		M.adjust_blurriness(1)
 	if (M.confused < 20)
 		M.confused += 3
 	if(prob(5))

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -753,8 +753,8 @@
 	taste_description = "pain"
 	taste_mult = 1.3
 	var/base_bleed = 10
-	var/bleed_tier_divisor = 3 //increasing this number makes the effect weaker
-	var/blood_loss_tier = 300 // Losing a multiple of this much will stack on an extra divisor
+	var/bleed_tier_divisor = 2 //increasing this number makes the effect weaker
+	var/blood_loss_tier = 200 // Losing a multiple of this much will stack on an extra divisor
 
 /datum/reagent/toxin/rattler_venom/on_mob_life(mob/living/carbon/M)
 	var/divisor = 1
@@ -762,7 +762,8 @@
 	while(blood_i_lost > blood_loss_tier)
 		blood_i_lost -= blood_loss_tier
 		divisor *= bleed_tier_divisor
-	M.bleed(base_bleed / tobleed)
+	var/blood_to_lose = max(round(base_bleed / tobleed)), 1)
+	M.bleed(blood_to_lose)
 	var/concentration = M.reagents.get_reagent_amount(/datum/reagent/toxin/rattler_venom)
 	M.damageoverlaytemp = concentration * 10
 	M.update_damage_hud()


### PR DESCRIPTION
## About The Pull Request
Rattler venom now divides its blood loss by 2 for every 200 blood you lose, starting at 200 blood loss.

Also eased up a bit on bloodloss blurrification, so it actually uses the caps.