### PR TITLE
Magic stuff, gun name fix, and particle cannon nerf (Good to go if it passes checks)

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -542,8 +542,8 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/wand/kelpmagic/magicmissile/improved
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
-				/obj/item/stack/crafting/metalparts = 10,
-				/obj/item/stack/crafting/goodparts = 5,
+				/obj/item/stack/crafting/metalparts = 3,
+				/obj/item/stack/crafting/goodparts = 1,
 				/obj/item/stack/sheet/mineral/gold = 1)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
 
@@ -553,8 +553,8 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/staff/kelpmagic/magicmissile
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
-				/obj/item/stack/crafting/metalparts = 15,
-				/obj/item/stack/crafting/goodparts = 5,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/goodparts = 3,
 				/obj/item/stack/sheet/mineral/plasma = 2)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
 
@@ -576,8 +576,8 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/staff/kelpmagic/lightning
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
-				/obj/item/stack/crafting/metalparts = 10,
-				/obj/item/stack/crafting/goodparts = 5,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/goodparts = 3,
 				/obj/item/stack/sheet/mineral/diamond = 2)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
 
@@ -587,7 +587,7 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/wand/kelpmagic/firebolt
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 10,
-				/obj/item/stack/crafting/metalparts = 10,
+				/obj/item/stack/crafting/metalparts = 5,
 				/obj/item/tool_upgrade/productivity/red_paint = 1,
 				/obj/item/stack/sheet/mineral/diamond = 1)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
@@ -598,7 +598,7 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/staff/kelpmagic/fireball
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
-				/obj/item/stack/crafting/metalparts = 20,
+				/obj/item/stack/crafting/metalparts = 10,
 				/obj/item/tool_upgrade/productivity/red_paint = 1,
 				/obj/item/stack/sheet/mineral/diamond = 2)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
@@ -609,9 +609,9 @@ datum/crafting_recipe/tribalwar/bone
 	result = /obj/item/gun/magic/staff/kelpmagic/acidstaff
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 20,
-				/obj/item/stack/crafting/metalparts = 15,
+				/obj/item/stack/crafting/metalparts = 5,
 				/obj/item/stack/sheet/mineral/plasma = 2,
-				/obj/item/stack/sheet/mineral/diamond = 2)
+				/obj/item/stack/sheet/mineral/uranium = 2)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
 
 // T1 Mending Wand (basic omni heal, ~50 HP all categories every 5 minutes)
@@ -637,3 +637,13 @@ datum/crafting_recipe/tribalwar/bone
 				/obj/item/stack/sheet/mineral/diamond = 1)
 	tools = list(TOOL_WORKBENCH, TOOL_RITUAL)
 
+// Perfected Staff of Healing (Literally just the medbeam but Bulky and needs magic)
+/datum/crafting_recipe/magic/healstaff/perfected
+	name = "Staff of Healing"
+	result = /obj/item/gun/medbeam/magic
+	time = 30
+	reqs = list(/obj/item/stack/crafting/metalparts = 20,
+				/obj/item/stack/crafting/goodparts = 10,
+				/obj/item/stack/sheet/bluespace_crystal = 5,
+				/obj/item/gun/magic/staff/kelpmagic/healstaff = 1)
+	tools = list(TOOL_WORKBENCH, TOOL_ALCHEMY_TABLE, TOOL_RITUAL)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -3074,6 +3074,7 @@
 * - Rare LMG
 * - High recoil with slowdown
 * * * * * * * * * * * * * * */
+
 /obj/item/gun/ballistic/automatic/rpd
 	name = "Russian RPK LMG"
 	desc = "A soviet made Russian LMG. Known as the RPK, ths LMG was champered in 7.62 Soviet. Now rechambered to .308 with a 40 drum mag, it has quite the kick for recoil and a bit heavy."
@@ -3098,10 +3099,19 @@
 	can_bayonet = FALSE
 	can_flashlight = FALSE
 
+/* * * * * * * * * * *
+* Oststrauß
+* 5.56 German LMG
+* - 60rnd Box only
+* - Fast and Faster RoF
+* - Harder Hitting
+* - Unique
+* - High recoil with slowdown
+* * * * * * * * * * * * * * */
 
 /obj/item/gun/ballistic/automatic/fastlmg
-	name = "OstStrauss LMG"
-	desc = "A OstStrauss LMG, this LMG is chambered in 5.56x45 NATO. The gun itself was created as the great great grandson of the distant past MG3, which was derived from the MG-42 which was derived from the MG-34. With a fast fire rate and a toggle between 'slow' and 'fast', it is a LMG perfect for squad cover. Albiet it eats ammo like no tomorrow."
+	name = "Oststrauß"
+	desc = "Chambered in 5.56x45 NATO, the Oststrauß is the great great grandson of the MG3, which itself was derived from the MG-42. Very little has changed between each model, showing the design to be one fit for centuries of warfare."
 	item_state = "mg3"
 	icon_state = "mg3"
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -239,6 +239,27 @@
 	recharge_rate = 60 SECONDS
 
 /****************/
+//Upgraded Staff of Healing//
+//Literally just a bulky medbeam/
+/***************/
+
+/obj/item/gun/medbeam/magic
+	name = "perfected staff of healing"
+	desc = "Through mastery of arcane alchemy, this staff has been brought to the peak of its power... And yet it still can't heal the wielder. Don't cross the streams!"
+	icon = 'icons/obj/guns/magic.dmi'
+	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+	icon_state = "medstaff"
+	item_state = "staff"
+	w_class = WEIGHT_CLASS_BULKY
+	force = 20
+	force_unwielded = 20
+	force_wielded = 30
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
+	is_kelpwand = TRUE
+	pin = /obj/item/firing_pin/magic
+
+/****************/
 //Staff of Acid//
 //OH GOD, IT'S EVERYWHERE - SMG adjacent/
 /***************/

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -891,10 +891,10 @@
 /obj/item/projectile/beam/laser/tg/particle
 	name = "hyper-velocity particle beam"
 	icon_state = "emitter"
-	damage = 100 // With no -HP traits, any light armor saves you and EVERYONE is armored; you get 5 shots and can't reload
-	damage_list = list("90" = 25, "100" = 25, "115" = 25, "130" = 24, "420634" = 1) //fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you ~TK
+	damage = 100 // With no -HP traits, any light armor saves you and EVERYONE is armored; you get 5 shots and can't reload in the field
+	damage_list = list("90" = 25, "100" = 25, "115" = 25, "130" = 24, "1000" = 1) //fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you ~TK
 	wound_bonus = 60 // nasty, but it's still a laser
-	supereffective_damage = 150 // Unlike .50 BMG guns, you can't reload
+	supereffective_damage = 150 // Unlike .50 BMG guns, you can't reload in the field
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/xray


### PR DESCRIPTION
## About The Pull Request
Title, basically. Phase 3 of magic didn't work out, so some random small stuff was done instead.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Added the Perfected Staff of Healing; literally just a medbeam but with Staff of Healing properties outside of the healbeam effect
- Added the Perfected Staff of Healing to the crafting list
- Tweaked a bunch of Magic crafting things to be more forgiving and less heavy on parts, also changed the staff of acid to uranium because green is green
- Fixed the Oststrauss LMG's name and description. Tox is probably going to re-expand the desc again but the core issues are fixed with it so I can just clean that up when done
- Made it so the Particle Cannon's crit doesn't basically Round Remove someone, but it still does screw you over no matter what you're wearing or doing

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
