### PR TITLE
Tweak to buff the .22 repeaters fire rate

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -117,11 +117,11 @@
 	gun_skill_check = AFFECTED_BY_FAST_PUMP | AFFECTED_BY_AUTO_PUMP
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_TWO_HAND_ONLY
-//	cock_delay = GUN_COCK_RIFLE_LIGHTNING // This actually just does nothing
+	cock_delay = GUN_COCK_RIFLE_BASE // Either this does nothing or it only affects bolt workers click to cock. 
 	damage_multiplier = GUN_EXTRA_DAMAGE_T5 // It'd be rpetty stupid if it did less damage than the snubnose .22 revolver that is a tiny sized thing
 	init_recoil = CARBINE_RECOIL(1, 0.8)
 	init_firemodes = list(
-		/datum/firemode/semi_auto/slow
+		/datum/firemode/semi_auto/fast
 	)
 	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
 
@@ -145,7 +145,7 @@
 	damage_multiplier = GUN_EXTRA_DAMAGE_T5 // It'd be rpetty stupid if it did less damage than the snubnose .22 revolver that is a tiny sized thing
 	init_recoil = CARBINE_RECOIL(1, 0.8)
 	init_firemodes = list(
-		/datum/firemode/semi_auto/slow
+		/datum/firemode/semi_auto/fast
 	)
 	fire_sound = 'sound/f13weapons/cowboyrepeaterfire.ogg'
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here --> Doubles the fire rate of the .22 repeaters. The full sized rifle when two handed, even when fired at its fastest possible fire rate with bolt worker, is basically unaffected by bloom, as a lever action .22 probably should be. The mares leg version, when one handed, can bloom very rapidly, as you'd expect given you have to twirl that thing around like you're some sort of exterminator.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
