### PR TITLE
dark vision and tribal carpet bombing

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -76,7 +76,8 @@
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0
 
-#define NIGHT_VISION_DARKSIGHT_RANGE 3
+#define NIGHT_VISION_DARKSIGHT_RANGE 4
+#define NIGHT_VISION_DARKSIGHT_RANGE_GREATER 6
 
 //lighting area defines
 #define DYNAMIC_LIGHTING_DISABLED 0 //dynamic lighting disabled (area stays at full brightness)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -254,6 +254,7 @@
 #define TRAIT_AGEUSIA			"ageusia"
 #define TRAIT_HEAVY_SLEEPER		"heavy_sleeper"
 #define TRAIT_NIGHT_VISION		"night_vision"
+#define TRAIT_NIGHT_VISION_GREATER		"night_vision_greater"
 #define TRAIT_LIGHT_STEP		"light_step"
 #define TRAIT_SILENT_STEP		"silent_step"
 #define TRAIT_SPEEDY_STEP		"speedy_step"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -611,20 +611,42 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 
 
 /datum/quirk/night_vision
-	name = "Night Vision"
+	name = "Dark Vision - Minor"
 	desc = "You can see slightly more clearly in full darkness than most people by one more whole tile."
-	value = 14
+	value = 22
 	category = "Vision Quirks"
-	mechanics = "You can see one more tile in the dark than normal without a light source."
+	mechanics = "You can see two more tiles in the dark than normal without a light source."
 	conflicts = list(
 		/datum/quirk/blindness,
+		/datum/quirk/night_vision_greater,
 	)
 	mob_trait = TRAIT_NIGHT_VISION
 	gain_text = span_notice("The shadows seem a little less dark.")
 	lose_text = span_danger("Everything seems a little darker.")
 
 
+
 /datum/quirk/night_vision/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.update_sight()
+
+/datum/quirk/night_vision_greater
+	name = "Dark Vision - Greater"
+	desc = "You can see slightly more clearly in full darkness than most people by one more whole tile."
+	value = 44
+	category = "Vision Quirks"
+	mechanics = "You can see four more tiles in the dark than normal without a light source."
+	conflicts = list(
+		/datum/quirk/blindness,
+		/datum/quirk/night_vision,
+	)
+	mob_trait = TRAIT_NIGHT_VISION_GREATER
+	gain_text = span_notice("The shadows seem a little less dark.")
+	lose_text = span_danger("Everything seems a little darker.")
+
+
+
+/datum/quirk/night_vision_greater/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.update_sight()
 

--- a/code/game/objects/items/grenades/f13grenade.dm
+++ b/code/game/objects/items/grenades/f13grenade.dm
@@ -116,6 +116,7 @@
 	ex_heavy = 0
 	ex_light = 3
 	ex_flame = 0
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/storage/box/dynamite_box
 	name = "dynamite crate"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -865,6 +865,9 @@
 		if(HAS_TRAIT(src, TRAIT_NIGHT_VISION))
 			lighting_alpha = min(LIGHTING_PLANE_ALPHA_NV_TRAIT, lighting_alpha)
 			see_in_dark = max(NIGHT_VISION_DARKSIGHT_RANGE, see_in_dark)
+		if(HAS_TRAIT(src, TRAIT_NIGHT_VISION_GREATER))
+			lighting_alpha = min(LIGHTING_PLANE_ALPHA_NV_TRAIT, lighting_alpha)
+			see_in_dark = max(NIGHT_VISION_DARKSIGHT_RANGE_GREATER, see_in_dark)
 
 	if(client.eye && client.eye != src)
 		var/atom/A = client.eye


### PR DESCRIPTION
makes dynamite tiny sized items
does 30 dmg, so the only way this can kill is if you piss off the whole tribe.

Will need a timer on sending birds, maybe five minutes, if this is used too much.

Also changes night vision to two perks
Dark vision - minor
dark vision - greater

2 and 4 tiles dark vision range, 22 and 44 point cost respectively