### PR TITLE
Fixes Deathclaws Always Destroying Walls

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/deathclaw.dm
@@ -139,7 +139,7 @@
 		if(is_low_health && health > 0)
 			A.ex_act(EXPLODE_HEAVY)
 			playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
-		DestroySurroundings()
+			DestroySurroundings()
 	..()
 
 // Mother death claw


### PR DESCRIPTION
Seems this was an oversight. Theyre supposed to only destroy walls on bump when angy, but they were doing it anyways.

The culprit was a single indent. It was making them smash walls if the walls were walls, not if the deathclaw was angry.