### PR TITLE
W I D E (character width slider)

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -130,6 +130,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define CHARCOAL_FONT "Candara"
 
 #define RESIZE_DEFAULT_SIZE 1
+#define RESIZE_DEFAULT_WIDTH 1
 
 //transfer_ai() defines. Main proc in ai_core.dm
 #define AI_TRANS_TO_CARD	1 //Downloading AI to InteliCard.

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -225,7 +225,8 @@
 		"meat_type"			= "Mammalian",
 		"taste"				= "taste",
 		"body_model"		= body_model,
-		"body_size"			= RESIZE_DEFAULT_SIZE
+		"body_size"			= RESIZE_DEFAULT_SIZE,
+		"body_width"		= RESIZE_DEFAULT_SIZE
 		))
 
 /proc/random_hair_style(gender)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -510,6 +510,17 @@
 	min_val = RESIZE_DEFAULT_SIZE
 	integer = FALSE
 
+/datum/config_entry/number/body_width_min
+	config_entry_value = RESIZE_DEFAULT_SIZE
+	min_val = 0.1 //to avoid issues with zeros and negative values.
+	max_val = RESIZE_DEFAULT_SIZE
+	integer = FALSE
+
+/datum/config_entry/number/body_width_max
+	config_entry_value = RESIZE_DEFAULT_SIZE
+	min_val = RESIZE_DEFAULT_SIZE
+	integer = FALSE
+
 //Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 //to compensate for their smaller hitbox.
 //To disable, just make sure the value is lower than 'body_size_min'

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -43,6 +43,7 @@
 	if(!istype(destination))
 		return
 	var/old_size = destination.dna.features["body_size"]
+	var/old_width = destination.dna.features["body_width"]
 	destination.dna.unique_enzymes = unique_enzymes
 	destination.dna.uni_identity = uni_identity
 	destination.dna.blood_type = blood_type
@@ -61,6 +62,7 @@
 		destination.dna.default_mutation_genes = default_mutation_genes
 
 	destination.dna.update_body_size(old_size)
+	destination.dna.update_body_width(old_width)
 
 	SEND_SIGNAL(destination, COMSIG_CARBON_IDENTITY_TRANSFERRED_TO, src, transfer_SE)
 
@@ -413,8 +415,10 @@
 
 	if(newfeatures)
 		var/old_size = dna.features["body_size"]
+		var/old_width = dna.features["body_width"]
 		dna.features = newfeatures
 		dna.update_body_size(old_size)
+		dna.update_body_width(old_width)
 
 	if(mrace)
 		var/datum/species/newrace = new mrace.type
@@ -699,6 +703,13 @@
 		holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
 	else if(old_size < danger)
 		holder.remove_movespeed_modifier(/datum/movespeed_modifier/small_stride)
+
+/datum/dna/proc/update_body_width(old_width)
+	if(!holder || features["body_width"] == old_width)
+		return
+	//holder.resize = features["body_width"] / old_width
+	holder.transform = holder.transform.Scale(features["body_width"]/old_width, 1)
+	holder.update_transform()
 
 // duplicated code *pwns*
 /datum/dna/proc/shift_genital_order(which_one, move_up)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -191,6 +191,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		"taste" = "something",
 		"body_model" = MALE,
 		"body_size" = RESIZE_DEFAULT_SIZE,
+		"body_width" = RESIZE_DEFAULT_WIDTH,
 		"color_scheme" = OLD_CHARACTER_COLORING,
 		"chat_color" = "whoopsie"
 		)
@@ -617,6 +618,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			if (CONFIG_GET(number/body_size_min) != CONFIG_GET(number/body_size_max))
 				dat += "<b>Sprite Size:</b> <a href='?_src_=prefs;preference=body_size;task=input'>[features["body_size"]*100]%</a><br>"
+			if (CONFIG_GET(number/body_width_min) != CONFIG_GET(number/body_width_max))
+				dat += "<b>Sprite Width:</b> <a href='?_src_=prefs;preference=body_width;task=input'>[features["body_width"]*100]%</a><br>"
 
 			if(!(NOEYES in pref_species.species_traits))
 				dat += "<h3>Eye Type</h3>"
@@ -3317,6 +3320,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(dorfy != "No")
 							features["body_size"] = new_body_size
 
