### PR TITLE
Makes claws and bites nastier ONLY for creatures, not humans [can be merged IF you want]

### DIFF
--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -219,6 +219,10 @@
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
 
+/obj/item/hand_item/biter/creature
+	force = 25
+	force_wielded = 30
+
 /obj/item/hand_item/biter/big
 	name = "Big Biter"
 	desc = "Talk shit, get BIG bit."
@@ -282,6 +286,10 @@
 	attack_speed = 2
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
+
+/obj/item/hand_item/clawer/creature
+	force = 25
+	force_wielded = 30
 
 /obj/item/hand_item/clawer/big
 	name = "Big Clawer"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -211,11 +211,19 @@
 		which_biter_to_spawn = /obj/item/hand_item/biter/sabre
 	else 
 		which_biter_to_spawn = /obj/item/hand_item/biter 
-	var/obj/item/hand_item/bite = new which_biter_to_spawn(user)
-	if(user.put_in_active_hand(bite)) 
-		to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+
+	if(ishuman(user))
+		var/obj/item/hand_item/bite = new which_biter_to_spawn(user)
+		if(user.put_in_active_hand(bite)) 
+			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+		else
+			qdel(bite)
 	else
-		qdel(bite)
+		var/obj/item/hand_item/biter/creature/bite = new(user)
+		if(user.put_in_active_hand(bite)) 
+			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+		else
+			qdel(bite)
 
 //Tailer//
 /datum/emote/living/carbon/tailer
@@ -271,11 +279,19 @@
 		which_clawer_to_spawn = /obj/item/hand_item/clawer/razor
 	else 
 		which_clawer_to_spawn =  /obj/item/hand_item/clawer 
-	var/obj/item/hand_item/clawer/claw = new which_clawer_to_spawn(user) 
-	if(user.put_in_active_hand(claw))
-		to_chat(user, span_notice("You get your claws ready to slice!"))
+
+	if(ishuman(user))
+		var/obj/item/hand_item/clawer/claw = new which_clawer_to_spawn(user) 
+		if(user.put_in_active_hand(claw))
+			to_chat(user, span_notice("You get your claws ready to slice!"))
+		else
+			qdel(claw)
 	else
-		qdel(claw)
+		var/obj/item/hand_item/clawer/creature/claw = new(user)
+		if(user.put_in_active_hand(claw))
+			to_chat(user, span_notice("You get your claws ready to slice!"))
+		else
+			qdel(claw)
 
 
 //Shover//

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -199,31 +199,26 @@
 		to_chat(user, span_warning("Your hands are too full to properly bite!  Don't ask!"))
 		return
 	var/which_biter_to_spawn
-	if(HAS_TRAIT(user, TRAIT_BIGBITE))
-		which_biter_to_spawn = /obj/item/hand_item/biter/big
-	else if(HAS_TRAIT(user, TRAIT_FASTBITE))
-		which_biter_to_spawn = /obj/item/hand_item/biter/fast
-	else if(HAS_TRAIT(user, TRAIT_PLAYBITE))
-		which_biter_to_spawn = /obj/item/hand_item/biter/play
-	else if(HAS_TRAIT(user, TRAIT_SPICYBITE))
-		which_biter_to_spawn = /obj/item/hand_item/biter/spicy
-	else if(HAS_TRAIT(user, TRAIT_SABREBITE))
-		which_biter_to_spawn = /obj/item/hand_item/biter/sabre
-	else 
-		which_biter_to_spawn = /obj/item/hand_item/biter 
-
 	if(ishuman(user))
-		var/obj/item/hand_item/bite = new which_biter_to_spawn(user)
-		if(user.put_in_active_hand(bite)) 
-			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
-		else
-			qdel(bite)
+		if(HAS_TRAIT(user, TRAIT_BIGBITE))
+			which_biter_to_spawn = /obj/item/hand_item/biter/big
+		else if(HAS_TRAIT(user, TRAIT_FASTBITE))
+			which_biter_to_spawn = /obj/item/hand_item/biter/fast
+		else if(HAS_TRAIT(user, TRAIT_PLAYBITE))
+			which_biter_to_spawn = /obj/item/hand_item/biter/play
+		else if(HAS_TRAIT(user, TRAIT_SPICYBITE))
+			which_biter_to_spawn = /obj/item/hand_item/biter/spicy
+		else if(HAS_TRAIT(user, TRAIT_SABREBITE))
+			which_biter_to_spawn = /obj/item/hand_item/biter/sabre
+		else 
+			which_biter_to_spawn = /obj/item/hand_item/biter 
 	else
