### PR TITLE
Comms Station Tweak

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -1125,11 +1125,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/building)
-"aJX" = (
-/obj/structure/lattice/catwalk,
- 
-/turf/open/water,
-/area/f13/building/sewers)
 "aKH" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -1196,10 +1191,6 @@
 	},
 /obj/item/gun/ballistic/revolver/m29/alt,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"aLZ" = (
- 
-/turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/caves)
 "aMp" = (
 /obj/structure/bed,
@@ -2211,10 +2202,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/caves)
-"bxz" = (
- 
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "bxH" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/indestructible/ground/inside/mountain,
@@ -3380,9 +3367,6 @@
 /obj/item/mine/stun,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bKP" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/radiation)
 "bKR" = (
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
@@ -9235,7 +9219,6 @@
 /area/f13/caves)
 "ezq" = (
 /obj/effect/decal/cleanable/dirt,
- 
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkrusty"
 	},
@@ -10385,7 +10368,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
- 
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "fon" = (
@@ -11331,11 +11313,6 @@
 	initial_gas_mix = "o2=22;n2=82;miasma=44;TEMP=293.15"
 	},
 /area/f13/caves)
-"fYQ" = (
-/obj/effect/decal/cleanable/dirt,
- 
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/caves)
 "fZg" = (
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -12117,12 +12094,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"gwu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkrusty"
-	},
-/area/f13/building/sewers)
 "gwH" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -12916,12 +12887,6 @@
 /obj/structure/nest/radroach,
 /turf/open/floor/plating/tunnel,
 /area/f13/building/sewers)
-"gYI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "gZn" = (
 /obj/structure/nest/deathclaw/mother,
 /turf/open/indestructible/ground/inside/mountain,
@@ -14218,10 +14183,6 @@
 	name = "cave"
 	},
 /area/f13/caves)
