### PR TITLE
Bubblegum loot overhaul

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -328,7 +328,8 @@ GLOBAL_LIST_INIT(default_all_armor_slot_allowed, typecacheof(list(
 	/obj/item/restraints/legcuffs/bola,
 	/obj/item/kitchen,
 	/obj/item/kinetic_crusher,
-	/obj/item/toy
+	/obj/item/toy,
+	/obj/item/cult_bastard
 	)))
 
 /// Things allowed in a toolbelt

--- a/code/datums/components/melee_special.dm
+++ b/code/datums/components/melee_special.dm
@@ -85,6 +85,16 @@
 	max_mobs_hit = 5
 	falloff_mult = 0.5 // even harsher fallff!
 
+/datum/component/weapon_special/ranged_spear/cult_bastard
+	max_distance = 1
+	max_mobs_hit = 3
+	always_do = TRUE
+	line_effect = ATTACK_EFFECT_PUNCH
+	effect_kind = null
+	target_mode = WS_ALL_POPULATED_TILES
+	target_flags = WS_TARGET_WALLS | WS_TARGET_IGNORE_DEAD | WS_TARGET_IGNORE_SELF | WS_TARGET_MOBS | WS_TARGET_STRUCTURES | WS_TARGET_MACHINES | WS_TARGET_WALLS
+	damage_flags = NONE
+
 /datum/component/weapon_special/Initialize()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -253,7 +253,7 @@
 	holder = user
 
 /datum/action/innate/cult/spin2win/IsAvailable(silent = FALSE)
-	if(iscarbon (holder) && cooldown <= world.time)
+	if(iscarbon(holder) && cooldown <= world.time)
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -105,11 +105,14 @@
 
 /obj/item/cult_bastard
 	name = "bloody bastard sword"
-	desc = "An enormous sword used by Nar'Sien cultists to rapidly harvest the souls of non-believers."
-	w_class = WEIGHT_CLASS_HUGE
-	block_chance = 50
+	desc = "An enormous rune covered sword, used by cultists of dark gods to rapidly cut down non-believers."
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BACK
+	block_chance = 40
 	throwforce = 20
-	force = 35
+	force = 30
+	force_unwielded = 30
+	force_wielded = 69
 	throw_speed = 1
 	throw_range = 3
 	sharpness = SHARP_EDGED
@@ -122,6 +125,7 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	weapon_special_component = /datum/component/weapon_special/ranged_spear/cult_bastard
 	actions_types = list()
 	var/datum/action/innate/dash/cult/jaunt
 	var/datum/action/innate/cult/spin2win/linked_action
@@ -138,14 +142,14 @@
 /obj/item/cult_bastard/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 50, 80)
-	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
+	//AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/cult_bastard/examine(mob/user)
 	. = ..()
 	if(contents.len)
 		. += "<br><b>There are [contents.len] souls trapped within the sword's core.</b>"
 	else
-		. += "<br>The sword appears to be quite lifeless."
+		. += "<br>The sword appears to be slowly pulsating."
 
 /obj/item/cult_bastard/can_be_pulled(user)
 	return FALSE
@@ -159,7 +163,7 @@
 
 /obj/item/cult_bastard/pickup(mob/living/user)
 	. = ..()
-	if(!iscultist(user))
+	if(!iscarbon(user))
 		if(!is_servant_of_ratvar(user))
 			to_chat(user, span_cultlarge("\"I wouldn't advise that.\""))
 			force = 5
@@ -203,19 +207,19 @@
 	if(dash_toggled && !proximity)
 		jaunt.Teleport(user, target)
 		return
-	if(proximity)
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.stat != CONSCIOUS)
-				var/obj/item/soulstone/SS = new /obj/item/soulstone(src)
-				SS.attack(H, user)
-				if(!LAZYLEN(SS.contents))
-					qdel(SS)
-		if(istype(target, /obj/structure/constructshell) && contents.len)
-			var/obj/item/soulstone/SS = contents[1]
-			if(istype(SS))
-				SS.transfer_soul("CONSTRUCT",target,user)
-				qdel(SS)
+	//if(proximity)
+		//if(ishuman(target))
+			//var/mob/living/carbon/human/H = target
+			//if(H.stat != CONSCIOUS)
+				//var/obj/item/soulstone/SS = new /obj/item/soulstone(src)
+				//SS.attack(H, user)
+				//if(!LAZYLEN(SS.contents))
+					//qdel(SS)
+		//if(istype(target, /obj/structure/constructshell) && contents.len)
+			//var/obj/item/soulstone/SS = contents[1]
+			//if(istype(SS))
+				//SS.transfer_soul("CONSTRUCT",target,user)
+				//qdel(SS)
 
 /datum/action/innate/dash/cult
 	name = "Rend the Veil"
