### PR TITLE
unscrews power fists

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -533,7 +533,7 @@ GLOBAL_LIST_INIT(loot_t4_melee, list(
 	/obj/item/melee/unarmed/lacerator,
 	/obj/item/melee/unarmed/maceglove,
 	/obj/item/melee/unarmed/punchdagger,
-	/obj/item/melee/powerfist/f13,
+	/obj/item/melee/unarmed/tigerclaw,
 	/obj/item/shield/riot
 ))
 
@@ -545,7 +545,7 @@ GLOBAL_LIST_INIT(loot_t5_melee, list(
 	/obj/item/gun/ballistic/revolver/ballisticfist,
 	/obj/item/twohanded/sledgehammer/supersledge,
 	/obj/item/shishkebabpack,
-	/obj/item/melee/powerfist/f13/goliath,
+	/obj/item/melee/unarmed/powerfist,
 	/obj/item/melee/unarmed/deathclawgauntlet,
 	/obj/item/melee/powerfist/f13/moleminer
 ))

--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -522,7 +522,7 @@
 		/obj/item/gun/energy/tesla/teslacannon = 10, //it'll be fiiiiine
 		/obj/item/melee/onehanded/dragonfire = 1, //edgy
 		/obj/item/melee/unarmed/deathclawgauntlet = 20,
-		/obj/item/melee/powerfist/f13/goliath = 20,
+		/obj/item/melee/unarmed/powerfist/goliath = 20,
 		/obj/item/melee/powered/ripper/prewar = 20,
 		/obj/item/twohanded/spear/bonespear/deathclaw = 20, //sure why not
 		/obj/item/twohanded/sledgehammer/atomsjudgement = 10,

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -887,6 +887,80 @@ obj/item/melee/unarmed/punchdagger/cyborg
 	target.apply_status_effect(/datum/status_effect/stacking/saw_bleed/yaoguaigauntlet)
 
 
+/////////////////
+// POWER FISTS //
+/////////////////		-Uses power (gas currently) for knockback. Heavy AP, specialized for attacking heavy armor
+
+// Power Fist			Throws targets. Max damage 52. Full AP.
+/obj/item/melee/unarmed/powerfist
+	name = "power fist"
+	desc = "A metal gauntlet with a piston-powered ram on top for that extra 'oomph' in your punch."
+	icon_state = "powerfist"
+	item_state = "powerfist"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	flags_1 = CONDUCT_1
+	attack_verb = list("whacked", "fisted", "power-punched")
+	force = 45 //needs more hefty damage to be worthwhile outside pvp. will have to test
+	throwforce = 10
+	throw_range = 3
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
+	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
+	var/throw_distance = 1
+	attack_speed = CLICK_CD_MELEE
+
+/obj/item/melee/unarmed/powerfist/attack(mob/living/target, mob/living/user, attackchain_flags = NONE)
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_warning("You don't want to harm other living beings!"))
+		return FALSE
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+	var/totalitemdamage = target.pre_attacked_by(src, user)
+	SSdamage.damage_mob(user, target, totalitemdamage)
+	target.visible_message(span_danger("[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!"), \
+		span_userdanger("You cry out in pain as [user]'s punch flings you backwards!"))
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	target.throw_at(throw_target, 2 * throw_distance, 0.5 + (throw_distance / 2))
+	log_combat(user, target, "power fisted", src)
+
+// Goliath				Throws targets far. Max damage 50.
+/obj/item/melee/unarmed/powerfist/goliath
+	name = "Goliath"
+	desc = "A massive, experimental metal gauntlet crafted by some poor bastard in Redwater that since outlived their usefulness. The piston-powered ram on top is designed to throw targets very, very far."
+	icon = 'icons/fallout/objects/melee/melee.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/melee1h_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/melee1h_righthand.dmi'
+	icon_state = "goliath"
+	item_state = "goliath"
+	force = 55 //legendary tier power fist, one of a kind, why should it hit for less than a machete
+	throw_distance = 5
+// Mole Miner
+/obj/item/melee/unarmed/powerfist/moleminer
+	name = "mole miner gauntlet"
+	desc = "A hand-held mining and cutting implement, repurposed into a deadly melee weapon.  Its name origins are a mystery..."
+	icon_state = "mole_miner_g"
+	item_state = "mole_miner_g"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	flags_1 = CONDUCT_1
+	force = 33 //tiger claws tier
+	throwforce = 10
+	throw_range = 7
+	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	tool_behaviour = TOOL_MINING
+	var/digrange = 2 //This should give it the 3x2 dig range that drills and some picks have
+	toolspeed = 0.2 //This should make it dig really quick. Like a moleminer!
+	sharpness = SHARP_EDGED
+	w_class = WEIGHT_CLASS_NORMAL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
+	armor = ARMOR_VALUE_GENERIC_ITEM
+
 ///////////
 // TOOLS //
 ///////////		-generally max 24 damage


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
ports over power fists to the unarmed weapon family path, which removes the damage stacking effect, also fixes the sprites so they show up when worn
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

