### PR TITLE
Tackle tweaks (TEST PR)

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -30,9 +30,13 @@
 	var/datum/thrownthing/tackle
 	/// Is it just a simple dive-kick?
 	var/simple_dunk
-
+	// is it just a STRONG simple dive-kick?
+	var/simple_dunkstrong
 /datum/component/tackler/simple
 	simple_dunk = TRUE
+
+/datum/component/tackler/simple_dunkstrong
+	simple_dunkstrong = TRUE
 
 /datum/component/tackler/Initialize(stamina_cost = 25, base_knockdown = 1 SECONDS, range = 4, speed = 1, skill_mod = 0, min_distance = min_distance)
 	if(!iscarbon(parent))
@@ -146,6 +150,10 @@
 
 	if(simple_dunk && isliving(hit))
 		simple_sack(user, hit)
+		return
+
+	if(simple_dunkstrong && isliving(hit))
+		simple_sackstrong(user, hit)
 		return
 
 	if(!iscarbon(hit))
@@ -296,6 +304,70 @@
 		return
 	var/atom/throw_target = get_ranged_target_turf(hit, get_dir(user, hit), rand(CEILING(damage_mod * 0.5, 1), CEILING(damage_mod, 1)), 2)
 	hit.safe_throw_at(throw_target, 10, 1, user, TRUE)
+
+	SEND_SIGNAL(user, COMSIG_CARBON_TACKLED, CEILING(damage_mod, 1))
+	return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH
+
+//crappy "strong" version of the simple dunk, meant for high tier quirks and raging boar.
+/datum/component/tackler/proc/simple_sackstrong(mob/living/carbon/user, mob/living/hit)
+	if(!iscarbon(user) || !isliving(hit))
+		return
+
+	var/roll = iscarbon(hit) ? rollTackle(hit) : 10// extra damage to simplemobs (For some reason it's less than it seems)
+	user.tackling = FALSE
+
+	var/tackle_damage = 10
+	if(HAS_TRAIT(user, TRAIT_IRONFIST))
+		tackle_damage = 20
+	else if(HAS_TRAIT(user, TRAIT_STEELFIST))
+		tackle_damage = 30 //for whatever reason the original code for this has fucked up calculations, only the fist values apply//
+	var/damage_mod = 1
+
+	switch(roll)
+		if(-INFINITY to -5)
+			damage_mod *= 0.5
+		if(-4 to -2)
+			damage_mod *= 0.8
+		if(2 to 3)
+			damage_mod *= 1.5
+		if(4 to INFINITY)
+			damage_mod *= 2
+
+	if(tackle?.dist_travelled)
+		damage_mod *= (1.5 + (2*tackle.dist_travelled))
+
+	switch(damage_mod)
+		if(-INFINITY to 1)
+			user.visible_message(
+				span_warning("[user] rams into [hit] with a flying tackle!"), 
+				span_userdanger("You rams into [hit] with a flying tackle!"), 
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] rams into you!"))
+		if(1.1 to 3)
+			user.visible_message(
+				span_warning("[user] slams into [hit] with a deadly charge!"), 
+				span_userdanger("You slam into [hit] with a deadly charge!"), 
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] slams into you!"))
+		if(3.1 to INFINITY)
+			user.visible_message(
+				span_warning("[user] CRASHES into [hit] with an powerful dropkick!"), 
+				span_userdanger("You CRASH into [hit] with a powerful dropkick!"), 
+				ignored_mobs = list(hit))
+			to_chat(hit, span_userdanger("[user] CRASHES into you!"))
+	playsound(user, 'sound/effects/flesh_impact_1.ogg', 60, TRUE)
+	if(damage_mod >= 2)
+		hit.emote("scream")
+	user.emote("scream")
+	
+	var/armormult = clamp(hit.getarmor(BODY_ZONE_CHEST, "melee"), 0, 1)
+
+	hit.apply_damage(tackle_damage, STAMINA, BODY_ZONE_CHEST, armormult)
+	hit.apply_damage(tackle_damage, BRUTE, BODY_ZONE_CHEST, armormult)
+	if(hit.anchored)
+		return
+	var/atom/throw_target = get_ranged_target_turf(hit, get_dir(user, hit), rand(CEILING(damage_mod * 0.5, 1), CEILING(damage_mod, 3)), 2)
+	hit.throw_at(throw_target, 10, 1, user, TRUE)
 
 	SEND_SIGNAL(user, COMSIG_CARBON_TACKLED, CEILING(damage_mod, 1))
 	return COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -313,7 +313,7 @@
 	if(!iscarbon(user) || !isliving(hit))
 		return
 
-	var/roll = iscarbon(hit) ? rollTackle(hit) : 10// extra damage to simplemobs (For some reason it's less than it seems)
+	var/roll = iscarbon(hit) ? rollTackle(hit) : 10 // extra damage to simplemobs (For some reason it's less than it seems)
 	user.tackling = FALSE
 
 	var/tackle_damage = 10

--- a/code/datums/martial/raging_boar.dm
+++ b/code/datums/martial/raging_boar.dm
@@ -108,8 +108,8 @@
 		return
 	//deftswitch.Grant(H)
 	//sidekick.Grant(H)
-	H.AddComponent(/datum/component/tackler/simple, \
-		stamina_cost = 5, \
+	H.AddComponent(/datum/component/tackler/simple_dunkstrong, \
+		stamina_cost = 10, \
 		base_knockdown = 0, \
 		range = 7, \
 		speed = 1, \

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -299,10 +299,10 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 
 /datum/quirk/tackler/add()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.AddComponent(/datum/component/tackler, \
+	H.AddComponent(/datum/component/tackler/simple, \
 		stamina_cost = 30, \
-		base_knockdown = 1.75 SECONDS, \
-		range = 5, \
+		base_knockdown = 0 SECONDS, \
+		range = 4, \
 		speed = 1, \
 		skill_mod = -1, \
 		min_distance = 0 \
@@ -329,8 +329,8 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 
 /datum/quirk/tackleradv/add()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.AddComponent(/datum/component/tackler, \
-		stamina_cost = 25, \
+	H.AddComponent(/datum/component/tackler/simple, \
+		stamina_cost = 20, \
 		base_knockdown = 0 SECONDS, \
 		range = 7, \
 		speed = 2, \
@@ -358,9 +358,9 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 
 /datum/quirk/tacklerapex/add()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.AddComponent(/datum/component/tackler, \
-		stamina_cost = 35, \
-		base_knockdown = 1 SECONDS, \
+	H.AddComponent(/datum/component/tackler/simple_dunkstrong, \
+		stamina_cost = 20, \
+		base_knockdown = 0 SECONDS, \
 		range = 5, \
 		speed = 1, \
 		skill_mod = 3, \


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Changes how the current in game tackles obtainable through the quirks + raging boar work, by adding a "strong" variant of the simple tackles that boar uses, turns out, the original code for the simple tackles has some strange errors in the calculation, and none of it actually applies, so the damage ends up being just a flat 5 every time, not taking into account distance or any of the different multipliers.
Simple tackles cannot knockdown enemies, it only deals some damage and knockback.
This replaces the raging boar tackle and max level tackle quirk with the "strong" version of the tackle, which deals 10 / 20 / 30 damage depending if you have no unarmed quirk / fists of iron / fists of steel, and can't be increased in any shape or form, and is also affected by armor, it also has some slightly increased knockback distance depending on how lucky your roll was.
the basic tackle quirks are assigned the regular "simple" tackle which only deals 5 damage and doesen't seems to scale despite what the code might imply (i've tested so many variations of this and NOTHING seemed to change that, i have no idea why)
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->
