### PR TITLE
Increases Mailbird Weight Limit, Misc. Fixes and Changes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Upper.dmm
@@ -1413,15 +1413,8 @@
 	},
 /area/f13/building/mall)
 "bgs" = (
-/obj/structure/bonfire/prelit{
-	pixel_y = 12
-	},
-/obj/item/stack/rods,
 /obj/structure/stone_tile/slab,
-/obj/structure/table/reinforced{
-	color = "#3c2c21";
-	max_integrity = 1000000
-	},
+/obj/structure/bonfire/dense/prelit/grill,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal)
 "bgu" = (
@@ -2293,6 +2286,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bSZ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#9c9c9c"
+	},
+/area/f13/building/tribal)
 "bTh" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12835,12 +12834,12 @@
 	},
 /area/f13/building)
 "kpQ" = (
-/obj/structure/reagent_dispensers/compostbin,
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
 	pixel_x = -15
 	},
+/obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -16495,13 +16494,13 @@
 	dir = 1;
 	pixel_x = -15
 	},
-/obj/structure/legion_extractor,
 /obj/structure/spacevine{
 	color = "#225522";
 	pixel_y = 10;
 	pixel_x = 14;
 	layer = 2
 	},
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -17938,20 +17937,12 @@
 	},
 /area/f13/building)
 "oAd" = (
-/obj/structure/table/reinforced{
-	color = "#3c2c21";
-	max_integrity = 1000000;
-	alpha = 0;
-	light_range = 3;
-	light_color = "#334477"
-	},
-/obj/structure/bonfire/prelit{
-	pixel_y = 5;
-	name = "the speakers blaze"
-	},
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
 	dir = 4
+	},
+/obj/structure/bonfire/dense/prelit{
+	name = "the speakers blaze"
 	},
 /turf/open/floor/grass{
 	color = "#444444"
@@ -19440,14 +19431,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "pSB" = (
-/obj/structure/fermenting_barrel{
-	name = "XANDER"
-	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
 	pixel_x = -15
 	},
+/obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -19513,9 +19502,7 @@
 	dir = 1;
 	pixel_x = -15
 	},
-/obj/structure/fermenting_barrel{
-	name = "XANDER"
-	},
+/obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -20938,10 +20925,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "reL" = (
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_x = -8;
-	pixel_y = 12
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -35532,7 +35517,7 @@ sqS
 kCD
 qFq
 tqT
-reL
+kCD
 sIR
 kCD
 kCD
@@ -35787,14 +35772,14 @@ oez
 oez
 pXV
 kCD
-dYg
+reL
 dYg
 eLX
 kCD
 vpi
 kCD
 pcM
-kCD
+bSZ
 jYv
 jFI
 ltE
@@ -37586,14 +37571,14 @@ mNn
 mNn
 mNn
 mNn
-dYg
+reL
 kCD
 pcM
 kCD
 kCD
 kCD
 kCD
-kCD
+bSZ
 jPp
 jFI
 qSl

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -15315,7 +15315,8 @@
 /obj/structure/sacredwell{
 	light_power = 20;
 	pixel_x = 16;
-	pixel_y = 23
+	pixel_y = 23;
+	density = 0
 	},
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -86796,15 +86797,8 @@
 	},
 /area/f13/wasteland/city/nash/theloop)
 "qkI" = (
-/obj/structure/bonfire/prelit{
-	pixel_y = 12
-	},
-/obj/item/stack/rods,
 /obj/structure/stone_tile/slab,
-/obj/structure/table/reinforced{
-	color = "#3c2c21";
-	max_integrity = 1000000
-	},
+/obj/structure/bonfire/dense/prelit,
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#999999"
 	},
