### PR TITLE
blindfold-and-repair-kits

### DIFF
--- a/code/datums/components/storage/concrete/boxes.dm
+++ b/code/datums/components/storage/concrete/boxes.dm
@@ -115,6 +115,7 @@
 /datum/component/storage/concrete/box/survivalkit/specialized/synthmed/Initialize()
 	. = ..()
 	can_hold = GLOB.toolbelt_allowed
+	can_hold |= typecacheof(list(/obj/item/clothing/glasses/sunglasses/blindfold))
 
 /// combat kit
 /datum/component/storage/concrete/box/survivalkit/specialized/combat


### PR DESCRIPTION
Blindfold can now fit back inside the synth repair kit.

## About The Pull Request
It allows the player to fit blindfolds in the synth repair kit.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: blindfold can rightfully fit repair kits now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
