### PR TITLE
Makes berserker crits work as intended

### DIFF
--- a/code/datums/martial/berserker.dm
+++ b/code/datums/martial/berserker.dm
@@ -38,14 +38,14 @@
 					span_userdanger("[A] [atk_verb]s you!"), null, null, A)
 	to_chat(A, span_danger("You [atk_verb] [D]!"))
 	if(prob(10))
-		crit_damage += (damage + 3.5)
+		crit_damage += (damage * 3.5)
 		playsound(get_turf(D), 'sound/weapons/bite.ogg', 50, TRUE, -1)
 		D.visible_message(span_warning("[D] staggers as they're slammed in the stomach"), span_userdanger("You are struck with incredible precision by [A]!"))
 		log_combat(A, D, "critcal hard punched (Berserker)")//log it here because a critical can swing for 40 force and it's important for the sake of how hard they hit
 	else
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 		log_combat(A, D, "hard punched punched (Berserker)")//so as to not double up on logging
-	D.apply_damage(damage + 2.5 + crit_damage, BRUTE, affecting, armor_block, wound_bonus = CANT_WOUND)
+	D.apply_damage(damage * 2.5 + crit_damage, BRUTE, affecting, armor_block, wound_bonus = CANT_WOUND)
 	return TRUE
 
 ///Shouldercheck: Harm Harm Harm combo, throws people seven tiles backwards


### PR DESCRIPTION
a typo in the code made the extra crit damage / regular hard punch damage be only a +3.5 increase rather than the intended multiplier, which unironically, made regular punches WEAKER than just punching them with no martial arts, somehow, this hopefully fixes the issue.

## About The Pull Request
<!-- Write here -->
What the title says.
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->
