### PR TITLE
Adds color to Smoke signals

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -397,7 +397,7 @@
 
 	for(var/mob/player in GLOB.player_list)
 		if(player == M)
-			var/msg = "You send a message by smoke signal: "+span_papyrus("\"[message]\"")
+			var/msg = span_engradio("You send a message by smoke signal: "+span_papyrus("\"[message]\""))
 			to_chat(player, msg)
 			continue
 		if(istype(player, /mob/dead))
@@ -427,7 +427,7 @@
 						dirmessage = "in the southeast"
 					if(SOUTHWEST)
 						dirmessage = "in the southwest"
-			var/msg = "Smoke rises [dirmessage]: "+span_papyrus("\"[message]\"")
+			var/msg = span_engradio("Smoke rises [dirmessage]: "+span_papyrus("\"[message]\""))
 			to_chat(player, msg)
 
 /obj/structure/bonfire/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)


### PR DESCRIPTION
## About The Pull Request
Makes the color of smoke signals orange.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Makes the smoke signal text color different.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
