### PR TITLE
Fixes power fists dealing 200 damage

### DIFF
--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -42,19 +42,19 @@
 		H.dna.species.punchdamagehigh -= enhancement
 		H.dna.species.punchdamagelow -= enhancement
 	return ..()
-/obj/item/melee/powerfist/f13/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wrench))
-		switch(fisto_setting)
-			if(1)
-				fisto_setting = 2
-			if(2)
-				fisto_setting = 1
-		W.play_tool_sound(src)
-		to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
-		attack_speed = CLICK_CD_MELEE * fisto_setting
+//obj/item/melee/powerfist/f13/attackby(obj/item/W, mob/user, params)
+	//if(istype(W, /obj/item/wrench))
+		//switch(fisto_setting)
+			//if(1)
+				//fisto_setting = 2
+			//.if(2)
+				//fisto_setting = 1
+		//W.play_tool_sound(src)
+		//to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
+		//attack_speed = CLICK_CD_MELEE * fisto_setting
 
-/obj/item/melee/powerfist/f13/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
-	return
+//obj/item/melee/powerfist/f13/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
+	//return
 
 /obj/item/melee/powerfist/f13/attack(mob/living/target, mob/living/user, attackchain_flags = NONE)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -15,8 +15,8 @@
 	armor = ARMOR_VALUE_GENERIC_ITEM
 	resistance_flags = FIRE_PROOF
 	attack_speed = CLICK_CD_MELEE * 1.5
-	var/fisto_setting = 1
-	var/gasperfist = 3
+	//var/fisto_setting = 1
+	//var/gasperfist = 3
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
 
 /obj/item/melee/powerfist/examine(mob/user)
@@ -28,27 +28,27 @@
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
 
 
-/obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank/internals))
-		if(!tank)
-			var/obj/item/tank/internals/IT = W
-			if(IT.volume <= 3)
-				to_chat(user, span_warning("\The [IT] is too small for \the [src]."))
-				return
-			updateTank(W, 0, user)
-	else if(istype(W, /obj/item/wrench))
-		switch(fisto_setting)
-			if(1)
-				fisto_setting = 2
-			if(2)
-				fisto_setting = 3
-			if(3)
-				fisto_setting = 1
-		W.play_tool_sound(src)
-		to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
-	else if(istype(W, /obj/item/screwdriver))
-		if(tank)
-			updateTank(tank, 1, user)
+//obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
+	//if(istype(W, /obj/item/tank/internals))
+		//if(!tank)
+			//var/obj/item/tank/internals/IT = W
+			//if(IT.volume <= 3)
+				//to_chat(user, span_warning("\The [IT] is too small for \the [src]."))
+				//return
+			//updateTank(W, 0, user)
+	//else if(istype(W, /obj/item/wrench))
+		//switch(fisto_setting)
+			//if(1)
+				//fisto_setting = 2
+			//if(2)
+				//fisto_setting = 3
+			//if(3)
+				//fisto_setting = 1
+		//W.play_tool_sound(src)
+		//to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
+	//else if(istype(W, /obj/item/screwdriver))
+		//if(tank)
+			//updateTank(tank, 1, user)
 
 /obj/item/melee/powerfist/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
 	if(removing)
@@ -116,7 +116,7 @@
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-	target.throw_at(throw_target, 2 * fisto_setting, 0.5 + (fisto_setting / 2))
+	target.throw_at(throw_target, 2 * 2, 0.5 + (2))
 
 	log_combat(user, target, "power fisted", src)
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
removes the code that gave it a power based on setting via wrench, which also happens to control things doing 4-5x the damage it was meant to, should be dealing the proper damage now.
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
RinPin :cl:
fix: powerfists are no longer so powerful
/:cl:

