### PR TITLE
Tweaks magic (and the p90) (good to go if it passes checks)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -589,6 +589,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m10mm_p90
 	init_mag_type = /obj/item/ammo_box/magazine/m10mm_p90
 	weapon_class = WEAPON_CLASS_CARBINE
+	w_class = WEIGHT_CLASS_NORMAL // Kelp here - the gun is extremely rare and even with the 50rnd magazine it's considered outclassed. This makes it a good, if unwieldy, secondary or holdout gun. Will let it cook and see if it needs removed.
 	weapon_weight = GUN_ONE_HAND_AKIMBO
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = AUTOCARBINE_RECOIL(1, 1)
@@ -633,7 +634,7 @@
 *- takes only uzi magazines
 * - high recoil
 * + comes supressed
-* * * * * * * * * * * */ 
+* * * * * * * * * * * */
 
 /obj/item/gun/ballistic/automatic/smg/m22
 	name = "M22 Night Ops SMG"
@@ -1288,7 +1289,7 @@
 * Matilda Rifle
 * Lightweight low damage dealing rifle with a 20 mag only
 * - MUCH slower than a varmint
-* + Higher damage than a varmint 
+* + Higher damage than a varmint
 * - Unable to be modified with bayonets, flashlights or a scope
 * + common tier rifle
 * * * * * * * * * * */
@@ -2550,7 +2551,7 @@
 	)
 	can_scope = TRUE
 	can_suppress = FALSE
-	can_flashlight = FALSE 
+	can_flashlight = FALSE
 	fire_sound = 'sound/f13weapons/automaticrifle_BAR.ogg'
 
 /obj/item/gun/ballistic/automatic/fnfal/g3battlerifle

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -272,7 +272,7 @@
 	desc = "A golden rod sits securely in a handle of runed wood. Attuned to this wand is the most iconic of mage spells, Magic Missile; it's a simple spell for more practical practitioners."
 	icon_state = "magicmissile"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/magicmissile/average
-	max_charges = 30
+	max_charges = 25
 	recharge_rate = 10 SECONDS
 
 /obj/item/ammo_casing/magic/kelpmagic/magicmissile/average
@@ -297,8 +297,8 @@
 	icon_state = "lightningrod"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/sparks
-	max_charges = 60
-	recharge_rate = 5 SECONDS
+	max_charges = 30
+	recharge_rate = 6 SECONDS
 	init_firemodes = list(
 		/datum/firemode/automatic/rpm150,
 		/datum/firemode/semi_auto/faster
@@ -341,7 +341,7 @@
 	icon_state = "fireboltwand"
 	fire_sound = 'sound/magic/fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/firebolt
-	max_charges = 15
+	max_charges = 10
 	recharge_rate = 20 SECONDS
 
 /obj/item/ammo_casing/magic/kelpmagic/firebolt


### PR DESCRIPTION
## About The Pull Request
Title

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- P90 is now normal sized due to being outclassed despite the 50rnd mag. May need to revert in the future, or disable it being used akimbo down the line
- Decreased Firebolt wand charges (outshone literally every high cal secondary, whoops)
- Sparks wand has decreased charges and slightly increased charge time per shot (still good v swarms, less good v tougher mobs now)
- Wand of Magic Missile slightly nerfed (intended to be just barely worse than Firebolt/Sparks, adjusted to stay there)

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
