### PR TITLE
Tweaks the Laser AK to meet Bayou standards (Good to go if it passes checks)

### DIFF
--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -448,6 +448,7 @@
 		/obj/item/gun/energy/laser/tg/rifle/heavy = 10,
 		/obj/item/gun/energy/laser/tg/rifle/auto = 10,
 		/obj/item/gun/energy/laser/tg/recharger/nuclear/rifle = 5,
+		/obj/item/gun/energy/laser/LaserAK = 1,
 		/obj/item/gun/energy/laser/ultra_rifle = 1,
 		/obj/item/gun/magic/staff/kelpmagic/fireball = 1,
 		/obj/item/gun/magic/staff/kelpmagic/lightning = 3,

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -246,8 +246,8 @@ Avoid decimals when possible when it comes to e_cost!
 	e_cost = 1000 // 40 shots
 
 /obj/item/ammo_casing/energy/laser/AK470M
-	projectile_type = /obj/item/projectile/beam/laser/solar
-	e_cost = 990 // 33 shots roughly.
+	projectile_type = /obj/item/projectile/beam/laser/pistol/AK470M
+	e_cost = 1000 // 30 shots
 	fire_sound = 'sound/f13weapons/WattzRifleFire.ogg'
 
 /obj/item/ammo_casing/energy/laser/solar

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -633,16 +633,17 @@
 	icon_state = "LaserAK"
 	item_state = null
 	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
-	cell_type = "/obj/item/stock_parts/cell/ammo/mfc"
+	cell_type = "/obj/item/stock_parts/cell/ammo/breeder"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/AK470M)
 	ammo_x_offset = 4
 	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_ONE_HAND_ONLY
+	damage_multiplier = GUN_LESS_DAMAGE_T1
 	init_firemodes = list(
 	/datum/firemode/semi_auto,
-	/datum/firemode/automatic/rpm300
+	/datum/firemode/automatic/rpm100
 	)
 	init_recoil = LASER_AUTORIFLE_RECOIL(1, 1)
 

--- a/code/modules/projectiles/guns/energy/plasma_cit.dm
+++ b/code/modules/projectiles/guns/energy/plasma_cit.dm
@@ -71,16 +71,16 @@
 	selfcharge = 1
 	icon_state = "LaserAK"
 	item_state = null
-	selfchargerate = 15
+	selfchargerate = 30 // It's a hardspawn gun that's apparently very easy to get
+	max_upgrades = 4 // +1 mod to make up for the AEP damage; +50% damage potentially and enough mods to negate the downsides should make it a good invest gun
 	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
 	cell_type = "/obj/item/stock_parts/cell/ammo/breeder"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/AK470M)
 	ammo_x_offset = 4
 	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_ONE_HAND_ONLY
-	damage_multiplier = GUN_LESS_DAMAGE_T1
 	init_firemodes = list(
 	/datum/firemode/semi_auto,
 	/datum/firemode/automatic/rpm100


### PR DESCRIPTION
## About The Pull Request
Title. The laser AK (470 and 470M) were both just utterly whack. The 470M still had the original 600 RPM despite being the worn / loadout version, and neither AK used the AK470's unique casing or projectile. TL;DR, I just brought it in line with other self-charging guns and made it use its actual casing/projectile

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Fixed the AK470 and M to use their unique casing/projectile
- Fixed the Laser 470M using a vanilla MFC, allowing an exploit to reload it despite can_remove = 0
- Adjusted the rechargerate of the laser AK to 30 (Read: 60 seconds) because it's a fully automatic self-charging gun. May be too harsh considering it does AEP damage, might adjust rate or damage later
- Added the AK470 as a rare loot because it was originally a hardspawn only and hardspawns icky
- Gave the AK470 +1 mod slot to make up for the damage nerf/charge nerf
- AK470 now has 30 shots not 33

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
