### PR TITLE
the penthouse hoehouse

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -85,8 +85,16 @@
 	},
 /area/f13/building)
 "abB" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/carpet/blue,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "abD" = (
 /obj/machinery/light/small{
@@ -383,8 +391,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "alA" = (
-/obj/machinery/light/small,
-/turf/open/floor/carpet/blue,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "alI" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1055,9 +1069,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "aLH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_pink,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "aLS" = (
 /turf/open/floor/plasteel/darkpurple/side{
@@ -1333,10 +1356,18 @@
 	},
 /area/f13/caves)
 "aZi" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "aZp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1378,21 +1409,6 @@
 	dir = 10
 	},
 /area/f13/caves)
-"aZU" = (
-/obj/structure/rack/shelf_metal,
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/dress/corset{
-	pixel_y = 5;
-	pixel_x = -7
-	},
-/obj/item/clothing/under/dress/corset{
-	pixel_y = 5;
-	pixel_x = -7
-	},
-/obj/item/clothing/under/dress/blacktango,
-/obj/item/clothing/under/dress/blacktango,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "aZZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -1404,12 +1420,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bat" = (
-/obj/machinery/door/unpowered/securedoor,
-/obj/effect/step_trigger/player_choice_log{
-	title = "Welcome to Heavens Night.";
-	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+/obj/structure/simple_door/metal/dirtystore{
+	name = "Warehouse"
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/car/rubbish1,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "bbc" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1513,10 +1532,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
 "bhR" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/rack/large/shelf{
+	pixel_x = -24;
+	pixel_y = -4
 	},
-/turf/open/floor/carpet/black,
+/obj/item/clothing/suit/armor/light/leather/leathersuit,
+/obj/item/clothing/suit/armor/medium/vest/breastplate/reinforced,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "bhT" = (
 /obj/structure/chair/wood{
@@ -4703,10 +4729,15 @@
 	},
 /area/f13/building/massfusion)
 "bRa" = (
-/obj/structure/noticeboard{
-	pixel_y = -30
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "bRc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5221,8 +5252,20 @@
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
 "bZa" = (
-/obj/structure/table/glass,
-/turf/open/floor/carpet/red,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "bZk" = (
 /obj/structure/table,
@@ -5270,23 +5313,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
 /area/f13/caves)
-"bZY" = (
-/obj/structure/table/wood,
-/obj/item/melee/chainofcommand/tailwhip/kitty{
-	pixel_y = 9;
-	pixel_x = 4
-	},
-/obj/item/melee/chainofcommand/tailwhip/kitty{
-	pixel_y = 9;
-	pixel_x = 4
-	},
-/obj/item/melee/chainofcommand/tailwhip/kitty{
-	pixel_y = 9;
-	pixel_x = 4
-	},
-/obj/item/melee/onehanded/slavewhip,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "cae" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -6661,8 +6687,18 @@
 /turf/closed/indestructible/rock,
 /area/f13/caves)
 "cCM" = (
-/obj/machinery/door/unpowered/securedoor,
-/turf/open/floor/carpet/red,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "cCQ" = (
 /obj/effect/decal/cleanable/oil,
@@ -6936,13 +6972,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/tunnel)
 "cPj" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/f13/rare_mats,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "cPn" = (
 /obj/structure/table/booth,
@@ -7046,15 +7085,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "cTK" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "cTO" = (
@@ -7556,8 +7597,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
 "doy" = (
-/obj/structure/sign/poster/contraband/red_rum,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "doI" = (
 /obj/structure/chair/folding,
@@ -8298,12 +8347,18 @@
 /turf/open/floor/wood_fancy,
 /area/f13/caves)
 "dQc" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/rare_mats,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "dQf" = (
@@ -8906,11 +8961,18 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "eoi" = (
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "eoj" = (
 /obj/structure/chair/wood,
@@ -9275,8 +9337,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eyd" = (
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/building)
 "eyh" = (
 /obj/structure/glowshroom,
@@ -9572,11 +9635,26 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
 "eHM" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/structure/rack/large/shelf_rust{
+	pixel_x = -6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
+/obj/item/clothing/suit/armor/medium/unmcwinter,
+/obj/item/clothing/suit/armor/medium/unmcmedic,
+/obj/item/clothing/suit/armor/medium/unmcmarine,
+/obj/item/clothing/head/helmet/unmchelmet,
+/obj/item/clothing/head/helmet/unmchelmet/medic,
+/obj/item/clothing/head/helmet/unmcwinterhelmet,
+/obj/item/clothing/shoes/unmcb,
+/obj/item/clothing/shoes/unmcb/winter,
+/obj/item/clothing/shoes/unmcb/winter,
+/obj/item/storage/backpack/trekker/marinepack,
+/obj/item/storage/backpack/trekker/marinepack,
+/obj/item/storage/backpack/trekker/marinepack,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "eHX" = (
 /obj/effect/turf_decal/bot,
@@ -9734,11 +9812,17 @@
 	},
 /area/f13/caves)
 "eND" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/pizza/vegetable,
-/turf/open/floor/carpet/red,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "eNE" = (
 /obj/machinery/light/broken,
@@ -10108,10 +10192,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "faf" = (
-/obj/structure/chair/folding{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "fap" = (
 /turf/closed/indestructible/vaultdoor,
@@ -10872,11 +10965,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/f13/building/museum)
-"fFY" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "fFZ" = (
 /obj/structure/junk/small/bed2,
 /turf/open/floor/f13{
@@ -11455,9 +11543,19 @@
 /turf/open/indestructible/ground/outside/dirt/bigdirtturf2,
 /area/f13/caves)
 "gdR" = (
-/obj/structure/railing/dancing_pole,
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/blue,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "gem" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -11494,11 +11592,14 @@
 	},
 /area/f13/caves)
 "geJ" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "geV" = (
 /obj/structure/rack/shelf_metal,
@@ -11544,8 +11645,14 @@
 /turf/open/indestructible/ground/outside/dirt/bigdirtturf,
 /area/f13/caves)
 "ghe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/simple_door/metal/dirtystore{
+	name = "Warehouse"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "ghn" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -11778,8 +11885,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/caves)
 "gnQ" = (
-/obj/structure/simple_door/repaired,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "gon" = (
 /obj/structure/table,
@@ -12118,14 +12231,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "gyE" = (
-/obj/structure/table/glass,
-/obj/item/lighter/bullet,
-/obj/item/lighter/iconic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/noticeboard{
-	pixel_y = -30
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "gyF" = (
 /obj/machinery/door/airlock/freezer{
@@ -12137,19 +12251,10 @@
 	},
 /area/f13/building/sewers)
 "gyK" = (
-/obj/structure/table/wood,
-/obj/item/clothing/neck/petcollar/leather,
-/obj/item/clothing/neck/petcollar/locked,
-/obj/item/clothing/neck/rubycollar,
-/obj/item/clothing/neck/sapphirecollar,
-/obj/item/clothing/neck/spikecollar,
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/item/restraints/handcuffs,
-/obj/item/cane,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/neck/petcollar,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/closed/wall/rust,
 /area/f13/building)
 "gzL" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -12696,29 +12801,18 @@
 /area/f13/caves)
 "gSE" = (
 /obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/dress/westernbustle{
-	pixel_x = -6
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/clothing/under/dress/westernbustle{
-	pixel_x = -6
-	},
-/obj/item/clothing/under/dress/westernbustle{
-	pixel_x = -6
-	},
-/obj/item/clothing/under/f13/erpdress{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/obj/item/clothing/under/f13/erpdress{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/obj/item/clothing/under/f13/erpdress{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "gTg" = (
 /obj/machinery/conveyor/inverted{
@@ -12765,11 +12859,18 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "gUN" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "gUO" = (
 /obj/structure/curtain{
@@ -13117,8 +13218,14 @@
 	},
 /area/f13/building)
 "hiR" = (
-/obj/structure/table/plasmaglass,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_8"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "hjo" = (
 /obj/structure/closet,
@@ -13871,13 +13978,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
-"hLt" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "hLQ" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 4
@@ -14128,13 +14228,10 @@
 /turf/open/floor/plasteel/f13/vault_floor,
 /area/f13/tunnel)
 "hWr" = (
-/obj/structure/table/wood/fancy/monochrome,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/grown/cucumber{
-	name = "Homewrecker";
-	desc = "Oblong and green, with pimples, this one smells a bit fishy and is... slimey?  Oh no."
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/closed/wall/rust,
 /area/f13/building)
 "hWD" = (
 /obj/effect/mob_spawn/human/corpse/vault/security,
@@ -14330,18 +14427,6 @@
 	},
 /turf/open/indestructible/ground/outside/river,
 /area/f13/caves)
-"idd" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/semen/femcum,
-/obj/effect/decal/cleanable/semen/femcum{
-	pixel_y = 10;
-	pixel_x = 5
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building)
 "idg" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -14425,17 +14510,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/caves)
-"ieT" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "ifg" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -14498,10 +14572,15 @@
 	},
 /area/f13/tunnel)
 "ihw" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/machinery/recycler,
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "ihO" = (
 /turf/open/floor/plating/tunnel{
@@ -14744,9 +14823,12 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building/hospital)
 "iqE" = (
-/obj/structure/table/booth,
-/obj/item/reagent_containers/food/snacks/pizza/mushroom,
-/turf/open/floor/carpet/blue,
+/obj/structure/window/reinforced,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "iqJ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15500,8 +15582,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/sewers)
 "iMO" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "iMX" = (
@@ -15576,8 +15666,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iPp" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/western,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "iQn" = (
 /obj/structure/table/wood,
@@ -15940,14 +16040,22 @@
 	},
 /area/f13/caves)
 "jdb" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/rare,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "jdc" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/table/reinforced,
+/obj/item/broom,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "jdq" = (
 /obj/structure/cable{
@@ -15987,8 +16095,18 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "jdS" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/carpet/blue,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "jek" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -16107,7 +16225,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "jix" = (
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/vault,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "jiZ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16398,8 +16525,14 @@
 	},
 /area/f13/caves)
 "jth" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/red,
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_11"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "jtF" = (
 /obj/structure/simple_door/brokenglass,
@@ -16493,11 +16626,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
 "jxx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/anchored,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/building)
 "jxX" = (
 /obj/structure/chair{
@@ -16787,15 +16917,15 @@
 	},
 /area/f13/tunnel)
 "jIp" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	density = 0;
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = 0
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/junk,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "jII" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -17366,8 +17496,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/tunnel)
 "kel" = (
-/obj/structure/sign/poster/contraband/pinup_couch,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/chair/office/dark,
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "keE" = (
 /obj/structure/wreck/trash/halftire,
@@ -17717,8 +17852,16 @@
 	},
 /area/f13/tunnel)
 "krl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
+/obj/structure/rug/big/rug_rubber{
+	dir = 4
+	},
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "krn" = (
 /obj/effect/decal/remains{
@@ -18896,10 +19039,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lgO" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+/obj/structure/rack/large/shelf{
+	pixel_x = -9;
+	pixel_y = -4
 	},
-/turf/open/floor/carpet/black,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/suit/armor/medium/ballisticvest/civvest,
+/obj/item/clothing/under/aurora/color/black,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/head/beanie/black,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "lhc" = (
 /obj/effect/decal/cleanable/blood{
@@ -19323,28 +19477,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
-"lwj" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/misc/black_dress{
-	pixel_x = -7
-	},
-/obj/item/clothing/under/misc/black_dress{
-	pixel_x = -7
-	},
-/obj/item/clothing/under/misc/black_dress{
-	pixel_x = -7
-	},
-/obj/item/clothing/under/maid,
-/obj/item/clothing/under/janimaid,
-/obj/item/clothing/head/maid,
-/obj/item/clothing/accessory/maidapron,
-/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "lxg" = (
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/floor/plasteel/caution{
@@ -19601,17 +19733,19 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "lEG" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/automatic/pistol/m1911{
-	name = "Muh Three Worldy Whores";
-	color = "#ff00ff"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 8;
-	pixel_y = -1;
-	pixel_x = 22
-	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "lER" = (
 /obj/item/pickaxe,
@@ -20070,14 +20204,14 @@
 	},
 /area/f13/tunnel)
 "lRN" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing{
-	dir = 6;
-	layer = 4.1
+/obj/structure/chair/sofa/corner{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "lSc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20633,7 +20767,17 @@
 	},
 /area/f13/caves)
 "mjN" = (
-/turf/open/floor/carpet/black,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "mkr" = (
 /turf/closed/wall/f13/tunnel,
@@ -20792,9 +20936,17 @@
 	},
 /area/f13/caves)
 "mqk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/securedoor,
-/turf/open/floor/carpet/red,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "mqL" = (
 /obj/item/trash/f13/steak,
@@ -20960,9 +21112,14 @@
 	},
 /area/f13/building)
 "mvT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/rare_money,
+/obj/effect/spawner/lootdrop/f13/rare_money,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "mvW" = (
 /obj/structure/chair/bench,
@@ -21097,12 +21254,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
-"mzG" = (
-/obj/structure/bonfire{
-	density = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/building)
 "mzH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
@@ -21476,15 +21627,14 @@
 	},
 /area/f13/caves)
 "mMz" = (
-/obj/structure/chair/folding,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/rack/large/shelf_rust{
+	pixel_x = 8
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "mMP" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -21643,8 +21793,19 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/caves)
 "mUp" = (
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/carpet/black,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "mVb" = (
 /obj/structure/table,
@@ -21689,8 +21850,17 @@
 	},
 /area/f13/building/sewers)
 "mWd" = (
-/obj/machinery/jukebox,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "mWj" = (
 /obj/structure/flora/tree/jungle,
@@ -22118,12 +22288,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building)
-"nmJ" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = -29
-	},
-/turf/open/water,
-/area/f13/building/sewers)
 "nmK" = (
 /obj/machinery/light/small,
 /turf/open/water,
@@ -22849,8 +23013,18 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/building/hospital)
 "nLd" = (
-/obj/structure/chair/stool/retro/backed,
-/turf/open/floor/carpet/red,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "nLr" = (
 /turf/open/floor/wood_mosaic,
@@ -22862,11 +23036,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/tunnel)
 "nLW" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_3"
 	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "nMm" = (
@@ -23428,8 +23604,20 @@
 	},
 /area/f13/tunnel)
 "oiF" = (
-/obj/effect/decal/cleanable/semen,
-/turf/open/floor/carpet/red,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "oiH" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -23940,12 +24128,20 @@
 /turf/open/floor/grass/fairy,
 /area/f13/caves)
 "ozN" = (
-/obj/effect/turf_decal/huge/heaven,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/building/sewers)
+/area/f13/building)
 "ozP" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -24216,7 +24412,15 @@
 	},
 /area/f13/bunker)
 "oJA" = (
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "oKm" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -24602,13 +24806,21 @@
 	},
 /area/f13/building/sewers)
 "oVY" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/kevlarhelmet/americandesert,
+/obj/item/clothing/suit/armor/medium/ballisticvest/fivetact,
+/obj/item/clothing/under/f13/modernbdu/americanstorm,
+/obj/item/clothing/shoes/f13/military/desert,
+/obj/item/clothing/gloves/rifleman,
+/obj/item/storage/backpack/trekker,
+/obj/item/storage/belt/military,
+/obj/item/clothing/neck/scarf/cptpatriot,
 /turf/open/floor/f13{
-	icon_state = "greenrustyfull"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/building/sewers)
+/area/f13/building)
 "oWf" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
@@ -24947,8 +25159,14 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
 "phe" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "phf" = (
 /obj/machinery/light/small{
@@ -26169,10 +26387,17 @@
 	},
 /area/f13/building/sewers)
 "pVl" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "pVm" = (
 /obj/effect/decal/cleanable/dirt{
@@ -26243,12 +26468,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
 "pWC" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/weapon/western,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "pXj" = (
@@ -26614,11 +26844,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qkE" = (
-/obj/structure/chair/sofa{
-	dir = 1
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/vault,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "qkN" = (
 /obj/structure/lattice/catwalk,
@@ -26826,12 +27065,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/tunnel)
-"qqA" = (
-/obj/structure/simple_door/repaired,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "qqB" = (
 /obj/structure/junk/drawer,
 /obj/effect/decal/cleanable/cobweb,
@@ -27010,14 +27243,19 @@
 	},
 /area/f13/building/massfusion)
 "qug" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "quQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27071,8 +27309,17 @@
 /turf/closed/wall/rust,
 /area/f13/building/sewers)
 "qwV" = (
-/obj/structure/sign/poster/contraband/pinup_funk,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "qxb" = (
 /obj/structure/table/booth,
@@ -27087,8 +27334,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "qxh" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/blue,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "qxi" = (
 /obj/item/paper_bin{
@@ -27434,18 +27691,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "qIo" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 6;
-	pixel_x = -9
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 3;
-	pixel_x = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "qIq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28157,9 +28411,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rhk" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_9"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "rhq" = (
 /obj/structure/bed/mattress{
@@ -28214,14 +28473,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
 "rjg" = (
-/obj/structure/closet/cabinet/anchored,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
-"rji" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rug/big/rug_rubber{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "rjK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28274,10 +28533,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "rkV" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/plush,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "rlc" = (
 /obj/structure/lattice{
@@ -28433,10 +28698,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "rqJ" = (
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "rqS" = (
 /obj/machinery/vending/cigarette,
@@ -28633,12 +28904,16 @@
 	},
 /area/f13/caves)
 "ryO" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "ryR" = (
 /turf/open/floor/mineral/plastitanium,
@@ -29046,22 +29321,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
 /area/f13/caves)
 "rMU" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/accessory/plaidblueshortskirt,
-/obj/item/clothing/accessory/plaidgreenlongskirt,
-/obj/item/clothing/accessory/plaidgreenshortskirt,
-/obj/item/clothing/accessory/plaidpurplelongskirt,
-/obj/item/clothing/accessory/plaidredlongskirt,
-/obj/item/clothing/accessory/plaidredshortskirt,
-/obj/item/clothing/accessory/pinkishskirt,
-/obj/item/clothing/accessory/maidskirt,
-/obj/item/clothing/accessory/greenfrillyskirt,
-/obj/item/clothing/under/rank/nursesuit,
-/obj/item/clothing/head/f13/nursehat,
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "rMV" = (
 /obj/structure/closet/wardrobe/botanist,
@@ -30035,10 +30302,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/caves)
 "sxz" = (
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/structure/rug/big/rug_rubber,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "sxN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30383,11 +30652,18 @@
 	},
 /area/f13/caves)
 "sIt" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_mods,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_ammo,
+/obj/effect/spawner/lootdrop/f13/trash_medicine,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "sIz" = (
 /obj/machinery/light/small{
@@ -30555,14 +30831,6 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"sOF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/repaired{
-	name = "bathroom"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "sOK" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -31703,8 +31971,13 @@
 	},
 /area/f13/building/massfusion)
 "tyW" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/structure/rug/big/rug_rubber,
+/obj/item/clothing,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "tzj" = (
 /obj/structure/rack,
@@ -32079,13 +32352,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"tOH" = (
-/obj/effect/decal/cleanable/semen{
-	pixel_x = 12;
-	pixel_y = -12
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building)
 "tOJ" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/wood/junk,
@@ -32093,7 +32359,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "tPr" = (
-/obj/effect/turf_decal/arrows/red,
+/obj/structure/car/rubbish4,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -32402,13 +32668,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/caves)
 "uay" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/trash_mods,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "uaH" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -32506,10 +32776,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "ueB" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "ufB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32716,18 +32987,11 @@
 	},
 /area/f13/tunnel)
 "uoY" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/obj/structure/decoration/vent,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
+/obj/structure/junk/small/table,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/building)
 "upm" = (
@@ -32824,12 +33088,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"usl" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/building)
 "ust" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -33157,12 +33415,19 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "uEv" = (
-/obj/structure/table/plasmaglass,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "uEJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33210,35 +33475,28 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "uGj" = (
-/obj/structure/table/wood/fancy/monochrome,
-/turf/open/floor/carpet/black,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/trash_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "uGn" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/under/misc/stripper{
-	pixel_x = -7
+/obj/structure/chair/f13chair1{
+	dir = 4
 	},
-/obj/item/clothing/under/misc/stripper{
-	pixel_x = -7
+/mob/living/simple_animal/hostile/ghoul/legendary,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/clothing/under/misc/stripper{
-	pixel_x = -7
-	},
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/green,
-/obj/item/clothing/under/misc/stripper/mankini{
-	pixel_x = 7
-	},
-/obj/item/clothing/under/misc/stripper/mankini{
-	pixel_x = 7
-	},
-/obj/item/clothing/under/misc/stripper/mankini{
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/costume/singer/yellow,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "uGv" = (
 /obj/structure/shelf_wood,
@@ -33656,10 +33914,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "uVo" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "uVz" = (
 /obj/structure/showcase/horrific_experiment,
@@ -33856,8 +34116,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "vcu" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/carpet/black,
+/obj/structure/shelf_wood,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/obj/item/storage/belt/durathread,
+/obj/item/storage/backpack/duffelbag/durathread,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "vcM" = (
 /obj/structure/table,
@@ -34038,18 +34308,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vhv" = (
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "vif" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt,
@@ -34175,9 +34433,17 @@
 	},
 /area/f13/caves)
 "vmF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_shower,
-/turf/closed/wall/f13/sunset/brick_small_dark,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/vault,
+/obj/effect/spawner/lootdrop/f13/rare_mats,
+/obj/effect/spawner/lootdrop/f13/common_ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "vmM" = (
 /obj/item/storage/trash_stack{
@@ -34507,11 +34773,15 @@
 	},
 /area/f13/caves)
 "vzl" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/f13/rare_mats,
+/obj/effect/spawner/lootdrop/f13/common_parts,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/carpet/blue,
 /area/f13/building)
 "vzy" = (
 /obj/structure/sink{
@@ -35340,11 +35610,17 @@
 	},
 /area/f13/caves)
 "wco" = (
-/obj/structure/mirror{
-	pixel_y = 28
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/rare_bombs,
+/obj/effect/spawner/lootdrop/f13/rare_bombs,
+/obj/effect/spawner/lootdrop/f13/rare_bombs,
+/obj/effect/spawner/lootdrop/f13/common_unique,
+/obj/effect/spawner/lootdrop/f13/common_armor,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/dresser,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "wcF" = (
 /obj/structure/decoration/rag,
@@ -35385,9 +35661,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "weN" = (
-/obj/structure/railing/dancing_pole/top,
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/blue,
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "weR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -35470,13 +35749,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "whR" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/weapon/western,
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
 /area/f13/building)
 "whX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36614,10 +36897,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/caves)
 "wYj" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/rare_medicine,
+/obj/effect/spawner/lootdrop/f13/rare_parts,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "wYE" = (
 /obj/effect/turf_decal/caution{
@@ -36943,8 +37233,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "xjO" = (
-/obj/structure/chair/folding,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
+/obj/item/clothing/suit/armor/light/tribal/geckocloak,
+/obj/item/clothing/suit/armor/medium/duster/cloak_armored,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/building)
 "xjW" = (
 /obj/structure/sign/poster/contraband/rebels_unite{
@@ -37377,7 +37672,7 @@
 	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/closed/indestructible/f13vaultrusted,
 /area/f13/building)
 "xyM" = (
 /obj/structure/rack,
@@ -37927,12 +38222,6 @@
 	initial_gas_mix = "o2=22;n2=82;miasma=44;TEMP=293.15"
 	},
 /area/f13/caves)
-"xOH" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building)
 "xOS" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -39205,14 +39494,14 @@ aae
 aae
 aae
 bOb
-mvT
-ghe
-ghe
-ghe
-ghe
-jix
-jix
-jix
+bOb
+bOb
+bOb
+bOb
+bOb
+bOb
+bOb
+bOb
 aae
 aae
 aae
@@ -39463,13 +39752,13 @@ aae
 aae
 bOb
 wco
-jdb
+ueB
 sxz
 jdb
 uGn
-aZU
+ueB
 rMU
-jix
+bOb
 aae
 aae
 aae
@@ -39715,20 +40004,20 @@ aae
 aae
 aae
 rBg
+rBg
+rBg
+rBg
 bOb
-bOb
-bOb
-bOb
-tyW
+ueB
+ueB
+kel
 oJA
-ghe
-oJA
-iaj
-iaj
-iaj
-jix
-jix
-jix
+ueB
+ueB
+ueB
+bOb
+bOb
+bOb
 aae
 aae
 aae
@@ -39976,16 +40265,16 @@ qzA
 hhE
 nsX
 bOb
-ghe
+ueB
+uVo
 mvT
-mvT
-oJA
-iaj
-iaj
-iaj
+jdc
+ueB
+ueB
+ueB
 gnQ
-oJA
-jix
+lRN
+bOb
 aae
 aae
 aae
@@ -40233,16 +40522,16 @@ rKh
 hiI
 nnI
 bOb
-wco
-jdb
-sxz
-oJA
-iaj
-iaj
-iaj
-ghe
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+rjg
+ueB
 phe
-jix
+bOb
 aae
 aae
 aae
@@ -40491,19 +40780,19 @@ bwU
 hhE
 mGF
 rhk
-oJA
-mvT
-jxx
+ueB
+ueB
+ueB
 hiR
-gSE
-lwj
-ghe
-oJA
-jix
-jix
-jix
-jix
-jix
+ueB
+ueB
+ueB
+oVY
+bOb
+bOb
+bOb
+bOb
+bOb
 aae
 aae
 aaa
@@ -40743,24 +41032,24 @@ bOb
 bOb
 bOb
 rBg
-bOb
+rBg
 xyL
 cWH
 bOb
-jix
-jix
-jix
-jix
-eoi
+bOb
+bOb
+bOb
+bOb
+bOb
 ghe
 ghe
+bOb
+bOb
+bOb
 aLH
-qqA
-jix
-aZi
 qug
-mjN
-jix
+wYj
+bOb
 aae
 aae
 aaa
@@ -41003,21 +41292,21 @@ rBg
 xXa
 eUU
 rsd
+rBg
+aae
+aae
 bOb
-aae
-aae
-jix
 uEv
-eyd
-wYj
+ueB
+ueB
 krl
-oJA
+ueB
 bRa
-jix
-vcu
-hWr
-mjN
-jix
+hiR
+ueB
+ueB
+ueB
+bOb
 aae
 aae
 aaa
@@ -41260,21 +41549,21 @@ rBg
 frb
 rnN
 rtD
+rBg
+aae
+aae
 bOb
-aae
-aae
-jix
 weN
-gdR
-wYj
-idd
-oJA
-phe
-jix
-mUp
-usl
-mjN
-jix
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+ueB
+bRa
+bOb
 aae
 aae
 aaa
@@ -41515,24 +41804,24 @@ qjZ
 bOb
 rBg
 rBg
-jix
-mvT
-ghe
-jix
-jix
-jix
-vzl
+rBg
+eyd
+jxx
+bOb
+bOb
+bOb
+ueB
 ryO
-lRN
-eHM
-oJA
-oJA
-jdc
-jix
-jix
-rqJ
-jix
-jix
+ueB
+ueB
+vmF
+ueB
+ueB
+gUN
+jth
+ueB
+bOb
+bOb
 aae
 aaa
 aak
@@ -41757,7 +42046,7 @@ jGk
 tkZ
 gcv
 gcv
-ozN
+hXn
 gcv
 awp
 gcv
@@ -41772,24 +42061,24 @@ gcv
 awp
 gcv
 tkZ
-jix
-vhv
-pWC
-uoY
-jix
+bOb
+bOb
+bOb
+bOb
+ozN
 iPp
-tOH
+ueB
 pVl
-xOH
+ueB
 geJ
-oJA
-oJA
-rqJ
+dQc
+ueB
+ueB
 mjN
-mjN
-mjN
+ueB
+ueB
 lgO
-jix
+bOb
 aae
 aaa
 aak
@@ -42015,38 +42304,38 @@ roN
 gcv
 gcv
 gcv
-tPr
-gcv
-gcv
-tPr
-gcv
-gcv
-tPr
 gcv
 gcv
 gcv
-tPr
+gcv
+gcv
+gcv
+gcv
+gcv
+gcv
+gcv
+gcv
 gcv
 mEa
-nmJ
-jix
+tkZ
+bOb
 cTK
 iMO
 nLW
-qwV
-oJA
-oJA
-oJA
-oJA
-oJA
-oJA
-oJA
-rqJ
-mjN
-mzG
-mjN
-qkE
-jix
+ueB
+ueB
+ueB
+pWC
+ueB
+ueB
+dQc
+rhk
+ueB
+uay
+ueB
+ueB
+ueB
+bOb
 aae
 aaa
 aak
@@ -42283,27 +42572,27 @@ gcv
 gcv
 lOZ
 hXn
-oVY
+gcv
 mEa
 tkZ
-jix
-dQc
-iMO
-ieT
-jix
+bOb
 ueB
-oJA
-oJA
-oJA
-oJA
-oJA
-oJA
+ueB
+ueB
+ueB
+ueB
+vzl
+uGj
+ueB
+ueB
+doy
+ueB
 rqJ
-mjN
-mjN
-mjN
+eoi
+ueB
+ueB
 bhR
-jix
+bOb
 aae
 aaa
 aaB
@@ -42543,24 +42832,24 @@ jNW
 hXn
 mEa
 qKz
+bOb
+weN
+ueB
+ueB
 jix
-vmF
-sOF
-ghe
-jix
-rjg
-oJA
-oJA
-oJA
-oJA
-oJA
-phe
-jix
-jix
-jix
-rqJ
-jix
-jix
+ueB
+ueB
+gSE
+ueB
+ueB
+mWd
+ueB
+ueB
+gdR
+ueB
+hiR
+bOb
+bOb
 aae
 aaa
 aaB
@@ -42797,26 +43086,26 @@ ief
 sNJ
 qae
 jNW
-tPr
+gcv
 gcv
 tPr
 bat
-jhP
-jhP
-hLt
+uoY
+tyW
+ueB
 cCM
-jhP
-jhP
-jhP
-gUN
-gUN
+rhk
+ueB
+qkE
+ueB
+ueB
 rkV
-rkV
-jix
+ueB
+weN
 aZi
-uVo
-mjN
-jix
+ueB
+ueB
+bOb
 aae
 aae
 aaa
@@ -43056,24 +43345,24 @@ otF
 jNW
 hXn
 gcv
-qKz
-jix
-jhP
-jhP
-jhP
+gcv
+ghe
+uoY
+ueB
+ueB
 mqk
-jhP
-jhP
-nLd
-fFY
-fFY
+ueB
+ueB
+oiF
+rhk
+ueB
 bZa
-gyE
-jix
-vcu
-uGj
-mjN
-jix
+ueB
+ueB
+ueB
+ueB
+ueB
+bOb
 aae
 aae
 aaa
@@ -43313,24 +43602,24 @@ jfO
 jNW
 hXn
 mEa
-tkZ
-jix
-xjO
-oJA
-xjO
-ghe
-mWd
-oJA
-nLd
-eND
-jhP
-oiF
-jhP
-jix
+qKz
+bOb
+eHM
+jth
+ueB
+qIo
+ueB
+ueB
+qwV
+ueB
+ueB
+ueB
+ueB
+ueB
 mUp
 whR
-mjN
-jix
+faf
+bOb
 aae
 aae
 aaa
@@ -43571,23 +43860,23 @@ jNW
 hXn
 mEa
 tkZ
-jix
+bOb
 mMz
-oJA
-xjO
-rji
-gyK
-oJA
+ueB
+ueB
+ueB
+ueB
+ueB
 nLd
-qIo
-jhP
-faf
+ueB
+gyE
+ueB
 jth
-jix
-jix
-jix
-jix
-jix
+bOb
+bOb
+bOb
+bOb
+bOb
 aae
 aae
 aae
@@ -43828,19 +44117,19 @@ hDm
 hXn
 mEa
 tkZ
-jix
+bOb
 xjO
-oJA
-xjO
-rji
-bZY
-oJA
-jhP
-uay
+vzl
+geJ
+ueB
+ueB
+ueB
+ueB
+weN
 sIt
 lEG
 jIp
-jix
+bOb
 aae
 aae
 aae
@@ -44085,19 +44374,19 @@ hDm
 gcv
 gcv
 tkZ
-jix
-jix
-jix
-jix
-ghe
-ghe
-sxz
-kel
-jix
-doy
-jix
-jix
-jix
+bOb
+bOb
+bOb
+bOb
+eND
+ueB
+vcu
+bOb
+bOb
+bOb
+bOb
+bOb
+bOb
 aae
 aae
 aae
@@ -44345,11 +44634,11 @@ tkZ
 tkZ
 tkZ
 jGk
-jix
+bOb
 qxh
-rpr
+iqE
 alA
-jix
+hWr
 uvv
 uvv
 uvv
@@ -44602,11 +44891,11 @@ tkZ
 gcv
 tkZ
 jGk
-jix
+bOb
 jdS
 iqE
-rpr
-jix
+alA
+hWr
 uvv
 jGk
 jGk
@@ -44859,11 +45148,11 @@ tkZ
 gcv
 tkZ
 jGk
-jix
+bOb
 abB
 cPj
 ihw
-jix
+hWr
 uvv
 jGk
 gcv
@@ -45116,11 +45405,11 @@ tkZ
 gcv
 tkZ
 jGk
-jix
-jix
-jix
-jix
-jix
+bOb
+bOb
+bOb
+gyK
+bOb
 uvv
 jGk
 gcv

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper-2.dmm
@@ -43,6 +43,22 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"aE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light/sign/heaven{
+	pixel_y = -32;
+	pixel_x = -16
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 1
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "aG" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -98,9 +114,15 @@
 /turf/open/floor/plasteel/solarpanel,
 /area/f13/wasteland)
 "be" = (
-/obj/item/chair/folding,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowleft"
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "bj" = (
 /obj/machinery/door/unpowered/securedoor{
 	name = "Sheriff's Office";
@@ -166,35 +188,11 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "bz" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
+/obj/structure/chair/f13foldupchair{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "bB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
@@ -211,23 +209,15 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
 "bO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 1
 	},
+/turf/open/floor/wood_wide,
 /area/f13/building)
 "bT" = (
 /obj/effect/decal/cleanable/blood,
@@ -293,41 +283,21 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "cs" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
+/obj/structure/closet/cabinet/anchored,
+/obj/item/clothing/under/fancy_red_formaldress,
+/obj/item/clothing/under/dress/blacktango,
+/obj/item/clothing/under/costume/singer/yellow,
+/obj/item/clothing/under/dress/westernbustle,
+/obj/item/clothing/under/misc/black_dress,
+/obj/item/clothing/under/f13/campfollowerfemale,
+/obj/item/clothing/under/f13/campfollowermale,
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "cv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/sofa{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola/radioactive,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola/radioactive,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "cw" = (
 /obj/structure/rack/shelf_metal,
@@ -354,6 +324,15 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"cE" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_corner_fill";
+	dir = 1
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "cG" = (
 /obj/item/binoculars,
 /obj/structure/table/wood,
@@ -364,6 +343,21 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"cO" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/structure/decoration/vent,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "cP" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -402,6 +396,11 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"dn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/pinup_shower,
+/turf/closed/wall/f13/sunset/brick_small_dark,
+/area/f13/building)
 "dp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -469,6 +468,13 @@
 "ed" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"eg" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "eh" = (
 /obj/structure/railing/handrail/blue/underlayer{
 	dir = 9;
@@ -493,28 +499,19 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"es" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "ey" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/building)
 "eA" = (
 /obj/structure/rack/shelf_metal,
@@ -530,6 +527,13 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"eJ" = (
+/obj/structure/chair/sofa/left{
+	pixel_y = 8;
+	color = "red"
+	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "eN" = (
 /obj/structure/railing/corner{
@@ -611,22 +615,12 @@
 	},
 /area/f13/wasteland)
 "fu" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lighter/heart,
+/obj/item/lighter/moff,
+/obj/structure/table/plasmaglass,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "fv" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -642,6 +636,14 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
+/area/f13/building)
+"fB" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "fG" = (
 /obj/structure/mopbucket,
@@ -702,20 +704,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "gh" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "gl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -730,6 +723,16 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"gm" = (
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowright"
+	},
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "gr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/shelf_metal,
@@ -740,17 +743,22 @@
 /turf/open/transparent/openspace,
 /area/f13/building/hospital/clinic)
 "gy" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_y = -5
-	},
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	layer = 2.8
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 9
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
+"gH" = (
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/building)
 "gL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/rag,
@@ -762,21 +770,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/abandoned)
 "gQ" = (
-/obj/effect/turf_decal/trimline/neutral/line{
+/obj/structure/chair/sofa/corp/left{
+	color = "pink";
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "gS" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -806,6 +805,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"hh" = (
+/obj/structure/chair/sofa/corp/left{
+	color = "#BED0FD";
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "hi" = (
 /obj/item/binoculars,
 /obj/structure/table/wood,
@@ -944,6 +950,14 @@
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"it" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "iA" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -993,7 +1007,9 @@
 	},
 /area/f13/wasteland)
 "jb" = (
-/obj/effect/spawner/lootdrop/f13/common,
+/obj/structure/fence{
+	dir = 4
+	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "jf" = (
@@ -1066,18 +1082,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "jP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack,
-/obj/item/reagent_containers/food/drinks/bottle/nukashine,
-/obj/item/stock_parts/chem_cartridge/simple,
-/obj/item/stock_parts/chem_cartridge/simple,
-/obj/item/stock_parts/chem_cartridge/simple,
-/obj/item/stock_parts/chem_cartridge/simple,
-/obj/item/vending_refill/boozeomat,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "jT" = (
 /obj/item/binoculars,
@@ -1104,15 +1112,24 @@
 "kd" = (
 /turf/open/transparent/openspace,
 /area/f13/building/hospital)
+"kg" = (
+/obj/structure/chair/sofa/corp{
+	color = "#BED0FD";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "ki" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "km" = (
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "kn" = (
 /mob/living/simple_animal/hostile/gecko/legacy/alpha,
 /turf/open/floor/f13/wood{
@@ -1123,6 +1140,9 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/red,
+/area/f13/building)
+"kp" = (
+/turf/open/floor/wood_wide,
 /area/f13/building)
 "kq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1182,16 +1202,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "kZ" = (
-/obj/structure/railing/corner{
-	dir = 8;
-	color = "#A47449"
-	},
-/obj/structure/fence{
-	icon_state = "end";
-	pixel_x = 18
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/pizza/vegetable,
+/obj/structure/table/plasmaglass,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "lg" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1212,23 +1228,22 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "lo" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
+/obj/structure/table/wood/fancy/blue,
+/obj/item/reagent_containers/food/snacks/grown/cucumber{
+	name = "Homewrecker";
+	desc = "Oblong and green, with pimples, this one smells a bit fishy and is... slimey?  Oh no."
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
+/turf/open/floor/carpet/black,
+/area/f13/building)
+"lt" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "#BED0FD";
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "ly" = (
 /obj/structure/bed/wooden,
 /obj/item/bedsheet/blue,
@@ -1245,19 +1260,12 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
 "lJ" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
+/obj/machinery/vending/kink{
+	pixel_y = 20;
+	pixel_x = -1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "lL" = (
 /obj/structure/railing{
 	dir = 10
@@ -1379,6 +1387,14 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"nc" = (
+/obj/structure/chair/sofa{
+	pixel_y = 8;
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "nh" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -1392,33 +1408,18 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "np" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/keg/hearty_punch,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "nt" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowleft"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
+/obj/structure/curtain{
+	color = "#c40e0e"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "nw" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -1532,25 +1533,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "oc" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/structure/chair/sofa/corp{
+	color = "pink"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "of" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -1569,22 +1556,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "on" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "oo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -1592,6 +1570,14 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"ou" = (
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "oy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1620,59 +1606,33 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "oO" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	color = "pink"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "oU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "oX" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
+/obj/structure/closet/cabinet/anchored,
+/obj/item/clothing/under/f13/mprostitute,
+/obj/item/clothing/under/f13/fprostitute,
+/obj/item/clothing/under/f13/erpdress,
+/obj/item/clothing/under/dress/corset,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "pf" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe/free,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -1696,12 +1656,14 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "po" = (
-/obj/structure/lamp_post/doubles/bent{
-	density = 0;
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "pp" = (
 /obj/item/stock_parts/cell/super/empty,
 /obj/structure/spacevine,
@@ -1754,6 +1716,16 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"pK" = (
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 8
+	},
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "pO" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -1779,24 +1751,11 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "qi" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = 14;
-	density = 0
+/obj/machinery/microwave/gas_stove{
+	pixel_y = 16
 	},
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = -14;
-	density = 0
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/building)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1810,12 +1769,10 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "qu" = (
-/obj/structure/chair/bench{
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/semen/femcum,
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "qA" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -1829,9 +1786,20 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "qF" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/structure/sink/greyscale{
+	pixel_y = 18;
+	pixel_x = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "qJ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/spacevine,
@@ -1843,6 +1811,10 @@
 	name = "Concrete wall";
 	smooth = 1
 	},
+/area/f13/building)
+"qN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "qV" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -1927,6 +1899,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"rL" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "rN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
@@ -1971,14 +1950,11 @@
 	},
 /area/f13/wasteland)
 "sf" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
+/obj/structure/chair/sofa/right{
+	dir = 4;
+	pixel_y = 0
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "sn" = (
 /turf/open/transparent/openspace{
@@ -1993,23 +1969,15 @@
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic)
 "st" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/table/wood/fancy/monochrome,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "sv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/plasmaglass,
+/obj/item/reagent_containers/food/snacks/pizza/mushroom,
+/turf/open/floor/carpet/red,
 /area/f13/building)
 "sx" = (
 /obj/effect/spawner/lootdrop/f13/common,
@@ -2044,33 +2012,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "sQ" = (
-/obj/structure/holohoop{
+/obj/structure/chair/f13foldupchair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
+/obj/effect/turf_decal/huge/heaven,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "sS" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -2096,6 +2043,12 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"tk" = (
+/obj/structure/chair/sofa/corp/corner{
+	color = "pink"
+	},
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "tn" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2120,6 +2073,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"tw" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cum,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "tA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -2133,38 +2098,24 @@
 	},
 /area/f13/wasteland)
 "tF" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "tG" = (
-/obj/machinery/grill,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "tM" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
 "tQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/structure/chair/sofa/corp/right{
+	color = "#ffc0cb"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral{
@@ -2268,10 +2219,8 @@
 /area/f13/building)
 "vd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/keg/milk,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "ve" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -2289,23 +2238,10 @@
 	},
 /area/f13/building)
 "vp" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = 14;
-	density = 0
+/obj/structure/chair/sofa/right{
+	dir = 4
 	},
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = -14;
-	density = 0
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "vw" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -2345,45 +2281,12 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "vK" = (
-/obj/structure/holohoop{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/sunset/brick_small_dark,
+/area/f13/building)
 "vQ" = (
-/obj/item/toy/beach_ball/holoball,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "vR" = (
 /obj/structure/fence{
 	icon_state = "end";
@@ -2392,6 +2295,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"vS" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "vT" = (
 /obj/machinery/light{
 	dir = 8
@@ -2421,6 +2331,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"wg" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/structure/sink/greyscale{
+	pixel_y = 18
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "wh" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -2466,20 +2387,13 @@
 	},
 /area/f13/wasteland)
 "wK" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_corner_fill";
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "wM" = (
 /obj/structure/fence{
 	dir = 4;
@@ -2508,6 +2422,16 @@
 	smooth = 1
 	},
 /area/f13/building)
+"wQ" = (
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 4
+	},
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "wX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -2523,6 +2447,11 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"xi" = (
+/obj/structure/table/plasmaglass,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "xm" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/outside/roof,
@@ -2569,6 +2498,14 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"xQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/repaired{
+	name = "bathroom"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "xU" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -2612,24 +2549,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "yo" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/sofa/left{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "yp" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe/free,
@@ -2660,6 +2583,10 @@
 /obj/item/locked_box/weapon/range/tier1_3,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"yH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "yJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -2682,12 +2609,16 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"za" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "zj" = (
-/obj/structure/table/wood,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/chair/sofa/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "zp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
@@ -2769,35 +2700,30 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/hospital)
 "zV" = (
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 4
+	},
 /turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/area/f13/building)
 "zX" = (
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior4"
 	},
 /area/f13/building)
 "zY" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
+"Ab" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/plasmaglass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Ad" = (
 /obj/structure/chair/comfy/plywood,
 /turf/open/floor/wood_common{
@@ -2978,6 +2904,14 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"BK" = (
+/obj/structure/chair/sofa/right{
+	pixel_y = 8;
+	color = "red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "BM" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -3012,30 +2946,8 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "BZ" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "Ce" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -3170,36 +3082,22 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Dg" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowright"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
+/obj/structure/curtain{
+	color = "#c40e0e"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "Dk" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_corner_fill";
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "Dm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/rock{
@@ -3247,20 +3145,10 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "DQ" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "DS" = (
 /obj/item/circuitboard/machine/smes,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -3316,38 +3204,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "EA" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "ED" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -3377,26 +3238,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "EQ" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "ES" = (
 /obj/machinery/mineral/wasteland_vendor/medical,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -3418,6 +3261,14 @@
 	name = "Lil Scriggler"
 	},
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"Fb" = (
+/obj/machinery/door/unpowered/securedoor,
+/obj/effect/step_trigger/player_choice_log{
+	title = "Welcome to Heavens Night.";
+	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Fg" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -3512,16 +3363,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
-"Gy" = (
-/obj/effect/turf_decal/trimline/neutral{
-	icon_state = "trimline_fill";
+"Gw" = (
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/obj/structure/chair/bench{
-	pixel_y = 10
-	},
 /turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/area/f13/building)
+"Gy" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/automatic/pistol/m1911{
+	name = "Muh Three Worldy Whores";
+	color = "#ff00ff"
+	},
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8;
+	pixel_y = -1;
+	pixel_x = 22
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "GB" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -3574,22 +3435,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic)
 "GW" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = 14;
-	density = 0
-	},
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = -14;
-	density = 0
-	},
-/obj/structure/spacevine,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/building)
 "He" = (
 /obj/structure/rack/shelf_metal,
@@ -3622,6 +3469,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic)
+"Hm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/plasmaglass,
+/obj/item/reagent_containers/food/snacks/pizza/mothic_white_pie,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Ho" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3655,11 +3509,16 @@
 	},
 /area/f13/wasteland)
 "Hy" = (
-/obj/structure/chair/folding{
-	dir = 1
-	},
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/f13/building)
+"Hz" = (
+/obj/machinery/jukebox,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "HG" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 8
@@ -3692,23 +3551,11 @@
 	},
 /area/f13/wasteland)
 "If" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/reagent_containers/food/drinks/bottle/nukashine,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "Ig" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -3867,9 +3714,11 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "Jm" = (
-/obj/structure/easel,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Jn" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -3904,24 +3753,9 @@
 	},
 /area/f13/wasteland)
 "JF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/item/reagent_containers/food/drinks/bottle/nukashine,
-/obj/item/reagent_containers/food/drinks/bottle/nukashine,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
 /area/f13/building)
 "JG" = (
 /obj/effect/turf_decal/caution/stand_clear{
@@ -3941,21 +3775,10 @@
 	},
 /area/f13/wasteland)
 "JT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/chair/sofa{
+	dir = 4
 	},
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "JW" = (
 /obj/structure/railing/corner{
@@ -3987,15 +3810,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Ky" = (
-/obj/effect/turf_decal/trimline/neutral{
-	icon_state = "trimline_fill";
-	dir = 4
-	},
-/obj/structure/lamp_post/doubles/bent{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/area/f13/building)
 "Kz" = (
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
@@ -4085,6 +3902,18 @@
 /obj/structure/table,
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic)
+"Lp" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "Lr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4093,27 +3922,17 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Lt" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - S"
-	},
-/area/f13/wasteland)
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/f13/building)
 "Lx" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/table/wood/fancy/monochrome,
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/machinery/light,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "LB" = (
 /obj/structure/rack/shelf_metal,
 /obj/machinery/light/broken{
@@ -4154,33 +3973,25 @@
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
 /area/f13/building/hospital)
+"LU" = (
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "LV" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Mk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/semen,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "Mm" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = 14;
-	density = 0
-	},
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = -14;
-	density = 0
-	},
-/obj/machinery/door/unpowered/securedoor{
-	name = "Bar";
-	req_access_txt = null;
-	req_one_access_txt = "25, 28"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Mo" = (
 /obj/machinery/light/small{
@@ -4199,24 +4010,11 @@
 	},
 /area/f13/wasteland)
 "Mu" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
+/obj/structure/bonfire{
+	density = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = -9
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/grass/fakebasalt,
+/area/f13/building)
 "Mx" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -4254,10 +4052,15 @@
 /area/f13/wasteland)
 "MM" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
+/obj/effect/decal/cleanable/cum,
+/turf/open/floor/carpet/blue,
+/area/f13/building)
+"MS" = (
+/obj/structure/chair/booth{
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "MV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -4340,6 +4143,12 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"NJ" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
 /area/f13/building)
 "NL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4443,8 +4252,13 @@
 	},
 /area/f13/wasteland)
 "OH" = (
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "OI" = (
 /obj/structure/railing/corner{
 	dir = 1;
@@ -4510,24 +4324,23 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Po" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
 	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "Pp" = (
-/obj/structure/chair/folding,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
-"Pr" = (
-/obj/effect/turf_decal/trimline/neutral{
-	icon_state = "trimline_fill";
-	dir = 8
+/obj/structure/chair/stool/retro/backed{
+	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/turf/open/floor/carpet/red,
+/area/f13/building)
+"Pr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "PC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/raider/ranged/boss{
@@ -4597,6 +4410,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
+"Qr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Qx" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4621,22 +4440,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "QS" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/structure/sink/greyscale{
+	dir = 4;
+	pixel_y = 10;
+	pixel_x = 12
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "QV" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -4644,6 +4454,12 @@
 /obj/structure/fluff/beach_umbrella/security,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"QZ" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "Rb" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant{
 	faction = list("raider")
@@ -4651,16 +4467,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Rg" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/machinery/light,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Ri" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -4723,28 +4531,16 @@
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
 "RH" = (
-/obj/structure/chair/bench{
-	pixel_y = 10
-	},
-/turf/open/floor/wood_wide,
-/area/f13/wasteland)
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "RN" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/structure/chair/f13foldupchair{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2bottom"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "RP" = (
 /obj/structure/fence/end/wooden{
 	pixel_x = -7;
@@ -4833,6 +4629,27 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"Sw" = (
+/obj/structure/table/wood,
+/obj/item/melee/onehanded/slavewhip,
+/obj/item/melee/chainofcommand/tailwhip/kitty,
+/obj/item/cane,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/clothing/neck/petcollar,
+/obj/item/clothing/neck/spikecollar,
+/obj/item/clothing/neck/sapphirecollar,
+/obj/item/clothing/neck/rubycollar,
+/obj/item/clothing/neck/petcollar/locked,
+/obj/item/clothing/neck/petcollar/leather,
+/obj/item/clothing/neck/petcollar/choker,
+/obj/item/clothing/neck/heartcollar,
+/obj/item/clothing/mask/muzzle,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/f13/building)
 "Sz" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
@@ -4935,6 +4752,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic)
+"TH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/semen/femcum,
+/obj/effect/decal/cleanable/semen/femcum,
+/obj/effect/decal/cleanable/semen/femcum,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "TN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -4975,22 +4800,24 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Ul" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	density = 0;
+	dir = 8;
+	pixel_x = 23;
+	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 3;
+	pixel_x = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 6;
+	pixel_x = -9
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop1"
-	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Um" = (
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/indestructible/ground/outside/roof,
@@ -5098,14 +4925,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"Vs" = (
+/obj/structure/table/booth,
+/obj/item/candle/infinite{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/candle/infinite{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/candle/infinite{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "Vu" = (
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building/abandoned)
 "Vv" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/fancy/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "VC" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -5138,26 +4981,17 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"VL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/blue,
+/area/f13/building)
 "VU" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/hospital/clinic)
 "VW" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2left"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building)
 "VX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/blood/drip,
@@ -5197,26 +5031,8 @@
 /area/f13/wasteland)
 "Wo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/sunset/brick_small_dark,
+/area/f13/building)
 "Wq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
@@ -5278,23 +5094,9 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "WX" = (
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = 14;
-	density = 0
-	},
-/obj/structure/fence/wooden{
-	dir = 1;
-	pixel_y = 0;
-	pixel_x = -14;
-	density = 0
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Xg" = (
 /obj/structure/sign/poster/prewar/poster72{
@@ -5330,6 +5132,13 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"Xx" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/purple,
+/area/f13/building)
 "XC" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -5442,9 +5251,7 @@
 /area/f13/building/abandoned)
 "YE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/f13/building)
 "YK" = (
 /obj/structure/barricade/sandbags,
@@ -5507,20 +5314,19 @@
 /area/f13/wasteland)
 "ZN" = (
 /obj/structure/fence{
-	dir = 4;
-	pixel_y = -5
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	layer = 2.8
-	},
-/obj/structure/fence{
 	icon_state = "end";
 	pixel_x = 18
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral{
+	icon_state = "trimline_fill";
+	dir = 5
+	},
+/turf/open/floor/wood_wide,
+/area/f13/building)
 "ZO" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
@@ -6208,20 +6014,20 @@ hm
 hm
 hm
 hm
-px
-px
-px
-px
-px
-px
-px
-px
-px
-px
-px
-px
-px
-px
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -6464,23 +6270,23 @@ hm
 hm
 hm
 hm
-CD
-SP
-qt
-qt
-qt
-qt
-qt
-qt
-qt
-qt
-qt
-qt
-qt
-Pr
-Pr
-BW
-AU
+hm
+gy
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+kp
+hm
 hm
 hm
 hm
@@ -6721,23 +6527,23 @@ hm
 hm
 hm
 hm
-CD
-nO
-qu
-st
-RH
-Wr
-Wr
-Wr
-RH
-Lx
-RH
-Wr
+hm
+bO
+vK
+QZ
+vp
+TH
+vK
+BZ
+WX
+Mm
+eg
+Xx
 km
-st
-st
-Xv
-AU
+tF
+vK
+Gw
+Ow
 hm
 hm
 hm
@@ -6978,23 +6784,23 @@ hm
 hm
 hm
 hm
-CD
-nO
-RH
-st
-RH
-Wr
+hm
+bO
+vK
+np
+lo
+yH
 tG
-Wr
+Mm
+WX
+BZ
 RH
-st
-RH
-Wr
-st
+GW
 tF
-st
-Xv
-AU
+tF
+nt
+Hy
+rK
 hm
 hm
 hm
@@ -7235,23 +7041,23 @@ hm
 hm
 hm
 hm
-CD
-nO
-RH
+hm
+bO
+vK
 zj
-RH
-Wr
-Wr
-Wr
-RH
-st
-RH
-Wr
+fB
+NJ
+vK
+BZ
+Mm
+Mm
+JF
+GW
 st
 Lx
-st
-Xv
-AU
+vS
+Hy
+rK
 hm
 hm
 hm
@@ -7492,23 +7298,23 @@ hm
 hm
 hm
 hm
-CD
-nO
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-st
-st
-Xv
-AU
+hm
+bO
+vK
+vK
+vK
+vK
+vK
+BZ
+Mm
+WX
+GW
+Mk
+GW
+tF
+Dg
+Hy
+rK
 hm
 hm
 hm
@@ -7749,23 +7555,23 @@ hm
 hm
 hm
 hm
-CD
-nO
-zV
-Wr
-Wr
-Wr
-Wr
-Wr
-jb
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+hm
+bO
+vK
+Lp
+po
+cO
+vK
+BK
+qN
+Mm
+GW
+lt
+kg
+hh
+vK
+rL
+Bh
 hm
 hm
 hm
@@ -8006,24 +7812,24 @@ hm
 hm
 hm
 hm
-CD
-nO
-Jm
+hm
+bO
+vK
 qF
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Zt
-Rg
-Rg
-vp
-GW
-Rg
-Rg
-Zt
+LU
+es
+vK
+nc
+qN
+Mm
+BZ
+WX
+Mm
+vK
+vK
+vK
+vK
+vK
 hm
 hm
 hm
@@ -8263,24 +8069,24 @@ hm
 hm
 hm
 hm
-CD
-nO
-Wr
-jb
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-rS
-np
-JF
-JT
+hm
+bO
+vK
+wg
+LU
+tw
+vK
+eJ
+za
+WX
+Mm
+Mm
+BZ
+vK
 yo
 JT
 sf
-qi
+vK
 hm
 hm
 hm
@@ -8520,24 +8326,24 @@ hm
 hm
 hm
 hm
-CD
-nO
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-po
-Wr
+hm
+aE
+vK
+dn
+xQ
+Wo
+vK
+Lt
+BZ
+BZ
 Mm
-vd
-Eq
+Mm
+BZ
+ou
 YE
-Eq
 YE
-Eq
-Rg
+qu
+be
 hm
 hm
 hm
@@ -8776,25 +8582,25 @@ hm
 hm
 hm
 hm
-LV
+hm
 gy
-nO
-RH
+Dk
+vK
 lJ
 BZ
 sQ
 bz
-on
-Hy
-Wr
+BZ
+Mm
+Mm
 WX
-JT
-Eq
+Mm
+Mm
 Po
-Po
+vd
+Mu
 YE
-Eq
-Rg
+it
 hm
 hm
 hm
@@ -9033,25 +8839,25 @@ Hl
 GS
 FS
 hm
-xU
 hm
-nO
-RH
-cs
-Dg
-DQ
+gH
+Ky
+Fb
+Mm
+WX
+BZ
+BZ
+Mm
+BZ
+WX
+WX
+WX
+Mm
+Po
 zY
-VW
-Hy
-Wr
-rS
-bO
 YE
-YE
-Eq
-WH
-Eq
-Rg
+vd
+gm
 hm
 hm
 hm
@@ -9290,25 +9096,25 @@ XR
 fq
 FS
 px
-kZ
+px
 ZN
-nO
-RH
-cs
-OH
-OH
-Vv
-lo
-be
-Wr
-rS
-Zt
-sv
-ey
+wK
+vK
+BZ
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
+WX
+BZ
+vK
 jP
 cv
 If
-WX
+vK
 hm
 hm
 hm
@@ -9548,24 +9354,24 @@ kF
 FS
 SP
 qt
-qt
-sF
-RH
+pK
+cE
+vK
 cs
+EQ
 DQ
-DQ
-QS
-fu
-be
-Wr
-Zt
+Mm
+Mm
+Mm
+BZ
+BZ
+Mm
 Rg
-Rg
-GW
-vp
-Rg
-Rg
-Zt
+vK
+vK
+vK
+vK
+vK
 hm
 hm
 hm
@@ -9806,21 +9612,21 @@ FS
 nO
 Wr
 jb
-Wr
-Wr
-cs
-Vv
-OH
-Vv
+Ky
+vK
+Sw
+vQ
+vQ
+BZ
 VW
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+cX
+cX
+VW
+VW
+VW
+cX
+vK
+hm
 hm
 hm
 hm
@@ -10062,22 +9868,22 @@ FS
 FS
 nO
 Wr
-Wr
-Wr
-Wr
+jb
+Ky
+vK
 oX
 EQ
 vQ
-Mu
+BZ
 EA
-Wr
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+EA
+on
+on
+cX
+Pr
+MS
+vK
+hm
 hm
 hm
 hm
@@ -10319,22 +10125,22 @@ Dc
 FS
 nO
 Wr
-Wr
-Wr
-Pp
+jb
+Ky
+vK
+Wo
 Wo
 OH
-OH
-Vv
+vK
 fu
-Wr
-Wr
-jb
-Wr
-Wr
-Wr
-Xv
-AU
+xi
+Ab
+sv
+Pp
+VW
+Vs
+vK
+hm
 hm
 hm
 hm
@@ -10576,22 +10382,22 @@ VU
 IW
 nO
 Wr
-Wr
-Wr
-be
+jb
+Ky
+vK
 tQ
-gQ
+VL
 gh
-gh
+vK
+ey
 VW
-RH
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+VW
+kZ
+Pp
+Pr
+Jm
+vK
+hm
 hm
 hm
 hm
@@ -10833,22 +10639,22 @@ jB
 UY
 nO
 Wr
-Wr
-Wr
-Pp
+jb
+Ky
+vK
 oc
 Vv
 MM
-OH
-Ul
-RH
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+vK
+qi
+RN
+cX
+Hm
+Pp
+Pr
+cX
+vK
+hm
 hm
 hm
 hm
@@ -11090,22 +10896,22 @@ IE
 UY
 nO
 Wr
-Wr
-Wr
-be
-oc
+jb
+Ky
+vK
+tk
 oO
 gQ
-wK
+vK
 Ul
-RH
-Wr
-Wr
-Wr
-Wr
-Wr
-Xv
-AU
+Gy
+QS
+cX
+cX
+Qr
+Hz
+vK
+hm
 hm
 hm
 hm
@@ -11347,22 +11153,22 @@ vy
 UY
 nO
 SR
-Mx
-Mx
-Ky
-nt
-Dk
+wQ
+zV
 vK
-RN
-Lt
-Gy
-Mx
-Mx
-Mx
-Mx
-Mx
-Fg
-AU
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+vK
+hm
 hm
 hm
 hm
@@ -11606,19 +11412,19 @@ nO
 Xv
 yj
 UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
-UZ
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -6841,7 +6841,7 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "gkm" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/medicine,
@@ -11742,6 +11742,8 @@
 /obj/structure/shelf_wood,
 /obj/item/storage/box/ingredients/carnivore,
 /obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/delights,
+/obj/item/storage/box/ingredients/delights,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -19014,14 +19016,14 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
 "qZs" = (
-/obj/structure/stairs/west{
+/obj/structure/railing{
 	color = "#A47449";
-	dir = 2
+	dir = 4
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "qZv" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/f13Cash/random/denarius/high,
@@ -20453,9 +20455,9 @@
 /area/f13/building/hospital)
 "sfC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/shelf_wood,
-/obj/item/storage/box/ingredients/delights,
-/obj/item/storage/box/ingredients/delights,
+/obj/structure/railing{
+	color = "#A47449"
+	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -30010,8 +30012,8 @@ oez
 oez
 oIp
 gjV
-xyP
-xyP
+mNn
+mNn
 ikS
 bwi
 lhH
@@ -30025,7 +30027,7 @@ lhH
 lhH
 hmG
 kow
-mNn
+qZs
 mNn
 cty
 ohv
@@ -30266,9 +30268,9 @@ oce
 oce
 oce
 oce
-xyP
-oez
-qZs
+mNn
+axq
+wKl
 eGR
 bwi
 lhH
@@ -30283,7 +30285,7 @@ lhH
 cOy
 sfC
 axq
-wKl
+mNn
 cBX
 ohv
 gtb
@@ -30523,9 +30525,9 @@ pzS
 pzS
 vOP
 oce
-xyP
-xyP
-xyP
+mNn
+cGe
+mNn
 eGR
 bwi
 swu

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -18397,7 +18397,7 @@
 /mob/living/simple_animal/pet/dog/eyebot{
 	desc = "This eyebot's weapons module has been removed and replaced with a loudspeaker. It appears to be shouting about Bighorn.";
 	name = "Bighorn eyebot";
-	speak = list("Need    a    drink?    Want    to    trade?    Need    your    cuts    and    bruises    mended?    Head    on    over    to    Bighorn!")
+	speak = list("Need        a        drink?        Want        to        trade?        Need        your        cuts        and        bruises        mended?        Head        on        over        to        Bighorn!")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building/coyote/nash/mall/groundfloor)
@@ -23018,6 +23018,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
+"ccc" = (
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = 0
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ccl" = (
 /obj/structure/table/wood/settler,
 /obj/item/clothing/ears/earmuffs,
@@ -23730,6 +23737,9 @@
 	dir = 1;
 	pixel_x = 14;
 	pixel_y = 0
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -25406,6 +25416,15 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city)
+"ctJ" = (
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = -16
+	},
+/obj/structure/flora/chomp/bush5{
+	color = "#338833"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ctP" = (
 /obj/structure/window/fulltile/ruins,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25936,6 +25955,10 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -28035,6 +28058,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"daF" = (
+/obj/structure/flora/chomp/thicket2{
+	color = "#224422"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "daN" = (
 /obj/machinery/microwave/stove{
 	icon_state = "stove_act";
@@ -29853,9 +29886,31 @@
 	},
 /area/f13/building/coyote/nash/massfus/lobby)
 "dyB" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/guitar,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola/radioactive,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola/radioactive,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/reagent_containers/food/drinks/bottle/nukashine,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -30430,9 +30485,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dFE" = (
-/obj/item/organ/genital/butt{
-	force = 30
-	},
+/obj/structure/reagent_dispensers/keg/milk,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -40962,6 +41015,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/building/abandoned)
+"gnt" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gnC" = (
 /obj/structure/nest/frog,
 /turf/open/indestructible/ground/outside/water,
@@ -42403,9 +42464,21 @@
 	},
 /area/f13/wasteland/city/nash/suburbs)
 "gEk" = (
-/obj/structure/table/wood/bar,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/metal/fifty,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -51187,6 +51260,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/store)
+"iKs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/tree/jungle/small{
+	color = "#d9b51c"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iKw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -54519,6 +54602,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/coyote/nash/grocery/southloop)
+"jBw" = (
+/obj/machinery/light/sign/heaven,
+/turf/closed/wall/mineral/brick,
+/area/f13/wasteland)
 "jBy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66929,6 +67016,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/coyote/nash/massfus/groundfloor/east)
+"mzM" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 2
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "mzU" = (
 /obj/structure/table/wood/fancy/purple{
 	name = "Three Gentle Judges"
@@ -72331,6 +72424,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/coyote/nash/cornerdiner)
+"nOS" = (
+/obj/structure/simple_door/metal/fence/wooden,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building)
 "nPa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -74117,6 +74218,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"okS" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/structure/flora/grass/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ole" = (
@@ -77897,11 +78009,15 @@
 	},
 /area/f13/wasteland/city/nash/starterroad)
 "pgF" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/lockbox/dueling/hugbox{
-	pixel_y = 8
-	},
-/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack,
+/obj/item/reagent_containers/food/drinks/bottle/nukashine,
+/obj/item/stock_parts/chem_cartridge/simple,
+/obj/item/stock_parts/chem_cartridge/simple,
+/obj/item/stock_parts/chem_cartridge/simple,
+/obj/item/stock_parts/chem_cartridge/simple,
+/obj/item/vending_refill/boozeomat,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -78307,6 +78423,16 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland/city/nash/downtown)
+"pll" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "plx" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -83098,6 +83224,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/city/nash/redriverdepotroad)
+"qwt" = (
+/obj/structure/simple_door/wood,
+/obj/structure/spacevine,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar)
 "qwI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/store,
@@ -85491,6 +85624,13 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"rax" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "raA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/revolver{
@@ -85863,6 +86003,10 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building)
+"rfD" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rfH" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -86656,8 +86800,21 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "rpi" = (
-/obj/structure/closet/crate/footchest,
-/obj/item/reagent_containers/food/snacks/store/cake/clown_cake,
+/obj/item/gun/ballistic/automatic/pistol/pistol22,
+/obj/item/ammo_box/magazine/m22,
+/obj/item/ammo_box/magazine/m22,
+/obj/item/tool_upgrade/productivity/ergonomic_grip,
+/obj/item/tool_upgrade/refinement/laserguide,
+/obj/item/tool_upgrade/refinement/ported_barrel,
+/obj/structure/closet/crate/footlocker{
+	color = "#5A5A5A";
+	name = "dead-drop footlocker"
+	},
+/obj/item/ammo_box/m22,
+/obj/item/paper{
+	name = "As Requested";
+	info = "M. Payment was recieved in full, enjoy your new toy. If anyone asks where you got it, say it was a gift from your grandma. -K"
+	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -94587,6 +94744,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/coyote/nash/mall/groundfloor)
+"tmS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/tree/jungle/small{
+	color = "#d9b51c"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tmX" = (
 /obj/structure/flora/chomp/barrelcacti2,
 /turf/open/indestructible/ground/outside/desert,
@@ -96071,6 +96239,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building/coyote/nash/school/groundfloor)
+"tDk" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tDq" = (
 /obj/item/trash/can,
 /turf/open/floor/f13/wood,
@@ -98167,6 +98347,12 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"ueA" = (
+/obj/structure/reagent_dispensers/keg/hearty_punch,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar)
 "ueE" = (
 /obj/effect/decal/marking{
 	icon_state = "singlehorizontal"
@@ -98713,6 +98899,15 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city/nash/theloop)
+"umI" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/gravel{
+	color = "#999999"
+	},
+/area/f13/wasteland)
 "umQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -105018,7 +105213,23 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building/abandoned)
 "vQr" = (
-/obj/structure/closet/cabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -107742,7 +107953,9 @@
 	},
 /area/f13/wasteland/city/nash/downtown)
 "wzN" = (
-/obj/structure/simple_door/metal/fence,
+/obj/structure/simple_door/metal/fence{
+	dir = 2
+	},
 /turf/open/indestructible/ground/outside/roaddirt{
 	icon_state = "innerpavement"
 	},
@@ -108210,8 +108423,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "wEY" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -108254,12 +108484,25 @@
 	},
 /area/f13/wasteland/city)
 "wFo" = (
-/obj/structure/table/wood/bar,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/reagent_containers/food/drinks/bottle/nukashine,
+/obj/item/reagent_containers/food/drinks/bottle/nukashine,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar)
 "wFy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -116252,8 +116495,8 @@ dRP
 dRP
 dRP
 dRP
-nxL
-uXd
+jxf
+tDk
 rLl
 uhN
 oeC
@@ -116508,9 +116751,9 @@ oTM
 oTM
 lVs
 twX
-gbX
-oTM
-bun
+okS
+aWK
+daF
 aOk
 cht
 cPF
@@ -116763,11 +117006,11 @@ cFK
 aOk
 mAk
 aOk
-pak
+ctJ
 cFK
-aOk
-cFK
-wqe
+flt
+gXa
+tmS
 aOk
 aOk
 aGO
@@ -117022,9 +117265,9 @@ mtI
 aOk
 aOk
 aOk
-cIY
-cIY
-cIY
+bSw
+aWK
+kkp
 aOk
 aOk
 aOk
@@ -117279,9 +117522,9 @@ fXK
 cIY
 aOk
 aOk
-cIY
-aOk
-aOk
+bSw
+aWK
+tfE
 aOk
 mAk
 aOk
@@ -117536,15 +117779,15 @@ cIY
 cIY
 cIY
 cIY
-wqe
-xFZ
-ncM
+iKs
+aWK
+qML
 xOW
-cFK
+wos
 bSt
 yhD
 yhD
-cIY
+leB
 aOk
 cFK
 ajv
@@ -117793,12 +118036,12 @@ aXa
 aOk
 aOk
 aOk
-aOk
-aOk
-aOk
+flt
+aWK
+tfE
 cFK
 pCp
-flt
+nql
 myM
 nFA
 nFA
@@ -118051,7 +118294,7 @@ jJv
 xQi
 bhr
 cjb
-fxm
+aWK
 cyI
 aOk
 wJZ
@@ -118308,11 +118551,11 @@ iAU
 iAU
 iAU
 vAc
-aOk
+umI
 usG
 rLT
-rLT
-nFA
+qwt
+kqJ
 nFA
 uAQ
 uAQ
@@ -118565,10 +118808,10 @@ gFz
 coF
 coF
 miR
-aOk
-agh
-nFA
-dFE
+gnt
+jBw
+rLT
+mkb
 rpi
 nFA
 uAQ
@@ -118823,7 +119066,7 @@ tPz
 aMz
 jml
 aOk
-flt
+agh
 rLT
 nFA
 nFA
@@ -119336,7 +119579,7 @@ tPz
 tPz
 tPz
 miR
-aOk
+ncM
 flt
 cnr
 hVW
@@ -119354,7 +119597,7 @@ fJj
 mkb
 mkb
 mkb
-mkb
+dFE
 hor
 vNv
 ksL
@@ -119611,13 +119854,18 @@ uYZ
 dZI
 mkb
 mkb
+<<<<<<< Updated upstream
 mkb
 fJj
+=======
+ueA
+hor
+>>>>>>> Stashed changes
 vNv
 ksL
 kgu
 wYh
-sFu
+nOS
 sFu
 wYh
 vRK
@@ -120107,9 +120355,9 @@ sCb
 bcq
 bcq
 miR
-aOk
-flt
-nFA
+rfD
+rax
+rLT
 bfD
 vFu
 tqM
@@ -120364,9 +120612,9 @@ bcq
 bcq
 oUq
 jml
-aOk
-flt
-nFA
+rfD
+pll
+rLT
 mkb
 mkb
 mkb
@@ -120621,8 +120869,8 @@ bcq
 rYZ
 bcq
 miR
-aOk
-flt
+rfD
+rax
 nFA
 mkb
 mkb
@@ -120878,7 +121126,7 @@ wGL
 jMq
 cOL
 iAU
-aOk
+aXa
 flt
 bsh
 vTG
@@ -121136,7 +121384,7 @@ bGz
 bGz
 hFN
 aOk
-cFK
+tbK
 bsh
 lgk
 lgk
@@ -121392,7 +121640,7 @@ bGz
 bGz
 vIJ
 sLx
-aOk
+fxm
 bZY
 ciM
 lgk
@@ -121650,7 +121898,7 @@ xRe
 cdS
 eTU
 aOk
-aOk
+ccc
 bsh
 pdj
 lXV
@@ -121906,7 +122154,7 @@ lsk
 iAU
 iAU
 wNX
-aOk
+nOB
 aOk
 rLT
 cnX
@@ -152038,7 +152286,7 @@ hmz
 hmz
 fOH
 xIR
-bdp
+mzM
 aum
 gMF
 eft
@@ -155634,7 +155882,7 @@ vGC
 hmz
 hmz
 hmz
-bdp
+mzM
 gMF
 ean
 anR

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -119854,13 +119854,8 @@ uYZ
 dZI
 mkb
 mkb
-<<<<<<< Updated upstream
-mkb
-fJj
-=======
 ueA
 hor
->>>>>>> Stashed changes
 vNv
 ksL
 kgu


### PR DESCRIPTION
replaces heavens night in the sewer with a large and very full warehouse to pick over (mostly just as filler for right now). This has been done because Heavens Night now exists on top of the bar in Nash, all the way up, like a penthouse of degeneracy. Actually, not like, thats exactly what it is.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: penthouse Heavens Night on top of the bar in Nash
add: warehouse in place of old heavens night location
del: sewer based Heavens Night is DEAD
tweak: minor tweaks and additions to the space around the bar in Nash to facilitate Heavens Night
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
