### PR TITLE
Hides players' ckeys from the orbit list

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -270,6 +270,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if(M.client && M.client.holder && M.client.holder.fakekey) //stealthmins
 			continue
 		var/name = avoid_assoc_duplicate_keys(M.name, namecounts)
+		if(findtext(ckey(name), M.ckey) || isnewplayer(M))
+			name = pick(GLOB.cow_names)
 
 		if(M.real_name && M.real_name != M.name)
 			name += " \[[M.real_name]\]"


### PR DESCRIPTION
## About The Pull Request
If you're a New Player (ghost mob that you are before you join the actual game) or your name contains your ckey, it'll replace the ghost name thing with a random cow name. Might make Aldric show up as Tux (short for Tuxedo), but that's  a risk I'm willing to take.