### PR TITLE
Bone Dancer Equipment (MERGE Ready)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -432,6 +432,7 @@
 //Bone Dancers
 
 datum/crafting_recipe/tribalwar/bone
+	category = CAT_PRIMAL
 	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/bone/lightarmour

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -97,6 +97,13 @@ GLOBAL_LIST_INIT(rustwalkers_traditions_recipes, list(
 	/datum/crafting_recipe/tribalwar/rustwalkers/garb,
 	/datum/crafting_recipe/tribalwar/rustwalkers/femalegarb))
 
+GLOBAL_LIST_INIT(bonedancer_traditions_recipes, list(
+	/datum/crafting_recipe/tribalwar/bone/lightarmour,
+	/datum/crafting_recipe/tribalwar/bone/armour,
+	/datum/crafting_recipe/tribalwar/bone/heavyarmour,
+	/datum/crafting_recipe/tribalwar/bone/garb,
+	/datum/crafting_recipe/tribalwar/bone/helmet))
+
 GLOBAL_LIST_INIT(energyweapon_crafting, list(
 	/datum/crafting_recipe/aer9_hotwired))
 
@@ -757,7 +764,7 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_RUSTWALKERS_TRAD, "Rustwalker Traditions")
-		H.mind.learned_recipes -= GLOB.rustwalkers_traditions_recipes
+	H.mind.learned_recipes -= GLOB.rustwalkers_traditions_recipes
 
 /datum/quirk/eightiestraditions
 	name = "Eighties traditions"
@@ -794,6 +801,19 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	gain_text = span_notice("The mysteries of your ancestors are revealed to you.")
 	lose_text = span_danger("You forget how your ancestors have created their garments.")
 	locked =  FALSE
+
+/datum/quirk/bonedancertraditions/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	ADD_TRAIT(H, TRAIT_BONEDANCER_TRAD, "Bone Dancer Traditions")
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.bonedancer_traditions_recipes
+
+/datum/quirk/bonedancertraditions/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(!QDELETED(H))
+		REMOVE_TRAIT(H, TRAIT_BONEDANCER_TRAD, "Bone Dancer Traditions")
+	H.mind.learned_recipes -= GLOB.bonedancer_traditions_recipes
 
 /datum/quirk/brickwall
 	name = "Brick wall"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

I added a global init to the Bone Dancer tribe. This means that people can actually get the crafts for selecting the neutral quirk Bone Dancer traditions.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
