### PR TITLE
You can now wear collars and necklaces on the mask slot!

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -10,7 +10,7 @@
 
 /obj/item/clothing/neck/equipped(mob/user, slot)
 	. = ..()
-	if (slot == (SLOT_NECK) && istype(user))
+	if (slot == SLOT_NECK && istype(user))
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "necklacebuff", mood_event_on_equip)
 	else
 		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "necklacebuff")

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -1,15 +1,16 @@
 /obj/item/clothing/neck
 	name = "necklace"
 	icon = 'icons/obj/clothing/neck.dmi'
+	mob_overlay_icon = 'icons/mob/clothing/neck.dmi'
 	body_parts_covered = NECK
-	slot_flags = INV_SLOTBIT_NECK
+	slot_flags = INV_SLOTBIT_NECK|INV_SLOTBIT_MASK
 	strip_delay = 40
 	equip_delay_other = 40
 	var/mood_event_on_equip = /datum/mood_event/equipped_necklace/any
 
 /obj/item/clothing/neck/equipped(mob/user, slot)
 	. = ..()
-	if (slot == SLOT_NECK && istype(user))
+	if (slot == (SLOT_NECK) && istype(user))
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "necklacebuff", mood_event_on_equip)
 	else
 		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "necklacebuff")


### PR DESCRIPTION
## About The Pull Request
It's now possible to wear some simple necklaces and collars on the mask slot. I think this could be interesting not only from an aesthetical point of view, but it could also incentivize players to get the 'masked mook perk'. Like for example, a mercenary that is deeply attached to their dog-tags.

On a side note, it's not possible to activate mood debuffs/buffs when wearing collars as a mask. Meaning that is not possible to stack two positive buffs using two collars. One of them simply becomes cosmetical. 
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/a78685a1-2b0e-4f5b-b395-f37f87f848ff)
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/61b95fa3-0214-439d-b88c-0c64f01d8056)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: This new cool thing that allows YOU to wear collars on the mask slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
