### PR TITLE
a wizard did it (cantrip PR)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -290,6 +290,8 @@
 #define TRAIT_FEV				"FEV_MUT" //OH BOY
 #define TRAIT_GHOULMELEE		"ghoulmelee"
 #define TRAIT_TRAPPER			"trapper"
+#define TRAIT_SHOCKINGGRASP		"shocking_grasp"
+#define TRAIT_BOOMING			"booming_blade"
 #define TRAIT_IRONFIST			"iron_fist"
 #define TRAIT_STEELFIST			"steel_fist"
 #define TRAIT_NOODLEFIST			"noodle_fist"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -2104,6 +2104,35 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	gain_text = span_notice("Your tail feels like a bludgeon!")
 	lose_text = span_danger("Your tail suddenly feels weak.")
 	medical_record_text = "Patient tripped me over with their tail this morning. Please be aware of it."
+//Cantrips//
+/datum/quirk/shocking
+	name = "Shocking Grasp"
+	desc = "You know how to cast the shocking grasp cantrip"
+	value = 32
+	category = "Cantrips"
+	mechanics = "When using the *shocking emote, you summon a melee spell cantrip that strikes fast and delivers powerful shocks to your foes"
+	conflicts = list(
+		/datum/quirk/littleleagues,
+		/datum/quirk/bigleagues
+	)
+	mob_trait = TRAIT_SHOCKINGGRASP
+	gain_text = span_notice("You know how to cast shocking grasp!")
+	lose_text = span_danger("You no longer know how to cast shocking grasp!.")
+	
+	
+/datum/quirk/booming
+	name = "Booming Blade"
+	desc = "You know how to cast the booming blade cantrip"
+	value = 44
+	category = "Cantrips"
+	mechanics = "When using the *booming emote, you summon a magic sword able to tag foes for extra damage on the next hit."
+	conflicts = list(
+		/datum/quirk/littleleagues,
+		/datum/quirk/bigleagues
+	)
+	mob_trait = TRAIT_BOOMING
+	gain_text = span_notice("You know how to cast booming blade!")
+	lose_text = span_danger("You no longer know how to cast booming blade!.")
 
 
 ///QUIRK PACKAGES/// QUACKAGES IF YOU WILL

--- a/code/game/objects/hand_items.dm
+++ b/code/game/objects/hand_items.dm
@@ -532,6 +532,42 @@
 		return
 	M.apply_damage(1, STAMINA, "chest", M.run_armor_check("chest", "melee"))
 
+
+
+/////////////
+//Cantrips//
+///////////
+
+
+/obj/item/hand_item/cantrip
+	name = "Cantrip"
+	desc = "it's magic yo."
+	icon = 'icons/obj/in_hands.dmi'
+	icon_state = "clawer"
+	w_class = WEIGHT_CLASS_TINY
+	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
+	force = 15
+	throwforce = 0
+	wound_bonus = 4
+	attack_speed = CLICK_CD_MELEE * 0.7
+	item_flags = DROPDEL | HAND_ITEM
+	weapon_special_component = /datum/component/weapon_special/single_turf
+
+
+/obj/item/hand_item/cantrip/godhand
+	icon_state = "disintegrate"
+	item_state = "disintegrate"
+	icon = 'icons/obj/items_and_weapons.dmi'
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	name = "Shocking Grasp"
+	desc = "A basic cantrip that allows the caster to inflict nasty shocks on touch"
+	item_flags = ABSTRACT | DROPDEL
+	force = 30
+	hitsound = 'sound/weapons/sear.ogg'
+	damtype = BURN
+	attack_verb = list("seared", "zapped", "fried", "shocked")
+
 // /obj/item/hand_item/healable/licker/proc/bandage_wound(mob/living/licked, mob/living/carbon/user)
 // 	if(!iscarbon(licked))
 // 		return FALSE

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -228,6 +228,66 @@
 /obj/item/kinetic_crusher/glaive/update_icon_state()
 	item_state = "crusher[wielded]-glaive" // this is not icon_state and not supported by 2hcomponent
 
