### PR TITLE
Adjusts Phobia Mechanics and Values

### DIFF
--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -129,6 +129,7 @@
 			//owner.Stun(70)
 			owner.Jitter(8)
 			owner.eye_blurry = 20
+			owner.emote("cry")
 		if(2)
 			owner.emote("scream")
 			owner.Jitter(5)

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -122,12 +122,13 @@
 		to_chat(owner, span_userdanger("Hearing \"[trigger_word]\" [message]!"))
 	else
 		to_chat(owner, span_userdanger("Something [message]!"))
-	var/reaction = rand(1,4)
+	var/reaction = rand(1,5)
 	switch(reaction)
 		if(1)
-			to_chat(owner, span_warning("You are paralyzed with fear!"))
-			owner.Stun(70)
+			to_chat(owner, span_warning("You break out in a fit of tears!"))
+			//owner.Stun(70)
 			owner.Jitter(8)
+			owner.eye_blurry = 20
 		if(2)
 			owner.emote("scream")
 			owner.Jitter(5)
@@ -143,6 +144,10 @@
 			owner.confused += 10
 			owner.Jitter(10)
 			owner.stuttering += 10
+		if(5)
+			to_chat(owner, span_warning("You faint out of shock!"))
+			owner.emote("faint")
+			owner.Jitter(5)
 
 /datum/brain_trauma/mild/phobia/proc/RealityCheck() // Checks if you're not your own fears.
 	if(HAS_TRAIT(owner, TRAIT_FEARLESS))

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -146,7 +146,7 @@
 			owner.stuttering += 10
 		if(5)
 			to_chat(owner, span_warning("You faint out of shock!"))
-			owner.emote("faint")
+			owner.emote("collapse")
 			owner.Jitter(5)
 
 /datum/brain_trauma/mild/phobia/proc/RealityCheck() // Checks if you're not your own fears.

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1695,7 +1695,7 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	desc = "Through some genetic quirk you have access to horrifying arm blades made out of bone with the *armblade verb."
 
 	value = 32
-	category = "Armblade Quirks"
+	category = "Mutant Quirks"
 	mechanics = "Your arm can turn into a horrible meat sword."
 	conflicts = list()
 	mob_trait = TRAIT_ARMBLADE
@@ -1704,10 +1704,9 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	name = "Arm Tentacle"
 	desc = "Through some genetic quirk you have access to horrifying arm tentacle to grab people and mobs with. Use *tentarm verb to summon it."
 	value = 32
-	category = "Armblade Quirks"
+	category = "Mutant Quirks"
 	mechanics = "Your arm can turn into a horrible meat sword."
 	conflicts = list()
-	category = "Mutant Quirks"
 	mob_trait = TRAIT_ARMTENT
 
 /datum/quirk/bigbiter
@@ -1960,13 +1959,13 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	ADD_TRAIT(H, TRAIT_FRIENDLY, "Friendly")
 
 
-/datum/quirk/tribal/remove()
+/datum/quirk/package/lifeoftheparty/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_MUSICIAN, "Musician")
 		REMOVE_TRAIT(H, TRAIT_FRIENDLY, "Friendly")
 
-/datum/quirk/package/Bruiser
+/datum/quirk/package/bruiser
 	name = "Bruiser"
 	desc = "You're a big guy."
 	value = 150
@@ -1979,13 +1978,13 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	gain_text = span_notice("DAMN BRO YOU SWOLE!")
 	lose_text = span_notice("Maybe you could skip gym day...")
 
-/datum/quirk/package/lifeoftheparty/add()
+/datum/quirk/package/bruiser/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, "Melee - Big Leagues")
 	ADD_TRAIT(H, TRAIT_LIFEGIVERPLUS, "Health - Tougher")
 
 
-/datum/quirk/package/lifeoftheparty/remove()
+/datum/quirk/package/bruiser/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_BIG_LEAGUES, "Melee - Big Leagues")
@@ -2040,6 +2039,29 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_FAST_PUMP, "Bolt Worker")
 		REMOVE_TRAIT(H, TRAIT_NICE_SHOT, "Straight Shooter")
