### PR TITLE
Pixel sliding iteration I [ready to merge]

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -130,6 +130,27 @@
 						to_chat(src, span_warning("[L] is restraining [P], you cannot push past."))
 					return 1
 
+		if(GLOB.pixel_slide)
+			var/origtargetloc = L.loc
+			if(!pulledby)
+				if(M.a_intent != INTENT_HELP)
+					GLOB.pixel_slide_other_has_help_int = 0
+					return TRUE
+				else
+					GLOB.pixel_slide_other_has_help_int = 1
+				if(IS_STAMCRIT(src))
+					to_chat(src, span_warning("You're too exhausted to scoot closer to [L]."))
+					return TRUE
+				visible_message(span_notice("[src] is attempting to scoot closer to [L]."),
+					span_notice("You are now attempting to scoot closer to [L]."),
+					target = L, target_message = span_notice("[src] is attempting to scoot closer to you."))
+			var/src_passmob = (pass_flags & PASSMOB)
+			pass_flags |= PASSMOB
+			Move(origtargetloc)
+			if(!src_passmob)
+				pass_flags &= ~PASSMOB
+			return TRUE
+
 	//CIT CHANGES START HERE - makes it so resting stops you from moving through standing folks without a short delay
 		if(!CHECK_MOBILITY(src, MOBILITY_STAND) && CHECK_MOBILITY(L, MOBILITY_STAND))
 			var/origtargetloc = L.loc

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1,3 +1,6 @@
+GLOBAL_VAR_INIT(pixel_slide, 0)  //if 1, initiate pixel sliding
+GLOBAL_VAR_INIT(pixel_slide_other_has_help_int, 0)  //This variable queries wheter or not the other mob is in help intent
+
 /mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
 	GLOB.mob_list -= src
 	GLOB.dead_mob_list -= src
@@ -818,6 +821,15 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	if(pixel_x <= (16 + get_standard_pixel_x_offset()))
 		pixel_x++
 		is_shifted = TRUE
+	if((pixel_x > (16 + get_standard_pixel_x_offset())) && !is_blocked_turf(get_step(src, EAST), 1))
+		if(!GLOB.pixel_slide)
+			GLOB.pixel_slide = 1
+			step(src, EAST)
+			spawn(1)  //this spawn is heavily needed to improve smoothness, remove carefully!
+				if(GLOB.pixel_slide_other_has_help_int)
+					pixel_x = -16
+			GLOB.pixel_slide = 0
+			is_shifted = TRUE
 
 /mob/living/westshift()
 	set hidden = TRUE
@@ -826,6 +838,15 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	if(pixel_x >= -(16 + get_standard_pixel_x_offset()))
 		pixel_x--
 		is_shifted = TRUE
+	if((pixel_x < -(16 + get_standard_pixel_x_offset())) && !is_blocked_turf(get_step(src, WEST), 1))
+		if(!GLOB.pixel_slide)
+			GLOB.pixel_slide = 1
+			step(src, WEST)
+			spawn(1)  //this spawn is heavily needed to improve smoothness, remove carefully!
+				if(GLOB.pixel_slide_other_has_help_int)
+					pixel_x = 16
+			GLOB.pixel_slide = 0
+			is_shifted = TRUE
 
 /mob/living/northshift()
 	set hidden = TRUE
@@ -834,6 +855,15 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	if(pixel_y <= (16 + get_standard_pixel_y_offset()))
 		pixel_y++
 		is_shifted = TRUE
+	if((pixel_y > (16 + get_standard_pixel_y_offset())) && !is_blocked_turf(get_step(src, NORTH), 1))
+		if(!GLOB.pixel_slide)
+			GLOB.pixel_slide = 1
+			step(src, NORTH)
+			spawn(1)  //this spawn is heavily needed to improve smoothness, remove carefully!
+				if(GLOB.pixel_slide_other_has_help_int)
+					pixel_y = -16
+			GLOB.pixel_slide = 0
+			is_shifted = TRUE
 
 /mob/living/southshift()
 	set hidden = TRUE
@@ -842,6 +872,15 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	if(pixel_y >= -(16 + get_standard_pixel_y_offset()))
 		pixel_y--
 		is_shifted = TRUE
+	if((pixel_y < -(16 + get_standard_pixel_y_offset())) && !is_blocked_turf(get_step(src, SOUTH), 1))
+		if(!GLOB.pixel_slide)
+			GLOB.pixel_slide = 1
+			step(src, SOUTH)
+			spawn(1)  //this spawn is heavily needed to improve smoothness, remove carefully!
+				if(GLOB.pixel_slide_other_has_help_int)
+					pixel_y = 16
+			GLOB.pixel_slide = 0
+			is_shifted = TRUE
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
This is a simple change to the pixel shifting system, what this basically does, is to allow a player to enter someone else's tile without the need to flop on the floor. There are a lot of rules and checks to this, such as the other person needs to be in help intent and more! Should be unexploitable now, but before this point, unlimited speed and the ability to phase through bunker walls thanks to your erp buddy was an actual threat.

![4e356ee15d4b0657c35b63b45787b67a](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/48703953-b21f-4317-9d9c-242c48579860)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds pixel sliding to another tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