-"hVy" = (
- 
-/turf/open/floor/f13/wood,
-/area/f13/caves)
 "hVC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -14405,11 +14366,6 @@
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
-/area/f13/caves)
-"iaq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "iaJ" = (
 /obj/machinery/light/small{
@@ -14675,7 +14631,6 @@
 /turf/open/floor/plating/f13,
 /area/f13/caves)
 "ika" = (
- 
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -16528,19 +16483,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/tunnel)
-"jrX" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "61"
-	},
-/obj/machinery/door/poddoor/shutters/old{
-	id = "factorybasement";
-	name = "shutters";
-	max_integrity = 1000000
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building/massfusion)
 "jsj" = (
 /obj/structure/stone_tile/block{
 	dir = 8;
@@ -16574,7 +16516,6 @@
 /area/f13/tunnel)
 "jsN" = (
 /mob/living/simple_animal/mouse/brown/Tom,
- 
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -18170,7 +18111,6 @@
 "kzm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
- 
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "kzp" = (
@@ -18264,9 +18204,6 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/sewers)
-"kDe" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark,
-/area/f13/building/hospital)
 "kDw" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/mountain,
@@ -18316,10 +18253,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/building/sewers)
-"kFw" = (
- 
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "kFQ" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -18348,7 +18281,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/old{
 	id = "commsroomlockdown";
-	max_integrity = 6000;
+	max_integrity = 10000;
 	name = "shutters";
 	obj_integrity = 1000000
 	},
@@ -19673,11 +19606,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"lxI" = (
-/obj/effect/decal/cleanable/dirt,
- 
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "lxU" = (
 /obj/effect/decal/fakelattice,
 /obj/item/ammo_casing/shotgun/improvised,
@@ -21229,10 +21157,6 @@
 /obj/structure/sink/deep_water,
 /turf/open/water,
 /area/f13/caves)
-"mto" = (
- 
-/turf/open/floor/f13/wood,
-/area/f13/tunnel)
 "mtF" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -22221,7 +22145,6 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "mYb" = (
- 
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/hospital)
 "mYl" = (
@@ -24040,10 +23963,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"olT" = (
- 
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/tunnel)
 "omh" = (
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13{
@@ -25832,7 +25751,6 @@
 /area/f13/building/massfusion)
 "pry" = (
 /obj/effect/decal/cleanable/dirt,
- 
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/sewers)
 "prI" = (
@@ -26599,10 +26517,6 @@
 /mob/living/simple_animal/pet/catslug,
 /turf/open/floor/grass/fairy,
 /area/f13/caves)
-"pOs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/sewers)
 "pOx" = (
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
 	pixel_x = 2;
@@ -26948,7 +26862,6 @@
 	},
 /area/f13/caves)
 "pYO" = (
- 
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "pYW" = (
@@ -27989,13 +27902,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"qEh" = (
-/obj/effect/decal/cleanable/dirt,
- 
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/caves)
 "qEI" = (
 /obj/structure/glowshroom{
 	color = "#4F7942";
@@ -29140,11 +29046,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"rqX" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/tunnel)
 "rrf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29582,10 +29483,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building)
-"rGP" = (
- 
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "rGX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
@@ -31311,10 +31208,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"sLF" = (
- 
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/sewers)
 "sLW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
@@ -31910,7 +31803,6 @@
 "tdi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
- 
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
@@ -31934,13 +31826,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
-	},
-/area/f13/caves)
-"tdT" = (
-/obj/effect/decal/cleanable/dirt,
- 
-/turf/open/indestructible/ground/inside/subway{
-	name = "cave"
 	},
 /area/f13/caves)
 "tep" = (
@@ -32024,10 +31909,6 @@
 	dir = 8
 	},
 /area/f13/building)
-"tha" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/museum)
 "thz" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -36462,7 +36343,6 @@
 /area/f13/tunnel)
 "weu" = (
 /obj/effect/decal/cleanable/dirt,
- 
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/building/museum)
 "wew" = (
@@ -38342,7 +38222,6 @@
 /area/f13/caves)
 "xqr" = (
 /obj/effect/decal/cleanable/dirt,
- 
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/building/museum)
 "xqv" = (
@@ -38714,7 +38593,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
- 
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/caves)
 "xAL" = (
@@ -41365,7 +41243,7 @@ kET
 adz
 adz
 adz
-iaq
+kzm
 mpk
 adz
 adz
@@ -41626,7 +41504,7 @@ adz
 mpk
 adz
 adz
-iaq
+kzm
 mpk
 adz
 adz
@@ -42006,7 +41884,7 @@ aaA
 aaA
 aaA
 rJf
-qEh
+jbP
 xdc
 aaA
 fCF
@@ -42139,7 +42017,7 @@ adz
 adz
 mpk
 mpk
-iaq
+kzm
 mpk
 adz
 adz
@@ -42397,7 +42275,7 @@ adz
 adz
 adz
 adz
-iaq
+kzm
 mpk
 adz
 adz
@@ -46122,7 +46000,7 @@ adz
 adz
 adz
 adz
-rGP
+adz
 adz
 adz
 adz
@@ -48570,8 +48448,8 @@ jRo
 bOb
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 pbU
 bOb
@@ -48826,11 +48704,11 @@ adE
 adE
 bOb
 jGf
-pOs
+pry
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 lVf
 jHd
 jHd
@@ -49085,8 +48963,8 @@ bOb
 rwa
 lmU
 pry
-pOs
-pOs
+pry
+pry
 pUc
 bOb
 xlI
@@ -49341,10 +49219,10 @@ fCC
 bOb
 ega
 vCB
-pOs
-pOs
+pry
+pry
 kyV
-pOs
+pry
 bOb
 xlI
 jHd
@@ -49447,7 +49325,7 @@ pwE
 pwE
 pwE
 pwE
-bxz
+aah
 aah
 aah
 jzi
@@ -49599,7 +49477,7 @@ bOb
 cHn
 qGD
 kyV
-pOs
+pry
 jGk
 iad
 bOb
@@ -49618,7 +49496,7 @@ bPE
 bPE
 bPE
 bPE
-pOs
+pry
 kyV
 bOb
 bOb
@@ -49855,8 +49733,8 @@ bOb
 bOb
 bOb
 bOb
-pOs
-pOs
+pry
+pry
 pKt
 oTQ
 bOb
@@ -49875,7 +49753,7 @@ hUy
 wGh
 sFx
 bPE
-pOs
+pry
 kyV
 bPE
 bPE
@@ -50092,8 +49970,8 @@ bAr
 jGk
 jGk
 jGk
-pOs
-pOs
+pry
+pry
 jGk
 jGk
 jGk
@@ -50112,8 +49990,8 @@ bOb
 jfF
 xhU
 bOb
-pOs
-pOs
+pry
+pry
 jGk
 lJS
 bOb
@@ -50132,7 +50010,7 @@ adE
 hUy
 sFx
 bPE
-pOs
+pry
 kyV
 jDE
 jHd
@@ -50348,9 +50226,9 @@ jGk
 jCm
 jGk
 kyV
-pOs
-pOs
-pOs
+pry
+pry
+pry
 kyV
 kyV
 jGk
@@ -50370,7 +50248,7 @@ jtM
 jHd
 xWW
 ikS
-pOs
+pry
 jGk
 esi
 bOb
@@ -50389,7 +50267,7 @@ nmE
 hUy
 sFx
 bPE
-pOs
+pry
 kyV
 xVj
 jHd
@@ -50605,7 +50483,7 @@ jGk
 xiw
 qIu
 seP
-pOs
+pry
 kyV
 kyV
 kyV
@@ -50627,7 +50505,7 @@ vjS
 jHd
 xWW
 ikS
-pOs
+pry
 bOb
 bOb
 bOb
@@ -50646,8 +50524,8 @@ nmE
 hUy
 hUy
 hzG
-pOs
-pOs
+pry
+pry
 lXG
 vAI
 jHd
@@ -50884,7 +50762,7 @@ kqm
 jHd
 xWW
 ikS
-pOs
+pry
 bOb
 sml
 jHd
@@ -50904,7 +50782,7 @@ wGh
 fuF
 bPE
 aCO
-pOs
+pry
 bPE
 bPE
 bPE
@@ -51160,8 +51038,8 @@ nmE
 adE
 nmE
 wwf
-pOs
-pOs
+pry
+pry
 jDE
 jHd
 uPC
@@ -51397,8 +51275,8 @@ bPE
 jHd
 xlI
 gCV
-pOs
-pOs
+pry
+pry
 bOb
 mBh
 jHd
@@ -51417,8 +51295,8 @@ nmE
 nmE
 nmE
 bPE
-pOs
-pOs
+pry
+pry
 xVj
 jHd
 qVS
@@ -51654,8 +51532,8 @@ bPE
 swd
 swd
 iad
-pOs
-pOs
+pry
+pry
 lOH
 xlI
 jHd
@@ -51675,7 +51553,7 @@ nmE
 nmE
 bPE
 kyV
-pOs
+pry
 lXG
 wew
 jHd
@@ -51840,9 +51718,9 @@ aae
 aae
 aae
 aae
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 aae
 aae
 aae
@@ -51903,7 +51781,7 @@ gcv
 gcv
 eFN
 kyV
-sLF
+kyV
 kyV
 kyV
 kyV
@@ -51911,8 +51789,8 @@ bPE
 bOb
 bOb
 bOb
-pOs
-pOs
+pry
+pry
 bOb
 qEU
 jHd
@@ -51932,7 +51810,7 @@ nmE
 nmE
 bPE
 kyV
-pOs
+pry
 bPE
 bPE
 bPE
@@ -52097,9 +51975,9 @@ aae
 aae
 aae
 aae
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 bLc
 aae
 aae
@@ -52168,8 +52046,8 @@ eFN
 thz
 thz
 jGk
-pOs
-pOs
+pry
+pry
 bOb
 iRf
 dqk
@@ -52189,7 +52067,7 @@ abt
 pWy
 bPE
 kyV
-pOs
+pry
 jGk
 aae
 aae
@@ -52355,16 +52233,16 @@ aae
 aae
 aae
 aae
-bKP
+pYO
 bLh
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 bLc
-bKP
+pYO
 bKS
-bKP
+pYO
 bLc
 aae
 bLI
@@ -52425,8 +52303,8 @@ eFN
 oVA
 tNR
 uIR
-pOs
-pOs
+pry
+pry
 bOb
 iiv
 tWE
@@ -52446,7 +52324,7 @@ bPE
 bPE
 bPE
 kyV
-pOs
+pry
 jGk
 aae
 aae
@@ -52520,7 +52398,7 @@ aah
 aah
 aah
 aah
-bxz
+aah
 jGc
 aah
 oxa
@@ -52613,17 +52491,17 @@ aae
 aae
 aae
 bLc
-bKP
+pYO
 woc
 bKS
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 bLY
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 boU
 bGl
 boU
@@ -52682,7 +52560,7 @@ eFN
 thz
 thz
 jGk
-pOs
+pry
 kyV
 bOb
 wdQ
@@ -52702,8 +52580,8 @@ bOb
 xlI
 xlI
 qWG
-pOs
-pOs
+pry
+pry
 eFN
 aae
 aae
@@ -52870,17 +52748,17 @@ aae
 aae
 aae
 aae
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 vdm
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 vdm
 bKS
-bKP
+pYO
 boU
 aae
 boU
@@ -53128,16 +53006,16 @@ aae
 aae
 aae
 aae
-bKP
-bKP
+pYO
+pYO
 vdm
 bLp
-bKP
+pYO
 bLh
 vdm
 vdm
-bKP
-bKP
+pYO
+pYO
 aae
 aae
 boU
@@ -53200,7 +53078,7 @@ kyV
 kyV
 kyV
 kyV
-sLF
+kyV
 kyV
 kyV
 kyV
@@ -53216,8 +53094,8 @@ hXU
 jHd
 jHd
 bOb
-pOs
-sLF
+pry
+kyV
 eFN
 aae
 aae
@@ -53385,18 +53263,18 @@ aae
 aae
 aae
 aae
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 nNP
-bKP
+pYO
 vdm
-bKP
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
+pYO
 bLc
 aae
 aae
@@ -53473,7 +53351,7 @@ bPE
 bPE
 iad
 bOb
-pOs
+pry
 kyV
 eFN
 aae
@@ -53644,16 +53522,16 @@ aae
 aae
 aae
 vdm
-bKP
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
+pYO
 nNP
-bKP
+pYO
 bMK
-bKP
-bKP
+pYO
+pYO
 nEq
 nEq
 aae
@@ -53721,16 +53599,16 @@ bOb
 bOb
 pdv
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 kyV
 wWp
-pOs
+pry
 uuS
-pOs
+pry
 aUZ
-pOs
+pry
 kyV
 jGk
 aae
@@ -53901,17 +53779,17 @@ aae
 aae
 aae
 nNP
-bKP
+pYO
 vdm
-bKP
-bKP
+pYO
+pYO
 vdm
 vdm
 vdm
 fWG
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 bMk
 aae
 aae
@@ -53979,14 +53857,14 @@ bOb
 kyV
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 kyV
-pOs
+pry
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 kyV
 jGk
@@ -54158,18 +54036,18 @@ aae
 aae
 aal
 fWG
-bKP
+pYO
 bLh
 vdm
 bLJ
-bKP
-bKP
+pYO
+pYO
 vdm
 vdm
-bKP
-bKP
+pYO
+pYO
 bNm
-bKP
+pYO
 aae
 aae
 aae
@@ -54224,7 +54102,7 @@ nZk
 gmj
 bOb
 kyV
-pOs
+pry
 bOb
 bOb
 qWG
@@ -54414,19 +54292,19 @@ aae
 aae
 aae
 fWG
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 vdm
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 bLh
-bKP
+pYO
 nNP
 bLp
-bKP
+pYO
 aae
 aae
 aae
@@ -54467,9 +54345,9 @@ sBw
 dHk
 tkZ
 uuS
-pOs
-pOs
-pOs
+pry
+pry
+pry
 uuS
 eFN
 aae
@@ -54670,19 +54548,19 @@ aae
 aae
 aae
 qTN
-bKP
-bKP
-bLz
-bKP
-bKP
 pYO
-bKP
+pYO
+bLz
+pYO
+pYO
+pYO
+pYO
 mos
-bKP
-bKP
+pYO
+pYO
 vdm
-bKP
-bKP
+pYO
+pYO
 aae
 aae
 aae
@@ -54726,7 +54604,7 @@ tkZ
 tkZ
 vOn
 uuS
-pOs
+pry
 kyV
 eFN
 aae
@@ -54738,7 +54616,7 @@ xlI
 xlI
 bOb
 kyV
-pOs
+pry
 bOb
 vle
 jTV
@@ -54925,20 +54803,20 @@ aae
 aae
 aae
 aae
-bKP
+pYO
 fWG
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 sri
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 bMr
 vdm
-bKP
-bKP
+pYO
+pYO
 boU
 boU
 boU
@@ -54994,8 +54872,8 @@ tgf
 xre
 rga
 iad
-pOs
-pOs
+pry
+pry
 bOb
 rfx
 jTV
@@ -55187,14 +55065,14 @@ vdm
 bLh
 vdm
 vdm
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 vdm
-bKP
+pYO
 vdm
-bKP
-bKP
+pYO
+pYO
 bLc
 aae
 aae
@@ -55439,19 +55317,19 @@ aae
 aae
 aae
 aae
-bKP
-bKP
+pYO
+pYO
 vdm
 vdm
-bKP
+pYO
 bLh
-bKP
+pYO
 vdm
 vdm
 bMl
-bKP
+pYO
 bKS
-bKP
+pYO
 aae
 aae
 aae
@@ -55695,19 +55573,19 @@ aae
 aae
 aae
 aae
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
 bKS
-bKP
+pYO
 bLq
-bKP
+pYO
 nNP
-bKP
-bKP
+pYO
+pYO
 bLh
-bKP
+pYO
 aae
 aae
 aae
@@ -55756,7 +55634,7 @@ uXj
 uXj
 foJ
 tkZ
-pOs
+pry
 tIx
 eFN
 aae
@@ -55952,18 +55830,18 @@ aae
 aae
 aae
 aae
-bKP
+pYO
 bKS
-bKP
-bKP
-bKP
-bKP
-bKP
-bKP
-bKP
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
+pYO
+pYO
+pYO
+pYO
+pYO
+pYO
+pYO
 bLc
 aae
 aae
@@ -56014,7 +55892,7 @@ uXj
 tkZ
 tkZ
 vOn
-pOs
+pry
 eFN
 aae
 aae
@@ -56210,16 +56088,16 @@ aae
 aae
 bpQ
 boU
-bKP
-bKP
+pYO
+pYO
 aae
 aae
-bKP
-bKP
+pYO
+pYO
 bLv
-bKP
-bKP
-bKP
+pYO
+pYO
+pYO
 aae
 aae
 aae
@@ -56256,7 +56134,7 @@ aae
 aae
 aae
 eFN
-pOs
+pry
 hab
 tkZ
 tkZ
@@ -56264,14 +56142,14 @@ tkZ
 etz
 wmX
 hab
-aJX
+dHk
 hab
 hkt
 vSi
 tkZ
 tkZ
 vOn
-pOs
+pry
 kyV
 bCt
 aak
@@ -56389,7 +56267,7 @@ bIy
 bIy
 mxj
 bIy
-kFw
+bIy
 aah
 pwE
 aaa
@@ -56472,10 +56350,10 @@ aae
 aae
 aae
 aae
-bKP
+pYO
 bLw
-bKP
-bKP
+pYO
+pYO
 aae
 aae
 aae
@@ -56513,7 +56391,7 @@ aae
 aae
 aae
 eFN
-pOs
+pry
 dHk
 tkZ
 tkZ
@@ -56528,8 +56406,8 @@ vSi
 tkZ
 tkZ
 tkZ
-pOs
-pOs
+pry
+pry
 eFN
 eFN
 eFN
@@ -56730,7 +56608,7 @@ aae
 aae
 aae
 aae
-bKP
+pYO
 bLc
 aae
 aae
@@ -56770,7 +56648,7 @@ aae
 aae
 aae
 eFN
-pOs
+pry
 dHk
 dHk
 tkZ
@@ -56785,13 +56663,13 @@ fLF
 tkZ
 tkZ
 tkZ
-pOs
-pOs
+pry
+pry
 kyV
-pOs
+pry
 kyV
 kyV
-sLF
+kyV
 kyV
 eFN
 xwF
@@ -57043,12 +56921,12 @@ tkZ
 tkZ
 tkZ
 kyV
-pOs
+pry
 kyV
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 eFN
 xwF
@@ -57284,7 +57162,7 @@ aae
 aae
 aae
 eFN
-pOs
+pry
 kyV
 dHk
 tkZ
@@ -57298,7 +57176,7 @@ uXj
 uXj
 foJ
 tkZ
-pOs
+pry
 uuS
 eFN
 eFN
@@ -57542,7 +57420,7 @@ aae
 aae
 eFN
 cDB
-pOs
+pry
 dHk
 dHk
 tkZ
@@ -57556,7 +57434,7 @@ tkZ
 tkZ
 dHk
 uuS
-pOs
+pry
 eFN
 aae
 aae
@@ -57799,9 +57677,9 @@ aae
 aae
 aae
 eFN
-pOs
-pOs
-pOs
+pry
+pry
+pry
 tkZ
 tkZ
 tkZ
@@ -57811,7 +57689,7 @@ dHk
 tkZ
 tkZ
 tkZ
-pOs
+pry
 uuS
 kyV
 eFN
@@ -58058,8 +57936,8 @@ aae
 eFN
 kyV
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 tkZ
 tkZ
@@ -58067,8 +57945,8 @@ dHk
 dHk
 tkZ
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 eFN
 eFN
@@ -58314,17 +58192,17 @@ aae
 aae
 eFN
 eFN
-pOs
-pOs
+pry
+pry
 kyV
-pOs
-pOs
+pry
+pry
 kyV
 kyV
 uuS
-pOs
-pOs
-pOs
+pry
+pry
+pry
 eFN
 eFN
 eFN
@@ -63900,7 +63778,7 @@ aah
 aah
 aah
 aah
-bxz
+aah
 aah
 aah
 aah
@@ -68764,7 +68642,7 @@ aae
 aae
 aae
 bFx
-bxz
+aah
 aah
 aah
 aah
@@ -70032,7 +69910,7 @@ aaa
 bJq
 bJq
 bJq
-olT
+boU
 aak
 aaa
 aak
@@ -73804,7 +73682,7 @@ aae
 djZ
 tov
 oai
-tha
+weu
 oSc
 djZ
 kMc
@@ -73977,7 +73855,7 @@ pkF
 uNI
 skT
 oFi
-rqX
+ika
 rPt
 bsC
 bsC
@@ -74216,7 +74094,7 @@ mVE
 bsC
 mVE
 mVE
-rqX
+ika
 fny
 wJK
 iVA
@@ -74801,7 +74679,7 @@ lqn
 lqn
 bsC
 aah
-bxz
+aah
 bKb
 bsC
 aae
@@ -75346,7 +75224,7 @@ aae
 djZ
 wwC
 lBG
-tha
+weu
 svy
 djZ
 bEi
@@ -77059,7 +76937,7 @@ nbe
 vRV
 bsC
 cyS
-rqX
+ika
 oFi
 jbA
 bsC
@@ -77114,7 +76992,7 @@ aae
 aae
 pwE
 aah
-bxz
+aah
 aah
 aah
 aah
@@ -77256,7 +77134,7 @@ aHf
 bGZ
 aah
 aah
-bxz
+aah
 bFx
 aae
 aae
@@ -77311,7 +77189,7 @@ tkZ
 tkZ
 gcv
 tGP
-rqX
+ika
 ihS
 elZ
 bsC
@@ -77560,8 +77438,8 @@ qtA
 hcZ
 noI
 tYU
-gwu
-gwu
+ezq
+ezq
 jGk
 oNM
 tkZ
@@ -77646,7 +77524,7 @@ blM
 gcv
 kyV
 iYL
-pOs
+pry
 gcv
 kyV
 jGk
@@ -77830,7 +77708,7 @@ nSM
 oFi
 bsC
 qeI
-rqX
+ika
 oFi
 pmD
 bsC
@@ -78075,7 +77953,7 @@ ovs
 jGk
 hff
 tYU
-gwu
+ezq
 jGk
 oNM
 tkZ
@@ -78157,11 +78035,11 @@ jGk
 jGk
 jGk
 blM
-pOs
+pry
 kyV
 blM
 bfe
-pOs
+pry
 kyV
 gLW
 pwE
@@ -78341,7 +78219,7 @@ gcv
 bsC
 bsC
 rxo
-rqX
+ika
 oFi
 iUK
 oFi
@@ -78600,7 +78478,7 @@ bsC
 vRV
 iyM
 uaR
-rqX
+ika
 iyM
 oqB
 bsC
@@ -78661,7 +78539,7 @@ bKb
 pwE
 xMX
 bBy
-pOs
+pry
 dZA
 ugz
 sMB
@@ -79115,7 +78993,7 @@ ldo
 iyM
 vdg
 iUK
-rqX
+ika
 vdg
 njj
 iyM
@@ -79185,8 +79063,8 @@ wPm
 jGk
 jGk
 blM
-pOs
-pOs
+pry
+pry
 blM
 blM
 ccw
@@ -79434,12 +79312,12 @@ lNV
 aUQ
 wfm
 aUQ
-pOs
+pry
 bCV
-pOs
+pry
 kyV
-pOs
-pOs
+pry
+pry
 lbd
 kyV
 kyV
@@ -79629,7 +79507,7 @@ yhM
 iUK
 vdg
 aJB
-rqX
+ika
 vdg
 dVV
 pkT
@@ -79693,10 +79571,10 @@ pLf
 aUQ
 kyV
 kyV
-pOs
+pry
 vHE
 ghx
-sLF
+kyV
 kyV
 kyV
 kyV
@@ -79953,8 +79831,8 @@ hUY
 hUY
 jGk
 blM
-pOs
-pOs
+pry
+pry
 jGk
 jGk
 jGk
@@ -80131,7 +80009,7 @@ cRX
 ijf
 xYr
 ihn
-pOs
+pry
 dhP
 oNM
 tkZ
@@ -80143,11 +80021,11 @@ xSA
 cAw
 vdg
 iyM
-rqX
+ika
 vdg
 uyq
 moJ
-rqX
+ika
 bsC
 bsC
 aah
@@ -80206,7 +80084,7 @@ nLr
 pLf
 aUQ
 pup
-gwu
+ezq
 tjh
 vvV
 gcZ
@@ -80397,7 +80275,7 @@ yau
 bCt
 iyM
 gAQ
-rqX
+ika
 rKK
 oFi
 hqq
@@ -80464,7 +80342,7 @@ iAs
 aUQ
 viM
 gXz
-gwu
+ezq
 lzl
 gcZ
 kyV
@@ -80724,7 +80602,7 @@ jGk
 aEQ
 jGk
 blM
-pOs
+pry
 fJM
 dzm
 uGG
@@ -81157,7 +81035,7 @@ bLy
 bsC
 gLJ
 vxI
-pOs
+pry
 put
 iLR
 jGk
@@ -81238,7 +81116,7 @@ fVu
 qtA
 qtA
 dzm
-pOs
+pry
 kyV
 gLw
 shG
@@ -81497,7 +81375,7 @@ ydM
 bsC
 kyV
 kyV
-pOs
+pry
 xbU
 hTI
 eFN
@@ -81987,11 +81865,11 @@ aae
 aae
 pwE
 bDc
-rqX
+ika
 rxf
-rqX
+ika
 rxf
-rqX
+ika
 rxf
 pwE
 aae
@@ -82244,12 +82122,12 @@ aae
 aae
 pwE
 bDc
-rqX
-rqX
-rqX
-rqX
-rqX
-rqX
+ika
+ika
+ika
+ika
+ika
+ika
 pwE
 aae
 pwE
@@ -82501,12 +82379,12 @@ aae
 aae
 pwE
 ihq
-rqX
-rqX
-rqX
-rqX
+ika
+ika
+ika
+ika
 vIE
-rqX
+ika
 pwE
 aae
 pwE
@@ -82758,7 +82636,7 @@ aae
 aae
 pwE
 nqr
-rqX
+ika
 pXF
 rxf
 rxf
@@ -82783,10 +82661,10 @@ cTO
 cTO
 bCt
 njF
-pOs
+pry
 kyV
 jZC
-gwu
+ezq
 tYU
 tYU
 pfJ
@@ -83040,7 +82918,7 @@ ovm
 qZn
 bCt
 xbU
-pOs
+pry
 kyV
 eFN
 byL
@@ -83272,11 +83150,11 @@ aae
 aae
 pwE
 eWp
-rqX
+ika
 kuI
 wFa
 iIr
-rqX
+ika
 xSd
 lZP
 jgU
@@ -83529,11 +83407,11 @@ aae
 aae
 pwE
 nYS
-rqX
+ika
 qVR
 iAu
 ika
-rqX
+ika
 dFM
 lZP
 nMm
@@ -83785,13 +83663,13 @@ pLf
 aae
 aae
 pwE
-rqX
-rqX
-rqX
+ika
+ika
+ika
 ref
-rqX
+ika
 wpZ
-rqX
+ika
 lZP
 jgU
 gna
@@ -83954,14 +83832,14 @@ aae
 aaa
 dEX
 nkA
-kDe
+mYb
 raz
 oLq
-kDe
-kDe
-kDe
-gYI
-gYI
+mYb
+mYb
+mYb
+fnO
+fnO
 ira
 dEX
 uUZ
@@ -83969,10 +83847,10 @@ tYi
 lag
 dEX
 kyb
-gYI
-kDe
+fnO
+mYb
 dEX
-kDe
+mYb
 knX
 dEX
 aaa
@@ -84210,26 +84088,26 @@ aae
 aae
 aaa
 dEX
-gYI
-gYI
+fnO
+fnO
 raz
-gYI
+fnO
 mIj
 mIj
 mIj
 mIj
 mIj
-kDe
+mYb
 dEX
-gYI
-gYI
+fnO
+fnO
 xGS
 dEX
 yjg
 rWH
 vuF
 dEX
-kDe
+mYb
 iIF
 dEX
 aaa
@@ -84299,9 +84177,9 @@ pLf
 aae
 aae
 pwE
-rqX
-rqX
-rqX
+ika
+ika
+ika
 bsC
 ocz
 mVE
@@ -84467,10 +84345,10 @@ aae
 aae
 aaa
 dEX
-kDe
+mYb
 nbm
 puP
-gYI
+fnO
 bPN
 gKe
 kyb
@@ -84478,13 +84356,13 @@ gMe
 bPN
 ycG
 dEX
-gYI
-gYI
+fnO
+fnO
 fNb
 dEX
 wYL
-gYI
-gYI
+fnO
+fnO
 dEX
 xHk
 dEX
@@ -84557,7 +84435,7 @@ aae
 aae
 pwE
 utC
-rqX
+ika
 bHZ
 bsC
 piA
@@ -84580,12 +84458,12 @@ bDG
 dua
 xvp
 kyV
-pOs
+pry
 wlO
 cgn
 ijd
 kyV
-sLF
+kyV
 gBF
 kyV
 blM
@@ -84725,7 +84603,7 @@ aae
 aaa
 dEX
 pEV
-gYI
+fnO
 puP
 hfs
 kyb
@@ -84733,18 +84611,18 @@ uUZ
 bPN
 bPN
 kyb
-gYI
+fnO
 dEX
-gYI
+fnO
 nRd
 qEQ
 dEX
 ucr
-gYI
+fnO
 nbm
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
 aaa
 aae
@@ -84813,8 +84691,8 @@ pLf
 aae
 aae
 pwE
-rqX
-rqX
+ika
+ika
 bHZ
 bsC
 aCD
@@ -84839,7 +84717,7 @@ blM
 kyV
 kyV
 kyV
-pOs
+pry
 kyV
 kyV
 izx
@@ -84981,26 +84859,26 @@ aae
 aae
 aaa
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
-gYI
+fnO
 xiY
 tDQ
 xiY
 wxL
 xiY
-gYI
+fnO
 dEX
-gYI
+fnO
 vuF
 wan
 dEX
 rbm
-gYI
-gYI
+fnO
+fnO
 xHk
-gYI
+fnO
 mrX
 dEX
 aaa
@@ -85070,8 +84948,8 @@ pLf
 aae
 aae
 pwE
-rqX
-rqX
+ika
+ika
 nYS
 bsC
 wbT
@@ -85096,11 +84974,11 @@ blM
 kyV
 mFf
 uLb
-sLF
-pOs
+kyV
+pry
 cgn
-pOs
-pOs
+pry
+pry
 kyV
 blM
 pwE
@@ -85239,23 +85117,23 @@ aae
 aaa
 dEX
 oqm
-gYI
+fnO
 dEX
 vmM
-kDe
-gYI
+mYb
+fnO
 coL
-kDe
+mYb
 fnO
 pnQ
 xHk
-kDe
-gYI
+mYb
+fnO
 kyb
 dEX
 oPJ
-gYI
-kDe
+fnO
+mYb
 dEX
 mrX
 nch
@@ -85329,7 +85207,7 @@ aae
 pwE
 sax
 inc
-rqX
+ika
 feP
 mVE
 czi
@@ -85352,11 +85230,11 @@ kiv
 blM
 kyV
 xul
-pOs
+pry
 kyV
 kyV
 kyV
-pOs
+pry
 yiL
 kyV
 pwE
@@ -85495,23 +85373,23 @@ aae
 aae
 aaa
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 dEX
 dEX
 dEX
 dEX
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
-kDe
-kDe
+mYb
+mYb
 adx
 dEX
 oPJ
-gYI
+fnO
 kuo
 dEX
 sPQ
@@ -85586,7 +85464,7 @@ aae
 pwE
 ofg
 llt
-rqX
+ika
 bsC
 tpI
 mVE
@@ -85609,11 +85487,11 @@ duA
 blM
 njF
 eXI
-pOs
+pry
 kJT
 hYr
-pOs
-pOs
+pry
+pry
 mrH
 pMB
 pwE
@@ -85753,7 +85631,7 @@ aae
 aaa
 dEX
 nbm
-kDe
+mYb
 dEX
 khs
 nvA
@@ -85771,8 +85649,8 @@ dEX
 dEX
 dEX
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
 aaa
 aae
@@ -85843,7 +85721,7 @@ aae
 pwE
 inc
 sax
-rqX
+ika
 bsC
 mVE
 mVE
@@ -86009,16 +85887,16 @@ aae
 aae
 aaa
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 rll
 mlj
 hoy
 kNp
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 ucB
 ivX
@@ -86028,8 +85906,8 @@ vON
 vON
 pHG
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 aaa
 aae
@@ -86267,7 +86145,7 @@ xwF
 aaa
 dEX
 tjr
-gYI
+fnO
 dEX
 nYd
 gRt
@@ -86277,16 +86155,16 @@ dEX
 pnQ
 kfw
 dEX
-kDe
+mYb
 jQi
 dEX
-kDe
-gYI
-gYI
-gYI
+mYb
+fnO
+fnO
+fnO
 dEX
 nbm
-gYI
+fnO
 dEX
 aaa
 aae
@@ -86531,18 +86409,18 @@ nvA
 jBD
 pmJ
 dEX
-gYI
-gYI
+fnO
+fnO
 xHk
 mrX
 kMM
 dEX
 brI
-gYI
+fnO
 vuF
-gYI
+fnO
 xHk
-gYI
+fnO
 rzA
 dEX
 aaa
@@ -86780,8 +86658,8 @@ aaB
 aaB
 aaa
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
 auG
 aoa
@@ -86794,12 +86672,12 @@ dEX
 pnQ
 ivX
 dEX
-gYI
-gYI
-gYI
-kDe
+fnO
+fnO
+fnO
+mYb
 dEX
-gYI
+fnO
 kXk
 dEX
 aaa
@@ -87037,16 +86915,16 @@ aaB
 aaB
 aaa
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 cjg
 qRL
 wKp
 nvA
 xHk
-kDe
-gYI
+mYb
+fnO
 dEX
 bnE
 pHG
@@ -87056,8 +86934,8 @@ oFG
 pHG
 iHK
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 aaa
 aae
@@ -87294,7 +87172,7 @@ xwF
 aaB
 aaa
 dEX
-gYI
+fnO
 nbm
 dEX
 xFT
@@ -87313,8 +87191,8 @@ dEX
 dEX
 dEX
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 aaa
 aae
@@ -87552,7 +87430,7 @@ aar
 aaa
 dEX
 pEV
-gYI
+fnO
 dEX
 cjg
 nvA
@@ -87560,7 +87438,7 @@ nvA
 mAM
 dEX
 pnQ
-gYI
+fnO
 dEX
 pRe
 ylq
@@ -87570,7 +87448,7 @@ pRe
 ylq
 bVE
 dEX
-gYI
+fnO
 nbm
 dEX
 aaa
@@ -87809,14 +87687,14 @@ xwF
 aaa
 dEX
 nkA
-gYI
+fnO
 dEX
 seI
 uvu
 sOK
 dUy
 dEX
-kDe
+mYb
 hKt
 dEX
 nRX
@@ -87827,7 +87705,7 @@ xzy
 tHm
 xzy
 dEX
-gYI
+fnO
 hXQ
 dEX
 aaa
@@ -88065,8 +87943,8 @@ xwF
 xwF
 aaa
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 yjm
 yjm
@@ -88074,7 +87952,7 @@ yjm
 yjm
 dEX
 nkA
-gYI
+fnO
 dEX
 xzy
 nRX
@@ -88322,16 +88200,16 @@ aae
 aae
 aaa
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 whm
 iqw
 dAT
 sGc
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 dEX
 dEX
@@ -88341,8 +88219,8 @@ dEX
 xHk
 dEX
 dEX
-gYI
-gYI
+fnO
+fnO
 dEX
 aaa
 aae
@@ -88579,26 +88457,26 @@ xwF
 xwF
 aaa
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
 lAG
 nKT
 nxU
 dQf
 xHk
-gYI
-gYI
+fnO
+fnO
 xHk
-kDe
-kDe
-kDe
+mYb
+mYb
+mYb
 fIf
-kDe
-kDe
-kDe
+mYb
+mYb
+mYb
 xHk
-gYI
+fnO
 sPQ
 dEX
 aaa
@@ -88836,18 +88714,18 @@ xwF
 xwF
 aaa
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 whm
 lkl
 sGc
 awR
 dEX
-kDe
-gYI
+mYb
+fnO
 dEX
-kDe
+mYb
 lAt
 pPS
 xnw
@@ -88855,8 +88733,8 @@ vLw
 oLq
 tLF
 dEX
-gYI
-kDe
+fnO
+mYb
 dEX
 aaa
 aae
@@ -89034,7 +88912,7 @@ pDI
 pDI
 pDI
 fzC
-jrX
+ueb
 pDI
 nOj
 pDI
@@ -89094,7 +88972,7 @@ xwF
 aaa
 dEX
 hfs
-gYI
+fnO
 dEX
 dEX
 dEX
@@ -89112,7 +88990,7 @@ dEX
 dEX
 dEX
 dEX
-gYI
+fnO
 elc
 dEX
 aaa
@@ -89350,27 +89228,27 @@ aaB
 aaB
 aaB
 qip
-gYI
-gYI
+fnO
+fnO
 raz
 tjr
 vrR
 oLq
-kDe
-kDe
-kDe
-gYI
-gYI
-gYI
-gYI
-kDe
-gYI
+mYb
+mYb
+mYb
+fnO
+fnO
+fnO
+fnO
+mYb
+fnO
 bhq
 nbm
-gYI
+fnO
 raz
-gYI
-gYI
+fnO
+fnO
 dEX
 aaa
 aae
@@ -89486,13 +89364,13 @@ xwF
 aaa
 xwF
 qoB
-rGP
+adz
 nEF
 ygq
 tOJ
 ygq
 mpk
-iaq
+kzm
 nnP
 gOQ
 xwF
@@ -89610,24 +89488,24 @@ qip
 fCp
 mYb
 eQX
-gYI
-gYI
-gYI
-gYI
+fnO
+fnO
+fnO
+fnO
 cHS
 flP
 tjr
 oLq
-gYI
+fnO
 bjf
-gYI
-gYI
-gYI
-kDe
+fnO
+fnO
+fnO
+mYb
 cHS
 eQX
-kDe
-kDe
+mYb
+mYb
 dEX
 aaa
 aae
@@ -89758,7 +89636,7 @@ aaa
 xwF
 adz
 bBl
-iaq
+kzm
 caY
 wFO
 ltL
@@ -90272,7 +90150,7 @@ xwF
 aaa
 xwF
 cCU
-iaq
+kzm
 nnP
 nYI
 mpk
@@ -90306,7 +90184,7 @@ cjJ
 nws
 pDI
 pDI
-ueb
+qlt
 kVx
 twv
 bVb
@@ -90316,7 +90194,7 @@ tKG
 qpK
 xDO
 ckn
-ueb
+qlt
 pDI
 cgt
 qlt
@@ -90563,7 +90441,7 @@ cjJ
 nws
 ciC
 nOj
-ueb
+qlt
 dfI
 xUW
 hnv
@@ -90573,7 +90451,7 @@ bRs
 hnv
 bsl
 tZD
-ueb
+qlt
 pDI
 mwi
 qlt
@@ -90791,7 +90669,7 @@ igy
 yeQ
 adz
 hhp
-iaq
+kzm
 vHT
 adz
 aar
@@ -90820,7 +90698,7 @@ cjJ
 nws
 pDI
 pDI
-ueb
+qlt
 kVx
 swo
 mCM
@@ -90830,7 +90708,7 @@ maA
 dVq
 aEH
 ckn
-ueb
+qlt
 pDI
 pDI
 qlt
@@ -91002,7 +90880,7 @@ bxS
 bRe
 dZX
 xxJ
-mto
+mVE
 mby
 jJz
 hHK
@@ -91049,7 +90927,7 @@ wFO
 rkJ
 mpk
 uri
-iaq
+kzm
 rkJ
 aar
 mpk
@@ -91301,7 +91179,7 @@ aaa
 xwF
 adz
 mpk
-iaq
+kzm
 iOS
 mpk
 bBl
@@ -91550,7 +91428,7 @@ aaB
 aaB
 xwF
 adz
-iaq
+kzm
 adz
 xwF
 aaa
@@ -91563,7 +91441,7 @@ iOS
 uri
 adz
 qPX
-iaq
+kzm
 jUP
 aar
 adz
@@ -91820,7 +91698,7 @@ wFO
 pgh
 nKv
 tEs
-iaq
+kzm
 qOQ
 aar
 aar
@@ -92118,7 +91996,7 @@ pDI
 nOj
 pDI
 dbK
-jrX
+ueb
 pDI
 pDI
 nOj
@@ -92322,7 +92200,7 @@ xwF
 xwF
 htL
 tjE
-iaq
+kzm
 xwF
 aaa
 xwF
@@ -92834,7 +92712,7 @@ xwF
 xwF
 xwF
 xwF
-iaq
+kzm
 qLa
 aaA
 xwF
@@ -93091,7 +92969,7 @@ xwF
 xwF
 xwF
 mpk
-iaq
+kzm
 mpk
 xwF
 xwF
@@ -93621,7 +93499,7 @@ xwF
 xwF
 mpk
 bBl
-iaq
+kzm
 cqh
 iuz
 tRm
@@ -93876,7 +93754,7 @@ xwF
 aaa
 aaa
 xwF
-iaq
+kzm
 mpk
 sWu
 mkG
@@ -94134,7 +94012,7 @@ xwF
 aaA
 bDi
 cPq
-iaq
+kzm
 mpk
 cqh
 caX
@@ -94344,7 +94222,7 @@ ikO
 mVE
 mVE
 mVE
-mto
+mVE
 bSp
 dzm
 aae
@@ -94738,7 +94616,7 @@ oHN
 xsE
 kuQ
 kEd
-fYQ
+gmM
 xsE
 xMl
 qJD
@@ -94895,12 +94773,12 @@ aaa
 xwF
 kqr
 adz
-iaq
+kzm
 cPn
 mpk
 aIM
 nnP
-iaq
+kzm
 jzc
 xwF
 aaa
@@ -96173,7 +96051,7 @@ rtz
 who
 oFz
 rKd
-iaq
+kzm
 aIM
 mpk
 owX
@@ -96432,7 +96310,7 @@ aGd
 aar
 agO
 aIM
-iaq
+kzm
 owX
 xwF
 aaa
@@ -97215,7 +97093,7 @@ mpk
 iqW
 hNz
 nnP
-iaq
+kzm
 bRl
 hHu
 hHu
@@ -97469,10 +97347,10 @@ adz
 adz
 adz
 iqW
-iaq
-iaq
+kzm
+kzm
 bMU
-iaq
+kzm
 ecc
 adz
 vBq
@@ -97726,7 +97604,7 @@ aak
 xwF
 adz
 nnP
-iaq
+kzm
 mpk
 ygq
 adz
@@ -98371,7 +98249,7 @@ bHT
 lMU
 fap
 mmz
-aLZ
+mmz
 nMW
 yig
 dwr
@@ -98488,7 +98366,7 @@ xwF
 xaX
 caY
 nlL
-hVy
+aGd
 vov
 shB
 jLj
@@ -99223,7 +99101,7 @@ htL
 aaa
 pxf
 mUb
-lxI
+mUb
 aaa
 aak
 xwF
@@ -101524,7 +101402,7 @@ aaa
 xwF
 aar
 sCX
-lxI
+mUb
 mUb
 bXW
 aaa
@@ -102503,7 +102381,7 @@ jnN
 jnN
 aaA
 adz
-rGP
+adz
 adz
 emp
 adz
@@ -102517,7 +102395,7 @@ xWj
 alR
 aFt
 emp
-rGP
+adz
 adz
 pPg
 adz
@@ -102544,7 +102422,7 @@ nre
 lGB
 fze
 oXC
-tdT
+tbh
 sta
 gvM
 iCD

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -44732,14 +44732,8 @@
 	},
 /area/f13/wasteland)
 "gMc" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "61";
-	name = "Maintenance Access"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building/coyote/nash/massfus/sidebuilding)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/massfusion/entrance)
 "gMn" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
