### PR TITLE
Ultracite Rifle and Loot Adjustments (Good to go if it passes checks!)

### DIFF
--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -205,6 +205,8 @@
 		/obj/item/gun/ballistic/automatic/autopipe = 1,
 		/obj/item/gun/ballistic/revolver/winchesterrebored = 5,
 		/obj/item/gun/ballistic/rifle/mosin/mini = 1,
+		/obj/item/gun/magic/wand/kelpmagic/magicmissile = 5,
+		/obj/item/gun/magic/wand/kelpmagic/basiczappies =5 ,
 	)
 
 /obj/effect/spawner/lootdrop/f13/common_guns
@@ -407,23 +409,30 @@
 /obj/effect/spawner/lootdrop/f13/common_energy
 	name = "common energy"
 	loot = list(
-		/obj/item/gun/energy/laser/wattz = 2,
-		/obj/item/gun/energy/laser/wattzs = 2,
-		/obj/item/gun/energy/laser/pistol = 1,
-		/obj/item/gun/energy/laser/complianceregulator = 1,
-		/obj/item/gun/energy/laser/auto = 1,
+		/obj/item/gun/energy/laser/wattz = 10,
+		/obj/item/gun/energy/laser/wattzs = 3,
+		/obj/item/gun/energy/laser/pistol = 10,
+		/obj/item/gun/energy/laser/complianceregulator = 3,
+		/obj/item/gun/energy/laser/auto = 5,
 		/obj/item/gun/energy/laser/tg/carbine/pistol = 2,
+		/obj/item/gun/energy/laser/tg/carbine = 2,
+		/obj/item/gun/magic/wand/kelpmagic/magicmissile/improved = 5,
+		/obj/item/gun/magic/wand/kelpmagic/sparky = 5,
 	)
 
 /obj/effect/spawner/lootdrop/f13/uncommon_energy
 	name = "uncommon energy"
 	loot = list(
-		/obj/item/gun/energy/laser/wattz2k = 2,
-		/obj/item/gun/energy/laser/aer9 = 5,
-		/obj/item/gun/energy/laser/plasma/pistol = 1,
-		/obj/item/gun/energy/laser/tg/rifle = 1,
-		/obj/item/gun/energy/laser/tg/carbine = 2,
-		/obj/item/gun/energy/laser/tg/recharger/nuclear = 1,
+		/obj/item/gun/energy/laser/wattz2k = 20,
+		/obj/item/gun/energy/laser/aer9 = 20,
+		/obj/item/gun/energy/laser/plasma/pistol = 10,
+		/obj/item/gun/energy/laser/tg/rifle = 24,
+		/obj/item/gun/energy/laser/tg/recharger/nuclear = 10,
+		/obj/item/gun/energy/laser/solar = 5,
+		/obj/item/gun/magic/wand/kelpmagic/firebolt = 5,
+		/obj/item/gun/magic/wand/kelpmagic/healwand = 1,
+		/obj/item/gun/magic/staff/kelpmagic/acidstaff = 5,
+		/obj/item/gun/magic/staff/kelpmagic/magicmissile =5,
 	)
 
 /obj/effect/spawner/lootdrop/f13/rare_energy
@@ -436,10 +445,13 @@
 		/obj/item/gun/energy/laser/plasma = 5,
 		/obj/item/gun/energy/ionrifle = 5,
 		/obj/item/gun/energy/laser/wattz2k/extended = 10,
-		/obj/item/gun/energy/laser/solar = 15,
-		/obj/item/gun/energy/laser/tg/rifle/heavy = 5,
-		/obj/item/gun/energy/laser/tg/rifle/auto = 5,
-		/obj/item/gun/energy/laser/tg/recharger/nuclear/rifle = 1,
+		/obj/item/gun/energy/laser/tg/rifle/heavy = 10,
+		/obj/item/gun/energy/laser/tg/rifle/auto = 10,
+		/obj/item/gun/energy/laser/tg/recharger/nuclear/rifle = 5,
+		/obj/item/gun/energy/laser/ultra_rifle = 1,
+		/obj/item/gun/magic/staff/kelpmagic/fireball = 1,
+		/obj/item/gun/magic/staff/kelpmagic/lightning = 3,
+		/obj/item/gun/magic/staff/kelpmagic/healstaff = 3,
 	)
 
 ////////////////////
@@ -484,10 +496,10 @@
 /obj/effect/spawner/lootdrop/f13/rare_cowboy
 	name = "rare cowboy"
 	loot = list(
-		/obj/item/gun/ballistic/revolver/m2405 = 1,
-		/obj/item/gun/ballistic/revolver/sequoia = 5,
-		/obj/item/gun/ballistic/rifle/repeater/brush = 10,
-		/obj/item/gun/ballistic/bow/compoundbow = 10,
+		/obj/item/gun/ballistic/revolver/m2405 = 5,
+		/obj/item/gun/ballistic/revolver/sequoia = 10,
+		/obj/item/gun/ballistic/rifle/repeater/brush = 20,
+		/obj/item/gun/ballistic/bow/compoundbow = 3,
 		/obj/item/m2flamethrowertank = 1,
 	)
 