+
+/datum/quirk/package/legendarywepsm
+	name = "Weaponsmith - Legendary"
+	desc = "You're just that good at making weapons. Maybe you should make a career out of this?"
+	value = 55
+	category = "Quirk Packages"
+	mechanics = "Grants access to Weaponsmith Basic and Masterwork."
+	conflicts = list(
+		/datum/quirk/gunsmith,
+		/datum/quirk/masterworksmith,
+	)
+
+/datum/quirk/package/legendarywepsm/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	ADD_TRAIT(H, TRAIT_MASTERWORKSMITH, "Weaponsmith - Masterwork")
+	ADD_TRAIT(H, TRAIT_WEAPONSMITH, "Weaponsmith - Basic")
+
+
+/datum/quirk/package/legendarywepsm/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(!QDELETED(H))
+		REMOVE_TRAIT(H, TRAIT_MASTERWORKSMITH, "Weaponsmith - Masterwork")
+		REMOVE_TRAIT(H, TRAIT_WEAPONSMITH, "Weaponsmith - Basic")
 
 /datum/quirk/package/reformedtribal
 	name = "Reformed Tribal Chemist"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -183,9 +183,9 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
-	value = -32
+	value = -44 // Constant brain DoT. Can and will result in death if not managed.
 	category = "Health Quirks"
-	mechanics = "You're going to need to hit the clinic for mannitol pretty regularly, consider getting a big supply."
+	mechanics = "You're going to need to hit the clinic for mannitol pretty regularly, consider getting a big supply. This WILL kill you if you dont take care of it."
 	conflicts = list(
 		
 	)
@@ -237,7 +237,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 /datum/quirk/badeyes
 	name = "Nearsighted - Trashed Vision"
 	desc = "You are badly nearsighted without prescription glasses, so much so that it's kind of a miracle you're still alive. You defintiely don't have any corrective lenses, but they would help."