@@ -45635,9 +45629,8 @@
 	},
 /area/f13/wasteland/city/nash/downtown)
 "gWj" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerpavement - W"
+	icon_state = "outerpavement - NW"
 	},
 /area/f13/wasteland/massfusion/entrance)
 "gWk" = (
@@ -55730,6 +55723,11 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
+"jmr" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavement - N"
+	},
+/area/f13/wasteland/massfusion/entrance)
 "jmD" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -87899,6 +87897,16 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building/coyote/nash/massfus/groundfloor/west)
+"qBy" = (
+/obj/machinery/door/unpowered/securedoor{
+	name = "Radio Station Lounge";
+	req_one_access_txt = "61";
+	desc = "Door with a built-in lock. Can't be padlocked. ((Does not lead to a dungeon. Ahelp to raid.))"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building/coyote/nash/massfus/sidebuilding)
 "qBA" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -101274,10 +101282,7 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerpavement - W"
-	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/massfusion/entrance)
 "tAT" = (
 /obj/structure/curtain,
@@ -110881,7 +110886,7 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/massfusion/entrance)
 "vQe" = (
 /obj/structure/flora/grass/jungle,
@@ -172677,12 +172682,12 @@ gIh
 bdf
 biP
 hiB
-auX
 hiB
-auX
+hiB
+hiB
 hiB
 vPY
-gqt
+jmr
 eXO
 gqt
 gqt
@@ -172937,9 +172942,9 @@ hiB
 hAB
 hAB
 hAB
-auX
-gqt
-gqt
+hiB
+gMc
+jmr
 gqt
 gqt
 aaa
@@ -173190,16 +173195,16 @@ tvz
 aDW
 odj
 eiE
-auX
+hiB
 hAB
 xUS
 hAB
-hiB
-gqt
-gqt
+qBy
+gMc
+jmr
 gqt
 aaa
-aae
+aaa
 aae
 aae
 aae
@@ -173452,10 +173457,10 @@ hAB
 ams
 hAB
 hiB
+gMc
+jmr
+gqt
 aaa
-aaa
-aaa
-aae
 aae
 aae
 aae
@@ -173705,14 +173710,14 @@ aDW
 agi
 hiB
 hiB
-gMc
 hiB
 hiB
 hiB
 hiB
-aae
-aae
-aae
+hiB
+aaa
+aaa
+aaa
 aae
 aae
 aae

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -8,6 +8,8 @@
 	icon_state = "comm_server"
 	desc = "A compact machine used for portable subspace telecommunications processing."
 	density = TRUE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	var/intercept = FALSE  // If true, only works on the Syndicate frequency.

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -14,6 +14,8 @@ GLOBAL_VAR_INIT(message_delay, 0) // To make sure restarting the recentmessages 
 	desc = "A dish-shaped machine used to broadcast processed subspace signals."
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	idle_power_usage = 25
 	circuit = /obj/item/circuitboard/machine/telecomms/broadcaster
 

--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -15,6 +15,8 @@
 	density = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 50
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	netspeed = 40
 	circuit = /obj/item/circuitboard/machine/telecomms/bus
 	var/change_frequency = FALSE

--- a/code/game/machinery/telecomms/machines/hub.dm
+++ b/code/game/machinery/telecomms/machines/hub.dm
@@ -15,6 +15,8 @@
 	density = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 80
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	long_range_link = TRUE
 	netspeed = 40
 	circuit = /obj/item/circuitboard/machine/telecomms/hub

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -11,6 +11,8 @@
 	icon_state = "blackbox"
 	name = "blackbox recorder"
 	density = TRUE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
 	active_power_usage = 100

--- a/code/game/machinery/telecomms/machines/processor.dm
+++ b/code/game/machinery/telecomms/machines/processor.dm
@@ -11,6 +11,8 @@
 	icon_state = "processor"
 	desc = "This machine is used to process large quantities of information."
 	density = TRUE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 30
 	circuit = /obj/item/circuitboard/machine/telecomms/processor

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -11,6 +11,8 @@
 	icon_state = "broadcast receiver"
 	desc = "This machine has a dish-like shape and green lights. It is designed to detect and process subspace radio activity."
 	density = TRUE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 30
 	circuit = /obj/item/circuitboard/machine/telecomms/receiver

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -12,6 +12,8 @@
 	desc = "A mighty piece of hardware used to send massive amounts of data far away."
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	idle_power_usage = 30
 	netspeed = 5
 	long_range_link = 1

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -11,6 +11,8 @@
 	desc = "A machine used to store data and network statistics."
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	flags_1 = DEFAULT_RICOCHET_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	idle_power_usage = 15
 	circuit = /obj/item/circuitboard/machine/telecomms/server
 	var/list/log_entries = list()


### PR DESCRIPTION
Separates the comms lounge a bit from the adjacent dungeon. Also adds an ooc warning to the entrance to it that clarifies its not part of the nearby dungeon.

Also makes the machines unmodifiable and indestructible. That way comms griefing can be curated, to prevent dick-moves.