### PR TITLE
Separates PVP and CI combat modes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -557,6 +557,11 @@
 #define COMSIG_LIVING_COMBAT_DISABLED "combatmode_disabled"			//from base of datum/component/combat_mode/disable_combat_mode() (was_forced)
 #define COMSIG_COMBAT_MODE_CHECK "combatmode_check"					//called when checking the combat mode flags (enabled/disabled/forced)
 
+//PVP Mode
+#define COMSIG_TOGGLE_PVP_MODE "toggle_pvp_mode"				//safely toggles combat mode.
+#define COMSIG_DISABLE_PVP_MODE "disable_pvp_mode"			//safely disables combat mode.
+#define COMSIG_ENABLE_PVP_MODE "enable_pvp_mode"				//safely enables combat mode.
+
 //Nanites
 #define COMSIG_HAS_NANITES "has_nanites"						//() returns TRUE if nanites are found
 #define COMSIG_NANITE_IS_STEALTHY "nanite_is_stealthy"			//() returns TRUE if nanites have stealth


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
The goal is to allow players to use CI regardless of if they're willing to engage in PVP or not. A new flag and hotkey will then inherit the exclamation point (or a brand new icon to overlay) and sound (waaa waaa waaaaaahhh). If you hear and see this, it should always mean that you intend on engaging in PVP matters.

- [ ] If not PVP Flagged - No damage at all from other players
- [ ] If pvp flagged - normal ss13 experience 
- [ ] If pvp flagged you can't unflag for x amount of time
- [ ] grace timer for pvp flag to come up (you don't count as flagged during this time but it is obvious that you are 'flagging'

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->