@@ -229,7 +233,7 @@
 	phaseout = /obj/effect/temp_visual/dir_setting/cult/phase/out
 
 /datum/action/innate/dash/cult/IsAvailable(silent = FALSE)
-	if(iscultist(holder) && current_charges)
+	if(iscarbon(holder) && current_charges)
 		return TRUE
 	else
 		return FALSE
@@ -249,7 +253,7 @@
 	holder = user
 
 /datum/action/innate/cult/spin2win/IsAvailable(silent = FALSE)
-	if(iscultist(holder) && cooldown <= world.time)
+	if(iscarbon (holder) && cooldown <= world.time)
 		return TRUE
 	else
 		return FALSE
@@ -259,14 +263,14 @@
 	holder.DelayNextAction(50)
 	holder.apply_status_effect(/datum/status_effect/sword_spin)
 	sword.spinning = TRUE
-	sword.block_chance = 100
+	sword.block_chance = 75
 	sword.slowdown += 1.5
 	addtimer(CALLBACK(src, .proc/stop_spinning), 50)
 	holder.update_action_buttons_icon()
 
 /datum/action/innate/cult/spin2win/proc/stop_spinning()
 	sword.spinning = FALSE
-	sword.block_chance = 50
+	sword.block_chance = 40
 	sword.slowdown -= 1.5
 	sleep(sword.spin_cooldown)
 	holder.update_action_buttons_icon()
@@ -296,6 +300,7 @@
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEEARS
 	flags_cover = HEADCOVERSEYES
 	armor = ARMOR_VALUE_MEDIUM
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_UP_DT_T3) // eldritch magic suit which is a boss reward, reinforced combat armor tier with boosted melee and less laser, should atleast be a little better than a super common set
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
 	heat_protection = HEAD
@@ -308,6 +313,8 @@
 	item_state = "cultrobes"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = ARMOR_VALUE_MEDIUM
+	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_MELEE_T3, ARMOR_MODIFIER_DOWN_LASER_T1, ARMOR_MODIFIER_UP_DT_T3) // eldritch magic suit which is a boss reward, reinforced combat armor tier with boosted melee and less laser, should atleast be a little better than a super common set
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
@@ -480,7 +487,7 @@
 
 /obj/item/clothing/suit/hooded/cultrobes/berserker/equipped(mob/living/user, slot)
 	..()
-	if(!iscultist(user))
+	if(!iscarbon(user))
 		if(!is_servant_of_ratvar(user))
 			to_chat(user, span_cultlarge("\"I wouldn't advise that.\""))
 			to_chat(user, span_warning("An overwhelming sense of nausea overpowers you!"))

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1107,8 +1107,12 @@
 	name = "bubblegum chest"
 
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
-	new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor/old(src)
-	new /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor/old(src)
+	//new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor/old(src)
+	//new /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor/old(src)
+	new /obj/item/cult_bastard(src)
+	new /obj/item/clothing/head/culthood(src)
+	new /obj/item/clothing/suit/cultrobes(src)
+	new /obj/item/reagent_containers/food/snacks/f13/bubblegum (src)
 	var/loot = rand(1,3)
 	switch(loot)
 		if(1)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Adds a reworked cult bastard sword to the chest bubblegum drops,  that when two handed dealing 69 damage, 40 block alongside some other special effects, but can't be stowed away inside a sheath, and takes up your back or main slot.
replaces the broken inquisitor hardsuit with a modified cultist robe, which is slightly better than reinforced combat armor when dealing with melee, but less against lasers.

also adds a custom special melee component to it so it can do turf based attacks like the other weapons.
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
RinPin :cl:
add: Replaces bubblegum loot with a reworked cult sword + robes

/:cl:
