### PR TITLE
Ports the last 2/3rd of tg 67273

### DIFF
--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -1,10 +1,8 @@
 SUBSYSTEM_DEF(npcpool)
 	name = "NPC Pool"
-	flags = SS_KEEP_TIMING | SS_NO_INIT
+	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_BACKGROUND
 	priority = FIRE_PRIORITY_NPC
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-	wait = 1 SECONDS // currently defines how often mobs attack and flip out
-	// wait = 1 DECISECOND makes retreat/approach mobs just wiggle around in place and cheesegrate people
 
 	var/list/currentrun = list()
 
@@ -25,8 +23,12 @@ SUBSYSTEM_DEF(npcpool)
 	while(currentrun.len)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
-		if(QDELETED(SA)) //sanity
-			break
+
+		if (QDELETED(SA)) // Some issue causes nulls to get into this list some times. This keeps it running, but the bug is still there.
+			GLOB.simple_animals[AI_ON] -= SA
+			stack_trace("Found a null in simple_animals active list [SA.type]!")
+			continue
+
 		if(!SA.ckey && !SA.mob_transforming)
 			if(SA.stat != DEAD)
 				SA.handle_automated_movement()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -947,6 +947,8 @@ GLOBAL_LIST_EMPTY(playmob_cooldowns)
 	LoadComponent(/datum/component/riding)
 
 /mob/living/simple_animal/proc/toggle_ai(togglestatus)
+	if(QDELETED(src))
+		return
 	if(!can_have_ai && (togglestatus != AI_OFF))
 		return
 	if (AIStatus != togglestatus)


### PR DESCRIPTION
I am going to beat jon with a shovel until he is a deer pudding.

Doesn't quite port it completely, specifically it still uses our version of mob transformation.  But it compiles, mother fucker.

@GremlingSS you are in danger, run

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
