### PR TITLE
Smart inventory slot unsheathing [ready to merge]

### DIFF
--- a/code/modules/keybindings/keybind/human.dm
+++ b/code/modules/keybindings/keybind/human.dm
@@ -22,9 +22,7 @@
 	else if(isanimal(user.mob))
 		var/mob/living/simple_animal/SA = user.mob
 		SA.quick_equip()
-	
 
-/*
 /datum/keybinding/human/quick_equipbelt
 	hotkey_keys = list("ShiftE")
 	name = "quick_equipbelt"
@@ -39,11 +37,10 @@
 /datum/keybinding/human/bag_equip
 	hotkey_keys = list("ShiftB")
 	name = "bag_equip"
-	full_name = "Bag equip"
+	full_name = "Quick equip bag"
 	description = "Put held thing in backpack or take out most recent thing from backpack"
 
 /datum/keybinding/human/bag_equip/down(client/user)
 	var/mob/living/carbon/human/H = user.mob
 	H.smart_equipbag()
 	return TRUE
-*/

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -1,7 +1,3 @@
-//This variable is needed in order to remember the origin of the storage of an item.
-// GLOBAL_VAR_INIT(quick_equip_memory_item, 0)
-// GLOBAL_VAR_INIT(quick_equip_memory_origin, 0)
-GLOBAL_VAR_INIT(quick_equip_cowboy_delay_negation, 0)
 //These procs handle putting s tuff in your hands
 //as they handle all relevant stuff like adding it to the player's screen and updating their overlays.
 
@@ -518,10 +514,8 @@ GLOBAL_VAR_INIT(quick_equip_cowboy_delay_negation, 0)
 						firearm = F
 						break
 					if(firearm && !firearm.on_found(src))
-						GLOB.quick_equip_cowboy_delay_negation = 1
+						firearm.allow_quickdraw = TRUE
 						firearm.attack_hand(src)  //Slap my hands with the contents of this storage, which is allegedly only one item.
-						spawn(1)  //it's not needed, but let's wait for the system to actually process the firedelay.
-							GLOB.quick_equip_cowboy_delay_negation = 0
 						return
 		storage = get_item_by_slot(SLOT_SHOES)  //Shoes are a little different, we don't want to return the item itself, but rather its contents.
 		if(storage)  //Are we carrying something in this storage slot?

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -492,14 +492,16 @@ GLOBAL_VAR_INIT(quick_equip_memory_origin, 0)
 	else  //Are we empty handed?
 		storage = get_item_by_slot(SLOT_S_STORE)
 		if(storage)  //Are we carrying something in this storage slot?
-			if(!SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))  //Is this NOT a storage item? (we don't want to return a pouch or something in our hands, only items that have no storage)
-				storage.attack_hand(src)  //Slap my hands with the contents of this storage, which is allegedly only one item.
-				return
+			if(!istype(storage, /obj/item/flashlight))  //this is my personal preference, basically it ignores returning flashlights on your hands, why? because it's silly otherwise!
+				if(!SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))  //Is this NOT a storage item? (we don't want to return a pouch or something in our hands, only items that have no storage)
+					storage.attack_hand(src)  //Slap my hands with the contents of this storage, which is allegedly only one item.
+					return
 		storage = get_item_by_slot(SLOT_BELT)
 		if(storage)  //We basically repeat the same checks but for belts
-			if(!SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))
-				storage.attack_hand(src)
-				return
+			if(!istype(storage, /obj/item/flashlight))  //this is my personal preference, basically it ignores returning flashlights on your hands, why? because it's silly otherwise!
+				if(!SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))
+					storage.attack_hand(src)
+					return
 		storage = get_item_by_slot(SLOT_NECK)  //Are we wearing a holster? If yes, we want to prioritize the unholstering of the gun.
 		if(storage)  //Are we carrying something in this storage slot?
 			if(SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))  //Is this a storage item?

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -1,6 +1,7 @@
 //This variable is needed in order to remember the origin of the storage of an item.
 GLOBAL_VAR_INIT(quick_equip_memory_item, 0)
 GLOBAL_VAR_INIT(quick_equip_memory_origin, 0)
+GLOBAL_VAR_INIT(quick_equip_cowboy_delay_negation, 0)
 //These procs handle putting s tuff in your hands
 //as they handle all relevant stuff like adding it to the player's screen and updating their overlays.
 
@@ -511,9 +512,12 @@ GLOBAL_VAR_INIT(quick_equip_memory_origin, 0)
 						firearm = F
 						break
 					if(firearm && !firearm.on_found(src))
+						GLOB.quick_equip_cowboy_delay_negation = 1
 						firearm.attack_hand(src)  //Slap my hands with the contents of this storage, which is allegedly only one item.
 						GLOB.quick_equip_memory_item = firearm
 						GLOB.quick_equip_memory_origin = "SLOT_NECK"
