### PR TITLE
Changes "Synthetic Lizardperson" to "Synthetic Anthropomorph" because the name is misleading now.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synthliz.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthliz.dm
@@ -1,5 +1,5 @@
 /datum/species/synthfurry
-	name = "Synthetic Lizardperson"
+	name = "Synthetic Anthropomorph"
 	id = "synthliz"
 	say_mod = "beeps"
 	default_color = "00FF00"


### PR DESCRIPTION
## About The Pull Request
Title says it all, I literally just changed the name since you can choose sprites other than lizard now.

Not tested yet.

## Pre-Merge Checklist
- [✓] You tested this on a local server.
- [✓] This code did not runtime during testing.
- [✓] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Changed the name of the synth race from "Synthetic Lizardperson" to "Synthetic Anthropomorph".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
