### PR TITLE
Makes claws and bites nastier ONLY for creatures, not humans [do not merge]

### DIFF
--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -223,6 +223,53 @@
 	force = 25
 	force_wielded = 35
 
+/obj/item/hand_item/biter/big
+	name = "Big Biter"
+	desc = "Talk shit, get BIG bit."
+	color = "#884444"
+	force = 15
+	force_wielded = 18
+	attack_speed = 5
+
+/obj/item/hand_item/biter/sabre
+	name = "Sabre Toothed Biter"
+	desc = "Damn bitch, you eat with them teeth?"
+	color = "#FF4444"
+	force = 5
+	force_wielded = 27
+	attack_speed = 6
+
+/obj/item/hand_item/biter/fast
+	name = "Big Biter"
+	desc = "Talk shit, get SPEED bit."
+	color = "#448844"
+	force = 4
+	force_wielded = 7
+	attack_speed = 3
+
+/obj/item/hand_item/biter/play
+	name = "Play Biter"
+	desc = "Someone really should just muzzle you."
+	color = "#ff44ff"
+	force = 0
+	force_wielded = 0
+	attack_speed = 1
+
+/obj/item/hand_item/biter/spicy
+	name = "Spicy Biter"
+	desc = "Your sickly little nibbler, good for dropping fools."
+	color = "#44FF44"
+	force = 5
+	force_wielded = 10
+	attack_speed = 5
+
+
+/obj/item/hand_item/biter/spicy/attack(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M))
+		return
+	M.apply_damage(30, STAMINA, "chest", M.run_armor_check("chest", "brute"))
+
 /obj/item/hand_item/clawer
 	name = "Clawer"
 	desc = "Thems some claws."

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -219,6 +219,10 @@
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
 
+/obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
+	force = 25
+	force_wielded = 35
+
 /obj/item/hand_item/clawer
 	name = "Clawer"
 	desc = "Thems some claws."
@@ -234,6 +238,10 @@
 	attack_speed = 2
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
+
+/obj/item/hand_item/clawer/creature		//creatures surely have bigger claws!
+	force = 20
+	force_wielded = 30
 
 /obj/item/hand_item/shover
 	name = "shover"

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -266,6 +266,7 @@
 		return
 	M.apply_damage(30, STAMINA, "chest", M.run_armor_check("chest", "brute"))
 
+
 /obj/item/hand_item/clawer
 	name = "Clawer"
 	desc = "Thems some claws."

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -290,6 +290,52 @@
 	force = 20
 	force_wielded = 30
 
+/obj/item/hand_item/clawer/big
+	name = "Big Clawer"
+	desc = "Thems some BIG ASS claws."
+	color = "#884444"
+	force = 7
+	force_wielded = 9
+	attack_speed = 3
+
+/obj/item/hand_item/clawer/razor
+	name = "Razor Sharp Clawers"
+	desc = "RIP AND TEAR."
+	color = "#FF4444"
+	force = 5
+	force_wielded = 17
+	attack_speed = 4
+
+/obj/item/hand_item/clawer/fast
+	name = "Fast Clawer"
+	desc = "Thems some FAST ASS claws."
+	color = "#448844"
+	force = 4
+	force_wielded = 7
+	attack_speed = 1
+
+/obj/item/hand_item/clawer/play
+	name = "Play Clawer"
+	desc = "Basically just a bean thwapper."
+	color = "#FF88FF"
+	force = 0
+	force_wielded = 0
+	attack_speed = 1
+
+/obj/item/hand_item/clawer/spicy
+	name = "Spicy Clawer"
+	desc = "Your gross little litter box rakes, good for puttings idiots on the ground."
+	color = "#44FF44"
+	force = 7
+	force_wielded = 11 //7-11 haha get it bad gas station food lmao ~TK
+	attack_speed = 4
+
+/obj/item/hand_item/clawer/spicy/attack(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M))
+		return
+	M.apply_damage(30, STAMINA, "chest", M.run_armor_check("chest", "brute"))
+
 /obj/item/hand_item/shover
 	name = "shover"
 	desc = "Stay back!"

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -427,15 +427,6 @@
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
 
