### PR TITLE
Makes wildshape innacessible to players until the bugs and exploits are ironed out.

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1740,9 +1740,9 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 		QDEL_NULL(moveto)
 
 /datum/quirk/wildshape
-	name = "Wild Shape"
+	name = "Wild Shape - Disabled for time being"
 	desc = "You've developed through some means the ability to adopt a lesser form. What it is was decided by yourself or mere circumstance, but you can transform back and forth at will."
-	value = 15
+	value = 9999
 	category = "Mutant Quirks"
 	mechanics = "You gain the shapeshift spell and can cast it nearly at will! This allows you to transform into an animal and back again. Once you select a shape, it cannot be changed."
 	conflicts = list(


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Title- 
Many mobs that you can transform into through wildshape have issues associated with them, and this PR will disable the quirk for now until those issues are fixed.
## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->
