### PR TITLE
fixes plumbing lagging the server (soft removal)

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -853,7 +853,7 @@ RLD
 	upgrade = RCD_UPGRADE_SIMPLE_CIRCUITS
 
 /obj/item/construction/plumbing
-	name = "Plumbing Constructor"
+	name = "\improper Plumbing Constructor"
 	desc = "An expertly modified RCD outfitted to construct plumbing machinery. Reload with compressed matter cartridges."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "arcd"
@@ -870,6 +870,13 @@ RLD
 	var/list/name_to_type = list()
 	///
 	var/list/machinery_data = list("cost" = list(), "delay" = list())
+
+//Server lag fixer-upper 9000
+/obj/item/construction/plumbing
+	name = "\improper Broken Plumbing Constructor"
+	desc = "An expertly modified RCD outfitted to construct plumbing machinery. Reload with compressed matter cartridges. This one's matter storage seems broken so it won't work anymore."
+	matter = 0
+	max_matter = 0
 
 /obj/item/construction/plumbing/attack_self(mob/user)
 	..()

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -16,7 +16,7 @@
 	///Flags for reagents, like INJECTABLE, TRANSPARENT bla bla everything thats in DEFINES/reagents.dm
 	var/reagent_flags = TRANSPARENT
 	///wheter we partake in rcd construction or not
-	var/rcd_constructable = TRUE
+	var/rcd_constructable = FALSE
 	///cost of the plumbing rcd construction
 	var/rcd_cost = 15
 	///delay of constructing it throught the plumbing rcd

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -963,7 +963,7 @@
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-
+/* Uncomment these and the Rapid Plumbing Device nerf in RCD.dm and _plumb_machinery.dm if plumbing ever gets fixed
 /datum/design/acclimator
 	name = "Plumbing Acclimator"
 	desc = "A heating and cooling device for pipes!"
@@ -1117,7 +1117,7 @@
 	build_path = /obj/item/construction/plumbing
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
-
+*/
 /datum/design/autosurgeon
 	name = "Autosurgeon"
 	desc = "An automatic surgeon used to install organs or implants automatically."


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This soft-removes the plumbing system by removing the ability to make plumbing devices with the (now-broken) rapid plumbing device. It also removes the ability to make the device in the first place so nobody will be losing materials by making it while it's disabled. Once someone fixes the plumbing runtime errors, they can have it back by reverting this PR.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->