### PR TITLE
fixes inventory ghosting

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -102,6 +102,9 @@
 
 	if(usr.attack_ui(slot_id))
 		usr.update_inv_hands()
+	//Remove the green object overlay since we never had a chance to use MouseExited(). Also removes the red one, but that's okay.
+	cut_overlay(object_overlay)
+	QDEL_NULL(object_overlay)
 	return TRUE
 
 /obj/screen/inventory/MouseEntered()


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
removes the green/red ghost thing when you click on an inventory slot instead of only when your mouse leaves the inventory slot
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->