### PR TITLE
binary insert player list

### DIFF
--- a/code/controllers/subsystem/who.dm
+++ b/code/controllers/subsystem/who.dm
@@ -303,10 +303,12 @@ SUBSYSTEM_DEF(who) // SS who? SS you!
 	var/list/players = list()
 	for(var/mob/plr in GLOB.player_list)
 		players += plr // these are also also mobs
+	/* player_list is already sorted alphabetically 
 	if(admeme) // only admins can see the actual names, so just sort em for them
 		admins = sortNames(admins)
 		mentors = sortNames(mentors)
 	players = sortNames(players)
+	*/
 
 	lines += "<hr>"
 	if(admeme && LAZYLEN(admins))

--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -37,7 +37,7 @@
 ///Adds the cliented mob reference to the list of all player-mobs, besides to either the of dead or alive player-mob lists, as appropriate. Called on Login().
 /mob/proc/add_to_player_list()
 	SHOULD_CALL_PARENT(TRUE)
-	GLOB.player_list |= src
+	BINARY_INSERT(src, GLOB.player_list, /mob, src, name, COMPARE_KEY)
 	if(!SSticker?.mode)
 		return
 	if(stat == DEAD)


### PR DESCRIPTION
moves the sorting proc up the chain so that the player list is always already sorted and doesn't need to be resorted every time someone uses a verb like Who()

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
