### PR TITLE
Synthjuice (Good to go if it passes checks)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1433,12 +1433,12 @@
 	return TRUE
 
 /datum/reagent/fuel/robo_repair_gel
-	name = "Synthetic repair gel"
+	name = "synthetic repair gel"
 	description = "A synthetic gel that can be used to repair damage to synthetic bodies."
 	color = "#33ff00" // rgb: 102, 0, 0
 	flammable = FALSE
-	heal_amount = 1
-	heal_amount_crit = 4
+	heal_amount = -1.0
+	heal_amount_crit = -1.5
 
 /datum/reagent/abraxo_cleaner
 	name = "Abraxo cleaner"

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -522,3 +522,9 @@
 	var/bottle_name = pick("candy", "fun", "discarded", "forgotten", "old", "ancient", "random", "unknown", "strange", "abandoned", "hobo", "trash", "forsaken", "alluring", "peculiar", "anomalous", "unfamiliar", "odd", "funny", "tasty", "neglected", "mysterious", "strange")
 	name = "[bottle_name] bottle"
 	. = ..()
+
+/obj/item/reagent_containers/glass/bottle/synthjuice
+	name = "synthetic repair paste"
+	desc = "A small bottle full of synthetic repair gel. Not for organic consumption."
+	volume = 30
+	list_reagents = list(/datum/reagent/fuel/robo_repair_gel = 30)

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
@@ -273,3 +273,11 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/vial/large
 	category = list("initial","Medical","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/synthjuice
+	name = "Synth Repair Gel"
+	id = "synthetic_repair_paste"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/gold = 500, /datum/material/silver = 500, /datum/material/glass = 500)
+	build_path = /obj/item/reagent_containers/glass/bottle/synthjuice
+	category = list("initial", "Medical")

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -166,6 +166,7 @@
 	materials = list(/datum/material/iron = 150, /datum/material/glass = 150)
 	build_path = /obj/item/geiger_counter
 	category = list("initial", "Tools")
+
 /datum/design/cleaner
 	name = "Abraxo cleaner"
 	id = "cleaner"


### PR DESCRIPTION
## About The Pull Request
Fixes the synth repair gel to, y'know, actually heal synths and makes it obtainable.

Personal note: This is largely a temporary setup. How temporary depends on how long it takes me to figure out how autocycling works and how to apply it to stuff like welders and cables. May end up moving the healjuice to the crafting tab down the line. Might even make a proper chem recipe, if I'm feeling insane.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Synth repair gel added to autolathe for 500/500/500 gold/silv/glass
- Synth repair gel now heals synthetics properly, and has a description reflecting this; has 2x the power of welding fuel but requires two in-demand materials and glass which can be hard to get (mostly because people forget about the materials vendor)

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
