### PR TITLE
fixes recoil and damage forever

### DIFF
--- a/code/controllers/subsystem/recoil.dm
+++ b/code/controllers/subsystem/recoil.dm
@@ -284,7 +284,7 @@ SUBSYSTEM_DEF(recoil)
 	if(LAZYLEN(modifiers) != 2)
 		modifiers = RECOIL_LIST_DEFAULT
 	var/list/item_recoil_args = RECOIL_TAG2LIST(recoil_tag)
-	if(LAZYLEN(item_recoil_args) != 2) // "UNWIELD" "WIELD"
+	if(!IS_RECOIL_LIST(item_recoil_args)) // "UNWIELD" "WIELD"
 		item_recoil_args = RECOIL_LIST_DEFAULT
 	var/my_one_handed_recoil = text2num(item_recoil_args[RECOIL_INDEX_UNWIELDED])
 	var/my_two_handed_recoil = text2num(item_recoil_args[RECOIL_INDEX_WIELDED])

--- a/modular_coyote/eris/code/gun_firemode.dm
+++ b/modular_coyote/eris/code/gun_firemode.dm
@@ -47,6 +47,7 @@
 	shoot_delay = shoot_delay_default
 	burst_delay = burst_delay_default
 	burst_count = burst_count_default
+	damage_multiplier_default = _gun.damage_multiplier
 	damage_multiplier = damage_multiplier_default
 	shot_cost_multiplier = shot_cost_multiplier_default
 	my_gun = WEAKREF(_gun)


### PR DESCRIPTION
## About The Pull Request
The firemode datum, which holds a gun's damage multiplier (why did I do that, again?), was always getting set to 1. So any gun that had a non-1 damage multiplier was getting set to 1. Mods worked, though. This is fix.

The recoil modifier proc was using a length value that was outdated. Used to expect 2 values, and it was since expanded to 4, so it always rejected every recoil list, good or otherwise. this is fix