### PR TITLE
Fuzzy's storage equip/unequip QoL [ready to merge]

### DIFF
--- a/code/datums/components/storage/storage_mode_switch.dm
+++ b/code/datums/components/storage/storage_mode_switch.dm
@@ -1,0 +1,80 @@
+//-->Fuzzy's QoL storage equip/unequip
+//right clicking on a storage item gives an option to set the equipping method.
+//as it is now:
+//STORAGE MODE 0: default
+//STORAGE MODE 1: take out the FIRST placed item when CTRL-CLICKING on storage
+//STORAGE MODE 2: take out the LAST placed item when CTRL-CLICKING on storage
+//STORAGE MODE 3: take out the FIRST placed item when ALT-CLICKING on storage
+//STORAGE MODE 4: take out the LAST placed item when ALT-CLICKING on storage
+//"""coder""": Leonzrygin
+//<--
+
+
+/obj/item/storage/verb/take_out_item_mode() 
+	set name = "Switch Pick Item Out Method"
+	set category = "Object"
+
+	pickoutitem_onclick += 1
+	if(pickoutitem_onclick > 4 || pickoutitem_onclick < 0)  //if for any reason it's lesser than 0, reset it. Keep the numbers updated here, if you add other modes, or it won't work
+		pickoutitem_onclick = 0
+
+	switch(pickoutitem_onclick)
+		if(0)
+			to_chat(usr, span_notice("..>STORAGE MODE 0: You'll now just open the inventory when CLICKING on \the [src]. (default mode)"))
+		if(1)
+			to_chat(usr, span_notice("..>STORAGE MODE 1: You'll now take out the FIRST placed item when CTRL-CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
+		if(2)
+			to_chat(usr, span_notice("..>STORAGE MODE 2: You'll now take out the LAST placed item when CTRL-CLICKING on \the [src]. (example of use: unsheathing weapons)"))
+		if(3)
+			to_chat(usr, span_notice("..>STORAGE MODE 3: You'll now take out the FIRST placed item when ALT-CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
+		if(4)
+			to_chat(usr, span_notice("..>STORAGE MODE 4: You'll now take out the LAST placed item when ALT-CLICKING on \the [src]. (example of use: unsheathing weapons)"))
+////////////////////////////////////////////////////////////////
+
+
+/obj/item/storage/CtrlClick(mob/user, params = "right")
+	. = ..()
+	if(pickoutitem_onclick == 1)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[1]  //return the first item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+
+	else if(pickoutitem_onclick == 2)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[contents.len]  //return the last item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+////////////////////////////////////////////////////////////////
+
+
+/obj/item/storage/AltClick(mob/user)
+	. = ..()
+	if(pickoutitem_onclick == 3)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[1]  //return the first item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+
+	else if(pickoutitem_onclick == 4)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[contents.len]  //return the last item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+////////////////////////////////////////////////////////////////

--- a/code/datums/components/storage/storage_mode_switch.dm
+++ b/code/datums/components/storage/storage_mode_switch.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(pickoutitem_onclick_methods, list(
 
 
 /obj/item/storage/verb/take_out_item_mode() 
-	set name = "Switch Pick Item Out Method"
+	set name = "Set How To Take Item Out"
 	set category = "Object"
 
 	var/new_input = input(usr, "Choose the way you'd like to pick an item out from this storage", "Storage Mode: [src]") as null|anything in GLOB.pickoutitem_onclick_methods

--- a/code/datums/components/storage/storage_mode_switch.dm
+++ b/code/datums/components/storage/storage_mode_switch.dm
@@ -2,56 +2,81 @@
 //right clicking on a storage item gives an option to set the equipping method.
 //as it is now:
 //STORAGE MODE 0: default
-//STORAGE MODE 1: take out the FIRST placed item when CTRL-CLICKING on storage
-//STORAGE MODE 2: take out the LAST placed item when CTRL-CLICKING on storage
+//STORAGE MODE 1: take out the FIRST placed item when simply CLICKING on storage
+//STORAGE MODE 2: take out the LAST placed item when simply CLICKING on storage
 //STORAGE MODE 3: take out the FIRST placed item when ALT-CLICKING on storage
 //STORAGE MODE 4: take out the LAST placed item when ALT-CLICKING on storage
+//STORAGE MODE 5: take out the FIRST placed item when CTRL-CLICKING on storage
+//STORAGE MODE 6: take out the LAST placed item when CTRL-CLICKING on storage
 //"""coder""": Leonzrygin
 //<--
+
+GLOBAL_LIST_INIT(pickoutitem_onclick_methods, list(
+	"Default" = 0,
+	"Take out FIRST item when CLICKING on it."			= 1,
+	"Take out LAST item when CLICKING on it." 			= 2,
+	"Take out FIRST item when ALT-CLICKING on it." 		= 3,
+	"Take out LAST item when ALT-CLICKING on it." 		= 4,
+	"Take out FIRST item when CTRL-CLICKING on it." 	= 5,
+	"Take out LAST item when CTRL-CLICKING on it." 		= 6))
 
 
 /obj/item/storage/verb/take_out_item_mode() 
 	set name = "Switch Pick Item Out Method"
 	set category = "Object"
 
-	pickoutitem_onclick += 1
-	if(pickoutitem_onclick > 4 || pickoutitem_onclick < 0)  //if for any reason it's lesser than 0, reset it. Keep the numbers updated here, if you add other modes, or it won't work
-		pickoutitem_onclick = 0
+	var/new_input = input(usr, "Choose the way you'd like to pick an item out from this storage", "Storage Mode: [src]") as null|anything in GLOB.pickoutitem_onclick_methods
+	if(new_input)
+		pickoutitem_onclick = GLOB.pickoutitem_onclick_methods[new_input]
 
 	switch(pickoutitem_onclick)
 		if(0)
 			to_chat(usr, span_notice("..>STORAGE MODE 0: You'll now just open the inventory when CLICKING on \the [src]. (default mode)"))
 		if(1)
-			to_chat(usr, span_notice("..>STORAGE MODE 1: You'll now take out the FIRST placed item when CTRL-CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
+			to_chat(usr, span_notice("..>STORAGE MODE 1: You'll now take out the FIRST placed item when CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
 		if(2)
-			to_chat(usr, span_notice("..>STORAGE MODE 2: You'll now take out the LAST placed item when CTRL-CLICKING on \the [src]. (example of use: unsheathing weapons)"))
+			to_chat(usr, span_notice("..>STORAGE MODE 2: You'll now take out the LAST placed item when CLICKING on \the [src]. (example of use: unsheathing weapons)"))
 		if(3)
 			to_chat(usr, span_notice("..>STORAGE MODE 3: You'll now take out the FIRST placed item when ALT-CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
 		if(4)
 			to_chat(usr, span_notice("..>STORAGE MODE 4: You'll now take out the LAST placed item when ALT-CLICKING on \the [src]. (example of use: unsheathing weapons)"))
+		if(5)
+			to_chat(usr, span_notice("..>STORAGE MODE 5: You'll now take out the FIRST placed item when CTRL-CLICKING on \the [src]. (example of use: taking out ammo from ammo storages)"))
+		if(6)
+			to_chat(usr, span_notice("..>STORAGE MODE 6: You'll now take out the LAST placed item when CTRL-CLICKING on \the [src]. (example of use: unsheathing weapons)"))
 ////////////////////////////////////////////////////////////////
 
 
-/obj/item/storage/CtrlClick(mob/user, params = "right")
+/obj/item/storage/attack_hand(mob/user)
+	var/obj/item/I = usr.get_active_held_item()
+	var/counter
 	. = ..()
 	if(pickoutitem_onclick == 1)
-		var/obj/item/I = usr.get_active_held_item()
 		if(!I)  //my hand is empty
 			if(contents.len)  //there's something to take out from the inventory
 				I = contents[1]  //return the first item in this case.
 				if(!I)
 					return
 				I.attack_hand(usr) // take out thing from storage
+				if(!counter)
+					counter += 1
+					attack_hand(usr)  //WE GET RECURSIVE ONLY ONCE I SWEAR
+					return
+				counter = 0
 				return
 
 	else if(pickoutitem_onclick == 2)
-		var/obj/item/I = usr.get_active_held_item()
 		if(!I)  //my hand is empty
 			if(contents.len)  //there's something to take out from the inventory
 				I = contents[contents.len]  //return the last item in this case.
 				if(!I)
 					return
 				I.attack_hand(usr) // take out thing from storage
+				if(!counter)
+					counter += 1
+					attack_hand(usr)  //WE GET RECURSIVE ONLY ONCE I SWEAR
+					return
+				counter = 0
 				return
 ////////////////////////////////////////////////////////////////
 
@@ -69,6 +94,30 @@
 				return
 
 	else if(pickoutitem_onclick == 4)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[contents.len]  //return the last item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+////////////////////////////////////////////////////////////////
+
+
+/obj/item/storage/CtrlClick(mob/user, params = "right")
+	. = ..()
+	if(pickoutitem_onclick == 5)
+		var/obj/item/I = usr.get_active_held_item()
+		if(!I)  //my hand is empty
+			if(contents.len)  //there's something to take out from the inventory
+				I = contents[1]  //return the first item in this case.
+				if(!I)
+					return
+				I.attack_hand(usr) // take out thing from storage
+				return
+
+	else if(pickoutitem_onclick == 6)
 		var/obj/item/I = usr.get_active_held_item()
 		if(!I)  //my hand is empty
 			if(contents.len)  //there's something to take out from the inventory

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -5,6 +5,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/component_type = /datum/component/storage/concrete
 	var/in_use = FALSE
+	var/pickoutitem_onclick = 0  //keep this at 0 if you want a standard issue storage.
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
 	return src

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,7 +17,7 @@ map pahrump-everything
 	adminonly
 endmap
 
-map pahrump-unit-test
+map pahrump-only
     default
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,7 +17,7 @@ map pahrump-everything
 	adminonly
 endmap
 
-map pahrump-only
+map pahrump-unit-test
     default
 endmap
 

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -585,6 +585,7 @@
 #include "code\datums\components\plumbing\reaction_chamber.dm"
 #include "code\datums\components\plumbing\splitter.dm"
 #include "code\datums\components\storage\storage.dm"
+#include "code\datums\components\storage\storage_mode_switch.dm"
 #include "code\datums\components\storage\ui.dm"
 #include "code\datums\components\storage\concrete\_concrete.dm"
 #include "code\datums\components\storage\concrete\backpack.dm"


### PR DESCRIPTION
## About The Pull Request
Allows players to choose how to pick up items out from their storages, by simply right clicking on a certain storage and clicking on the right verb.
The mode we added in:

- STORAGE MODE 0: default
- STORAGE MODE 1: take out the FIRST placed item when simply CLICKING on storage
- STORAGE MODE 2: take out the LAST placed item when simply CLICKING on storage
- STORAGE MODE 3: take out the FIRST placed item when ALT-CLICKING on storage
- STORAGE MODE 4: take out the LAST placed item when ALT-CLICKING on storage
- STORAGE MODE 5: take out the FIRST placed item when CTRL-CLICKING on storage
- STORAGE MODE 6: take out the LAST placed item when CTRL-CLICKING on storage

![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/f949c506-9068-400f-b797-031bd4a1dc73)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds a verb that lets you choose how to pick items up from a storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
