### PR TITLE
salt ratling nerf PR + fixes the ammo count for the laser AK

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -242,8 +242,8 @@ Avoid decimals when possible when it comes to e_cost!
 	e_cost = 1500 // 20 shots, 2rnd burst
 
 /obj/item/ammo_casing/energy/laser/AK470M
-	projectile_type = /obj/item/projectile/beam/laser/pistol/AK470M
-	e_cost = 300 // 30 shots roughly.
+	projectile_type = /obj/item/projectile/beam/laser/solar
+	e_cost = 990 // 33 shots roughly.
 	fire_sound = 'sound/f13weapons/WattzRifleFire.ogg'
 
 /obj/item/ammo_casing/energy/laser/solar

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -75,8 +75,8 @@
 	icon_state = "ammobox"
 	ammo_type = /obj/item/ammo_casing/caseless/flintlock
 	caliber = list(CALIBER_FLINTLOCK)
-	max_ammo = 200
-	w_class = WEIGHT_CLASS_GIGANTIC // It holds 200 my guy
+	max_ammo = 50
+	w_class = WEIGHT_CLASS_GIGANTIC // It holds 100 my guy
 	custom_materials = list(/datum/material/iron = MATS_LIGHT_MEGA_CAN_MAGAZINE)
 
 /obj/item/ammo_box/magazine/ratling/empty

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -3013,12 +3013,13 @@
 	mag_type = /obj/item/ammo_box/magazine/ratling
 	init_mag_type = /obj/item/ammo_box/magazine/ratling
 	weapon_class = WEAPON_CLASS_RIFLE
+	added_spread = GUN_SPREAD_AWFUL
 	weapon_weight = GUN_TWO_HAND_ONLY
-	damage_multiplier = GUN_LESS_DAMAGE_T4
+	damage_multiplier = GUN_LESS_DAMAGE_T6
 	init_recoil = LMG_RECOIL(1.2, 1.2)
 	slowdown = GUN_SLOWDOWN_RIFLE_LMG * 2
 	init_firemodes = list(
-		/datum/firemode/automatic/rpm300
+		/datum/firemode/automatic/rpm100
 	)
 
 

--- a/code/modules/projectiles/guns/energy/plasma_cit.dm
+++ b/code/modules/projectiles/guns/energy/plasma_cit.dm
@@ -71,8 +71,9 @@
 	selfcharge = 1
 	icon_state = "LaserAK"
 	item_state = null
+	selfchargerate = 15
 	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
-	cell_type = "/obj/item/stock_parts/cell/pulse/carbine"
+	cell_type = "/obj/item/stock_parts/cell/ammo/breeder"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz)
 	ammo_x_offset = 4
 	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Makes the ratling (an easily craftable, black powder makeshift minigun) no longer be a better weapon in almost every way compared to the minigun and other high tier legendaries, considering how easy it is to craft.
20 damage per bullet down from 60 (while still using the flintlock damage table which can roll for 200 damage), 50 round mags from 200, reduced the RPM from 300 (which in reality was 600) to 100, made it far more innacurate.

unfucked the laser AK cells to hold the 30'ish shots it was meant to have rather than the 8 it currently does, slightly increases the recharge rate.
## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->