### PR TITLE
No more limb loss by big explosions [ready to merge]

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -348,16 +348,16 @@
 	take_overall_damage(brute_loss,burn_loss)
 
 	//attempt to dismember bodyparts
-	if(severity <= 2 || !bomb_armor)
-		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
-		for(var/X in bodyparts)
-			var/obj/item/bodypart/BP = X
-			if(prob(15/severity) && !prob(getarmor(BP, "bomb")) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
-				BP.brute_dam = BP.max_damage
-				BP.dismember()
-				max_limb_loss--
-				if(!max_limb_loss)
-					break
+	// if(severity <= 2 || !bomb_armor)
+	// 	var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
+	// 	for(var/X in bodyparts)
+	// 		var/obj/item/bodypart/BP = X
+	// 		if(prob(15/severity) && !prob(getarmor(BP, "bomb")) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
+	// 			BP.brute_dam = BP.max_damage
+	// 			BP.dismember()
+	// 			max_limb_loss--
+	// 			if(!max_limb_loss)
+	// 				break
 
 
 /mob/living/carbon/human/blob_act(obj/structure/blob/B)


### PR DESCRIPTION
## About The Pull Request
As the name states, no more loosing limbs due to big explosions, as requested.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: Removed limb loss by explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