-/obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
-	force = 25
-	force_wielded = 35
-
-
-/obj/item/hand_item/clawer/creature		//creatures surely have bigger claws!
-	force = 20
-	force_wielded = 30
-
 
 // /obj/item/hand_item/healable/licker/proc/bandage_wound(mob/living/licked, mob/living/carbon/user)
 // 	if(!iscarbon(licked))
@@ -489,4 +480,12 @@
 // 	user.visible_message(span_alert("[user] was interrupted!"))
 // 	return LICK_CANCEL
 
+/obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
+	force = 25
+	force_wielded = 35
+
+
+/obj/item/hand_item/clawer/creature		//creatures surely have bigger claws!
+	force = 20
+	force_wielded = 30
 

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -348,6 +348,85 @@
 	. = ..()
 	AddComponent(/datum/component/knockback, 1, FALSE, TRUE)
 
+/obj/item/hand_item/playfultail/
+	name = "playful tail"
+	desc = "A playful tail, good for teasing."
+	icon_state = "proboscis"
+	force = 0
+	force_wielded = 0
+	attack_speed = 3
+	weapon_special_component = /datum/component/weapon_special/single_turf
+
+/obj/item/hand_item/tail
+	name = "tailwhack"
+	desc = "A tail. Good for whacking."
+	icon_state = "proboscis"
+	force = 5
+	force_wielded = 10
+	attack_speed = 4 
+	weapon_special_component = /datum/component/weapon_special/single_turf
+
+/obj/item/hand_item/tail/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/knockback, 1, FALSE, TRUE)
+
+/obj/item/hand_item/tail/fast
+	name = "fast tail"
+	desc = "A speedy tail that's very good at whackin' fast."
+	icon_state = "proboscis"
+	color = "#448844"
+	force = 3
+	force_wielded = 7
+	attack_speed = 2
+
+/obj/item/hand_item/tail/big
+	name = "big tail"
+	desc = "A big tail that whacks hard."
+	icon_state = "proboscis"
+	color = "#884444"
+	force = 10
+	force_wielded = 20
+	attack_speed = 5
+
+/obj/item/hand_item/tail/spicy
+	name = "spicy tail"
+	desc = "A tail with something that can inject venom on it."
+	icon_state = "proboscis"
+	color = "#44FF44"
+	force = 4
+	force_wielded = 8
+	attack_speed = 5
+
+/obj/item/hand_item/tail/spicy/attack(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M))
+		return
+	M.apply_damage(30, STAMINA, "chest", M.run_armor_check("chest", "brute"))
+
+/obj/item/hand_item/tail/thago
+	name = "dangerous tail"
+	desc = "A god damn mighty tail that would kill an allosaurus.  Maybe."
+	icon_state = "proboscis"
+	color = "#FF4444"
+	force = 12
+	force_wielded = 24
+	attack_speed = 6
+
+/obj/item/hand_item/beans
+	name = "beans"
+	desc = "Them's ya' beans. Touch em' to things."
+	icon = 'icons/obj/in_hands.dmi'
+	icon_state = "bean"
+	color = "#ff88bb"
+	attack_verb = list("beans", "baps", "smushes")
+	hitsound = "sound/effects/attackblob.ogg"
+	force = 0
+	force_wielded = 0
+	throwforce = 0
+	attack_speed = 0
+	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	weapon_special_component = /datum/component/weapon_special/single_turf
+
 /obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
 	force = 25
 	force_wielded = 35

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -219,10 +219,6 @@
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
 
-/obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
-	force = 25
-	force_wielded = 35
-
 /obj/item/hand_item/biter/big
 	name = "Big Biter"
 	desc = "Talk shit, get BIG bit."
@@ -285,10 +281,6 @@
 	attack_speed = 2
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
-
-/obj/item/hand_item/clawer/creature		//creatures surely have bigger claws!
-	force = 20
-	force_wielded = 30
 
 /obj/item/hand_item/clawer/big
 	name = "Big Clawer"
@@ -355,6 +347,14 @@
 	. = ..()
 	AddComponent(/datum/component/knockback, 1, FALSE, TRUE)
 
