### PR TITLE
WANDerful: Quirk to use wands, creatures don't need the quirk to use them [ready to merge]

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -304,6 +304,7 @@
 #define TRAIT_NO_ALCOHOL		"alcohol_intolerance"
 #define TRAIT_MUTATION_STASIS			"mutation_stasis" //Prevents processed genetics mutations from processing.
 #define TRAIT_FAST_PUMP				"fast_pump"
+#define TRAIT_WAND_PROFICIENT 	"wand_proficient"
 #define TRAIT_AUTO_DRAW				"auto_draw" //can use bows good
 #define TRAIT_PLAY_DEAD "play_dead" // gives 10u ghoul powder every *deathgasp
 #define TRAIT_NO_PROCESS_FOOD	"no-process-food" // You don't get benefits from nutriment, nor nutrition from reagent consumables

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1492,6 +1492,19 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	lose_text = span_danger("After picking some 250 year old cosmoline out from under one of your nails you realize that... Uh, no, the Mosin Nagant is a piece of shit.")
 	locked =  FALSE
 
+/datum/quirk/wandproficient
+	name = "Wand Proficient"
+	desc = "You know how to use magic wands!"
+	value = 0
+	category = "Ranged Quirks"
+	mechanics = "You can use magic wands."
+	// conflicts = list(
+	// )
+	mob_trait = TRAIT_WAND_PROFICIENT
+	gain_text = span_notice("You feel magic flowing through your veins!")
+	lose_text = span_danger("The magic within you fades away.")
+	locked = FALSE
+
 /datum/quirk/playdead
 	name = "Play Dead"
 	desc = "You're good at acting!"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1497,7 +1497,7 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	desc = "You know how to use magic wands!"
 	value = 0
 	category = "Ranged Quirks"
-	mechanics = "You can use magic wands."
+	mechanics = "You can use magic wands, but the cost for such is to not being able to learn a martial art. The moment you'll learn one, you'll never be able to use wands!"
 	// conflicts = list(
 	// )
 	mob_trait = TRAIT_WAND_PROFICIENT

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -557,9 +557,7 @@ ATTACHMENTS
 
 	if(is_kelpwand)
 		if(iscarbon(user))
-			
 			if(type == /obj/item/gun/magic/wand/kelpmagic/magicmissile)
-			//if(istype(src, /obj/item/gun/magic/wand/kelpmagic/magicmissile))
 				if(HAS_TRAIT(user, TRAIT_NOGUNS))
 					to_chat(user, span_danger("You don't know how to use magic wands!"))
 					return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -554,9 +554,20 @@ ATTACHMENTS
 	if(on_cooldown(user))
 		return
 	clear_cooldown_mods()
-	if(is_kelpwand && !HAS_TRAIT(user, TRAIT_WAND_PROFICIENT))
-		to_chat(user, span_danger("You don't know how to use magic wands!"))
-		return
+
+	if(is_kelpwand)
+		if(iscarbon(user))
+			
+			if(type == /obj/item/gun/magic/wand/kelpmagic/magicmissile)
+			//if(istype(src, /obj/item/gun/magic/wand/kelpmagic/magicmissile))
+				if(HAS_TRAIT(user, TRAIT_NOGUNS))
+					to_chat(user, span_danger("You don't know how to use magic wands!"))
+					return
+			else
+				if(HAS_TRAIT(user, TRAIT_NOGUNS) || !HAS_TRAIT(user, TRAIT_WAND_PROFICIENT))
+					to_chat(user, span_danger("You don't know how to use magic wands!"))
+					return
+
 	if(safety)
 		to_chat(user, span_danger("The gun's safety is on!"))
 		shoot_with_empty_chamber(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -175,6 +175,8 @@ ATTACHMENTS
 	var/prefered_power
 	/// Does the gun use the bullet's sounds, instead of its own?
 	var/use_casing_sounds
+	/// Is one of Kelp's wands?
+	var/is_kelpwand = FALSE
 	/// Cooldown between times the gun will tell you it shot, 0.5 seconds cus its not super duper important
 	COOLDOWN_DECLARE(shoot_message_antispam)
 
@@ -552,6 +554,9 @@ ATTACHMENTS
 	if(on_cooldown(user))
 		return
 	clear_cooldown_mods()
+	if(is_kelpwand && !HAS_TRAIT(user, TRAIT_WAND_PROFICIENT))
+		to_chat(user, span_danger("You don't know how to use magic wands!"))
+		return
 	if(safety)
 		to_chat(user, span_danger("The gun's safety is on!"))
 		shoot_with_empty_chamber(user)

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -220,6 +220,7 @@
 	throwforce = 10 // Same.
 	fire_sound = 'sound/weapons/pulse2.ogg'
 	draw_time = GUN_DRAW_QUICK
+	is_kelpwand = TRUE
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slow
 	)


### PR DESCRIPTION
## About The Pull Request
I do as the kelpmaster commands.
Quirk for wands! Now you need to be proficient to use wands. Wands and martial arts can't be used together. Creatures on the other hand, can use all wands.
The bone one can be used by everyone, quirk or not, as long as they don't know a martial art.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added TRAIT_WAND_PROFICIENT
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
