### PR TITLE
Set a default silly status message

### DIFF
--- a/modular_coyote/code/modules/verbies/whocares.dm
+++ b/modular_coyote/code/modules/verbies/whocares.dm
@@ -105,12 +105,16 @@
 
 /mob/Login()
 	. = ..()
+	var/const/defaultStatusMessage = "Heehoo, default status message!"
 	if(client) // cursed way to get around disconnects and mob changes.
 		if(length(statusMessage))
 			client.statusMessage = statusMessage
 		else
 			if(length(client.statusMessage))
 				statusMessage = client.statusMessage
+			else
+				client.statusMessage = defaultStatusMessage
+				statusMessage = defaultStatusMessage
 
 // Make the verb here.
 /mob/verb/SetStatusMsg()


### PR DESCRIPTION
## About The Pull Request
Blind change to set a silly default status message

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
