### PR TITLE
Try to un-runtime the runtimes

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -61,7 +61,8 @@
 	STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
-		to_chat(quirk_holder, lose_text)
+		if(lose_text)
+			to_chat(quirk_holder, lose_text)
 		quirk_holder.mob_quirks -= src
 		if(mob_trait)
 			if(!islist(mob_trait))

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -285,6 +285,7 @@
 	.["Nash"] = oasis
 	.["Wastelanders"] = wastelanders
 	.["Other"] = misc
+	.["Round Time"] = ROUND_TIME
 	return json_encode(.)
 
 /datum/world_topic/jsonrevision

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -20,7 +20,7 @@
 	hand_bodyparts = null		//Just references out bodyparts, don't need to delete twice.
 	remove_from_all_data_huds()
 	QDEL_NULL(dna)
-	QDEL_NULL(last_mind)
+	last_mind = null
 	GLOB.carbon_list -= src
 
 /mob/living/carbon/relaymove(mob/user, direction)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -20,6 +20,7 @@
 	hand_bodyparts = null		//Just references out bodyparts, don't need to delete twice.
 	remove_from_all_data_huds()
 	QDEL_NULL(dna)
+	QDEL_NULL(last_mind)
 	GLOB.carbon_list -= src
 
 /mob/living/carbon/relaymove(mob/user, direction)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -57,6 +57,7 @@
 	remove_from_all_data_huds()
 	GLOB.mob_living_list -= src
 	QDEL_LIST(diseases)
+	QDEL_LIST(mob_quirks)
 	return ..()
 
 /mob/living/onZImpact(turf/T, levels)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -24,7 +24,6 @@ GLOBAL_VAR_INIT(pixel_slide_other_has_help_int, 0)  //This variable queries whet
 	ghostize()
 	QDEL_LIST(actions)
 	QDEL_LIST(mob_spell_list)
-	QDEL_NULL(mind)
 
 	return ..() // Coyote Modify, Mobs wont lag the server when gibbed :o
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -25,8 +25,6 @@ GLOBAL_VAR_INIT(pixel_slide_other_has_help_int, 0)  //This variable queries whet
 	QDEL_LIST(actions)
 	QDEL_LIST(mob_spell_list)
 	QDEL_NULL(mind)
-	if (LAZYLEN(datum_components))
-		QDEL_LIST_ASSOC_VAL(datum_components)
 
 	return ..() // Coyote Modify, Mobs wont lag the server when gibbed :o
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -22,6 +22,11 @@ GLOBAL_VAR_INIT(pixel_slide_other_has_help_int, 0)  //This variable queries whet
 		qdel(cc)
 	client_colours = null
 	ghostize()
+	QDEL_LIST(actions)
+	QDEL_LIST(mob_spell_list)
+	QDEL_NULL(mind)
+	if (LAZYLEN(datum_components))
+		QDEL_LIST_ASSOC_VAL(datum_components)
 
 	return ..() // Coyote Modify, Mobs wont lag the server when gibbed :o
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -193,7 +193,7 @@
 	var/part = amount / src.total_volume
 	var/trans_data = null
 	var/list/transferred = list()
-	if (part > 0 && amount > 0) //You cannot transfer a negative part or amount
+	if (part > 0 && amount > 0) // You cannot transfer a negative part or amount
 		for(var/reagent in cached_reagents)
 			var/datum/reagent/T = reagent
 			var/transfer_amount = T.volume * part
@@ -236,12 +236,13 @@
 	amount = min(min(amount, total_volume), R.maximum_volume-R.total_volume)
 	var/part = amount / total_volume
 	var/trans_data = null
-	for(var/reagent in cached_reagents)
-		var/datum/reagent/T = reagent
-		var/copy_amount = T.volume * part
-		if(preserve_data)
-			trans_data = T.data
-		R.add_reagent(T.type, copy_amount * multiplier, trans_data)
+	if (part > 0 && amount > 0) // You cannot transfer a negative amount
+		for(var/reagent in cached_reagents)
+			var/datum/reagent/T = reagent
+			var/copy_amount = T.volume * part
+			if(preserve_data)
+				trans_data = T.data
+			R.add_reagent(T.type, copy_amount * multiplier, trans_data)
 
 	src.update_total()
 	R.update_total()


### PR DESCRIPTION
## About The Pull Request
Mobs runtime in nullspace, who knew.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
