### PR TITLE
Minor robes buff for cult event

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -223,8 +223,7 @@
 	armor = ARMOR_VALUE_MEDIUM
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_DT_T2)
-	mutantrace_variation = NONE
-	
+
 /obj/item/clothing/head/hooded/robes
 	name = "brown hood"
 	desc = "Perfect for concealing your identity."
@@ -232,7 +231,6 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES
 	flash_protect = 2
-	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_DT_T2)
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -218,14 +218,23 @@
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/robes
-
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/duster/armored
+	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
+	armor = ARMOR_VALUE_MEDIUM
+	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T1 * ARMOR_SLOWDOWN_GLOBAL_MULT
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_DT_T2)
+	mutantrace_variation = NONE
+	
 /obj/item/clothing/head/hooded/robes
 	name = "brown hood"
 	desc = "Perfect for concealing your identity."
 	icon_state = "eldritch"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags_cover = HEADCOVERSEYES
 	flash_protect = 2
+	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
+	armor = ARMOR_VALUE_MEDIUM
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_DT_T2)
 
 /obj/item/clothing/suit/hooded/robes/grey
 	name = "grey robes"

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -11,12 +11,12 @@
 /datum/gear/suit/greyrobes
 	name = "Grey robes"
 	path = /obj/item/clothing/suit/hooded/robes/grey
-	cost = 0
+	cost = 2
 
 /datum/gear/suit/brownrobes
 	name = "Brown robes"
 	path = /obj/item/clothing/suit/hooded/robes
-	cost = 0
+	cost = 2
 
 /datum/gear/suit/hoodedmask
 	name = "patched heavy leather cloak"


### PR DESCRIPTION
makes the loadout grey and brown robes be equivalent to medium loadout armor, 2 point cost, same as the other armors.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

