### PR TITLE
Adds appropriate credits to our codebase

### DIFF
--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,22 @@
+# Licensing
+
+This section is to credit where external assets were sourced from with appropriate licensing.
+
+## Formatting
+
+Ensure that the license of the codebase you're using has the correct type which we can properly use.
+For CC by SA v3, we have to link to the license, then provide a link to the source, and name it.
+
+If it's under the AGPL/GPL license, we also should credit them.
+
+For example:
+
+Coyote Bayou | [Creative Commons Attribution-ShareAlike 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | [Source Code](https://github.com/ARF-SS13/coyote-bayou)
+
+Coyote Bayou | [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) | [Source Code](https://github.com/ARF-SS13/coyote-bayou)
+
+## Licenses
+
+Chompstation | [Creative Commons Attribution-ShareAlike 3.0](http://creativecommons.org/licenses/by-sa/3.0/) & [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) | [Source Code](https://github.com/CHOMPStation2/CHOMPStation2)
+
+HaloSpaceStation13 | [Creative Commons Attribution-ShareAlike 3.0](http://creativecommons.org/licenses/by-sa/3.0/) & [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) | [Source Code](https://github.com/HaloSpaceStation/HaloSpaceStation13)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

Basically, it stops us from getting DMCA'd even though we have all rights to use other codebases we've been using.

Mostly because the CC by SA license requires crediting, even if we are under fair use for using the sprites, I don't think any of us wants to bother disputing it if we do get an abusive DMCA.

This makes it so
1: The license is valid.
2: We don't get DMCA'd
3: We at least show where we source some assets from.

Feel free to add more codebases onto it, I just did the ones I know we've definitely sourced from.

Basically addresses and solve the little unnecessary drama #2707 gave to us. We actually don't have to strictly follow those guidelines due to fair use.