### PR TITLE
Nerfs Toys and Fixes Some Cargo Packs

### DIFF
--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -577,6 +577,7 @@
 
 
 /datum/export/item/toyslow
+	k_elasticity = 1/100 // Toy lathe is scary
 	cost = 500
 	unit_name = "basic toy"
 	export_types = list(/obj/item/toy,
@@ -584,6 +585,7 @@
 
 
 /datum/export/item/toyshigh
+	k_elasticity = 1/100 // Toy lathe is scary
 	cost = 1000
 	unit_name = "advanced toy"
 	export_types = list(/obj/item/toy/prize,

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -7,7 +7,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/emergency
-	group = "Emergency"
+	group = "Kits"
 
 /datum/supply_pack/emergency/stealthkit
 	name = "Kit - Stealth Mercenary"
@@ -78,7 +78,7 @@
 	crate_type = /obj/structure/closet/crate/internals */
 
 /datum/supply_pack/emergency/medicalemergency
-	name = "Emergency Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
+	name = "Kit - Medical Supplies" //Almost all of this can be ordered seperatly for a much cheaper price, but the HUD increases it.
 	desc = "Emergency supplies for a front-line medic. Contains two boxes of body bags, a medical HUD, a defib unit, medical belt, toxin bottles, epipens, and several types of medical kits."
 	cost = 10000
 	contains = list(/obj/item/storage/box/bodybags,
@@ -96,7 +96,7 @@
 	crate_type = /obj/structure/closet/crate/medical
 
 /datum/supply_pack/emergency/medemergencylite
-	name = "Emergency Medical Supplies (Lite)"
+	name = "Kit - Surplus Medical Supplies"
 	desc = "A less than optimal, but still effective, set of tools for emergency care. Contains a box of bodybags, some normal (and advanced) health analyzers, healing sprays, a single first aid kit, charcoal, some gauze, a bottle of toxins, and some spare medipens."
 	cost = 2800
 	contains = list(/obj/item/storage/box/bodybags,

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -9,8 +9,24 @@
 /datum/supply_pack/emergency
 	group = "Emergency"
 
+/datum/supply_pack/emergency/stealthkit
+	name = "Kit - Stealth Mercenary"
+	desc = "All your needs for covert operations. Contains a stealth boy and ultracite cell, dark clothing, boots, and a chameleon mask. Even comes with some light weight armor and a specialized rifle with a scope rail and silencer."
+	cost = 12500
+	contains = list(
+		/obj/item/clothing/under/f13/locust,
+		/obj/item/clothing/shoes/combat/coldres,
+		/obj/item/clothing/mask/chameleon,
+		/obj/item/clothing/suit/armor/medium/odstcqb,
+		/obj/item/stealthboy,
+		/obj/item/stock_parts/cell/bluespace,
+		/obj/item/gun/ballistic/automatic/fnfal/g3battlerifle,
+		/obj/item/gun_upgrade/muzzle/silencer,
+)
+	crate_name = "Stealth Mercenary Kit"
+
 /datum/supply_pack/emergency/vehicle
-	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
+	name = "Kit - Biker Gang" //TUNNEL SNAKES OWN THIS TOWN
 	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
 	cost = 100000
 	contains = list(/obj/vehicle/ridden/atv,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -9,15 +9,6 @@
 /datum/supply_pack/medical
 	group = "Medical"
 	crate_type = /obj/structure/closet/crate/medical
-	var/num_contained = 1
-
-/datum/supply_pack/medical/randomized
-	num_contained = 15
-
-/datum/supply_pack/medical/fill(obj/structure/closet/crate/C)
-	for(var/i in 1 to num_contained)
-		var/item = pick(contains)
-		new item(C)
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Equipment ////////////////////////////////////
@@ -117,16 +108,9 @@
 
 /datum/supply_pack/medical/potions
 	name = "Ambrosia Elixirs"
-	desc = "Two bottles of precious Elixir Vitae. May contain greens or blues."
+	desc = "Four bottles of precious Ambrosia Elixirs. Two reds, one blue, and one green included.."
 	cost = 5000
-	num_contained = 2
 	contains = list(
-		/obj/item/reagent_containers/pill/redambrosia,
-		/obj/item/reagent_containers/pill/redambrosia,
-		/obj/item/reagent_containers/pill/redambrosia,
-		/obj/item/reagent_containers/pill/redambrosia,
-		/obj/item/reagent_containers/pill/redambrosia,
-		/obj/item/reagent_containers/pill/redambrosia,
 		/obj/item/reagent_containers/pill/redambrosia,
 		/obj/item/reagent_containers/pill/redambrosia,
 		/obj/item/reagent_containers/pill/blueambrosia,

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -541,23 +541,6 @@
 )
 	crate_name = "packed uncommon weapon crate"
 
-/datum/supply_pack/security/stealthkit
-	name = "Kit - Stealth Mercenary"
-	desc = "All your needs for covert operations. Contains a stealth boy and ultracite cell, dark clothing, boots, and a chameleon mask. Even comes with some light weight armor and a specialized rifle with a scope rail and silencer."
-	cost = 10000
-	num_contained = 8
-	contains = list(
-		/obj/item/clothing/under/f13/locust,
-		/obj/item/clothing/shoes/combat/coldres,
-		/obj/item/clothing/mask/chameleon,
-		/obj/item/clothing/suit/armor/medium/odstcqb,
-		/obj/item/stealthboy,
-		/obj/item/stock_parts/cell/bluespace,
-		/obj/item/gun/ballistic/automatic/fnfal/g3battlerifle,
-		/obj/item/gun_upgrade/muzzle/silencer,
-)
-	crate_name = "Stealth Mercenary Kit"
-
 
 // Commented out temporarily. Could be a good change, could be a terrible idea
 


### PR DESCRIPTION
## About The Pull Request
Makes toys lose value after 100 sales, as there was a way to print thousands of them endlessly round start as shopkeep
Also fixes some packs from medical and moves a pack from security to emergency, the latter of which is renamed to Kits because everything in it is just that.
