### PR TITLE
Rebalances the Laser AK yet again (Good to go if it passes checks)

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -1329,7 +1329,7 @@
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_ONE_HAND_ONLY
-	damage_multiplier = GUN_LESS_DAMAGE_T1
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_firemodes = list(
 	/datum/firemode/semi_auto,
 	/datum/firemode/automatic/rpm100

--- a/code/modules/projectiles/guns/energy/plasma_cit.dm
+++ b/code/modules/projectiles/guns/energy/plasma_cit.dm
@@ -81,8 +81,9 @@
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_ONE_HAND_ONLY
+	damage_multiplier = GUN_EXTRA_DAMAGE_T2
 	init_firemodes = list(
 	/datum/firemode/semi_auto,
 	/datum/firemode/automatic/rpm200
 	)
-	init_recoil = LASER_AUTORIFLE_RECOIL(2, 2)
+	init_recoil = LASER_AUTORIFLE_RECOIL(2, 1)

--- a/code/modules/vending/sovietvend.dm
+++ b/code/modules/vending/sovietvend.dm
@@ -18,7 +18,7 @@
 		/obj/item/clothing/mask/balaclava = 4,
 		/obj/item/clothing/head/helmet/rus_ushanka = 4,
 		/obj/item/clothing/suit/space/hardsuit/soviet = 3,
-		/obj/item/gun/energy/laser/LaserAK = 4
+		/obj/item/gun/energy/laser/LaserAK/worn = 3
 		)
 	premium = list()
 


### PR DESCRIPTION
## About The Pull Request
Title

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Replaces vendor Laser AK470 with worn variant
- Removes -10% damage nerf to AK470M (worn)
- Adds +20% damage to AK470 (normal)
- Increases 2-handed handling of the AK470 and 470M

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
