### PR TITLE
Re-Adds Eigenstasium Locker Functionality

### DIFF
--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -1,4 +1,4 @@
-#define REAGENTS_BASE_VOLUME 100 // actual volume is REAGENTS_BASE_VOLUME plus REAGENTS_BASE_VOLUME * rating for each matterbin
+#define REAGENTS_BASE_VOLUME 1 // actual volume is REAGENTS_BASE_VOLUME plus REAGENTS_BASE_VOLUME * rating for each matterbin
 
 /obj/machinery/smoke_machine
 	name = "smoke machine"

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/eigentstasium.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/eigentstasium.dm
@@ -173,7 +173,7 @@
 
 /datum/reagent/fermi/eigenstate/reaction_turf(turf/T, reac_volume)
 	//if(cached_purity < 0.99) To add with next batch of fixes and tweaks.
-	/*
+
 	var/obj/structure/closet/First
 	var/obj/structure/closet/Previous
 	for(var/obj/structure/closet/C in T.contents)
@@ -200,5 +200,5 @@
 	First.alpha = 200
 	do_sparks(5,FALSE,First)
 	First.visible_message("The lockers' eigenstates spilt and merge, linking each of their contents together.")
-	*/
+
 //eigenstate END


### PR DESCRIPTION
## About The Pull Request
Restores eigenstatsium's locker fast travel functionality.
Also massively reduces the volume capacity of smoke machines to reduce the likelihood and effectiveness of chemistry grief.


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

