### PR TITLE
[Testmerge ONLY!!] Fixes chest-mounted equipment from displaying on top of clothes when they shouldn't.

### DIFF
--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -130,7 +130,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		L = get_equipped_items()
 	for(var/A in L)
 		var/obj/item/I = A
-		if(I.body_parts_hidden & GROIN)
+		if(I.body_parts_covered & GROIN)
 			return FALSE
 	return TRUE
 
@@ -139,7 +139,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		L = get_equipped_items()
 	for(var/A in L)
 		var/obj/item/I = A
-		if(I.body_parts_hidden & CHEST)
+		if(I.body_parts_covered & CHEST)
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Reverts a change of #448 that broke a lot of clothing items.
What it did was make it so the game stops looking at what parts of your body your clothes cover up, and instead look at a new variable that _should_ do the same thing, but still allow you 'female body armor™'. This new variable, however, is not set on a lot of clothing items, thus breaking them.

It this works, we can re-implant the changes of #448 as a simple "show-it-anyway" override. So instead, we still check at what parts are covered up, but we also check for this override that'll be set to no by default.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] ~~This code did not runtime during testing.~~ This code did not runtime during testing to anything related.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Fixes a lot of clothing items to only show your off your enterprise resource planning assets when they should be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
