### PR TITLE
*augh Fixed sounds not working between z levels & that freeclimbing oopsie.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -159,6 +159,7 @@
 	for(var/atom/movable/movable as anything in moving_movs)
 		movable.currently_z_moving = currently_z_moving || CURRENTLY_Z_MOVING_GENERIC
 		movable.forceMove(target)
+		movable.update_z(target.z)
 		movable.set_currently_z_moving(FALSE, TRUE)
 	// This is run after ALL movables have been moved, so pulls don't get broken unless they are actually out of range.
 	if(z_move_flags & ZMOVE_CHECK_PULLS)
@@ -168,6 +169,10 @@
 			if(z_move_flags & ZMOVE_CHECK_PULLING)
 				moved_mov.check_pulling(TRUE)
 	return TRUE
+
+// Some leftover legacy code to help support the sound system working when mobs are moved between z levels.
+/atom/movable/proc/update_z(new_z)
+	return // Used for mob/living and mob/dead
 
 /// Returns a list of movables that should also be affected when src moves through zlevels, and src.
 /atom/movable/proc/get_z_move_affected(z_move_flags)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -348,6 +348,8 @@
 	if(user.stat)
 		return
 	if(HAS_TRAIT(user, TRAIT_FREERUNNING))
+		if(!user.can_reach(src)) // Huh, why wasn't this here? I sworn I put this here when I first made this. H m s t v e
+			return
 		if(user.restrained())
 			return
 		var/turf/aboveT = get_step_multiz(get_turf(user), UP)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -96,7 +96,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	C << link("[addr]?server_hop=[key]")
 
-/mob/dead/proc/update_z(new_z) // 1+ to register, null to unregister
+/mob/dead/update_z(new_z) // 1+ to register, null to unregister
 	if (registered_z != new_z)
 		if (registered_z)
 			SSmobs.dead_players_by_zlevel[registered_z] -= src

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -136,7 +136,7 @@
 	if(. && client)
 		reset_perspective()
 
-/mob/living/proc/update_z(new_z) // 1+ to register, null to unregister
+/mob/living/update_z(new_z) // 1+ to register, null to unregister
 	if(isnull(new_z) && audiovisual_redirect)
 		return
 	if (registered_z != new_z)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

Swear on me mum, yeah, that that bug didnt exist when I made it, cause I recall testing it 'n all, roight? Must be some other code which caused it m8

Either way, fixed, and the mobs system finally remembers to keep track of the mobs when moving between z levels. <3

Please can someone verify that the sounds work on their end too because I don't know what the *exact* issue is. All I know is that you only heard mobs from a specific z level and that's it.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
