### PR TITLE
Large Survival Pouch Change

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -924,13 +924,13 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BOX_SURVIVAL_SPECIALIZED_MAX_TOTAL_SPACE STORAGE_BOX_SURVIVAL_SPECIALIZED_DEFAULT_MAX_ITEMS * STORAGE_BOX_SURVIVAL_SPECIALIZED_MAX_SIZE
 
 /// How many items total fit in a triple survival kit
-#define STORAGE_BOX_SURVIVAL_TRIPLE_DEFAULT_MAX_ITEMS 21
+#define STORAGE_BOX_SURVIVAL_TRIPLE_DEFAULT_MAX_ITEMS 14
 /// How big a thing can fit in a triple survival kit
-#define STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE WEIGHT_CLASS_TINY
+#define STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a triple survival kit
 #define STORAGE_BOX_SURVIVAL_TRIPLE_MAX_TOTAL_SPACE STORAGE_BOX_SURVIVAL_TRIPLE_DEFAULT_MAX_ITEMS * STORAGE_BOX_SURVIVAL_TRIPLE_MAX_SIZE
 /// How many rows in a triple survival kit
-#define STORAGE_ROWS_SURVIVAL_TRIPLE 3 // triple after all~
+#define STORAGE_ROWS_SURVIVAL_TRIPLE 1 // More than one row messes with volumetric UI for this particular item
 
 /* * * * * * *
  * Backpacks!

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(leather_recipes, list (
 	new/datum/stack_recipe("medical pouch", /obj/item/storage/survivalkit/medical/empty, 5),
 	new/datum/stack_recipe("combat pouch", /obj/item/storage/survivalkit/combat, 5),
 	new/datum/stack_recipe("tribal medicine pouch", /obj/item/storage/survivalkit/medical/tribal/empty, 5),
-	new/datum/stack_recipe("extra large pouch", /obj/item/storage/survivalkit/triple, 15),
+	new/datum/stack_recipe("extra large pouch", /obj/item/storage/survivalkit/triple, 25),
 	new/datum/stack_recipe("sack", /obj/item/storage/bag/trash/sack, 15),
 ))
 


### PR DESCRIPTION
## About The Pull Request
Changes large survival pouches to be able to contain small items, which includes ammo, tools, hand sized items.
The change includes reducing its max capacity from 21 items to 14, which is slightly better than two pocket pouches.
Now costs 150% more than just making two pocket pouches, convenience tax. Situationally useful, as it can only be stores on the suit slot. Not the most desirable storage method, as there are better options that dont take up your suit slot.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->