### PR TITLE
Shameless rider kit buff (and to some degree, beastmaster buff)

### DIFF
--- a/code/game/objects/items/loadout_toolkits.dm
+++ b/code/game/objects/items/loadout_toolkits.dm
@@ -60,9 +60,9 @@
 	new /obj/item/brahminbridle(src)
 	new /obj/item/brahminsaddle(src)
 	new /obj/item/brahminbrand(src)
-		/obj/item/capturedevice(src)//hopefully this will make having a pet motorcycle a lot less annoying
+	new /obj/item/capturedevice(src)//hopefully this will make having a pet motorcycle a lot less annoying
 	new /obj/item/choice_beacon/pet/mountable(src)
-        /object
+
 /datum/loadout_box/ranching
 	entry_tag = "riding tools"
 	entry_flags = LOADOUT_FLAG_TOOL_WASTER
@@ -579,7 +579,7 @@
 
 /obj/item/storage/box/tools/beastmaster/PopulateContents()
 	new /obj/item/capturedevice(src)
-		/obj/item/capturedevice(src)
+	new	/obj/item/capturedevice(src)
 	new /obj/item/lazarus_injector(src)
 	new /obj/item/lazarus_injector(src)
 	new /obj/item/lazarus_injector(src)

--- a/code/game/objects/items/loadout_toolkits.dm
+++ b/code/game/objects/items/loadout_toolkits.dm
@@ -60,8 +60,9 @@
 	new /obj/item/brahminbridle(src)
 	new /obj/item/brahminsaddle(src)
 	new /obj/item/brahminbrand(src)
+		/obj/item/capturedevice(src)//hopefully this will make having a pet motorcycle a lot less annoying
 	new /obj/item/choice_beacon/pet/mountable(src)
-
+        /object
 /datum/loadout_box/ranching
 	entry_tag = "riding tools"
 	entry_flags = LOADOUT_FLAG_TOOL_WASTER
@@ -578,6 +579,7 @@
 
 /obj/item/storage/box/tools/beastmaster/PopulateContents()
 	new /obj/item/capturedevice(src)
+		/obj/item/capturedevice(src)
 	new /obj/item/lazarus_injector(src)
 	new /obj/item/lazarus_injector(src)
 	new /obj/item/lazarus_injector(src)


### PR DESCRIPTION
adds a capture device to the rider kit, so it's a lot easier to have your own pet chocobo / motorcycle without them constantly dying due to ghouls attacking them or getting stolen due to the lack of keys, buffs beastmaster by adding an additional capture egg to the kit, to hopefully encourage more diversity in battle pets, (i'll probably make an eggless version of the rider kit for cargo if people abuse this)

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->
