### PR TITLE
fixed dual wielding being procced when attempting to unwield a two-ha

### DIFF
--- a/modular_coyote/eris/code/wielding.dm
+++ b/modular_coyote/eris/code/wielding.dm
@@ -14,7 +14,7 @@
 	var/obj/item/J = get_inactive_held_item()
 	if(!I)
 		return
-	else if(I && J)  //Dual wielding starts here, see {dual_wielding.dm}
+	else if(I && J && I.wielded == FALSE)  //Dual wielding starts here, see {dual_wielding.dm}
 		if(I.force != 0 || J.force != 0)  //at least one of these two item needs to be dangerous
 			attempt_dual_wield(usr, I, J, min(I.dual_wielded_mult, J.dual_wielded_mult))  //actually initiate dual wielding! uses the worst damage multiplier between your two weapons
 			return


### PR DESCRIPTION
fixed dual wielding being procced when attempting to unwield a two-handed weapon

## About The Pull Request
simple bugfix

## Pre-Merge Checklist
- [ x] You tested this on a local server.
- [ x] This code did not runtime during testing.
- [ x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: unwielding two-handed weapons works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