+/obj/item/hand_item/biter/creature		//creatures surely have nastier bites!
+	force = 25
+	force_wielded = 35
+
+
+/obj/item/hand_item/clawer/creature		//creatures surely have bigger claws!
+	force = 20
+	force_wielded = 30
 
 
 // /obj/item/hand_item/healable/licker/proc/bandage_wound(mob/living/licked, mob/living/carbon/user)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -154,6 +154,39 @@
 	else
 		qdel(tendy)
 
+//We are not naming this 'beaner' so help me god
+/datum/emote/living/carbon/bean
+	key = "bean"
+	key_third_person = "beans"
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/bean/run_emote(mob/user)
+	. = ..()
+	if(user.get_active_held_item())
+		to_chat(user, span_warning("Your beans are too full to bean the beans, what the hell are you doing???!?"))
+		return
+	var/obj/item/hand_item/beans/bean = new(user)
+	if(user.put_in_active_hand(bean))
+		to_chat(user, span_notice("You ready your beans for WAR!!"))
+	else
+		qdel(bean)
+
+/datum/emote/living/carbon/cuphand
+	key = "cuphand"
+	key_third_person = "uses their hand as a cup."
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/cuphand/run_emote(mob/user)
+	. = ..()
+	if(user.get_active_held_item())
+		to_chat(user, span_warning("Your cup your hand to hold liquids."))
+		return
+	var/obj/item/reagent_containers/food/drinks/sillycup/handcup/handcup = new(user)
+	if(user.put_in_active_hand(handcup))
+		to_chat(user, span_notice("Your cuphand is ready!"))
+	else
+		qdel(handcup)
+
 //Biter//
 /datum/emote/living/carbon/bite
 	key = "bite"
@@ -165,6 +198,7 @@
 	if(user.get_active_held_item())
 		to_chat(user, span_warning("Your hands are too full to properly bite!  Don't ask!"))
 		return
+<<<<<<< upstream/some-love-for-creatures
 	if(ishuman(user))
 		var/obj/item/hand_item/biter/bite = new(user)
 		if(user.put_in_active_hand(bite))
@@ -178,12 +212,59 @@
 		else
 			qdel(bite)
 
+	var/which_biter_to_spawn
+	if(HAS_TRAIT(user, TRAIT_BIGBITE))
+		which_biter_to_spawn = /obj/item/hand_item/biter/big
+	else if(HAS_TRAIT(user, TRAIT_FASTBITE))
+		which_biter_to_spawn = /obj/item/hand_item/biter/fast
+	else if(HAS_TRAIT(user, TRAIT_PLAYBITE))
+		which_biter_to_spawn = /obj/item/hand_item/biter/play
+	else if(HAS_TRAIT(user, TRAIT_SPICYBITE))
+		which_biter_to_spawn = /obj/item/hand_item/biter/spicy
+	else if(HAS_TRAIT(user, TRAIT_SABREBITE))
+		which_biter_to_spawn = /obj/item/hand_item/biter/sabre
+	else 
+		which_biter_to_spawn = /obj/item/hand_item/biter 
+	var/obj/item/hand_item/bite = new which_biter_to_spawn(user)
+	if(user.put_in_active_hand(bite)) 
+		to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+	
+
+//Tailer//
+/datum/emote/living/carbon/tailer
+	key = "tailer"
+	key_third_person = "tails"
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/tailer/run_emote(mob/user)
+	. = ..()
+	if(user.get_active_held_item())
+		to_chat(user, span_warning("Your brains too busy to use your tail right now, maybe empty up your hands a bit?"))
+		return
+	var/which_tail_to_spawn
+	if(HAS_TRAIT(user, TRAIT_TAILWHIP))
+		which_tail_to_spawn = /obj/item/hand_item/tail/fast
+	else if(HAS_TRAIT(user, TRAIT_TAILSMASH))
+		which_tail_to_spawn = /obj/item/hand_item/tail/big
+	else if(HAS_TRAIT(user, TRAIT_TAILSPICY))
+		which_tail_to_spawn = /obj/item/hand_item/tail/spicy
+	else if(HAS_TRAIT(user, TRAIT_TAILTHAGO))
+		which_tail_to_spawn = /obj/item/hand_item/tail/thago
+	else if(HAS_TRAIT(user, TRAIT_TAILPLAY))
+		which_tail_to_spawn = /obj/item/hand_item/playfultail
+	else 
+		which_tail_to_spawn = /obj/item/hand_item/tail
+	var/obj/item/hand_item/tail = new which_tail_to_spawn(user)
+	if(user.put_in_active_hand(tail)) 
+		to_chat(user, span_notice("You swing your tail around, ready for action!"))
+	else
+		qdel(tail)
 
 //Clawer//
