### PR TITLE
Wildshape bug fix and balance palooza

### DIFF
--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -3775,7 +3775,7 @@
 	},
 /area/f13/building)
 "Bw" = (
-/obj/effect/landmark/start/f13/wastelander/ashdown,
+/obj/effect/landmark/start/f13/ashdown,
 /turf/open/indestructible/cobble{
 	light_color = null;
 	color = "#777777"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1102,7 +1102,7 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 	CRASH(msg)
 
 /datum/proc/stack_trace(msg)
-	CRASH(msg)
+d	CRASH(msg)
 
 GLOBAL_REAL_VAR(list/stack_trace_storage)
 /proc/gib_stack_trace()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1102,7 +1102,7 @@ proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 	CRASH(msg)
 
 /datum/proc/stack_trace(msg)
-d	CRASH(msg)
+	CRASH(msg)
 
 GLOBAL_REAL_VAR(list/stack_trace_storage)
 /proc/gib_stack_trace()

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1740,9 +1740,9 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 		QDEL_NULL(moveto)
 
 /datum/quirk/wildshape
-	name = "Wild Shape - Disabled for time being"
+	name = "Wild Shape"
 	desc = "You've developed through some means the ability to adopt a lesser form. What it is was decided by yourself or mere circumstance, but you can transform back and forth at will."
-	value = 9999
+	value = 15
 	category = "Mutant Quirks"
 	mechanics = "You gain the shapeshift spell and can cast it nearly at will! This allows you to transform into an animal and back again. Once you select a shape, it cannot be changed."
 	conflicts = list(

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -810,7 +810,7 @@ obj/effect/landmark/start/f13/ncrlogisticsofficer
 	name = "Wastelander"
 	icon_state = "Wastelander"
 
-/obj/effect/landmark/start/f13/wastelander/ashdown
+/obj/effect/landmark/start/f13/ashdown
 	name = "Ashdown Citizen"
 	icon_state = "Wastelander"
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -54,7 +54,9 @@
 		to_chat(caster, span_warning("You're already shapeshifted!"))
 		return
 
-	var/mob/living/shape = new shapeshift_type(caster.loc)
+	var/mob/living/shape = new shapeshift_type(get_turf(caster))
+	shape.maxHealth = caster.maxHealth
+	shape.health = caster.health
 	H = new(shape,src,caster)
 
 	clothes_req = NONE

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -1,3 +1,5 @@
+#define SHAPESHIFT_CAST_TIME	2 SECONDS
+
 /obj/effect/proc_holder/spell/targeted/shapeshift
 	name = "Shapechange"
 	desc = "Take on the shape of another for a time to use their natural abilities. Once you've made your choice it cannot be changed."
@@ -18,10 +20,8 @@
 	var/list/possible_shapes = list(/mob/living/simple_animal/mouse)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/Initialize()
-	var/list/poke = list()
-	for(var/pkmn in GLOB.creature_selectable)
-		poke += GLOB.creature_selectable[pkmn]
-	possible_shapes = poke
+	if(!LAZYLEN(GLOB.creature_selectable))
+		generate_selectable_creatures()
 	. = ..()
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/cast(list/targets,mob/user = usr)
@@ -32,24 +32,21 @@
 		user.buckled.unbuckle_mob(src,force=TRUE)
 	for(var/mob/living/M in targets)
 		if(!shapeshift_type)
-			var/list/animal_list = list()
-			for(var/path in possible_shapes)
-				var/mob/living/simple_animal/A = path
-				animal_list[initial(A.name)] = path
-			var/new_shapeshift_type = input(M, "Choose Your Animal Form!", "It's Morphing Time!", null) as null|anything in animal_list
-			if(shapeshift_type)
+			var/new_shapeshift_type = input(M, "Choose Your Animal Form!", "It's Morphing Time!", null) as null|anything in GLOB.creature_selectable
+			if(shapeshift_type || !new_shapeshift_type) //Menu stacking check
 				return
-			shapeshift_type = new_shapeshift_type
-			if(!shapeshift_type) //If you aren't gonna decide I am!
-				shapeshift_type = pick(animal_list)
-			shapeshift_type = animal_list[shapeshift_type]
-
+			shapeshift_type = GLOB.creature_selectable[new_shapeshift_type]
 		var/obj/shapeshift_holder/S = locate() in M
 		if(S)
-			Restore(M)
+			if(do_after_advanced(user, SHAPESHIFT_CAST_TIME, M, DO_AFTER_DISALLOW_MOVING_ABSOLUTE_USER))
+				Restore(M)
+			else
+				to_chat(user,span_warning("Your concentration fails!"))
 		else
-			Shapeshift(M)
-
+			if(do_after_advanced(user, SHAPESHIFT_CAST_TIME, M, DO_AFTER_DISALLOW_MOVING_ABSOLUTE_USER))
+				Shapeshift(M)
+			else
+				to_chat(user,span_warning("Your concentration fails!"))
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Shapeshift(mob/living/caster)
 	var/obj/shapeshift_holder/H = locate() in caster

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -1,4 +1,4 @@
-#define ispokemon(A)		istype(A, /mob/living/simple_animal/pokemon)
+#define isadvancedmob(A)		istype(A, /mob/living/simple_animal/advanced)
 
 #define P_TYPE_FIRE 	"fire"
 #define P_TYPE_WATER 	"water"
@@ -38,8 +38,8 @@ GLOBAL_LIST_EMPTY(pokemon_selectable)
 /proc/generate_selectable_pokemon(clear = FALSE)
 	if(clear)
 		GLOB.pokemon_selectable = list()
-	for(var/I in subtypesof(/mob/living/simple_animal/pokemon))
-		var/mob/living/simple_animal/pokemon/P = I
+	for(var/I in subtypesof(/mob/living/simple_animal/advanced))
+		var/mob/living/simple_animal/advanced/P = I
 		var/list/traits = initial(P.p_traits)
 		if(!(P_TRAIT_BLACKLIST in traits))//Not blacklisted from being added to the list
 			GLOB.pokemon_selectable[capitalize("[initial(P.name)]")] = P
@@ -101,8 +101,8 @@ GLOBAL_LIST_INIT(creature_whitelist, list(
 	/mob/living/simple_animal/armadillo,
 	/mob/living/simple_animal/pet/kiwi,
 	/mob/living/simple_animal/pet/sheep,
-	/mob/living/simple_animal/pokemon/tenderclawmale,
-	/mob/living/simple_animal/pokemon/tenderclawfemale,
-	/mob/living/simple_animal/pokemon/tenderclawherm,
-	/mob/living/simple_animal/pokemon/nightstalker
+	/mob/living/simple_animal/advanced/tenderclawmale,
+	/mob/living/simple_animal/advanced/tenderclawfemale,
+	/mob/living/simple_animal/advanced/tenderclawherm,
+	/mob/living/simple_animal/advanced/nightstalker
 	))

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -1,5 +1,6 @@
 #define isadvancedmob(A)		istype(A, /mob/living/simple_animal/advanced)
 
+// Should make these into bitflags later if we want to use them for realsies
 #define P_TYPE_FIRE 	"fire"
 #define P_TYPE_WATER 	"water"
 #define P_TYPE_ICE 		"ice"
@@ -33,37 +34,24 @@
 //This pokemon can be buckled to, ridden, and steered like a vehicle
 #define P_TRAIT_RIDEABLE	"rideable"
 
-//List of pokemon subtypes that a player can choose from when spawning in. Exclude pokemon by giving them the P_TRAIT_BLACKLIST trait.
-GLOBAL_LIST_EMPTY(pokemon_selectable)
-/proc/generate_selectable_pokemon(clear = FALSE)
-	if(clear)
-		GLOB.pokemon_selectable = list()
-	for(var/I in subtypesof(/mob/living/simple_animal/advanced))
-		var/mob/living/simple_animal/advanced/P = I
-		var/list/traits = initial(P.p_traits)
-		if(!(P_TRAIT_BLACKLIST in traits))//Not blacklisted from being added to the list
-			GLOB.pokemon_selectable[capitalize("[initial(P.name)]")] = P
 
-///Creatures that players can select for creature characters
+///Creatures that players can select for creature characters. Exclude mobs by giving them the P_TRAIT_BLACKLIST trait (see Bud for example).
 GLOBAL_LIST_EMPTY(creature_selectable)
 
 /proc/generate_selectable_creatures(clear = FALSE)
 	if(clear)
 		GLOB.creature_selectable = list()
-	if(!LAZYLEN(GLOB.pokemon_selectable))//Pokemon list hasn't been generated so do it now
-		generate_selectable_pokemon()
- 	GLOB.creature_selectable |= GLOB.pokemon_selectable //Merge pokemon into master creature list
-	for(var/T in typesof(/mob/living/simple_animal))
-		var/mob/living/simple_animal/SA = T
-		if(initial(SA.gold_core_spawnable) == FRIENDLY_SPAWN)
-			if(!(SA in GLOB.creature_blacklist))
-				GLOB.creature_selectable[capitalize(initial(SA.name))] = SA
+	for(var/I in subtypesof(/mob/living/simple_animal/advanced))
+		var/mob/living/simple_animal/advanced/P = I
+		var/list/traits = initial(P.p_traits)
+		if(!(P_TRAIT_BLACKLIST in traits))//Not blacklisted from being added to the list
+			GLOB.creature_selectable[capitalize("[initial(P.name)]")] = P
 	for(var/T in GLOB.creature_whitelist)
 		var/mob/living/simple_animal/SA = T
 		GLOB.creature_selectable[capitalize(initial(SA.name))] = T
 
 ///List of all pokemon on the whole map.
-GLOBAL_LIST_EMPTY(pokemon_list)
+GLOBAL_LIST_EMPTY(advanced_mob_list)
 
 ///List of available spawnpoints for creatures to choose from when spawning
 GLOBAL_LIST_INIT(creature_spawnpoints, list(
@@ -71,38 +59,9 @@ GLOBAL_LIST_INIT(creature_spawnpoints, list(
 	"Wasteland" = /obj/effect/landmark/start/f13/wastelander
 	))
 
-///Creatures that are not allowed for players to select for characters
-GLOBAL_LIST_INIT(creature_blacklist, list(
-	/mob/living/simple_animal/chick,
-	/mob/living/simple_animal/hostile/retaliate/goat,
-	/mob/living/simple_animal/cow/random,
-	/mob/living/simple_animal/opossum/poppy,
-	/mob/living/simple_animal/radstag/rudostag,
-	/mob/living/simple_animal/cow/brahmin/nightstalker,
-	/mob/living/simple_animal/cow/brahmin/sgtsillyhorn,
-	/mob/living/simple_animal/cow/brahmin/calf,
-	/mob/living/simple_animal/cow/brahmin,
-	/mob/living/simple_animal/cow/brahmin/motorbike,
-	/mob/living/simple_animal/cow/brahmin/horse/honse,
-	/mob/living/simple_animal/pet/cat/cak,
-	/mob/living/simple_animal/pet/cat/kitten,
-	/mob/living/simple_animal/pet/bumbles,
-	/mob/living/simple_animal/pet/redpanda/stinky,
-	/mob/living/simple_animal/pet/fox/paws,
-	/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,
-	/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck
-	))
-
-///Creatures that should be added to the playable creature list. Only put mobs in here if they aren't gold slime core spawnable already.
+///Creatures that should be added to the playable creature list.
+///DO NOT ADD MOBS HERE UNLESS THEY ARE SUBTYPES OF /mob/living/simple_animal/advanced. CATSLUGS CAN STAY BECAUSE THEY ARE BASICALLY ALREADY ADVANCED MOBS.
 GLOBAL_LIST_INIT(creature_whitelist, list(
-	/mob/living/simple_animal/pet/catslug,
-	/mob/living/simple_animal/pet/wolf/direwolf,
-	/mob/living/simple_animal/raccoon,
-	/mob/living/simple_animal/armadillo,
-	/mob/living/simple_animal/pet/kiwi,
-	/mob/living/simple_animal/pet/sheep,
-	/mob/living/simple_animal/advanced/tenderclawmale,
-	/mob/living/simple_animal/advanced/tenderclawfemale,
-	/mob/living/simple_animal/advanced/tenderclawherm,
-	/mob/living/simple_animal/advanced/nightstalker
+	/mob/living/simple_animal/pet/catslug
 	))
+///DO NOT ADD MOBS HERE UNLESS THEY ARE SUBTYPES OF /mob/living/simple_animal/advanced. CATSLUGS CAN STAY BECAUSE THEY ARE BASICALLY ALREADY ADVANCED MOBS.

--- a/modular_coyote/code/_pmon_defines.dm
+++ b/modular_coyote/code/_pmon_defines.dm
@@ -56,7 +56,8 @@ GLOBAL_LIST_EMPTY(advanced_mob_list)
 ///List of available spawnpoints for creatures to choose from when spawning
 GLOBAL_LIST_INIT(creature_spawnpoints, list(
 	"Nash" = /obj/effect/landmark/start/f13/settler,
-	"Wasteland" = /obj/effect/landmark/start/f13/wastelander
+	"Wasteland" = /obj/effect/landmark/start/f13/wastelander,
+	"Ashdown" = /obj/effect/landmark/start/f13/ashdown
 	))
 
 ///Creatures that should be added to the playable creature list.

--- a/modular_coyote/code/drakeborgs/drakeborg.dm
+++ b/modular_coyote/code/drakeborgs/drakeborg.dm
@@ -1,48 +1,48 @@
 //Drakeborgs, ported from Virgo
 
-/mob/living/simple_animal/pokemon/medicaldrake
+/mob/living/simple_animal/advanced/medicaldrake
 	name = "medical drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakemed"
 	icon_living = "drakemed"
 	icon_dead = "drakemed_wreck"
 
-/mob/living/simple_animal/pokemon/securitydrake
+/mob/living/simple_animal/advanced/securitydrake
 	name = "security drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakesec"
 	icon_living = "drakesec"
 	icon_dead = "drakesec_wreck"
 
-/mob/living/simple_animal/pokemon/drakeeng
+/mob/living/simple_animal/advanced/drakeeng
 	name = "engineering drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakeeng"
 	icon_living = "drakeeng"
 	icon_dead = "drakeeng_wreck"
 
-/mob/living/simple_animal/pokemon/drakemine
+/mob/living/simple_animal/advanced/drakemine
 	name = "mining drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakemine"
 	icon_living = "drakemine"
 	icon_dead = "drakemine_wreck"
 
-/mob/living/simple_animal/pokemon/drakesci
+/mob/living/simple_animal/advanced/drakesci
 	name = "science drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakesci"
 	icon_living = "drakesci"
 	icon_dead = "drakesci_wreck"
 
-/mob/living/simple_animal/pokemon/drakejanit
+/mob/living/simple_animal/advanced/drakejanit
 	name = "janitor drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "drakejanit"
 	icon_living = "drakejanit"
 	icon_dead = "drakejaniti_wreck"
 
-/mob/living/simple_animal/pokemon/draketrauma
+/mob/living/simple_animal/advanced/draketrauma
 	name = "trauma drake borg"
 	icon = 'modular_coyote/code/drakeborgs/drakeborg_vr.dmi'
 	icon_state = "draketrauma"

--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -461,7 +461,7 @@
 	. = ..()
 	recenter_wide_sprite()
 
-/mob/living/simple_animal/pokemon/tenderclawmale
+/mob/living/simple_animal/advanced/tenderclawmale
 	name = "male tenderclaw"
 	desc = "A..deathclaw? Or, well. It sort of looks like a deathclaw. Just, softer and friendler!"
 	icon = 'modular_coyote/icons/mob/newclaws.dmi'
@@ -469,7 +469,7 @@
 	icon_living = "newclaw"
 	icon_dead = "newclaw_d"
 
-/mob/living/simple_animal/pokemon/tenderclawfemale
+/mob/living/simple_animal/advanced/tenderclawfemale
 	name = "female tenderclaw"
 	desc = "A..deathclaw? Or, well. It sort of looks like a deathclaw. Just, softer and friendler!"
 	icon = 'modular_coyote/icons/mob/newclaws.dmi'
@@ -477,7 +477,7 @@
 	icon_living = "femclaw"
 	icon_dead = "femclaw_d"
 
-/mob/living/simple_animal/pokemon/tenderclawherm
+/mob/living/simple_animal/advanced/tenderclawherm
 	name = "herm tenderclaw"
 	desc = "A..deathclaw? Or, well. It sort of looks like a deathclaw. Just, softer and friendler!"
 	icon = 'modular_coyote/icons/mob/newclaws.dmi'
@@ -485,7 +485,7 @@
 	icon_living = "hermclaw"
 	icon_dead = "hermclaw_d"
 
-/mob/living/simple_animal/pokemon/nightstalker
+/mob/living/simple_animal/advanced/nightstalker
 	name = "nightstalker"
 	desc = "A nightstalker!"
 	icon = 'icons/fallout/mobs/animals/nightstalker.dmi'
@@ -493,7 +493,7 @@
 	icon_living = "nightstalker"
 	icon_dead = "nightstalker-dead"
 
-/mob/living/simple_animal/pokemon/wendigo
+/mob/living/simple_animal/advanced/wendigo
 	name = "wendigo"
 	desc = "A mythological man-eating legendary creature, you probably aren't going to survive this.!"
 	icon = 'icons/mob/icemoon/64x64megafauna.dmi'
@@ -505,15 +505,15 @@
 
 //Actual chooseable mouse colors
 
-/mob/living/simple_animal/pokemon/mousewhite
+/mob/living/simple_animal/advanced/mousewhite
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "mouse_white"
 
-/mob/living/simple_animal/pokemon/mousegray
+/mob/living/simple_animal/advanced/mousegray
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "mouse_gray"
 
-/mob/living/simple_animal/pokemon/mousebrown
+/mob/living/simple_animal/advanced/mousebrown
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "mouse_brown"
 
@@ -521,140 +521,140 @@
 //The simple version of the dog borgs.
 
 
-/mob/living/simple_animal/pokemon/blade//Yes they are pokemon, shut.
+/mob/living/simple_animal/advanced/blade//Yes they are pokemon, shut.
 	name = "blade borg"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "blade"
 	icon_living = "blade"
 	icon_dead = "blade-wreck"
 
-/mob/living/simple_animal/pokemon/k9
+/mob/living/simple_animal/advanced/k9
 	name = "k9"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "k9"
 	icon_living = "k9"
 	icon_dead = "k9-wreck"
 
-/mob/living/simple_animal/pokemon/k9
+/mob/living/simple_animal/advanced/k9
 	name = "k9"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "k9"
 	icon_living = "k9"
 	icon_dead = "k9-wreck"
 
-/mob/living/simple_animal/pokemon/medihound
+/mob/living/simple_animal/advanced/medihound
 	name = "medihound"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "medihound"
 	icon_living = "medihound"
 	icon_dead = "medihound-wreck"
 
-/mob/living/simple_animal/pokemon/k69
+/mob/living/simple_animal/advanced/k69
 	name = "k69"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "k69"
 	icon_living = "k69"
 	icon_dead = "k69-wreck"
 
-/mob/living/simple_animal/pokemon/scrubpup
+/mob/living/simple_animal/advanced/scrubpup
 	name = "scrubpup"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "scrubpup"
 	icon_living = "scrubpup"
 	icon_dead = "scrubpup-wreck"
 
-/mob/living/simple_animal/pokemon/alinaeng
+/mob/living/simple_animal/advanced/alinaeng
 	name = "engineering hound"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "alina-eng"
 	icon_living = "alina-eng"
 	icon_dead = "alina-eng-wreck"
 
-/mob/living/simple_animal/pokemon/alinasec
+/mob/living/simple_animal/advanced/alinasec
 	name = "security hound"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "alina-sec"
 	icon_living = "alina-sec"
 	icon_dead = "alina-sec-wreck"
 
-/mob/living/simple_animal/pokemon/alinamed
+/mob/living/simple_animal/advanced/alinamed
 	name = "medical hound"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "alina-med"
 	icon_living = "alina-med"
 	icon_dead = "alina-med-wreck"
 
-/mob/living/simple_animal/pokemon/medihounddark
+/mob/living/simple_animal/advanced/medihounddark
 	name = "medical hound dark"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "medihounddark"
 	icon_living = "medihounddark"
 	icon_dead = "medihounddark-wreck"
 
-/mob/living/simple_animal/pokemon/pupdozer
+/mob/living/simple_animal/advanced/pupdozer
 	name = "pupdozer"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "pupdozer"
 	icon_living = "pupdozer"
 	icon_dead = "pupdozer-wreck"
 
-/mob/living/simple_animal/pokemon/k9dark
+/mob/living/simple_animal/advanced/k9dark
 	name = "k9 dark"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "k9dark"
 	icon_living = "k9dark"
 	icon_dead = "k9dark-wreck"
 
-/mob/living/simple_animal/pokemon/valemed
+/mob/living/simple_animal/advanced/valemed
 	name = "vale med"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valemed"
 	icon_living = "valemed"
 	icon_dead = "valemed-wreck"
 
-/mob/living/simple_animal/pokemon/valesci
+/mob/living/simple_animal/advanced/valesci
 	name = "vale sci"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valesci"
 	icon_living = "valesci"
 	icon_dead = "valesci-wreck"
 
-/mob/living/simple_animal/pokemon/valesesc
+/mob/living/simple_animal/advanced/valesesc
 	name = "Vale sec"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valesec"
 	icon_living = "valesec"
 	icon_dead = "valesec-wreck"
 
-/mob/living/simple_animal/pokemon/valeseng
+/mob/living/simple_animal/advanced/valeseng
 	name = "Vale eng"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valeeng"
 	icon_living = "valeeng"
 	icon_dead = "valeeng-wreck"
 
-/mob/living/simple_animal/pokemon/valemine
+/mob/living/simple_animal/advanced/valemine
 	name = "Vale mine"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valemine"
 	icon_living = "valemine"
 	icon_dead = "valemine-wreck"
 
-/mob/living/simple_animal/pokemon/k50
+/mob/living/simple_animal/advanced/k50
 	name = "k50"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "k50"
 	icon_living = "k50"
 	icon_dead = "k50-wreck"
 
-/mob/living/simple_animal/pokemon/valeserv
+/mob/living/simple_animal/advanced/valeserv
 	name = "vale serv"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valeserv"
 	icon_living = "valeserv"
 	icon_dead = "valeserv-wreck"
 
-/mob/living/simple_animal/pokemon/valeservdark
+/mob/living/simple_animal/advanced/valeservdark
 	name = "vale serv dark"
 	icon = 'modular_coyote/icons/mob/dogborg.dmi'
 	icon_state = "valeservdark"
@@ -663,63 +663,63 @@
 
 
 //Raptor borgs from Virgo
-/mob/living/simple_animal/pokemon/secraptor
+/mob/living/simple_animal/advanced/secraptor
 	name = "security raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "secraptor"
 	icon_living = "secraptor"
 	icon_dead = "secraptor-wreck"
 
-/mob/living/simple_animal/pokemon/sciraptor
+/mob/living/simple_animal/advanced/sciraptor
 	name = "science raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "sciraptor"
 	icon_living = "sciraptor"
 	icon_dead = "sciraptor-wreck"
 
-/mob/living/simple_animal/pokemon/mediraptor
+/mob/living/simple_animal/advanced/mediraptor
 	name = "medical raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "medraptor"
 	icon_living = "medraptor"
 	icon_dead = "medraptor-wreck"
 
-/mob/living/simple_animal/pokemon/engiraptor
+/mob/living/simple_animal/advanced/engiraptor
 	name = "engineering raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "engiraptor"
 	icon_living = "engiraptor"
 	icon_dead = "engiraptor-wreck"
 
-/mob/living/simple_animal/pokemon/mineraptor
+/mob/living/simple_animal/advanced/mineraptor
 	name = "mining raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "mineraptor"
 	icon_living = "mineraptor"
 	icon_dead = "mineraptor-wreck"
 
-/mob/living/simple_animal/pokemon/traumaraptor
+/mob/living/simple_animal/advanced/traumaraptor
 	name = "trauma raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "traumaraptor"
 	icon_living = "traumaraptor"
 	icon_dead = "traumaraptor-wreck"
 
-/mob/living/simple_animal/pokemon/janiraptor
+/mob/living/simple_animal/advanced/janiraptor
 	name = "janitor raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "janiraptor"
 	icon_living = "janiraptor"
 	icon_dead = "janiraptor-wreck"
 
-/mob/living/simple_animal/pokemon/serviraptor
+/mob/living/simple_animal/advanced/serviraptor
 	name = "service raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "serviraptor"
 	icon_living = "serviraptor"
 	icon_dead = "serviraptor-wreck"
 
-/mob/living/simple_animal/pokemon/fancyraptor
+/mob/living/simple_animal/advanced/fancyraptor
 	name = "fancy raptor"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "fancyraptor"
@@ -730,42 +730,42 @@
 
 //raptor mobs from virgo
 
-/mob/living/simple_animal/pokemon/purpleraptor
+/mob/living/simple_animal/advanced/purpleraptor
 	name = "purple raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorpurple"
 	icon_living = "raptorpurple"
 	icon_dead = "raptorpurple_dead"
 
-/mob/living/simple_animal/pokemon/greenraptor
+/mob/living/simple_animal/advanced/greenraptor
 	name = "green raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorgreen"
 	icon_living = "raptorgreen"
 	icon_dead = "raptorgreen_dead"
 
-/mob/living/simple_animal/pokemon/redraptor
+/mob/living/simple_animal/advanced/redraptor
 	name = "red raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorred"
 	icon_living = "raptorred"
 	icon_dead = "raptorred_dead"
 
-/mob/living/simple_animal/pokemon/blueraptor
+/mob/living/simple_animal/advanced/blueraptor
 	name = "blue raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorblue"
 	icon_living = "raptorblue"
 	icon_dead = "raptorblue_dead"
 
-/mob/living/simple_animal/pokemon/blackraptor
+/mob/living/simple_animal/advanced/blackraptor
 	name = "black raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorblack"
 	icon_living = "raptorblack"
 	icon_dead = "raptorblack_dead"
 
-/mob/living/simple_animal/pokemon/whiteraptor
+/mob/living/simple_animal/advanced/whiteraptor
 	name = "white raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
 	icon_state = "raptorwhite"

--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -727,45 +727,48 @@
 	icon_dead = "fancyraptor-wreck"
 
 //raptor mobs from virgo
-/* These straight up don't have sprites????
+
+/* All advanced mobs need to have dead and resting sprites equal to "[icon_living]_rest"
+// Fix these before uncommenting them.
+
 /mob/living/simple_animal/advanced/purpleraptor
 	name = "purple raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorpurple"
 	icon_living = "raptorpurple"
 	icon_dead = "raptorpurple_dead"
 
 /mob/living/simple_animal/advanced/greenraptor
 	name = "green raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorgreen"
 	icon_living = "raptorgreen"
 	icon_dead = "raptorgreen_dead"
 
 /mob/living/simple_animal/advanced/redraptor
 	name = "red raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorred"
 	icon_living = "raptorred"
 	icon_dead = "raptorred_dead"
 
 /mob/living/simple_animal/advanced/blueraptor
 	name = "blue raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorblue"
 	icon_living = "raptorblue"
 	icon_dead = "raptorblue_dead"
 
 /mob/living/simple_animal/advanced/blackraptor
 	name = "black raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorblack"
 	icon_living = "raptorblack"
 	icon_dead = "raptorblack_dead"
 
 /mob/living/simple_animal/advanced/whiteraptor
 	name = "white raptor - animal"
-	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
+	icon = 'modular_coyote/icons/mob/raptor.dmi'
 	icon_state = "raptorwhite"
 	icon_living = "raptorwhite"
 	icon_dead = "raptorwhite_dead"

--- a/modular_coyote/code/mob.dm
+++ b/modular_coyote/code/mob.dm
@@ -726,10 +726,8 @@
 	icon_living = "fancyraptor"
 	icon_dead = "fancyraptor-wreck"
 
-
-
 //raptor mobs from virgo
-
+/* These straight up don't have sprites????
 /mob/living/simple_animal/advanced/purpleraptor
 	name = "purple raptor - animal"
 	icon = 'modular_coyote/icons/mob/raptorborg.dmi'
@@ -771,13 +769,11 @@
 	icon_state = "raptorwhite"
 	icon_living = "raptorwhite"
 	icon_dead = "raptorwhite_dead"
+*/
 
-/mob/living/simple_animal/pokemon/bat
+/mob/living/simple_animal/advanced/bat
 	name = "bat"
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "bat"
 	icon_living = "bat"
 	icon_dead = "bat_dead"
-
-
-

--- a/modular_coyote/code/pmon_actions.dm
+++ b/modular_coyote/code/pmon_actions.dm
@@ -12,8 +12,8 @@
 /datum/action/cooldown/pokemon_rest/Trigger()
 	if(!..())
 		return FALSE
-	if(ispokemon(owner))
-		var/mob/living/simple_animal/pokemon/O = owner
+	if(isadvancedmob(owner))
+		var/mob/living/simple_animal/advanced/O = owner
 		O.lay_down()
 		O.update_mobility()
 		return TRUE

--- a/modular_coyote/code/pmon_mob.dm
+++ b/modular_coyote/code/pmon_mob.dm
@@ -1,6 +1,6 @@
 //Pokemon!
 
-/mob/living/simple_animal/pokemon
+/mob/living/simple_animal/advanced
 	name = "eevee"
 	desc = "It has the ability to alter the composition of its body to suit its surrounding environment."
 	icon = 'modular_coyote/icons/mob/pokemon64.dmi'
@@ -45,7 +45,7 @@
 	///Moves/Abilities that this mob is currently using
 	var/list/p_active_moves = list()
 
-/mob/living/simple_animal/pokemon/Initialize()
+/mob/living/simple_animal/advanced/Initialize()
 	. = ..()
 	recenter_wide_sprite()
 	var/datum/action/cooldown/pokemon_rest/R = new(src)
@@ -63,10 +63,10 @@
 		return TRUE
 	return FALSE
 
-/mob/living/simple_animal/pokemon/Life()
+/mob/living/simple_animal/advanced/Life()
 	. = ..()
 
-/mob/living/simple_animal/pokemon/regenerate_icons()
+/mob/living/simple_animal/advanced/regenerate_icons()
 	if(stat == DEAD)
 		icon_state = icon_dead
 	else if(stat != DEAD && !CHECK_MOBILITY(src, MOBILITY_STAND))//Not dead but can't move
@@ -74,11 +74,11 @@
 	else
 		icon_state = icon_living
 
-/mob/living/simple_animal/pokemon/update_mobility()
+/mob/living/simple_animal/advanced/update_mobility()
 	. = ..()
 	regenerate_icons()
 
-/mob/living/simple_animal/pokemon/Destroy()
+/mob/living/simple_animal/advanced/Destroy()
 	GLOB.pokemon_list -= src
 	. = ..()
 
@@ -86,7 +86,7 @@
 //////ALPHABETICAL PLEASE//////
 ///////////////////////////////
 
-/mob/living/simple_animal/pokemon/absol
+/mob/living/simple_animal/advanced/absol
 	name = "absol"
 	icon_state = "absol"
 	icon_living = "absol"
@@ -94,7 +94,7 @@
 	p_types = list(P_TYPE_DARK)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/megaabsol
+/mob/living/simple_animal/advanced/megaabsol
 	name = "mega absol"
 	icon_state = "megaabsol"
 	icon_living = "megaabsol"
@@ -102,7 +102,7 @@
 	p_types = list(P_TYPE_DARK)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/aggron
+/mob/living/simple_animal/advanced/aggron
 	name = "aggron"
 	icon_state = "aggron"
 	icon_living = "aggron"
@@ -111,7 +111,7 @@
 	mob_size = MOB_SIZE_LARGE
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/alolanvulpix
+/mob/living/simple_animal/advanced/alolanvulpix
 	name = "alolan vulpix"
 	icon_state = "alolanvulpix"
 	icon_living = "alolanvulpix"
@@ -120,7 +120,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/ampharos
+/mob/living/simple_animal/advanced/ampharos
 	name = "ampharos"
 	icon_state = "ampharos"
 	icon_living = "ampharos"
@@ -128,7 +128,7 @@
 	p_types = list(P_TYPE_ELEC)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/articuno
+/mob/living/simple_animal/advanced/articuno
 	name = "Articuno"
 	icon_state = "articuno"
 	icon_living = "articuno"
@@ -137,7 +137,7 @@
 	p_types = list(P_TYPE_ICE, P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/arcanine
+/mob/living/simple_animal/advanced/arcanine
 	name = "Acanine"
 	icon_state = "arcanine"
 	icon_living = "arcanine"
@@ -146,21 +146,21 @@
 
 
 
-/mob/living/simple_animal/pokemon/blastoise
+/mob/living/simple_animal/advanced/blastoise
 	name = "blastoise"
 	icon_state = "blastoise"
 	icon_living = "blastoise"
 	icon_dead = "blastoise_d"
 	p_types = list(P_TYPE_WATER)
 
-/mob/living/simple_animal/pokemon/braixen
+/mob/living/simple_animal/advanced/braixen
 	name = "braixen"
 	icon_state = "braixen"
 	icon_living = "braixen"
 	icon_dead = "braixen_d"
 	p_types = list(P_TYPE_FIRE)
 
-/mob/living/simple_animal/pokemon/celebi
+/mob/living/simple_animal/advanced/celebi
 	name = "celebi"
 	icon_state = "celebi"
 	icon_living = "celebi"
@@ -168,7 +168,7 @@
 	p_types = list(P_TYPE_PSYCH, P_TYPE_GRASS)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/charmander
+/mob/living/simple_animal/advanced/charmander
 	name = "charmander"
 	icon_state = "charmander"
 	icon_living = "charmander"
@@ -177,7 +177,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/charizard
+/mob/living/simple_animal/advanced/charizard
 	name = "charizard"
 	icon_state = "charizard"
 	icon_living = "charizard"
@@ -186,16 +186,16 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/ditto
+/mob/living/simple_animal/advanced/ditto
 	name = "ditto"
 	icon_state = "ditto"
 	icon_living = "ditto"
 	icon_dead = "ditto_d"
 	p_types = list(P_TYPE_NORM)
-//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/pokemon/proc/move_imposter)//amogus
+//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/advanced/proc/move_imposter)//amogus
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/dragonair
+/mob/living/simple_animal/advanced/dragonair
 	name = "dragonair"
 	desc = "A Dragonair stores an enormous amount of energy inside its body. It is said to alter the weather around it by loosing energy from the crystals on its neck and tail."
 	icon_state = "dragonair"
@@ -203,24 +203,24 @@
 	icon_dead = "dragonair_d"
 	p_types = list(P_TYPE_DRAGON)
 //	aquatic_movement = 1
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_fly,
-//							/mob/living/simple_animal/pokemon/proc/move_hover)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_fly,
+//							/mob/living/simple_animal/advanced/proc/move_hover)
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/dragonair/shiny
+/mob/living/simple_animal/advanced/dragonair/shiny
 	name = "shiny dragonair"
 	icon_state = "shinydragonair"
 	icon_living = "shinydragonair"
 	icon_dead = "shinydragonair_d"
 
-/mob/living/simple_animal/pokemon/dunsparce
+/mob/living/simple_animal/advanced/dunsparce
 	name = "dunsparce"
 	icon_state = "dunsparce"
 	icon_living = "dunsparce"
 	icon_dead = "dunsparce_d"
 
-/mob/living/simple_animal/pokemon/dragonite
+/mob/living/simple_animal/advanced/dragonite
 	name = "dragonite"
 	desc = "It can circle the globe in just 16 hours. It is a kindhearted Pokemon that leads lost and foundering ships in a storm to the safety of land."
 	icon_state = "dragonite"
@@ -231,7 +231,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/dratini
+/mob/living/simple_animal/advanced/dratini
 	name = "dratini"
 	desc = "A Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels."
 	icon_state = "dratini"
@@ -242,7 +242,7 @@
 	p_types = list(P_TYPE_DRAGON)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/eevee
+/mob/living/simple_animal/advanced/eevee
 	name = "eevee"
 	desc = "Eevee has an unstable genetic makeup that suddenly mutates due to its environment. Radiation from various stones causes this Pokemon to evolve."
 	icon_state = "eevee"
@@ -252,7 +252,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/espeon
+/mob/living/simple_animal/advanced/espeon
 	name = "espeon"
 	desc = "Espeon is extremely loyal to any trainer it considers to be worthy. It is said to have developed precognitive powers to protect its trainer from harm."
 	icon_state = "espeon"
@@ -261,7 +261,7 @@
 	p_types = list(P_TYPE_PSYCH)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/fennekin
+/mob/living/simple_animal/advanced/fennekin
 	name = "fennekin"
 	icon_state = "fennekin"
 	icon_living = "fennekin"
@@ -270,7 +270,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/flaaffy
+/mob/living/simple_animal/advanced/flaaffy
 	name = "flaaffy"
 	icon_state = "flaaffy"
 	icon_living = "flaaffy"
@@ -278,7 +278,7 @@
 	p_types = list(P_TYPE_ELEC)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/flareon
+/mob/living/simple_animal/advanced/flareon
 	name = "flareon"
 	desc = "Flareon's fluffy fur releases heat into the air so that its body does not get excessively hot. Its body temperature can rise to a maximum of 1,650 degrees F."
 	icon_state = "flareon"
@@ -287,19 +287,19 @@
 	p_types = list(P_TYPE_FIRE)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/flygon
+/mob/living/simple_animal/advanced/flygon
 	name = "flygon"
 	desc = "The flapping of its wings sounds something like singing. Those lured by the sound are enveloped in a sandstorm, becoming Flygon's prey."
 	icon_state = "flygon"
 	icon_living = "flygon"
 	icon_dead = "flygon_d"
 	p_types = list(P_TYPE_GROUND, P_TYPE_DRAGON)
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_fly,
-//							/mob/living/simple_animal/pokemon/proc/move_hover)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_fly,
+//							/mob/living/simple_animal/advanced/proc/move_hover)
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/furret
+/mob/living/simple_animal/advanced/furret
 	name = "furret"
 	icon_state = "furret"
 	icon_living = "furret"
@@ -307,21 +307,21 @@
 	p_types = list(P_TYPE_NORM)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/gallade
+/mob/living/simple_animal/advanced/gallade
 	name = "gallade"
 	icon_state = "gallade"
 	icon_living = "gallade"
 	icon_dead = "gallade_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FIGHT)
 
-/mob/living/simple_animal/pokemon/gardevoir
+/mob/living/simple_animal/advanced/gardevoir
 	name = "gardevoir"
 	icon_state = "gardevoir"
 	icon_living = "gardevoir"
 	icon_dead = "gardevoir_d"
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FAIRY)
 
-/mob/living/simple_animal/pokemon/gastly
+/mob/living/simple_animal/advanced/gastly
 	name = "gastly"
 	desc = "Almost invisible, this gaseous Pokemon cloaks the target and puts it to sleep without notice."
 	icon_state = "gastly"
@@ -329,7 +329,7 @@
 	icon_dead = "gastly_d"
 	p_types = list(P_TYPE_GHOST, P_TYPE_POISON)
 
-/mob/living/simple_animal/pokemon/gengar
+/mob/living/simple_animal/advanced/gengar
 	name = "gengar"
 	desc = "It hides in shadows. It is said that if Gengar is hiding, it cools the area by nearly 10 degrees F."
 	icon_state = "gengar"
@@ -338,7 +338,7 @@
 	p_types = list(P_TYPE_GHOST, P_TYPE_POISON)
 
 
-/mob/living/simple_animal/pokemon/glaceon
+/mob/living/simple_animal/advanced/glaceon
 	name = "glaceon"
 	desc = "By controlling its body heat, it can freeze the atmosphere around it to make a diamond-dust flurry."
 	icon_state = "glaceon"
@@ -347,7 +347,7 @@
 	p_types = list(P_TYPE_ICE)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/haunter
+/mob/living/simple_animal/advanced/haunter
 	name = "haunter"
 	desc = "If you get the feeling of being watched in darkness when nobody is around, Haunter may be there."
 	icon_state = "haunter"
@@ -355,17 +355,17 @@
 	icon_dead = "haunter_d"
 	p_types = list(P_TYPE_GHOST, P_TYPE_POISON)
 
-/mob/living/simple_animal/pokemon/jirachi
+/mob/living/simple_animal/advanced/jirachi
 	name = "jirachi"
 	desc = "Generations have believed that any wish written on a note on its head will come true when it awakens."
 	icon_state = "jirachi"
 	icon_living = "jirachi"
 	icon_dead = "jirachi_d"
 	p_types = list(P_TYPE_STEEL, P_TYPE_PSYCH)
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_fly,
-//							/mob/living/simple_animal/pokemon/proc/move_hover)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_fly,
+//							/mob/living/simple_animal/advanced/proc/move_hover)
 
-/mob/living/simple_animal/pokemon/jolteon
+/mob/living/simple_animal/advanced/jolteon
 	name = "jolteon"
 	desc = "Its cells generate weak power that is amplified by its fur's static electricity to drop thunderbolts. The bristling fur is made of electrically charged needles."
 	icon_state = "jolteon"
@@ -374,11 +374,11 @@
 	p_types = list(P_TYPE_ELEC)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/jolteon/bud
+/mob/living/simple_animal/advanced/jolteon/bud
 	name = "Bud"
 	p_active_moves = list(M_SHOCK) //Shocks you by default
 
-/mob/living/simple_animal/pokemon/kirlia
+/mob/living/simple_animal/advanced/kirlia
 	name = "kirlia"
 	icon_state = "kirlia"
 	icon_living = "kirlia"
@@ -386,7 +386,7 @@
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FAIRY)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/larvitar
+/mob/living/simple_animal/advanced/larvitar
 	name = "larvitar"
 	desc = "It is born deep underground. It can't emerge until it has entirely consumed the soil around it."
 	icon_state = "larvitar"
@@ -395,7 +395,7 @@
 	p_types = list(P_TYPE_ROCK, P_TYPE_GROUND)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/leafeon
+/mob/living/simple_animal/advanced/leafeon
 	name = "leafeon"
 	icon_state = "leafeon"
 	icon_living = "leafeon"
@@ -403,7 +403,7 @@
 	p_types = list(P_TYPE_GRASS)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/linoone
+/mob/living/simple_animal/advanced/linoone
 	name = "linoone"
 	icon_state = "linoone"
 	icon_living = "linoone"
@@ -412,7 +412,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/lugia
+/mob/living/simple_animal/advanced/lugia
 	name = "Lugia"
 	icon_state = "lugia"
 	icon_living = "lugia"
@@ -421,7 +421,7 @@
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/growlithe
+/mob/living/simple_animal/advanced/growlithe
 	name = "growlithe"
 	icon_state = "growlithe"
 	icon_living = "growlithe"
@@ -430,7 +430,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/mareep
+/mob/living/simple_animal/advanced/mareep
 	name = "mareep"
 	icon_state = "mareep"
 	icon_living = "mareep"
@@ -440,7 +440,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/mightyena
+/mob/living/simple_animal/advanced/mightyena
 	name = "mightyena"
 	icon_state = "mightyena"
 	icon_living = "mightyena"
@@ -448,7 +448,7 @@
 	p_types = list(P_TYPE_DARK)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/miltank
+/mob/living/simple_animal/advanced/miltank
 	name = "miltank"
 	icon_state = "miltank"
 	icon_living = "miltank"
@@ -457,19 +457,19 @@
 	var/datum/reagents/udder = null
 //	movement_cooldown = 3
 
-/mob/living/simple_animal/pokemon/miltank/Initialize()
+/mob/living/simple_animal/advanced/miltank/Initialize()
 	udder = new(50)
 	udder.my_atom = src
 	..()
 
-/mob/living/simple_animal/pokemon/miltank/Life()
+/mob/living/simple_animal/advanced/miltank/Life()
 	. = ..()
 	if(stat == CONSCIOUS)
 		if(udder && prob(5))
 			udder.add_reagent("milk", rand(5, 10))
 
 /* TODO fix milking i guess
-/mob/living/simple_animal/pokemon/miltank/attackby(var/obj/item/O as obj, var/mob/user as mob)
+/mob/living/simple_animal/advanced/miltank/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/item/weapon/reagent_containers/glass/G = O
 	if(stat == CONSCIOUS && istype(G) && G.is_open_container())
 		user.visible_message(span_notice("[user] milks [src] using \the [O]."))
@@ -481,7 +481,7 @@
 		..()
 */
 
-/mob/living/simple_animal/pokemon/poochyena
+/mob/living/simple_animal/advanced/poochyena
 	name = "poochyena"
 	icon_state = "poochyena"
 	icon_living = "poochyena"
@@ -490,7 +490,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/snivy
+/mob/living/simple_animal/advanced/snivy
 	name = "snivy"
 	desc = "Being exposed to sunlight makes its movements swifter. It uses vines more adeptly than its hands."
 	icon_state = "snivy"
@@ -499,7 +499,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_types = list(P_TYPE_GRASS)
 
-/mob/living/simple_animal/pokemon/sprigatito
+/mob/living/simple_animal/advanced/sprigatito
 	name = "sprigatito"
 	desc = "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
 	icon_state = "sprigatito"
@@ -508,7 +508,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_types = list(P_TYPE_GRASS)
 
-/mob/living/simple_animal/pokemon/sylveon
+/mob/living/simple_animal/advanced/sylveon
 	name = "sylveon"
 	desc = "Sylveon, the Intertwining Pokemon. Sylveon affectionately wraps its ribbon-like feelers around its Trainer's arm as they walk together."
 	icon_state = "sylveon"
@@ -517,7 +517,7 @@
 	p_types = list(P_TYPE_FAIRY)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/umbreon
+/mob/living/simple_animal/advanced/umbreon
 	name = "umbreon"
 	icon_state = "umbreon"
 	icon_dead = "umbreon_d"
@@ -525,7 +525,7 @@
 	p_types = list(P_TYPE_DARK)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/vulpix
+/mob/living/simple_animal/advanced/vulpix
 	name = "vulpix"
 	icon_state = "vulpix"
 	icon_living = "vulpix"
@@ -534,7 +534,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/tentacruel
+/mob/living/simple_animal/advanced/tentacruel
 	name = "tentacruel"
 	icon_state = "tentacruel"
 	icon_living = "tentacruel"
@@ -543,7 +543,7 @@
 	p_types = list(P_TYPE_WATER)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/thievul
+/mob/living/simple_animal/advanced/thievul
 	name = "thievul"
 	icon_state = "thievul"
 	icon_living = "thievul"
@@ -551,16 +551,16 @@
 	p_types = list(P_TYPE_DARK)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/ninetales
+/mob/living/simple_animal/advanced/ninetales
 	name = "ninetales"
 	icon_state = "ninetales"
 	icon_living = "ninetales"
 	icon_dead = "ninetales_d"
 	p_types = list(P_TYPE_FIRE)
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_telepathy)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_telepathy)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/ponyta
+/mob/living/simple_animal/advanced/ponyta
 	name = "ponyta"
 	icon_state = "ponyta"
 	icon_living = "ponyta"
@@ -570,7 +570,7 @@
 	mob_size = MOB_SIZE_SMALL
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/zubat
+/mob/living/simple_animal/advanced/zubat
 	name = "zubat"
 	icon_state = "zubat"
 	icon_living = "zubat"
@@ -579,7 +579,7 @@
 	p_types = list(P_TYPE_FLY, P_TYPE_POISON)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/tangela
+/mob/living/simple_animal/advanced/tangela
 	name = "tangela"
 	icon_state = "tangela"
 	icon_living = "tangela"
@@ -587,14 +587,14 @@
 	p_types = list(P_TYPE_GRASS, P_TYPE_POISON)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/pinsir
+/mob/living/simple_animal/advanced/pinsir
 	name = "pinsir"
 	icon_state = "pinsir"
 	icon_living = "pinsir"
 	icon_dead = "pinsir_d"
 	p_types = list(P_TYPE_BUG)
 
-/mob/living/simple_animal/pokemon/omanyte
+/mob/living/simple_animal/advanced/omanyte
 	name = "omanyte"
 	icon_state = "omanyte"
 	icon_living = "omanyte"
@@ -603,7 +603,7 @@
 	p_types = list(P_TYPE_ROCK, P_TYPE_WATER)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/magmar
+/mob/living/simple_animal/advanced/magmar
 	name = "magmar"
 	icon_state = "magmar"
 	icon_living = "magmar"
@@ -611,7 +611,7 @@
 //	movement_cooldown = 3
 	p_types = list(P_TYPE_FIRE)
 
-/mob/living/simple_animal/pokemon/magicarp
+/mob/living/simple_animal/advanced/magicarp
 	name = "magicarp"
 	icon_state = "magicarp"
 	icon_living = "magicarp"
@@ -621,7 +621,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/lapras
+/mob/living/simple_animal/advanced/lapras
 	name = "lapras"
 	icon_state = "lapras"
 	icon_living = "lapras"
@@ -630,7 +630,7 @@
 	p_types = list(P_TYPE_WATER)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/lycanroc
+/mob/living/simple_animal/advanced/lycanroc
 	name = "lycanroc"
 	desc = "Its quick movements confuse its enemies. Well equipped with claws and fangs, it also uses the sharp rocks in its mane as weapons."
 	icon_state = "lycanroc"
@@ -638,14 +638,14 @@
 	icon_dead = "lycanroc_d"
 	p_types = list(P_TYPE_ROCK)
 
-/mob/living/simple_animal/pokemon/kabuto
+/mob/living/simple_animal/advanced/kabuto
 	name = "kabuto"
 	icon_state = "Kabuto"
 	icon_living = "Kabuto"
 	icon_dead = "Kabuto_d"
 	p_types = list(P_TYPE_ROCK, P_TYPE_WATER)
 
-/mob/living/simple_animal/pokemon/aerodactyl
+/mob/living/simple_animal/advanced/aerodactyl
 	name = "aerodactyl"
 	icon_state = "Aerodactyl"
 	icon_living = "Aerodactyl"
@@ -653,14 +653,14 @@
 	p_types = list(P_TYPE_ROCK, P_TYPE_FLY)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/lickitung
+/mob/living/simple_animal/advanced/lickitung
 	name = "lickitung"
 	icon_state = "lickitung"
 	icon_living = "lickitung"
 	icon_dead = "lickitung_d"
 	p_types = list(P_TYPE_NORM)
 
-/mob/living/simple_animal/pokemon/cubone
+/mob/living/simple_animal/advanced/cubone
 	name = "cubone"
 	icon_state = "cubone"
 	icon_living = "cubone"
@@ -668,28 +668,28 @@
 	p_types = list(P_TYPE_GROUND)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/mew
+/mob/living/simple_animal/advanced/mew
 	name = "mew"
 	icon_state = "mew"
 	icon_living = "mew"
 	icon_dead = "mew_d"
 	p_types = list(P_TYPE_PSYCH)
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_fly,
-//							/mob/living/simple_animal/pokemon/proc/move_hover,
-//							/mob/living/simple_animal/pokemon/proc/move_imposter,
-//							/mob/living/simple_animal/pokemon/proc/move_invisibility)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_fly,
+//							/mob/living/simple_animal/advanced/proc/move_hover,
+//							/mob/living/simple_animal/advanced/proc/move_imposter,
+//							/mob/living/simple_animal/advanced/proc/move_invisibility)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/mewtwo
+/mob/living/simple_animal/advanced/mewtwo
 	name = "mewtwo"
 	icon_state = "mewtwo"
 	icon_living = "mewtwo"
 	icon_dead = "mewtwo_d"
 	p_types = list(P_TYPE_PSYCH)
-//	p_additional_moves = list(/mob/living/simple_animal/pokemon/proc/move_fly,
-//							/mob/living/simple_animal/pokemon/proc/move_hover)
+//	p_additional_moves = list(/mob/living/simple_animal/advanced/proc/move_fly,
+//							/mob/living/simple_animal/advanced/proc/move_hover)
 
-/mob/living/simple_animal/pokemon/purrloin
+/mob/living/simple_animal/advanced/purrloin
 	name = "purrloin"
 	icon_state = "purrloin"
 	icon_living = "purrloin"
@@ -697,7 +697,7 @@
 	p_types = list(P_TYPE_DARK)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/ralts
+/mob/living/simple_animal/advanced/ralts
 	name = "ralts"
 	icon_state = "ralts"
 	icon_living = "ralts"
@@ -705,7 +705,7 @@
 	p_types = list(P_TYPE_PSYCH, P_TYPE_FAIRY)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/rayquaza
+/mob/living/simple_animal/advanced/rayquaza
 	name = "Rayquaza"
 	icon_state = "rayquaza"
 	icon_living = "rayquaza"
@@ -714,7 +714,7 @@
 	p_types = list(P_TYPE_FLY)
 	mob_size = MOB_SIZE_LARGE
 
-/mob/living/simple_animal/pokemon/snorlax
+/mob/living/simple_animal/advanced/snorlax
 	name = "snorlax"
 	icon_state = "snorlax"
 	icon_living = "snorlax"
@@ -722,7 +722,7 @@
 	p_types = list(P_TYPE_NORM)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/vaporeon
+/mob/living/simple_animal/advanced/vaporeon
 	name = "vaporeon"
 	icon_state = "vaporeon"
 	icon_living = "vaporeon"
@@ -730,7 +730,7 @@
 	p_types = list(P_TYPE_WATER)
 	p_traits = list(P_TRAIT_RIDEABLE)
 
-/mob/living/simple_animal/pokemon/zigzagoon
+/mob/living/simple_animal/advanced/zigzagoon
 	name = "zigzagoon"
 	icon_state = "zigzagoon"
 	icon_living = "zigzagoon"
@@ -739,37 +739,37 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/zoroark
+/mob/living/simple_animal/advanced/zoroark
 	name = "zoroark"
 	icon_state = "zoroark"
 	icon_living = "zoroark"
 	icon_dead = "zoroark_d"
 	p_types = list(P_TYPE_DARK)
-//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/pokemon/proc/move_imposter)
+//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/advanced/proc/move_imposter)
 
-/mob/living/simple_animal/pokemon/zorua
+/mob/living/simple_animal/advanced/zorua
 	name = "zorua"
 	icon_state = "zorua"
 	icon_living = "zorua"
 	icon_dead = "zorua_d"
 	p_types = list(P_TYPE_DARK)
-//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/pokemon/proc/move_imposter)
+//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/advanced/proc/move_imposter)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/zorua_hisuian
+/mob/living/simple_animal/advanced/zorua_hisuian
 	name = "hisuian zorua"
 	icon_state = "zorua_hisuian"
 	icon_living = "zorua_hisuian"
 	icon_dead = "zorua_hisuian_d"
 	p_types = list(P_TYPE_NORM, P_TYPE_GHOST)
-//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/pokemon/proc/move_imposter)
+//	p_additional_moves = list(/mob/living/proc/hide, /mob/living/simple_animal/advanced/proc/move_imposter)
 	mob_size = MOB_SIZE_SMALL
 
 ///////////////////////
 //ALPHABETICAL PLEASE//
 ///////////////////////
 
-/mob/living/simple_animal/pokemon/rattata
+/mob/living/simple_animal/advanced/rattata
 	name = "rattata"
 	icon_state = "rattata"
 	icon_living = "rattata"
@@ -778,7 +778,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/raticate
+/mob/living/simple_animal/advanced/raticate
 	name = "raticate"
 	icon_state = "raticate"
 	icon_living = "raticate"
@@ -787,7 +787,7 @@
 	p_traits = list(P_TRAIT_RIDEABLE)
 	mob_size = MOB_SIZE_SMALL
 
-/mob/living/simple_animal/pokemon/skuntank
+/mob/living/simple_animal/advanced/skuntank
 	name = "Skuntank"
 	icon_state = "skunktank"
 	icon_living = "skunktank"

--- a/modular_coyote/code/pmon_mob.dm
+++ b/modular_coyote/code/pmon_mob.dm
@@ -51,7 +51,7 @@
 	var/datum/action/cooldown/pokemon_rest/R = new(src)
 	R.Grant(src)
 	regenerate_icons()
-	GLOB.pokemon_list += src
+	GLOB.advanced_mob_list += src
 
 ///Will recenter a mob's icon on their tile if it's wider than 32 pixels. Will do nothing if it's 32 or less. To use correctly, position the mob in the center of the icon_state in your dmi.
 /mob/proc/recenter_wide_sprite()
@@ -79,7 +79,7 @@
 	regenerate_icons()
 
 /mob/living/simple_animal/advanced/Destroy()
-	GLOB.pokemon_list -= src
+	GLOB.advanced_mob_list -= src
 	. = ..()
 
 ///////////////////////////////


### PR DESCRIPTION
- [x] - Reverts ARF-SS13/coyote-bayou#3553
- [x] - Snips the list for selectable creatures down to just advanced mobs and scugs. If your favorite creature is gone, add it again as an advanced mob with resting and dead sprites. We can't balance the 9000 simple mobs and all of their special abilities.
- [x] - repaths pokes into something more generic so that coders and spriters can add non-pokes and not feel weird about it
- [x] - Adds a 2 second cast time to wild shape spell
- [x] - Your human form's max and current health now translates into your wild shape's health when you transform. I think this will move all your damage to your torso but whatever.
- [x] Fixed creature wasteland spawn putting you in Ashdown and added it as its own spawnpoint.