-		var/obj/item/hand_item/biter/creature/bite = new(user)
-		if(user.put_in_active_hand(bite)) 
-			to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
-		else
-			qdel(bite)
+		which_biter_to_spawn = /obj/item/hand_item/biter/creature
+	var/obj/item/hand_item/bite = new which_biter_to_spawn(user)
+	if(user.put_in_active_hand(bite)) 
+		to_chat(user, span_notice("You show your fangs and prepare to bite the mess out of something or someone!"))
+	else
+		qdel(bite)
 
 //Tailer//
 /datum/emote/living/carbon/tailer
@@ -267,31 +262,26 @@
 		to_chat(user, span_warning("Your hands are too full to use your claws!"))
 		return
 	var/which_clawer_to_spawn
-	if(HAS_TRAIT(user, TRAIT_BIGCLAW))
-		which_clawer_to_spawn = /obj/item/hand_item/clawer/big
-	else if(HAS_TRAIT(user, TRAIT_FASTCLAW))
-		which_clawer_to_spawn = /obj/item/hand_item/clawer/fast
-	else if(HAS_TRAIT(user, TRAIT_PLAYCLAW))
-		which_clawer_to_spawn = /obj/item/hand_item/clawer/play
-	else if(HAS_TRAIT(user, TRAIT_SPICYCLAW))
-		which_clawer_to_spawn = /obj/item/hand_item/clawer/spicy
-	else if(HAS_TRAIT(user, TRAIT_RAZORCLAW))
-		which_clawer_to_spawn = /obj/item/hand_item/clawer/razor
-	else 
-		which_clawer_to_spawn =  /obj/item/hand_item/clawer 
-
 	if(ishuman(user))
-		var/obj/item/hand_item/clawer/claw = new which_clawer_to_spawn(user) 
-		if(user.put_in_active_hand(claw))
-			to_chat(user, span_notice("You get your claws ready to slice!"))
-		else
-			qdel(claw)
+		if(HAS_TRAIT(user, TRAIT_BIGCLAW))
+			which_clawer_to_spawn = /obj/item/hand_item/clawer/big
+		else if(HAS_TRAIT(user, TRAIT_FASTCLAW))
+			which_clawer_to_spawn = /obj/item/hand_item/clawer/fast
+		else if(HAS_TRAIT(user, TRAIT_PLAYCLAW))
+			which_clawer_to_spawn = /obj/item/hand_item/clawer/play
+		else if(HAS_TRAIT(user, TRAIT_SPICYCLAW))
+			which_clawer_to_spawn = /obj/item/hand_item/clawer/spicy
+		else if(HAS_TRAIT(user, TRAIT_RAZORCLAW))
+			which_clawer_to_spawn = /obj/item/hand_item/clawer/razor
+		else 
+			which_clawer_to_spawn =  /obj/item/hand_item/clawer 
 	else
-		var/obj/item/hand_item/clawer/creature/claw = new(user)
-		if(user.put_in_active_hand(claw))
-			to_chat(user, span_notice("You get your claws ready to slice!"))
-		else
-			qdel(claw)
+		which_clawer_to_spawn =  /obj/item/hand_item/clawer/creature
+	var/obj/item/hand_item/clawer/claw = new which_clawer_to_spawn(user) 
+	if(user.put_in_active_hand(claw))
+		to_chat(user, span_notice("You get your claws ready to slice!"))
+	else
+		qdel(claw)
 
 
 //Shover//


### PR DESCRIPTION
## About The Pull Request
This is just an academic exercise, it can be approved or denied, especially if it's game-breaking. What this PR does is simply discriminating between human and creatures. The emotes *bite and *claw are buffed ONLY if the user is a creature, if a human or any sub-specie runs the same emote it will return the untouched regular values.
Why I did this... well because whenever I see a creature running around on the server defending itself with a knife it makes me a little sad and makes me think: "wouldn't it be cool if the creature could actually use claws or bite?".

I'm not a game designer, so... if the strength values of this is too high just tell me and I'll tune it down.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds nastier claws and bites for creatures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