@@ -532,7 +544,7 @@
 		/obj/item/gun/ballistic/automatic/pistol/goldendeag = 2,
 		/obj/item/gun/ballistic/automatic/recoilessrifle = 1,
 		/obj/item/gun/energy/laser/tg/recharger = 5,
-		/obj/item/melee/transforming/plasmacutter/sword/cx = 5, 
+		/obj/item/melee/transforming/plasmacutter/sword/cx = 5,
 	)
 
 /obj/effect/spawner/lootdrop/f13/rare_unique //most uniques gonna end up here: the epitome of high tier loot

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -241,6 +241,10 @@ Avoid decimals when possible when it comes to e_cost!
 	projectile_type = /obj/item/projectile/beam/laser/lasgun/hitscan/focused
 	e_cost = 1500 // 20 shots, 2rnd burst
 
+/obj/item/ammo_casing/energy/laser/lasgun/ultra
+	projectile_type = /obj/item/projectile/beam/laser/ultra_rifle
+	e_cost = 1000 // 40 shots
+
 /obj/item/ammo_casing/energy/laser/AK470M
 	projectile_type = /obj/item/projectile/beam/laser/solar
 	e_cost = 990 // 33 shots roughly.

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -515,7 +515,7 @@
 	)
 	init_recoil = LASER_SMG_RECOIL(1, 1)
 
-//Ultracite Laser pistol
+//Ultracite Laser pistol - staying commented out because the gammagun shares its sprite.
 /obj/item/gun/energy/laser/ultra_pistol
 	name = "\improper Ultracite laser pistol"
 	desc = "An ultracite enhanced energy-based laser gun that fires concentrated beams of light."
@@ -699,10 +699,10 @@
 //Ultracite Laser rifle
 /obj/item/gun/energy/laser/ultra_rifle
 	name = "\improper Ultracite laser rifle"
-	desc = "A sturdy and advanced military grade pre-war service laser rifle, now enhanced with ultracite"
+	desc = "An incredibly rare variant of the AER-9 laser rifle that uses Ultracite microfusion cells."
 	icon_state = "ultra_rifle"
 	item_state = "laser-rifle9"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun/ultra)
 	cell_type = /obj/item/stock_parts/cell/ammo/ultracite
 	can_scope = FALSE
 	zoom_factor = 1
@@ -1090,10 +1090,11 @@
 
 /obj/item/gun/energy/laser/tg/carbine/pistol
 	name = "miniture laser pistol"
-	desc = "An ultracompact version of the Trident Gammaworks laser carbine, this gun is small enough to fit in a pocket or pouch. While it retains the carbine's power, its battery is less efficient due to the size."
+	desc = "An ultracompact version of the Trident Gammaworks laser carbine, this gun is small enough to fit in a pocket or pouch. While it retains most of the carbine's power, its battery is less efficient due to the size."
 	icon_state = "laspistol"
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_SMALL
+	damage_multiplier = GUN_LESS_DAMAGE_T1
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/tg)
 	can_flashlight = 0
 	can_scope = FALSE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -112,7 +112,7 @@
 	damage_list = list("20" = 30, "25" = 50, "30" = 20)
 	flag = "energy"
 	damage_type = "burn"
-	irradiate = 200 //incase friendly fire
+	irradiate = 400 // rad armor is easy to get; testing showed its old value to be basically useless
 	range = 15
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
 
@@ -414,10 +414,17 @@
 	damage = 40
 	irradiate = 200
 
-/obj/item/projectile/beam/laser/ultra_rifle //unused
-	name = "laser beam"
-	damage = 45
-	irradiate = 200
+/obj/item/projectile/beam/laser/ultra_rifle
+	name = "ultracite beam"
+	damage = 32
+	damage_list = list("28" = 30, "32" = 50, "37" = 20)
+	hitscan = TRUE
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
+	light_color = LIGHT_COLOR_GREEN
+	tracer_type = /obj/effect/projectile/tracer/xray
+	muzzle_type = /obj/effect/projectile/muzzle/xray
+	impact_type = /obj/effect/projectile/impact/xray
+	irradiate = 300
 
 /obj/item/projectile/beam/laser/gatling //Gatling Laser Projectile
 	name = "rapid-fire laser beam"
@@ -483,7 +490,7 @@
 	name = "laser beam"
 	damage = 20
 	damage_list = list( "18" = 30, "20" = 70)
-	
+
 	icon_state = "arcane_barrage"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PURPLE
@@ -870,7 +877,7 @@
 /obj/item/projectile/beam/laser/tg/nuclear
 	name = "nuclear laser bolt"
 	icon_state = "xray"
-	irradiate = 200
+	irradiate = 300
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 	tracer_type = /obj/effect/projectile/tracer/xray


### PR DESCRIPTION
## About The Pull Request
Title, basically. Ultracite rifle is ugly, but the energy loot lists are both anemic and unrewarding. It'll do for now.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Adjusted the Ultracite rifle to a radioactive 40 shot AER-9. Ultracite ammo cells are stupid rare and can't be made, so it's basically an ugly TG blaster
- Adjusted some irradiate damage on weapons because radarmor is so easy to get and stack
- Adjusted the loot lists to include kelpmagic items
- Adjusted the rarity of Solar Scorchers so finding a safe, self-charging gun is no longer incredibly common
- Adjusted energy loot lists in general to account for new items and to make some items more reasonably common, uncommon, or rare

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
