### PR TITLE
Makes Prosthetics Not A Death Sentence

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -272,32 +272,32 @@
 	name = "reinforced surplus prosthetic left arm"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
+	brute_reduction = 5
+	burn_reduction = 5
 	max_damage = 70
 
 /obj/item/bodypart/r_arm/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right arm"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
+	brute_reduction = 5
+	burn_reduction = 5
 	max_damage = 70
 
 /obj/item/bodypart/l_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic left leg"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
+	brute_reduction = 5
+	burn_reduction = 5
 	max_damage = 70
 
 /obj/item/bodypart/r_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right leg"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
+	brute_reduction = 5
+	burn_reduction = 5
 	max_damage = 70
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -241,7 +241,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 50
 
 /obj/item/bodypart/r_arm/robot/surplus
 	name = "surplus prosthetic right arm"
@@ -249,7 +249,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 50
 
 /obj/item/bodypart/l_leg/robot/surplus
 	name = "surplus prosthetic left leg"
@@ -257,7 +257,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 50
 
 /obj/item/bodypart/r_leg/robot/surplus
 	name = "surplus prosthetic right leg"
@@ -265,7 +265,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 50
 
 // Upgraded Surplus lims - Better then robotic lims
 /obj/item/bodypart/l_arm/robot/surplus_upgraded
@@ -274,7 +274,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 3
 	burn_reduction = 2
-	max_damage = 55
+	max_damage = 70
 
 /obj/item/bodypart/r_arm/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right arm"
@@ -282,7 +282,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 3
 	burn_reduction = 2
-	max_damage = 55
+	max_damage = 70
 
 /obj/item/bodypart/l_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic left leg"
@@ -290,7 +290,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 3
 	burn_reduction = 2
-	max_damage = 55
+	max_damage = 70
 
 /obj/item/bodypart/r_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right leg"
@@ -298,7 +298,7 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	brute_reduction = 3
 	burn_reduction = 2
-	max_damage = 55
+	max_damage = 70
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG


### PR DESCRIPTION
Right now normal bodyparts have a dmg threshold of 50 hp
This seems to only affect wounds

Prosthetics cant be wounded, so when they reach their dmg threshold, it cripples the limb until replaced or fixed

Surplus prosthetics had 20 max dmg, which meant a gecko could cripple you with a single, solitary nibble.

Now prosthetics start off with 50 max, with enhanced prosthetics having 70 with a little dmg negation
Makes you able to take more than two hits from a gecko on a single prosthetic, now. 