-/datum/emote/living/carbon/claw
-	key = "claw"
-	key_third_person = "claws"
-	restraint_check = TRUE
+/datum/emote/living/carbon/claw 
+	key = "claw" 
+	key_third_person = "claws" 
+	restraint_check = TRUE 
 
 /datum/emote/living/carbon/claw/run_emote(mob/user)
 	. = ..()
@@ -202,6 +283,24 @@
 			to_chat(user, span_notice("You get your claws ready to slice!"))
 		else
 			qdel(claw)
+
+	var/which_clawer_to_spawn
+	if(HAS_TRAIT(user, TRAIT_BIGCLAW))
+		which_clawer_to_spawn = /obj/item/hand_item/clawer/big
+	else if(HAS_TRAIT(user, TRAIT_FASTCLAW))
+		which_clawer_to_spawn = /obj/item/hand_item/clawer/fast
+	else if(HAS_TRAIT(user, TRAIT_PLAYCLAW))
+		which_clawer_to_spawn = /obj/item/hand_item/clawer/play
+	else if(HAS_TRAIT(user, TRAIT_SPICYCLAW))
+		which_clawer_to_spawn = /obj/item/hand_item/clawer/spicy
+	else if(HAS_TRAIT(user, TRAIT_RAZORCLAW))
+		which_clawer_to_spawn = /obj/item/hand_item/clawer/razor
+	else 
+		which_clawer_to_spawn =  /obj/item/hand_item/clawer 
+	var/obj/item/hand_item/clawer/claw = new which_clawer_to_spawn(user) 
+	if(user.put_in_active_hand(claw))
+		to_chat(user, span_notice("You get your claws ready to slice!"))
+
 
 
 //Shover//
@@ -301,3 +400,116 @@
 	hasPickedUp = FALSE
 	timerEnabled = FALSE
 	damageMult = initial(damageMult)
