### PR TITLE
allows shields to fit into suit storage

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -329,7 +329,8 @@ GLOBAL_LIST_INIT(default_all_armor_slot_allowed, typecacheof(list(
 	/obj/item/kitchen,
 	/obj/item/kinetic_crusher,
 	/obj/item/toy,
-	/obj/item/cult_bastard
+	/obj/item/cult_bastard,
+	/obj/item/shield
 	)))
 
 /// Things allowed in a toolbelt


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
currently, if you sheath your sword before your shield it will go into the belt slot and then your shield can't be sheathed in your suit storage so you just have your shield chilling in your hand awkwardly
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->