### PR TITLE
Turns the *claw emote and variants into wearable gloves.

### DIFF
--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -277,44 +277,74 @@
 	desc = "Thems some claws."
 	icon = 'icons/obj/in_hands.dmi'
 	icon_state = "clawer"
-	attack_verb = list("clawed", "swiped", "raked")
-	hitsound = "sound/weapons/bladeslice.ogg"
+	slot_flags = INV_SLOTBIT_GLOVES
 	w_class = WEIGHT_CLASS_TINY
-	force = 5
-	force_wielded = 8
+	flags_1 = CONDUCT_1
+	sharpness = SHARP_EDGED
+	attack_verb = list("punched", "jabbed", "whacked")
+	force = 8
 	throwforce = 0
 	wound_bonus = 4
 	sharpness = SHARP_EDGED
 	attack_speed = 2
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	weapon_special_component = /datum/component/weapon_special/single_turf
+	var/can_adjust_unarmed = TRUE
+	var/unarmed_adjusted = TRUE
+
+/obj/item/hand_item/clawer/equipped(mob/user, slot)
+	. = ..()
+	var/mob/living/carbon/human/H = user
+	if(unarmed_adjusted)
+		mob_overlay_icon = righthand_file
+	if(!unarmed_adjusted)
+		mob_overlay_icon = lefthand_file
+	if(ishuman(user) && slot == SLOT_GLOVES)
+		ADD_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
+		if(HAS_TRAIT(user, TRAIT_UNARMED_WEAPON))
+			H.dna.species.punchdamagehigh += force + 8 //Work around for turbo bad code here. Makes this correctly stack with your base damage. No longer makes ghouls the kings of melee.
+			H.dna.species.punchdamagelow += force + 8
+			H.dna.species.attack_sound = hitsound
+			if(sharpness == SHARP_POINTY || sharpness ==  SHARP_EDGED)
+				H.dna.species.attack_verb = pick("slash","slice","rip","tear","cut","dice")
+			if(sharpness == SHARP_NONE)
+				H.dna.species.attack_verb = pick("punch","jab","whack")
+	if(ishuman(user) && slot != SLOT_GLOVES && !H.gloves)
+		REMOVE_TRAIT(user, TRAIT_UNARMED_WEAPON, "glove")
+		if(!HAS_TRAIT(user, TRAIT_UNARMED_WEAPON)) //removing your funny trait shouldn't make your fists infinitely stack damage.
+			H.dna.species.punchdamagehigh = 10
+			H.dna.species.punchdamagelow = 1
+		if(HAS_TRAIT(user, TRAIT_IRONFIST))
+			H.dna.species.punchdamagehigh = 12
+			H.dna.species.punchdamagelow = 6
+		if(HAS_TRAIT(user, TRAIT_STEELFIST))
+			H.dna.species.punchdamagehigh = 16
+			H.dna.species.punchdamagelow = 10
+		H.dna.species.attack_sound = 'sound/weapons/punch1.ogg'
+		H.dna.species.attack_verb = "punch"
 
 /obj/item/hand_item/clawer/creature
-	force = 25
-	force_wielded = 30
+	force = 30
 
 /obj/item/hand_item/clawer/big
 	name = "Big Clawer"
 	desc = "Thems some BIG ASS claws."
 	color = "#884444"
-	force = 7
-	force_wielded = 9
+	force = 9
 	attack_speed = 3
 
 /obj/item/hand_item/clawer/razor
 	name = "Razor Sharp Clawers"
 	desc = "RIP AND TEAR."
 	color = "#FF4444"
-	force = 5
-	force_wielded = 17
+	force = 17
 	attack_speed = 4
 
 /obj/item/hand_item/clawer/fast
 	name = "Fast Clawer"
 	desc = "Thems some FAST ASS claws."
 	color = "#448844"
-	force = 4
-	force_wielded = 7
+	force = 7
 	attack_speed = 1
 
 /obj/item/hand_item/clawer/play
@@ -322,15 +352,13 @@
 	desc = "Basically just a bean thwapper."
 	color = "#FF88FF"
 	force = 0
-	force_wielded = 0
 	attack_speed = 1
 
 /obj/item/hand_item/clawer/spicy
 	name = "Spicy Clawer"
 	desc = "Your gross little litter box rakes, good for puttings idiots on the ground."
 	color = "#44FF44"
-	force = 7
-	force_wielded = 11 //7-11 haha get it bad gas station food lmao ~TK
+	force = 11//7-11 haha get it bad gas station food lmao ~TK
 	attack_speed = 4
 
 /obj/item/hand_item/clawer/spicy/attack(mob/living/M, mob/living/user)

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -281,7 +281,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
 	sharpness = SHARP_EDGED
-	attack_verb = list("punched", "jabbed", "whacked")
+	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	force = 8
 	throwforce = 0
 	wound_bonus = 4
@@ -320,8 +320,8 @@
 		if(HAS_TRAIT(user, TRAIT_STEELFIST))
 			H.dna.species.punchdamagehigh = 16
 			H.dna.species.punchdamagelow = 10
-		H.dna.species.attack_sound = 'sound/weapons/punch1.ogg'
-		H.dna.species.attack_verb = "punch"
+		H.dna.species.attack_sound = 'sound/weapons/slice.ogg'
+		H.dna.species.attack_verb = "clawed"
 
 /obj/item/hand_item/clawer/creature
 	force = 30


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Gives the *claw item and children proper unarmed tags and glove slots, so it becomes compatible with unarmed quirks / martial arts, while still keeping the versatile melee nature for big leagues and other quirks, also replaces the wielded damage by just regular force damage, since they are all quite low and weak to begin with. (plus makes it less of a headache to work with the current unarmed system)

## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->
