### PR TITLE
Touches up ammolathed gauss and guarantees full ammo for loadouts

### DIFF
--- a/code/__DEFINES/ammo.dm
+++ b/code/__DEFINES/ammo.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(hobo_gun_mag_fluff, list(
 #define MATS_SHOTGUN_BULLET (MATS_AMMO_BULLET_BASE * 5)
 #define MATS_GRENADE_BULLET (MATS_AMMO_BULLET_BASE * 20)
 #define MATS_ROCKET_BULLET (MATS_AMMO_BULLET_BASE * 1)
-#define MATS_GAUSS_BULLET (MATS_AMMO_BULLET_BASE * 100)
+#define MATS_GAUSS_BULLET (MATS_AMMO_BULLET_BASE * 20)
 #define MATS_FLINTLOCK_LIGHT_BULLET (MATS_AMMO_BULLET_BASE * 5)
 #define MATS_FLINTLOCK_HEAVY_BULLET (MATS_AMMO_BULLET_BASE * 8)
 
@@ -242,10 +242,12 @@ GLOBAL_LIST_INIT(hobo_gun_mag_fluff, list(
 #define MATS_AMMO_GLOBAL_COST_MULT 1
 #define MATS_AMMO_METAL_COST_MULT (1.5 * MATS_AMMO_GLOBAL_COST_MULT)
 #define MATS_AMMO_POWDER_COST_MULT (1.1 * MATS_AMMO_GLOBAL_COST_MULT)
+#define MATS_AMMO_TIT_COST_MULT (1.1 * MATS_AMMO_GLOBAL_COST_MULT)
 
 GLOBAL_LIST_INIT(ammo_material_multipliers, list(
 	/datum/material/iron = MATS_AMMO_METAL_COST_MULT,
-	/datum/material/blackpowder = MATS_AMMO_POWDER_COST_MULT
+	/datum/material/blackpowder = MATS_AMMO_POWDER_COST_MULT,
+	/datum/material/titanium = MATS_AMMO_TIT_COST_MULT,
 ))
 
 /// Just so I dont have to do bespoke shit for deducting powder and bullet costs

--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -414,6 +414,10 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	if(contents.len == 0)
 		qdel(src)
 
+/obj/item/storage/box/gun/PostPopulateContents()
+	for(var/obj/item/thing in contents)
+		SEND_SIGNAL(thing, COMSIG_GUN_MAG_ADMIN_RELOAD) // no more empty clippazines
+
 /// Guns for the LAWman
 /obj/item/storage/box/gun/law
 	name = "American 180 case" //it was meant to be a police rifle anyways~

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -12,6 +12,7 @@
 /obj/item/storage/Initialize()
 	. = ..()
 	PopulateContents()
+	PostPopulateContents()
 
 /obj/item/storage/ComponentInitialize()
 	AddComponent(component_type)
@@ -28,6 +29,9 @@
 
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"
 /obj/item/storage/proc/PopulateContents()
+
+//In case we ant to do smth 2 da stuf aftr spwn D:
+/obj/item/storage/proc/PostPopulateContents()
 
 /obj/item/storage/proc/dump_everything(datum/source, obj/vore_belly/gut, mob/living/vorer)
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -233,7 +233,8 @@
 	casing_quality = BULLET_IS_SURPLUS
 	custom_materials = list(
 		/datum/material/iron = MATS_GAUSS_CASING + MATS_GAUSS_BULLET,
-		/datum/material/blackpowder = MATS_GAUSS_POWDER)
+		/datum/material/blackpowder = MATS_GAUSS_POWDER,
+		/datum/material/titanium = MATS_GAUSS_BULLET)
 	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
 	sound_properties = CSP_GAUSS
 
@@ -242,3 +243,7 @@
 	desc = "A 2mm gauss projectile casing, \"Blender\" variant. Bounces off walls at hypersonic speeds."
 	projectile_type = /obj/item/projectile/bullet/c2mm/blender
 	fire_power = CASING_POWER_HEAVY_RIFLE * CASING_POWER_MOD_MATCH
+	custom_materials = list(
+		/datum/material/iron = MATS_GAUSS_CASING + MATS_GAUSS_BULLET * 1.1,
+		/datum/material/blackpowder = MATS_GAUSS_POWDER,
+		/datum/material/titanium = MATS_GAUSS_BULLET * 1.1)

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -1028,19 +1028,45 @@
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
 	randomize_ammo_count = TRUE
 
+//gauss
+/obj/item/ammo_box/gauss
+	name = "gauss projectile rack (2mm)"
+	desc = "A rack of 2mm gauss ammo, for when you need something dead on the other side of a building."
+	icon_state = "50mg"
+	caliber = "a50mg"
+	ammo_type = /obj/item/ammo_casing/c2mm
+	caliber = list(CALIBER_2MM)
+	max_ammo = 5
+	multiple_sprites = 1
+	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
+	randomize_ammo_count = FALSE
+
+//gauss blander
+/obj/item/ammo_box/gauss_blender
+	name = "gauss blender rack (2mm)"
+	desc = "A rack of 2mm gauss blender ammo, for when you want to die and take everyone with you."
+	icon_state = "50ap"
+	ammo_type = /obj/item/ammo_casing/c2mm/blender
+	caliber = list(CALIBER_2MM)
+	max_ammo = 5
+	multiple_sprites = 1
+	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
+	randomize_ammo_count = FALSE
+
 //.50 BMG
 /obj/item/ammo_box/a50MG
 	name = "anti-materiel ammo rack (.50MG)"
 	desc = "A rack of .50 MG ammo, for when you really need something dead."
 	icon_state = "50mg"
-	caliber = "a50mg"
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = list(CALIBER_50MG)
 	max_ammo = 5
 	multiple_sprites = 1
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
-	randomize_ammo_count = TRUE
+	randomize_ammo_count = FALSE
 
 /obj/item/ammo_box/a50MG/incendiary
 	name = "anti-materiel incendiary ammo rack (.50MG)"

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -112,6 +112,7 @@
 	icon_state = "enbloc-8"
 	ammo_type = /obj/item/ammo_casing/a3006
 	caliber = list(CALIBER_3006)
+	randomize_ammo_count = FALSE
 	max_ammo = 8
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
@@ -129,6 +130,7 @@
 /obj/item/ammo_box/magazine/sks
 	name = ".308 SKS clip"
 	icon_state = "enbloc-8"
+	randomize_ammo_count = FALSE
 	ammo_type = /obj/item/ammo_casing/a308
 	caliber = list(CALIBER_308)
 	max_ammo = 8
@@ -149,6 +151,7 @@
 	name = "rifle magazine (.308)"
 	icon_state = "mag308"
 	ammo_type = /obj/item/ammo_casing/a308
+	randomize_ammo_count = FALSE
 	caliber = list(CALIBER_308)
 	max_ammo = 10
 	multiple_sprites = 2
@@ -203,10 +206,14 @@
 	icon_state = "2mm"
 	ammo_type = /obj/item/ammo_casing/c2mm
 	caliber = list(CALIBER_2MM)
+	randomize_ammo_count = FALSE
 	max_ammo = 10
 	multiple_sprites = 2
 	custom_materials = list(/datum/material/iron = MATS_MISC)
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/ammo_box/magazine/m2mm/empty
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/m2mm/blender
 	name = "2mm \"Blender\" electromagnetic magazine"

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "50mag"
 	max_ammo = 8
+	randomize_ammo_count = FALSE
 	ammo_type = /obj/item/ammo_casing/a50MG
 	caliber = list(CALIBER_50MG)
 	multiple_sprites = 2

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -770,7 +770,7 @@
 	name = "2mm Blender Clip"
 	id = "2mm_gauss_clip"
 	materials = list(/datum/material/iron = 12500, /datum/material/titanium = 7500)
-	build_path = /obj/item/ammo_box/gauss/blender
+	build_path = /obj/item/ammo_box/gauss_blender
 	category = list("initial", "Advanced Ammo")
 
 /datum/design/ammolathe/m473fmj

--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -743,14 +743,35 @@
 	build_path = /obj/item/ammo_box/magazine/pps9mm/empty
 	category = list("initial", "Intermediate Magazines")
 
-//Tier 4 Ammo
-/datum/design/ammolathe/m2mm
-	name = "2mm Electromagnetic Magazine"
-	id = "2mm"
+/datum/design/ammolathe/m2mm_mag
+	name = "2mm Gauss Magazine (empty)"
+	id = "2mm_magazine"
 	materials = list(/datum/material/iron = 25000, /datum/material/titanium = 15000)
-	build_path = /obj/item/ammo_box/magazine/m2mm
+	build_path = /obj/item/ammo_box/magazine/m2mm/empty
+	category = list("initial", "Advanced Magazines")
+
+//Tier 4 Ammo
+//	/datum/design/ammolathe/m2mm
+//		name = "2mm Electromagnetic Magazine"
+//		id = "2mm"
+//		materials = list(/datum/material/iron = 25000, /datum/material/titanium = 15000)
+//		build_path = /obj/item/ammo_box/magazine/m2mm
+//		category = list("initial", "Advanced Ammo")
+//		autocalc_material_values = FALSE
+
+/datum/design/ammolathe/m2mm_rack
+	name = "2mm Gauss Clip"
+	id = "2mm_clip"
+	materials = list(/datum/material/iron = 12500, /datum/material/titanium = 7500)
+	build_path = /obj/item/ammo_box/gauss
 	category = list("initial", "Advanced Ammo")
-	autocalc_material_values = FALSE
+
+/datum/design/ammolathe/m2mm_rack_blender
+	name = "2mm Blender Clip"
+	id = "2mm_gauss_clip"
+	materials = list(/datum/material/iron = 12500, /datum/material/titanium = 7500)
+	build_path = /obj/item/ammo_box/gauss/blender
+	category = list("initial", "Advanced Ammo")
 
 /datum/design/ammolathe/m473fmj
 	name = "4.73mm caseless ammo box"


### PR DESCRIPTION
## About The Pull Request
The gauss mag in the ammolathe comes empty.

You can print out racks of 5 gauss shots from the lathe, as well as blender rounds. Dunno if they're the same price, should be a bit cheaper?

Ammo that comes from a loadout beacon will be fully filled.