### PR TITLE
Wild Shape and Stack Sizes Fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -692,7 +692,7 @@
 	return language_holder
 
 /// Grants the supplied language and sets omnitongue true.
-/atom/movable/proc/grant_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_ATOM)
+/atom/movable/proc/grant_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_MIND)
 	var/datum/language_holder/LH = get_language_holder()
 	return LH.grant_language(language, understood, spoken, source)
 
@@ -712,12 +712,12 @@
 	return LH.remove_all_languages(source, remove_omnitongue)
 
 /// Adds a language to the blocked language list. Use this over remove_language in cases where you will give languages back later.
-/atom/movable/proc/add_blocked_language(language, source = LANGUAGE_ATOM)
+/atom/movable/proc/add_blocked_language(language, source = LANGUAGE_MIND)
 	var/datum/language_holder/LH = get_language_holder()
 	return LH.add_blocked_language(language, source)
 
 /// Removes a language from the blocked language list.
-/atom/movable/proc/remove_blocked_language(language, source = LANGUAGE_ATOM)
+/atom/movable/proc/remove_blocked_language(language, source = LANGUAGE_MIND)
 	var/datum/language_holder/LH = get_language_holder()
 	return LH.remove_blocked_language(language, source)
 

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -2,7 +2,7 @@
 	name = "crafting part"
 	icon = 'icons/fallout/objects/items.dmi'
 	amount = 1
-	max_amount = 50
+	max_amount = 100
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	throw_speed = 3
 	throw_range = 7
 	custom_materials = list(/datum/material/iron=1000)
-	max_amount = 50
+	max_amount = 100
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	embedding = list()
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=1000, /datum/material/plasma=500, /datum/material/titanium=2000)
-	max_amount = 50
+	max_amount = 100
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	merge_type = /obj/item/stack/rods/lava
 
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		/datum/material/titanium = (MINERAL_MATERIAL_AMOUNT * 0.5),
 		/datum/material/lead = (MINERAL_MATERIAL_AMOUNT * 0.5)
 		)
-	max_amount = 50
+	max_amount = 100
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	merge_type = /obj/item/stack/rods/scaffold
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -737,7 +737,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	icon = 'icons/obj/stack_objects.dmi'
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	throwforce = 10
-	max_amount = 50
+	max_amount = 100
 	throw_speed = 1
 	throw_range = 3
 	turf_type = /turf/open/floor/clockwork
@@ -945,7 +945,7 @@ new /datum/stack_recipe("paper frame door", /obj/structure/mineral_door/paperfra
 /obj/item/stack/sheet/cotton
 	name = "raw cotton bundle"
 	desc = "A bundle of raw cotton ready to be spun on the loom."
-	max_amount = 50
+	max_amount = 100
 	singular_name = "raw cotton ball"
 	icon_state = "sheet-cotton"
 	resistance_flags = FLAMMABLE
@@ -1040,7 +1040,7 @@ GLOBAL_LIST_INIT(hay_recipes, list ( \
 	throwforce = 1
 	throw_speed = 1
 	throw_range = 2
-	max_amount = 50 //reduced from 500, made stacks sprites irrelevant due to scaling.
+	max_amount = 100 //reduced from 500, made stacks sprites irrelevant due to scaling.
 	armor = ARMOR_VALUE_GENERIC_ITEM
 	resistance_flags = FLAMMABLE
 	attack_verb = list("tickled", "poked", "whipped")

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -5,7 +5,7 @@
 	full_w_class = WEIGHT_CLASS_NORMAL
 	force = 5
 	throwforce = 5
-	max_amount = 200
+	max_amount = 100
 	throw_speed = 1
 	throw_range = 3
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "smashed")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -15,7 +15,7 @@
 	var/list/datum/stack_recipe/recipes
 	var/singular_name
 	var/amount = 1
-	var/max_amount = 50 //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
+	var/max_amount = 100 //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/is_cyborg = 0 // It's 1 if module is used by a cyborg, and uses its storage
 	var/datum/robot_energy_storage/source
 	var/cost = 1 // How much energy from storage it costs

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -6,7 +6,7 @@
 	icon_state = "telecrystal"
 	grind_results = list(/datum/reagent/telecrystal = 20)
 	w_class = WEIGHT_CLASS_TINY
-	max_amount = 50
+	max_amount = 100
 	item_flags = NOBLUDGEON
 	merge_type = /obj/item/stack/telecrystal
 

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -391,7 +391,7 @@ All the important duct code:
 	custom_materials = list(/datum/material/iron=500)
 	w_class = WEIGHT_CLASS_TINY
 	novariants = FALSE
-	max_amount = 50
+	max_amount = 100
 	item_flags = NOBLUDGEON
 	merge_type = /obj/item/stack/ducts
 	///Color of our duct

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -101,6 +101,8 @@
 	stored = caster
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
+		shape.real_name = stored.real_name
+		shape.name = stored.real_name
 	stored.forceMove(src)
 	stored.mob_transforming = TRUE
 	if(source.convert_damage)


### PR DESCRIPTION
Makes all stackable materials have a max amount of 100, bumped from 200 and raised from 50 for everything.

Also makes it to where wild shape now maintains your name and languages when transforming back and forth.