@@ -115817,15 +115811,8 @@
 	},
 /area/f13/wasteland)
 "wPV" = (
-/obj/structure/bonfire/prelit{
-	pixel_y = 11
-	},
 /obj/structure/stone_tile/surrounding/burnt,
-/obj/item/stack/rods,
-/obj/structure/table/reinforced{
-	color = "#3c2c21";
-	max_integrity = 1000000
-	},
+/obj/structure/bonfire/dense/prelit,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_donut.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_donut.dm
@@ -446,7 +446,7 @@
 /datum/crafting_recipe/food/dessert/hotcrossbun
 	name = "Hot-Cross Bun"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/bun = 1,
 		/datum/reagent/consumable/sugar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/hotcrossbun

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -148,7 +148,7 @@
 /datum/crafting_recipe/food/hotcrossbun
 	name = "Hot-Cross Bun"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/bun = 1,
 		/datum/reagent/consumable/sugar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/hotcrossbun

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -189,8 +189,12 @@
 	end_sound = list(SOUND_LOOP_ENTRY('sound/machines/fire_crackle1.ogg', 1 SECONDS, 1))
 	volume = 100
 
-/obj/structure/bonfire/dense
+/obj/structure/bonfire/dense/Initialize()
+	. = ..()
 	density = TRUE
+	stones = TRUE
+	add_overlay("bonfire_stones")
+	return
 
 /obj/structure/bonfire/prelit/Initialize()
 	. = ..()
@@ -200,6 +204,20 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 	StartBurning()
+
+/obj/structure/bonfire/dense/prelit/Initialize()
+	. = ..()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+	StartBurning()
+
+/obj/structure/bonfire/dense/prelit/grill/Initialize()
+	. = ..()
+	grill = TRUE
+	add_overlay("bonfire_grill")
 
 /obj/structure/bonfire/CanAllowThrough(atom/movable/mover, border_dir)
 	..()

--- a/modular_coyote/code/mailbird.dm
+++ b/modular_coyote/code/mailbird.dm
@@ -51,7 +51,7 @@
 		to_chat(user, span_warning("You need an item to give to the bird you call!"))
 		return FALSE
 
-	if(mail.w_class > WEIGHT_CLASS_TINY)
+	if(mail.w_class > WEIGHT_CLASS_SMALL)
 		to_chat(user, span_warning("This item is too heavy to give to a bird!"))
 		return FALSE
 
@@ -115,7 +115,7 @@
 			mail = I
 			break
 
-	if(!istype(nut) || !istype(mail) || mail.w_class > WEIGHT_CLASS_TINY)
+	if(!istype(nut) || !istype(mail) || mail.w_class > WEIGHT_CLASS_SMALL)
 		playsound(src.loc, 'modular_coyote/sound/mobsounds/crowpeck.ogg', 50, TRUE)
 		C.visible_message(span_warning("[C] was pecked by the messenger crow!"), span_userdanger("The messenger crow pecked you and flew off!"))
 		var/obj/item/bodypart/head = C.get_bodypart("head")


### PR DESCRIPTION
## About The Pull Request
Implements a bunch of very much non-atomized changes. Sue me, I guess. If any of the following changes are contentious, I don't mind removing them!

- The Tribal mailbird's weight limit has been increased to `WEIGHT_CLASS_SMALL` from `WEIGHT_CLASS_TINY`, significantly increasing its usability. This can potentially have negative consequences, so I expect this to be the most contentious change!
- The recipe for Hot Cross Buns now uses buns instead of entire loaves of bread to produce a single serving bun.
- The bonfires in the tribe are no longer set on top of tables, and instead use a new subtype that leverages the pre-existing way of making bonfires dense. There is an additional subtype used to give the tribe kitchen a pre-existing grill.
- The barrels in the tribe garden are no longer named XANDER (presumably a holdover from Bitter Drink production). Goodbye, XANDER.
- The positions of the seed extractor and the compost bin have been swapped to allow someone to stand in arms' reach of both the seed extractor and the seed bin.
- The sacrificial well in the tribe area is no longer dense, making its' pixel-adjusted position make more sense.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: We fired two barrels named Xander. Sorry, Xander(s).
tweak: The tribe's bonfires are no longer propped up on top of tables, and wooden fuel no longer melts kitchen grills.
tweak: The position of some of the tribe's gardening tools has been shuffled around to a more logical order.
balance: The lovely Tribal mail-carrying crow Rosy has gotten stronger!
fix: New developments in Hot-Cross Bun technology allow them to be made using 3x less dough, as they no longer require a whole loaf of bread to produce!
fix: A random tile in front of the tribe's sacrificial well has gotten over its' misanthropic nature, is once again willing to let people into its life.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
