### PR TITLE
Makes raging boar ANGRIER

### DIFF
--- a/code/datums/martial/raging_boar.dm
+++ b/code/datums/martial/raging_boar.dm
@@ -10,7 +10,7 @@
 /datum/martial_art/raging_boar/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak,WHIRLWIND_COMBO))
 		streak = ""
-		whirlwind(A,D)
+		whirlwind(A,D) 
 		return TRUE
 	return FALSE
 
@@ -33,7 +33,7 @@
 	add_to_streak("D", D, TRUE)
 	if(check_streak(A,D))
 		return TRUE
-	var/damage = damage_roll(A,D) * 0.4
+	var/damage = damage_roll(A,D) * 0.8
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	D.visible_message(span_danger("[A] shoves [D]!"), \
 				span_userdanger("You're shoved by [A]!"), span_hear("You hear a whump!"), COMBAT_MESSAGE_RANGE, A)
@@ -55,7 +55,7 @@
 	if(check_streak(A,D))
 		return TRUE
 	. = TRUE
-	var/damage = damage_roll(A,D)
+	var/damage = (damage_roll(A,D) + 15)
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 	D.visible_message(span_danger("[A] sends [D] reeling with an atomic pork hammer!"), \
 				span_userdanger("You're sent reeling by [A]'s atomic pork hammer!"), span_hear("You hear a whump!"), COMBAT_MESSAGE_RANGE, A)
@@ -109,15 +109,17 @@
 	//deftswitch.Grant(H)
 	//sidekick.Grant(H)
 	H.AddComponent(/datum/component/tackler/simple, \
-		stamina_cost = 10, \
+		stamina_cost = 5, \
 		base_knockdown = 0, \
-		range = 6, \
+		range = 7, \
 		speed = 1, \
 		skill_mod = 0, \
 		min_distance = 1\
 	)
 	ADD_TRAIT(H, TRAIT_NOGUNS, RAGING_BOAR_TRAIT)
 	ADD_TRAIT(H, TRAIT_AUTO_CATCH_ITEM, RAGING_BOAR_TRAIT)
+	H.physiology.stamina_mod *= 0.5 //more stamina
+	H.physiology.stun_mod *= 0.5 //better stun resistance
 
 /datum/martial_art/raging_boar/on_remove(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
as it stands, raging boar is very weak compared to the other martial arts, this gives it a buff to make it more viable, by adding a flat damage boost to the punches, while making it scale worse than the beserker's multipliers, reduces slightly the stamina cost of the tackles, and gives it a weaker stamina/ stun modifier than the other martial arts (which was previously lacking)

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
