### PR TITLE
Allow Player controlled mobs to vore

### DIFF
--- a/code/controllers/subsystem/vore.dm
+++ b/code/controllers/subsystem/vore.dm
@@ -54,7 +54,7 @@ PROCESSING_SUBSYSTEM_DEF(vore)
 
 /datum/controller/subsystem/processing/vore/proc/build_list_of_mobtypes_that_should_vore()
 	approved_vore_mobtypes |= typecacheof(/mob/living/carbon/human)
-	approved_vore_mobtypes |= typecacheof(/mob/living/simple_animal/pet/catslug)
+	approved_vore_mobtypes |= typecacheof(/mob/living/simple_animal)	//It's ok we check if we have a client. Only player controlled mobs get vore.
 
 /datum/controller/subsystem/processing/vore/proc/build_list_of_items_that_can_be_vored()
 	for(var/itempath in VORABLE_TYPES)

--- a/code/modules/vore/eating/vore_core.dm
+++ b/code/modules/vore/eating/vore_core.dm
@@ -1,4 +1,4 @@
-/* 
+/*
  * VORE COMPONENT FOR MOBS
  * Allows someone to be a predator
  * Not needed for prey!!!
@@ -34,6 +34,11 @@
 /datum/component/vore/Initialize()
 	if(!SSvore.should_have_vore(parent))
 		return COMPONENT_INCOMPATIBLE
+	var/mob/living/master
+	if(isliving(parent))
+		master = parent
+		if(!master.client)	//Don't generate vore component if there's no client.
+			return
 	RegisterSignal(parent, list(COMSIG_MOB_CLIENT_LOGIN), .proc/setup_vore)
 	RegisterSignal(parent, list(COMSIG_VORE_SAVE_PREFS), .proc/save_prefs)
 	RegisterSignal(parent, list(COMSIG_VORE_LOAD_PREFS), .proc/load_prefs)
@@ -60,10 +65,8 @@
 	RegisterSignal(parent, list(COMSIG_PARENT_EXAMINE), .proc/examine_bellies)
 	RegisterSignal(parent, list(COMSIG_MOB_DEATH), .proc/you_died) // casual
 	START_PROCESSING(SSvore, src)
-	if(isliving(parent))
-		var/mob/living/master = parent
-		if(master.client)
-			setup_vore()
+	if(master.client)
+		setup_vore()	//A bit redundant to double check if we still have a client. But just in case.
 
 /datum/component/vore/proc/setup_vore(force)
 	VORE_MASTER
@@ -149,7 +152,7 @@
 	if(!load_vore_prefs())
 		return FALSE
 	return TRUE
-	
+
 /datum/component/vore/proc/load_vore_prefs()
 	VORE_MASTER
 	// vore prefs are loaded with the client and up to date to the last save
@@ -503,7 +506,7 @@
 
 	//Timer and progress bar
 	if(!do_after(
-			master, 
+			master,
 			swallow_time,
 			FALSE,
 			movable_prey,
@@ -671,7 +674,7 @@
 	if(number_of_stuff == cached_belly_contents)
 		if(prob(80)) // how 2 fix atmos
 			return // We don't need to update slowdowns if the number of things in bellies hasn't changed.
-	cached_belly_contents = number_of_stuff	
+	cached_belly_contents = number_of_stuff
 	var/item_slow = 0
 	var/mob_slow = 0
 	for(var/obj/vore_belly/belly in vore_organs)


### PR DESCRIPTION
Simple fix. A pal of mine wants to mainly play simple mobs and was sad when realising they didn't get a vore panel.
I noticed that player controlled mobs didn't inherit the vore component, aside from catslugs, as defined by the vore subsystem.
So I changed it to include all vore mobs, but only generate the component if there's a client in control of the mob.

aka: Spawning via the creature spawner have the vore component.

No, NPC mobs do not get vore, and never will.