+
+//booming blade//
+/obj/item/kinetic_crusher/booming
+	icon_state = "spellblade"
+	item_state = "spellblade"
+	icon = 'icons/obj/guns/magic.dmi'
+	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	hitsound = 'sound/weapons/rapierhit.ogg'
+	name = "Booming Blade"
+	desc = "A magic weapon summoned into being by the will of the user, able to mark foes with a arcane mark that deals extra damage on the next melee strike"
+	force_unwielded = 25
+	force_wielded = 40 
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb = list("sliced", "slashed", "cleaved", "chopped", "stabbed")
+	block_parry_data = /datum/block_parry_data/crusherglaive
+	item_flags = DROPDEL
+	actions_types = list(NONE)
+	
+/datum/block_parry_data/crusherglaive // small perfect window, active for a fair while, time it right or use the Forbidden Technique
+	parry_time_windup = 0
+	parry_time_active = 8
+	parry_time_spindown = 0
+	parry_time_perfect = 1
+	parry_time_perfect_leeway = 2
+	parry_imperfect_falloff_percent = 20
+	parry_efficiency_to_counterattack = 100 // perfect parry or you're cringe
+	parry_failed_stagger_duration = 1.5 SECONDS // a good time to reconsider your actions...
+	parry_failed_clickcd_duration = 1.5 SECONDS // or your failures
+
+/obj/item/kinetic_crusher/booming/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time) // if you're dumb enough to go for a parry...
+	var/turf/proj_turf = owner.loc // destabilizer bolt, ignoring cooldown
+	if(!isturf(proj_turf))
+		return
+	var/obj/item/projectile/destabilizer/D = new /obj/item/projectile/destabilizer(proj_turf)
+	for(var/t in trophies)
+		var/obj/item/crusher_trophy/T = t
+		T.on_projectile_fire(D, owner)
+	D.preparePixelProjectile(attacker, owner)
+	D.firer = owner
+	D.hammer_synced = src
+	playsound(owner, 'sound/weapons/plasma_cutter.ogg', 100, 1)
+	D.fire()
+
+/obj/item/kinetic_crusher/glaive/active_parry_reflex_counter(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/return_list, parry_efficiency, list/effect_text)
+	if(owner.Adjacent(attacker) && (!attacker.anchored || ismegafauna(attacker))) // free backstab, if you perfect parry
+		attacker.dir = get_dir(owner,attacker)
+
+/// triggered on wield of two handed item
+/obj/item/kinetic_crusher/booming/on_wield(obj/item/source, mob/user)
+	wielded = TRUE
+	item_flags |= (ITEM_CAN_PARRY)
+
+/// triggered on unwield of two handed item
+/obj/item/kinetic_crusher/booming/on_unwield(obj/item/source, mob/user)
+	wielded = FALSE
+	item_flags &= ~(ITEM_CAN_PARRY)
+
+/obj/item/kinetic_crusher/booming/update_icon_state()
+	item_state = "spellblade" // this is not icon_state and not supported by 2hcomponent
 //destablizing force
 /obj/item/projectile/destabilizer
 	name = "destabilizing force"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -295,6 +295,51 @@
 	else
 		qdel(claw)
 
+//shocking grasp//
+/datum/emote/living/carbon/shocking
+	key = "shocking"
+	key_third_person = "casts shocking grasp!"
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/shocking/run_emote(mob/user)
+	. = ..()
+	if(user.get_active_held_item())
+		to_chat(user, span_warning("Your hands are too full to cast!"))
+		return
+	var/which_cantrip_to_spawn
+	if(HAS_TRAIT(user, TRAIT_SHOCKINGGRASP))
+		which_cantrip_to_spawn = /obj/item/hand_item/cantrip/godhand
+	else 
+		to_chat(user, span_notice("You don't know how to cast this spell!"))
+	var/obj/item/hand_item/cantrip/godhand/cantrip = new which_cantrip_to_spawn(user) 
+	if(user.put_in_active_hand(cantrip))
+		to_chat(user, span_notice("You are ready to zap"))
+	else
+		qdel(cantrip)
+
+//booming blade//
+
+/datum/emote/living/carbon/booming
+	key = "booming"
+	key_third_person = "casts booming blade!"
+	restraint_check = TRUE
+
+/datum/emote/living/carbon/booming/run_emote(mob/user)
+	. = ..()
+	if(user.get_active_held_item())
+		to_chat(user, span_warning("Your hands are too full to cast!"))
+		return
+	var/which_cantrip_to_spawn
+	if(HAS_TRAIT(user, TRAIT_BOOMING))
+		which_cantrip_to_spawn = /obj/item/kinetic_crusher/booming
+	else 
+		to_chat(user, span_notice("You don't know how to cast this spell!"))
+	var/obj/item/kinetic_crusher/booming/cantrip = new which_cantrip_to_spawn(user) 
+	if(user.put_in_active_hand(cantrip))
+		to_chat(user, span_notice("You are ready to smite your foes"))
+	else
+		qdel(cantrip)
+
 //Tackler//
 
 


### PR DESCRIPTION
Adds 2 cantrips to work as the foundation for a more interesting magic system, being quirks you can pick as a more unique alternative to the regular claws / bites / unarmed ones.

The current ones are - Shocking grasp - a fast melee based cantrip that deals burn damage

-Booming blade - effectively a weaker kinetic crusher, able to mark targets with a projectile to deal extra melee on the next hit.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [Y ] You tested this on a local server.
- [Y ] This code did not runtime during testing.
- [Y ] You documented all of your changes.
<!-- Tick these after making the PR. -->