+						spawn(1)  //it's not needed, but let's wait for the system to actually process the firedelay.
+							GLOB.quick_equip_cowboy_delay_negation = 0
 					return
 		storage = get_item_by_slot(SLOT_SHOES)  //Shoes are a little different, we don't want to return the item itself, but rather its contents.
 		if(storage)  //Are we carrying something in this storage slot?

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -470,8 +470,12 @@ GLOBAL_VAR_INIT(quick_equip_cowboy_delay_negation, 0)
 	set name = "quick-equip"
 	set hidden = 1
 
+	if(incapacitated())
+		return
+
 	var/obj/item/storage
 	var/obj/item/I = get_active_held_item()
+
 	if(I)
 		if(I == GLOB.quick_equip_memory_item)  //did I unsheathe my item from a holster or my boots?
 			if(GLOB.quick_equip_memory_origin == "SLOT_NECK")  //was it previously coming from my holster?

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -458,8 +458,7 @@
 // 4-Boot contents.
 
 // There's one more twist to this, for example, if the user had previously unsheathed a revolver from a shoulder holster,
-// we clearly want the revolver to be re-sheathed in the previous location, this is why there are these new variables:
-// quick_equip_memory_item and quick_equip_memory_origin, that keep track of this exact thing.
+// we clearly want the revolver to be re-sheathed in the previous location.
 // If anything is broken, or not working properly, contact me or fix it -leonzrygin
 //<--
 /mob/verb/quick_equip()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -325,7 +325,7 @@
 	stored.attack_hand(src) // take out thing from backpack
 	return
 
-/mob/living/carbon/human/proc/smart_equipbelt() // put held thing in belt or take most recent item out of belt
+/mob/living/carbon/human/proc/smart_equipbelt() // put held thing in belt or take most recent item out of belt //
 	if(incapacitated())
 		return
 	var/obj/item/thing = get_active_held_item()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -177,6 +177,8 @@ ATTACHMENTS
 	var/use_casing_sounds
 	/// Is one of Kelp's wands?
 	var/is_kelpwand = FALSE
+	/// Allow quickdraw (delay to draw the gun is 0s)
+	var/allow_quickdraw = FALSE
 	/// Cooldown between times the gun will tell you it shot, 0.5 seconds cus its not super duper important
 	COOLDOWN_DECLARE(shoot_message_antispam)
 
@@ -876,7 +878,8 @@ ATTACHMENTS
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message(span_danger("[user] grabs \a [G]!")) // probably could code in differences as to where you're picking it up from and so forth. later.
 	var/time_till_gun_is_ready = max(draw_time,(user.AmountWeaponDrawDelay()))
-	if(GLOB.quick_equip_cowboy_delay_negation)
+	if(allow_quickdraw)
+		allow_quickdraw = FALSE
 		time_till_gun_is_ready = 0
 	user.SetWeaponDrawDelay(time_till_gun_is_ready)
 	if(safety && user.a_intent == INTENT_HARM)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -876,6 +876,8 @@ ATTACHMENTS
 /obj/item/gun/proc/weapondraw(obj/item/gun/G, mob/living/user) // Eventually, this will be /obj/item/weapon and guns will be /obj/item/weapon/gun/etc. SOON.tm
 	user.visible_message(span_danger("[user] grabs \a [G]!")) // probably could code in differences as to where you're picking it up from and so forth. later.
 	var/time_till_gun_is_ready = max(draw_time,(user.AmountWeaponDrawDelay()))
+	if(GLOB.quick_equip_cowboy_delay_negation)
+		time_till_gun_is_ready = 0
 	user.SetWeaponDrawDelay(time_till_gun_is_ready)
 	if(safety && user.a_intent == INTENT_HARM)
 		toggle_safety(user, ignore_held = TRUE)


### PR DESCRIPTION
## About The Pull Request
Stupidly complicated smart equip/unequip, what is this supposed to do:
If the user is empty handed and triggers this function, then unholster an item with priority and with exceptions in the following order:
1-Backpack slot;
2-Armor slot;
3-Belt slot;
4-Holster contents, return ONLY firearms, all other items will be ignored;
5-Boot contents.

It also ignores people who wear their flashlights on these slots, it's smart, smarter than me.

There's one more twist to this, for example, if the user had previously unsheathed a revolver from a shoulder holster,
we clearly want the revolver to be re-sheathed in the previous location, this is why memory of item and origin of said item have been added.

There's one edit of this, if using quick equip with shoulder holsters, the cocking delay of the gun is close to 0, but before you freak out and call this change unbalanced, let's think about consequences of this.
First of all, in order to quick equip a weapon on your hands from the shoulder holster, it needs to follow a priority order, meaning that armor slot and belt slot need to be free of weapons. This implies that your handgun in your shoulder holster is your main weapon, there aren't many guns that can fit in this space to begin with too.
Second of all, committing to a shoulder holster means that you're not going to wear other also useful items such as the casing bag or the vietnam-war style flashlight, this on its own it's a big investment.

This pr also reactivates the quick backpack and quick belt equip, because they can be useful for QoL stuff. we can always turn them off if these becomes an issue, but benefit of the doubt.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds smart unsheathing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
