### PR TITLE
Trio of fixes (Good to go if it passes checks)

### DIFF
--- a/code/__DEFINES/armor.dm
+++ b/code/__DEFINES/armor.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_INIT(armor_token_operation_legend, list(
 		"linemelee" = "ADD",
 		"linebullet" = "ADD",
 		"linelaser" = "ADD",
-		"energy" = "MULT",
+		"energy" = "ADD",
 		"bomb" = "MULT",
 		"bio" = "MULT",
 		"rad" = "MULT",

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -639,7 +639,7 @@ datum/crafting_recipe/tribalwar/bone
 
 // Perfected Staff of Healing (Literally just the medbeam but Bulky and needs magic)
 /datum/crafting_recipe/magic/healstaff/perfected
-	name = "Staff of Healing"
+	name = "Perfected Staff of Healing"
 	result = /obj/item/gun/medbeam/magic
 	time = 30
 	reqs = list(/obj/item/stack/crafting/metalparts = 20,

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -864,7 +864,7 @@ armor	//Baseline hardsuits
 	desc = "A suit of semi-powered armor produced by Cydonian Arms and Armor. It sports less armor than its contemporaries, but allows for improved mobility and recoloring of the inbuilt light strips."
 	item_state = "swat_suit"
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_LESS_T3 * ARMOR_SLOWDOWN_GLOBAL_MULT
-	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T2, ARMOR_MODIFIER_UP_LASER_T2, ARMOR_MODIFIER_DOWN_MELEE_T3, ARMOR_MODIFIER_UP_ENV_T3, ARMOR_MODIFIER_UP_DT_T2) // combat armor but bad melee; use that speed dummy
+	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENERGY_T1, ARMOR_MODIFIER_DOWN_MELEE_T3, ARMOR_MODIFIER_UP_ENV_T3, ARMOR_MODIFIER_UP_DT_T2) // combat armor but bad melee; use that speed dummy
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	pocket_storage_component_path = null // alt click function makes suit storage not great


### PR DESCRIPTION
## About The Pull Request
Title. Fixes an issue in defines, the cydonian powersuit, and a naming error in crafting.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Energy armor in defines now adds instead of multiplies. This should fix *several* issues regarding energy armor
- The Cydonian Powersuit is now +1 Laser/Bullet/Plasma and +3 Speed at the cost of -3 Melee. It's about as common as regular combat armor, so it might be fine? Seeing comments, I may need to make it 1:1 of combat armor because I want people to have the funny RGB armor but I don't want it being OP and that +3 speed is strong if you know how to balance your mood
- Fixed the Perfected Staff of Healing having the wrong name in the crafting menu

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
