### PR TITLE
Nerfs pellet and beanbag bane damage on simplemobs

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -22,8 +22,8 @@
 
 	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
-	supereffective_damage = BULLET_DAMAGE_PISTOL_22
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
+//	supereffective_damage = 2
+//	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 
 //ratshot pellet: 6 damage instead of 8, fewer pellets. would make many tiny damage pellets but performance
@@ -44,7 +44,7 @@
 
 	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
-	supereffective_damage = BULLET_DAMAGE_PISTOL_22_HANDLOAD
+	supereffective_damage = 2
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 /* rubber pellet
@@ -76,7 +76,7 @@
 	//This does mean theres no reason to print handloaded buckshot unless you're hunting men.
 	//However, you can find handloaded buckshot in the trash, you can't find rubbershot.
 	//This means that you'll always be paying to use rubbershot, whereas handloaded buckshot is often a freebie.
-	supereffective_damage = BULLET_DAMAGE_PISTOL_22_HANDLOAD
+	supereffective_damage = 2
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 /* handload pellet
@@ -101,7 +101,7 @@
 
 	zone_accuracy_type = ZONE_WEIGHT_SHOTGUN
 
-	supereffective_damage = BULLET_DAMAGE_PISTOL_22_HANDLOAD
+	supereffective_damage = 2
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 /obj/item/projectile/bullet/pellet/shotgun_improvised/Initialize()
@@ -189,7 +189,7 @@
 
 	zone_accuracy_type = ZONE_WEIGHT_PRECISION
 
-	supereffective_damage = BULLET_DAMAGE_RIFLE_50MG_MATCH
+	supereffective_damage = BULLET_DAMAGE_PISTOL_9MM
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 /* train


### PR DESCRIPTION
## About The Pull Request
<!-- Write here --> All pellets now only get 2 extra bane damage per pellet on simplemobs instead of 15, and benabags now only get 9mm damage for their bane damage. I think beanbags do 6 brute, and 9mm does 25 damage, so that should equal out to 30 damage. Not useless against mobs if you pick up a shotgun you get from a mob, but also not too overpowered.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