+
+/datum/emote/living/carbon/tsk
+	key = "tsk"
+	message = "tsks audibly."
+
+/datum/emote/living/carbon/braidpull
+	key = "braidpull"
+	message = "pulls their braid fitfully."
+
+/datum/emote/living/carbon/hairfix
+	key = "hairfix"
+	message = "is trying to fix their hair."
+
+/datum/emote/living/carbon/handclasp
+	key = "clasp"
+	message = "clasps their hands in front of them."
+
+/datum/emote/living/carbon/eyeroll
+	key = "eyeroll"
+	message = "rolls their eyes."
+
+/datum/emote/living/carbon/tongueclick
+	key = "tongueclick"
+	message = "clicks their tongue as if annoyed."
+
+/datum/emote/living/carbon/kneel
+	key = "kneel"
+	message = "slowly drops to the ground, kneeling with their legs underneath them."
+
+/datum/emote/living/carbon/snicker
+	key = "snicker"
+	message = "snickers quietly to themselves."
+
+/datum/emote/living/carbon/huff
+	key = "huff"
+	message = "huffs loudly, exhausted or exasperated. Who knows."
+
+/datum/emote/living/carbon/wait
+	key = "wait"
+	message = "holds up one finger, giving the universal sign for 'wait a moment'."
+
+/datum/emote/living/carbon/waveon
+	key = "waveon"
+	message = "waves a hand motioning someone, or something, onward."
+
+/datum/emote/living/carbon/halt
+	key = "halt"
+	message = "raises a hand palm out, motioning for someone or something to halt."
+
+/datum/emote/living/carbon/eh
+	key = "eh"
+	message = "raises a hand then motions with it horizontal, similar to waves. A pretty noncomital thing."
+
+/datum/emote/living/carbon/daydream
+	key = "daydream"
+	message = "seems lost in a daydream, their eyes slightly glazed over and giving a thousand yard stare."
+
+/datum/emote/living/carbon/drool
+	key = "drool"
+	message = "looks like they're drooling a little."
+
+/datum/emote/living/carbon/blank
+	key = "blank"
+	message = "looks like they have no thoughts in their head."
+
+//hahadorks
+
+/datum/emote/living/carbon/powerpose
+	key = "powerpose"
+	message = "puts their hands on their hips and takes a steady pose."
+	message_param = "power poses like a super hero at %t."
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/snaplook
+	key = "snaplook"
+	message = "snaps their gaze around!"
+	message_param = "snaps their gaze around, locking onto %t!"
+
+/datum/emote/living/carbon/peace
+	key = "peace"
+	message = "throws up a peace sign!"
+	message_param = "throws up a peace sign at %t!"
+
+/datum/emote/living/carbon/thebird
+	key = "thebird"
+	message = "fires off the bird!"
+	message_param = "full sends the bird at %t!"
+
+/datum/emote/living/carbon/thebirds
+	key = "thebirds"
+	message = "gives both barrels of the bird!"
+	message_param = "double barrels the birds at %t!"
+
+/datum/emote/living/carbon/vlick
+	key = "vlick"
+	message = "pretends to lick between their spread pointer and middle finger!"
+
+/datum/emote/living/carbon/cheekpoke
+	key = "cheekpoke"
+	message = "pushes their tongue into their cheek."
+
+/datum/emote/living/carbon/headbob
+	key = "headbob"
+	message = "is bobbing their head to something."
+
+/datum/emote/living/carbon/hairflick
+	key = "hairflick"
+	message = "flicks their hair back out of their face."
+
+/datum/emote/living/carbon/hairchew
+	key = "hairchew"
+	message = "chews on their bangs a little bit."
+

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -165,11 +165,18 @@
 	if(user.get_active_held_item())
 		to_chat(user, span_warning("Your hands are too full to properly bite!  Don't ask!"))
 		return
-	var/obj/item/hand_item/biter/bite = new(user)
-	if(user.put_in_active_hand(bite))
-		to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+	if(ishuman(user))
+		var/obj/item/hand_item/biter/bite = new(user)
+		if(user.put_in_active_hand(bite))
+			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+		else
+			qdel(bite)
 	else
-		qdel(bite)
+		var/obj/item/hand_item/biter/creature/bite = new(user)
+		if(user.put_in_active_hand(bite))
+			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+		else
+			qdel(bite)
 
 
 //Clawer//
@@ -183,11 +190,18 @@
 	if(user.get_active_held_item())
 		to_chat(user, span_warning("Your hands are too full to use your claws!"))
 		return
-	var/obj/item/hand_item/clawer/claw = new(user)
-	if(user.put_in_active_hand(claw))
-		to_chat(user, span_notice("You get your claws ready to slice!"))
+	if(ishuman(user))
+		var/obj/item/hand_item/clawer/claw = new(user)
+		if(user.put_in_active_hand(claw))
+			to_chat(user, span_notice("You get your claws ready to slice!"))
+		else
+			qdel(claw)
 	else
-		qdel(claw)
+		var/obj/item/hand_item/clawer/creature/claw = new(user)
+		if(user.put_in_active_hand(claw))
+			to_chat(user, span_notice("You get your claws ready to slice!"))
+		else
+			qdel(claw)
 
 
 //Shover//


### PR DESCRIPTION
## About The Pull Request
This is just an academic exercise, it can be approved or denied, especially if it's game-breaking. What this PR does is simply discriminating between human and creatures. The emotes *bite and *claw are buffed ONLY if the user is a creature, if a human or any sub-specie runs the same emote it will return the untouched regular values.
Why I did this... well because whenever I see a creature running around on the server defending itself with a knife it makes me a little sad and makes me think: "wouldn't it be cool if the creature could actually use claws or bite?".

I'm not a game designer, so... if the strength values of this is too high just tell me and I'll tune it down.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds nastier claws and bites for creatures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
