### PR TITLE
Add crafting recipes to quirk packages

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -2244,13 +2244,18 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_MASTERWORKSMITH, "Weaponsmith - Masterwork")
 	ADD_TRAIT(H, TRAIT_WEAPONSMITH, "Weaponsmith - Basic")
-
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.weaponcrafting_gun_recipes
+	H.mind.learned_recipes |= GLOB.weapons_of_texarkana
 
 /datum/quirk/package/legendarywepsm/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_MASTERWORKSMITH, "Weaponsmith - Masterwork")
 		REMOVE_TRAIT(H, TRAIT_WEAPONSMITH, "Weaponsmith - Basic")
+	if(H)
+		H.mind.learned_recipes -= GLOB.weaponcrafting_gun_recipes
 
 /datum/quirk/package/reformedtribal
 	name = "Reformed Tribal Chemist"
@@ -2401,11 +2406,14 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	var/mob/living/carbon/human/H = quirk_holder
 	ADD_TRAIT(H, TRAIT_CHEMWHIZ, "Chem Whiz")
 	ADD_TRAIT(H, TRAIT_SURGERY_LOW, "Minor Surgery")
-
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.chemwhiz_recipes
 
 /datum/quirk/package/generalmedicalpractitioner/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_CHEMWHIZ, "Chem Whiz")
 		REMOVE_TRAIT(H, TRAIT_SURGERY_LOW, "Minor Surgery")
-
+	if(H)
+		H.mind.learned_recipes -= GLOB.chemwhiz_recipes


### PR DESCRIPTION
## About The Pull Request
Adds the crafting recipes from Chem Whiz to General Medical Practitioner and adds the crafting recipes from Weaponsmith (basic) to Weaponsmith (Legendary).

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: See desc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
