### PR TITLE
Destructible Research Vendor Fix

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -57,4 +57,4 @@
 #define PRICE_STIMPAK          50  // Normal craftable Stimpak
 #define PRICE_SUPER_STIM       120 // Super Stimpak
 #define PRICE_RESEARCH         200 // Research Documents
-#define PRICE_RESEARCH_PLUS    300 // More Expensive Research Documents
+#define PRICE_RESEARCH_PLUS    700 // More Expensive Research Documents

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -207,6 +207,7 @@
 	product_slogans = ""
 	products = list(/obj/item/blueprint/research = 5)
 	contraband = list()
-	premium = list(/obj/item/blueprint/research = 10)
+	premium = list(/obj/item/documents/syndicate/blue = 3)
+	resistance_flags = INDESTRUCTIBLE
 	default_price = PRICE_RESEARCH
 	extra_price = PRICE_RESEARCH_PLUS


### PR DESCRIPTION
Makes the research grants vendor indestructible, and swaps some numbers around in its prices.