### PR TITLE
Fixes the Wand of Firebolt craft (Good to go if it passes checks)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -554,7 +554,7 @@ datum/crafting_recipe/tribalwar/bone
 // T1 Firebolt Wand (anti-elite sidearm)
 /datum/crafting_recipe/magic/fireboltwand
 	name = "Wand of Firebolt"
-	result = /obj/item/gun/magic/staff/kelpmagic/fireball
+	result = /obj/item/gun/magic/wand/kelpmagic/firebolt
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
 				/obj/item/stack/crafting/metalparts = 10,


### PR DESCRIPTION
## About The Pull Request
Title. Accidentally made it so the Wand of Firebolt and Staff of Fireball had the same output.

Wand of Firebolt now *actually* gives you a Wand of Firebolt.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