+				if("body_width")
+					var/min = CONFIG_GET(number/body_width_min)
+					var/max = CONFIG_GET(number/body_width_max)
+					var/new_body_width = input(user, "Choose your desired sprite size: ([min*100]%-[max*100]%)\nWarning: This may make your character look distorted", "Character Preference", features["body_width"]*100) as num|null
+					if (new_body_width)
+						new_body_width = clamp(new_body_width * 0.01, min, max)
+						features["body_width"] = new_body_width
+
 				if("tongue")
 					var/selected_custom_tongue = input(user, "Choose your desired tongue (none means your species tongue)", "Character Preference") as null|anything in GLOB.roundstart_tongues
 					if(selected_custom_tongue)
@@ -3913,6 +3924,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		save_character()
 
 	var/old_size = character.dna.features["body_size"]
+	var/old_width = character.dna.features["body_width"]
 
 	character.dna.features = features.Copy()
 	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
@@ -3939,6 +3951,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.give_genitals(TRUE) //character.update_genitals() is already called on genital.update_appearance()
 
 	character.dna.update_body_size(old_size)
+	character.dna.update_body_width(old_width)
 
 	//speech stuff
 	if(custom_tongue != "default")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -572,6 +572,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		"taste" = "something salty",
 		"body_model" = MALE,
 		"body_size" = RESIZE_DEFAULT_SIZE,
+		"body_width" = RESIZE_DEFAULT_SIZE,
 		"color_scheme" = OLD_CHARACTER_COLORING,
 		"chat_color" = "whoopsie")
 
@@ -617,6 +618,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["gender"]					>> gender
 	S["body_model"]				>> features["body_model"]
 	S["body_size"]				>> features["body_size"]
+	S["body_width"]				>> features["body_width"]
 	S["age"]					>> age
 	S["hair_color"]				>> hair_color
 	S["facial_hair_color"]		>> facial_hair_color
@@ -915,6 +917,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		size_max = CONFIG_GET(number/body_size_max)
 	features["body_size"]			= sanitize_num_clamp(features["body_size"], size_min, size_max, RESIZE_DEFAULT_SIZE, 0.01)
 
+	var/static/width_min
+	if(!width_min)
+		width_min = CONFIG_GET(number/body_width_min)
+	var/static/width_max
+	if(!width_max)
+		width_max = CONFIG_GET(number/body_width_max)
+	features["body_width"]			= sanitize_num_clamp(features["body_width"], width_min, width_max, RESIZE_DEFAULT_SIZE, 0.01)
+
 	var/static/list/B_sizes
 	if(!B_sizes)
 		var/list/L = CONFIG_GET(keyed_list/breasts_cups_prefs)
@@ -1094,6 +1104,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["gender"]					, gender)
 	WRITE_FILE(S["body_model"]				, features["body_model"])
 	WRITE_FILE(S["body_size"]				, features["body_size"])
+	WRITE_FILE(S["body_width"]				, features["body_width"])
 	WRITE_FILE(S["age"]						, age)
 	WRITE_FILE(S["hair_color"]				, hair_color)
 	WRITE_FILE(S["facial_hair_color"]		, facial_hair_color)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -688,6 +688,10 @@ BELLY_MAX_SIZE_PREFS 11
 BODY_SIZE_MIN 0.8
 BODY_SIZE_MAX 1.2
 
+## Body width configs, the feature will be disabled if both min and max have the same value.
+BODY_WIDTH_MIN 0.5
+BODY_WIDTH_MAX 2.0
+
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
 ## To disable, just make sure the value is lower than 'body_size_min'


### PR DESCRIPTION
## About The Pull Request
Allow me to explain everything with a single picture:
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/dbced598-0957-4979-b825-7f2e41ae8ed3)

just kidding have more:
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/bef0363a-c0be-40ae-b73e-2add82b575a8)

Basically this adds a way to modify a charater's body width, this is... supposed to be used as a tool to counter distortion, but I already know I'll regret it. Here's an example, note the eyes:
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/b897892e-1a17-488d-9f44-e7713634a29c)


## Pre-Merge Checklist
- [x] You tested this on a local server. (oh boy, I did, I really hope this won't screw player characters in the future).
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds character width.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
