### PR TITLE
Buffs Stun Weapons

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -381,6 +381,7 @@
 	tracer_type = /obj/effect/projectile/tracer/disabler
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
+	is_reflectable = FALSE
 
 
 /obj/item/projectile/beam/laser/recharger/hitscan //hitscan recharger pistol

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -2,7 +2,7 @@
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
-	nodamage = TRUE
+	nodamage = FALSE
 	knockdown = 60
 	knockdown_stamoverride = 36
 	knockdown_stam_max = 50
@@ -16,6 +16,8 @@
 	impact_type = /obj/effect/projectile/impact/stun
 	var/tase_duration = 50
 	var/strong_tase = TRUE
+	damage = 75
+	damage_type = STAMINA
 
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()


### PR DESCRIPTION
Should make stun weaponry hit a little harder. Non-Hitscan tasers given 75 Stam Damage. They already stun but they don't **stun** yet.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Added Stamina Damage to the non-hitscan projectile Tasers.
tweak: Reduced chance for disabler beams to be reflected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
