### PR TITLE
Disabling broken recipes

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -1389,5 +1389,5 @@
 		/datum/crafting_recipe/tommygun,
 		/datum/crafting_recipe/m1911,
 		/datum/crafting_recipe/policebaton,
-		/datum/crafting_recipe/bowman,
-		/datum/crafting_recipe/radiokeyresponder)
+		/*/datum/crafting_recipe/bowman,
+		/datum/crafting_recipe/radiokeyresponder*/)


### PR DESCRIPTION
## About The Pull Request
I broke the recipe for my own donator item, currently disabling until I can be bothered to fix it.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: No more NTOS error crafting menu upon reading the book.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
