### PR TITLE
Wattz 2k Sport fix (good to go if it passes checks)

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -360,7 +360,7 @@ Avoid decimals when possible when it comes to e_cost!
 
 /obj/item/ammo_casing/energy/wattz2ks/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/wattz2ks/hitscan
-	e_cost = 1600 // 25 shots
+	e_cost = 1200 // 25 shots
 	damage_threshold_penetration = 7 //You're a sniper laser, act like it.
 
 //musket

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -624,9 +624,10 @@
 	icon_state = "wattz2ks"
 	item_state = "sniper_rifle"
 	ammo_type = list(/obj/item/ammo_casing/energy/wattz2ks/hitscan)
-	cell_type = /obj/item/stock_parts/cell/ammo/ultracite
+	cell_type = /obj/item/stock_parts/cell/ammo/breeder
 	can_scope = FALSE
 	zoom_factor = 1
+	can_remove = 0
 	can_charge = 0
 	selfcharge = 1
 	selfchargerate = 15


### PR DESCRIPTION
## About The Pull Request
Just a hotfix

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Changes the Wattz 2k Sport to use the Microfusion Breeder
- Changes the Wattz 2k Sport to be unable to eject the cell

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
