### PR TITLE
stops emitters from being auto-on draining server resources

### DIFF
--- a/code/modules/awaymissions/mission_code/challenge.dm
+++ b/code/modules/awaymissions/mission_code/challenge.dm
@@ -28,7 +28,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 
-	active = TRUE
+	active = FALSE // no more lag pls i beg
 	locked = TRUE
 	state = 2
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -205,7 +205,7 @@
 		sparks.start()
 	P.firer = user ? user : src
 	P.fired_from = src
-	if(last_projectile_params)
+	if(last_projectile_params) // Note: this never never procs as only a /obj/item/turret_control updates the last_projectile params via calling afterattack.
 		P.p_x = last_projectile_params[2]
 		P.p_y = last_projectile_params[3]
 		P.fire(last_projectile_params[1])


### PR DESCRIPTION
Only easy optimisation possible rn, otherwise I cba aha.

Possible things to look into is the sound loop, possible items/systems causing this is:
- vore sounds
- /obj/item/storage/battery_box
- /obj/item/storage/blender_belt
- /obj/machinery/shower
- /obj/structure/bonfire
- /obj/machinery/mineral/wasteland_trader
- /obj/item/geiger_counter