-	value = -33
+	value = -32
 	category = "Vision Quirks"
 	mechanics = "Bro your eyes are straight up having a bad time, your vision is absolutely recked and you have no immediate way of helping it."
 	conflicts = list(
@@ -501,7 +501,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/catphobia
 	name = "Phobia - Cats"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with cats."
-	value = -11
+	value = -32 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of cats, dog."
 	conflicts = list(
@@ -526,7 +526,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/ratphobia
 	name = "Phobia - Rats"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with rats."
-	value = -11
+	value = -44 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of rats, cheesebag."
 	conflicts = list(
@@ -551,7 +551,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/spiderphobia
 	name = "Phobia - Spiders"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with spiders."
-	value = -11
+	value = -44 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of spiders, check your shoes!"
 	conflicts = list(
@@ -576,7 +576,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/lizardphobia
 	name = "Phobia - Lizards"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with lizards and reptiles."
-	value = -11
+	value = -32 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of lizards. I...  Yeah, you're scared of lizards."
 	conflicts = list(
@@ -600,7 +600,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/robotphobia
 	name = "Phobia - Robots/Synths"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with robot or synthetics."
-	value = -22 // I do this because there's many enemy mobs which fit in this category, which effects a lot of gameplay.
+	value = -54 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of robots, time traveller."
 	conflicts = list(
@@ -624,7 +624,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/birdphobia
 	name = "Phobia - Birds"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with birds."
-	value = -11
+	value = -32 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = ""
 	conflicts = list(
@@ -648,7 +648,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/dogphobia
 	name = "Phobia - Dogs"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with dogs."
-	value = -11
+	value = -44 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be. This one gets the lottery because apparently most of our players play canines.
 	category = "Phobia Quirks"
 	mechanics = "You're scared of dogs, cat."
 	conflicts = list(
@@ -672,7 +672,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/skelephobia
 	name = "Phobia - Skeletons"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with bones."
-	value = -22
+	value = -32 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be.
 	category = "Phobia Quirks"
 	mechanics = "You really hate it when shit gets spooky."
 	conflicts = list(
@@ -697,7 +697,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/maskphobia
 	name = "Phobia - Masked People"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with someone wearing a mask."
-	value = -11
+	value = -66 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be. Literally everyone wears some manner of mask. You'd be better off with pacifist.
 	category = "Phobia Quirks"
 	mechanics = "Chic chicy boom?  No thanks."
 	conflicts = list(
@@ -722,7 +722,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/doctorphobia
 	name = "Phobia - Doctors"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with doctors."
-	value = -32
+	value = -54 // Mostly experimental, with tweaks to how phobia works and accounting for how common the target phobia seems to be. This accounts for everything medical. Red crosses, medical clothes, medical tools, surgery, etc. If its expected in medical treatment, it will trigger this.
 	category = "Phobia Quirks"
 	mechanics = "Healthcare really is way too expensive these days."
 	conflicts = list(
@@ -744,21 +744,6 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 	var/mob/living/carbon/human/H = quirk_holder
 	H?.cure_trauma_type(/datum/brain_trauma/mild/phobia/doctors, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/quirk/catphobia
-	name = "Phobia - Cats"
-	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with cats."
-	value = -11
-	category = "Phobia Quirks"
-	mechanics = "You're scared of cats, dog."
-	conflicts = list(
-		
-	)
-	mob_trait = TRAIT_CATPHOBIA
-	gain_text = span_danger("You begin to tremble as an immeasurable fear of the feline menace grips your mind.")
-	lose_text = span_notice("Your confidence wipes away the fear that had been plaguing you.")
-	medical_record_text = "Patient has an extreme or irrational fear and aversion to an undefined stimuli."
-	locked = FALSE
-
 /datum/quirk/catphobia/post_add()
 	. = ..()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -772,7 +757,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/eyephobia
 	name = "Phobia - Eyes"
 	desc = "You've had a traumatic past, one that has scarred you for life, and it had something to do with eyes."
-	value = -11
+	value = -32
 	category = "Phobia Quirks"
 	mechanics = "You really hope they don't have their eyes on you."
 	conflicts = list(
@@ -822,7 +807,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/unstable
 	name = "Unstable"
 	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
-	value = -22
+	value = -33
 	category = "Emotional Quirks"
 	mechanics = "This quirk stops you from recovering mood levels. Be very careful with it as it can tank your mood rapidly with negative traits like depressed."
 	conflicts = list(
@@ -836,7 +821,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/blindness
 	name = "Blind"
 	desc = "You are completely blind, nothing can counteract this."
-	value = -32
+	value = -42 // Since trashed vision's a step below this, it makes sense to up it by ten.
 	category = "Vision Quirks"
 	mechanics = "You can't see."
 	conflicts = list(
@@ -1101,7 +1086,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/slow
 	name = "Mobility - Wasteland Slug"
 	desc = "You've spent some time in the wastes, you don't get around great."
-	value = -11
+	value = -22 // Increasing htese because the slowdown is for everything but grass, road, and manmade tiles.
 	category = "Movement Quirks"
 	mechanics = "Slows you down a fair deal if you're going off roads and normal paths."
 	conflicts = list(
@@ -1118,7 +1103,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/slower
 	name = "Mobility - Wasteland Molasses"
 	desc = "You don't get around well off road. Like. At all."
-	value = -22
+	value = -33 // Increasing htese because the slowdown is for everything but grass, road, and manmade tiles.
 	category = "Movement Quirks"
 	mechanics = "Slows you down a lot if you go off roads and normal paths."
 	conflicts = list(
@@ -1177,7 +1162,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/nosleep
 	name = "Can Not Sleep"
 	desc = "For whatever reason you literally lack the ability to sleep."
-	value = -22
+	value = -33 // Increased by ten after observing people with it dying far more often than normal. Might be a skill issue, we'll see how it feels.
 	category = "Lifepath Quirks"
 	mechanics = "You can't sleep. Why is this serious?  We have sleep healing."
 	conflicts = list(
@@ -1207,7 +1192,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/cantrun
 	name = "Mobility - Can not Run"
 	desc = "For whatever reason you just can't muster up the go to run."
-	value = -32
+	value = -44 // Upped because its perma walk. Just as bad as wasteland molasses, and they both get to stack. :>
 	category = "Movement Quirks"
 	mechanics = "Yeah, pretty self explanitory."
 	conflicts = list(

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -177,6 +177,18 @@
 		var/mob/living/L = user
 		L.SetSleeping(200)
 
+/datum/emote/living/faint
+	key = "collapse"
+	key_third_person = "collapse"
+	message = "collapses."
+	message_param = "collapses from %t."
+
+/datum/emote/living/faint/run_emote(mob/user, params)
+	. = ..()
+	if(. && isliving(user))
+		var/mob/living/L = user
+		L.SetSleeping(20)
+
 
 /* Fortuna edit: flapping your wings disabled
 /datum/emote/living/flap


### PR DESCRIPTION
Makes phobias not cause a 7 second stun, but adds two new debilitating effects to make up for the vaccum.
Can synergize with heavy sleeper with a new faint mechanic, making it even more severe.

Increases all phobias besides darkness, as they all take from the above mechanics. Comments attached to their values with my thought process. Feel free to change if it tastes funny.

Also tweaks some other negative quirks' values to make more sense for how they will affect the player in regards to combat.

Also makes a new weaponsmith category under quirk packages, combining both basic and masterwork (cost of 42) for a total of 55