### PR TITLE
No More Manifest

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -28,13 +28,13 @@
 
 /obj/item/pda/security
 	name = "security PDA"
-	default_cartridge = /obj/item/cartridge/security
+	//default_cartridge = /obj/item/cartridge/security
 	icon_state = "pda-security"
 	skindex = "Security PDA"
 
 /obj/item/pda/detective
 	name = "detective PDA"
-	default_cartridge = /obj/item/cartridge/detective
+	//default_cartridge = /obj/item/cartridge/detective
 	icon_state = "pda-detective"
 	skindex = "Detective PDA"
 
@@ -71,7 +71,7 @@
 
 /obj/item/pda/heads/hos
 	name = "head of security PDA"
-	default_cartridge = /obj/item/cartridge/hos
+	//default_cartridge = /obj/item/cartridge/hos
 	icon_state = "pda-hos"
 	skindex = "Head of Security PDA"
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

PDAs for security law jobs will no longer have cartridges. This will keep them from informing people of the entire region's population and also having a way to check on DNA and fingerprints. These are SS13 features that aren't really productive to wasteland roleplay. Mostly because there is no way they have a record of each Wastelander and non citizen that will come by.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
