### PR TITLE
Makes shoes behave like all the rest of the wearable equipment that have a storage slot [ready to merge]

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -106,7 +106,7 @@
 
 /// shoes
 /datum/component/storage/concrete/pockets/shoes
-	attack_hand_interact = FALSE
+	attack_hand_interact = TRUE
 	quickdraw = TRUE
 	silent = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Literally turning a false in a true to make shoes behave like the rest of the equipment.
Now it's not possible to take off your shoes while trying to unsheathe your favourite boot knife in a panic situation.
Alt clicking to unsheathe still works, Though now to remove the shoes you have to click drag them to your hand.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Shoes behave like the rest of the wearable equipment that have a strorage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
