### PR TITLE
Fixes titanium arrows turning to regular arrows

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -34,7 +34,7 @@
 /obj/item/ammo_casing/caseless/arrow/titanium
 	name = "titanium arrow"
 	desc = "a durable arrow with a sturdy titanium head."
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow
+	projectile_type = /obj/item/projectile/bullet/reusable/arrow/titanium
 	icon_state = "titaniumarrow"
 	custom_materials = list(/datum/material/titanium = MINERAL_MATERIAL_AMOUNT*2)
 


### PR DESCRIPTION
## About The Pull Request
It used the wrong projectile.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Titanium arrows now fire titanium arrows.
/:cl:
