### PR TITLE
Fixes all cases where a forcemove desyncs the listening z level of ghosts/objects/anything.

### DIFF
--- a/code/game/atoms_movement.dm
+++ b/code/game/atoms_movement.dm
@@ -473,6 +473,7 @@
 		var/movement_dir = get_dir(src, destination)
 
 		moving_diagonally = 0
+		update_z(destination.z) // Forces it so EVERYTHING keeps updated with the correct z level!!!
 
 		loc = destination
 
@@ -484,7 +485,7 @@
 			destination.Entered(src, oldloc)
 			if(destarea && old_area != destarea)
 				destarea.Entered(src, old_area)
-
+		
 		. = TRUE
 
 	//If no destination, move the atom into nullspace (don't do this unless you know what you're doing)
@@ -497,7 +498,6 @@
 			if(old_area)
 				old_area.Exited(src, NONE)
 
-	update_z(destination.z) // Forces it so EVERYTHING keeps updated with the correct z level!!!
 	Moved(oldloc, NONE, TRUE)
 
 

--- a/code/game/atoms_movement.dm
+++ b/code/game/atoms_movement.dm
@@ -497,6 +497,7 @@
 			if(old_area)
 				old_area.Exited(src, NONE)
 
+	update_z(destination.z) // Forces it so EVERYTHING keeps updated with the correct z level!!!
 	Moved(oldloc, NONE, TRUE)
 
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

ebic, does exactly as the title says.
Problem was that update_z didn't call on ghosts when going "move_up" or "move_down" originally, fixed that,  but orbiting and such doesnt trigger update_z.

Sound works on this code by checking the z level for clients, it refers to a list, where the first entry is z level 1, and that contains all clients on z level 1. The problem was is that orbitting didn't update that list, so if you moved to a different z level, that list stayed the same, so you could only hear sound on the z level you teleported from.

This fixes that, it forces every "forcemove" call to call "update_z", forcemove shouldn't be used willynilly as it's a forceful move, this bypasses safety checks and sanity checks because it's a forceful action, not a graceful one. So ye, it be fixed now

also discovered a fun adminbuse proc called "orbit"
simply mark your object you want to orbit via right clicking,
call proc on the thing you want to orbit it with
`orbit`, set params to `1` and select marked datum.

This can be anything. :)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->
