### PR TITLE
"Sleep Toggle" button, to sleep for much longer.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -19,6 +19,7 @@ GLOBAL_VAR_INIT(crotch_call_cooldown, 0)
 
 /mob/living/carbon/human/Initialize()
 	add_verb(src, /mob/living/proc/mob_sleep)
+	add_verb(src, /mob/living/proc/toggle_mob_sleep)
 	add_verb(src, /mob/living/proc/lay_down)
 	add_verb(src, /mob/living/carbon/human/verb/underwear_toggle)
 	add_verb(src, /mob/living/verb/subtle)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -520,10 +520,10 @@
 	set category = "IC"
 
 	if(IsSleeping())
-		if(alert(src, "Would you like to wake up soon?", "Wake", "Yes", "No") == "Yes")
+		if(alert(src, "Would you like to wake up soon? (You'll wake up after sleeping a little more, be patient and don't spam the button!)", "Wake Up", "Yes", "No") == "Yes")
 			SetSleeping(400)	//puts you to sleep for 40 seconds, so it's not abusable.
 	else
-		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
+		if(alert(src, "Are you sure you want to sleep for a long time? (You can wake up by pressing this button again)", "Sleep", "Yes", "No") == "Yes")
 			SetSleeping(18000)	//puts you to sleep for 30 minutes, better than never waking up in case my code sucks badly.
 
 /mob/proc/get_contents()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -515,6 +515,17 @@
 		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
 			SetSleeping(400) //Short nap
 
+/mob/living/proc/toggle_mob_sleep()
+	set name = "Sleep Toggle"
+	set category = "IC"
+
+	if(IsSleeping())
+		if(alert(src, "Would you like to wake up soon?", "Wake", "Yes", "No") == "Yes")
+			SetSleeping(400)	//puts you to sleep for 40 seconds, so it's not abusable.
+	else
+		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
+			SetSleeping(18000)	//puts you to sleep for 30 minutes, better than never waking up in case my code sucks badly.
+
 /mob/proc/get_contents()
 
 /*CIT CHANGE - comments out lay_down proc to be modified in modular_citadel


### PR DESCRIPTION
## About The Pull Request
Adds a new button called "Sleep Toggle" in the IC tab, as the name states, toggles the sleeping status. In order to wake this button needs to be used again, it will then make you sleep for a set amount of time (depending on the heavy sleeper trait) after that you'll up. This decision was taken in order to avoid exploits of this button. (in reality this button is a lie, it makes the player sleep for 30 minutes with the option of waking up after 40 seconds if toggled back again, so if something bad happens in the code I guess they won't sleep forever).

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: "Sleep Toggle" button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
