### PR TITLE
fixes smithing and damage estimate bugs

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -43,6 +43,7 @@
 	var/atom/movable/pulling
 	var/grab_state = 0
 	var/throwforce = 0
+	var/throwforce_bonus = 0
 	var/datum/component/orbiter/orbiting
 	var/can_be_z_moved = TRUE
 	///If we were without gravity and another animation happened, the bouncing will stop, and we need to restart it in next life().

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -354,10 +354,16 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	. = ..()
 
 	if(href_list["list_melee"])
-		var/InitialF = initial(force)
-		var/InitialFW = initial(force_wielded)
-		var/InitialFUW = initial(force_unwielded)
+		var/DamMult = 1
+		if(material_flags & MATERIAL_AFFECT_STATISTICS && istype(custom_materials[1], /datum/material))
+			var/datum/material/MyMat = custom_materials[1]
+			if(MyMat.strength_modifier)
+				DamMult = MyMat.strength_modifier
+		var/InitialF = (initial(force) + force_bonus) * DamMult//force_bonus is added by things like smithing and sharpening
+		var/InitialFW = (initial(force_wielded) + force_bonus) * DamMult
+		var/InitialFUW = (initial(force_unwielded) + force_bonus) * DamMult
 		var/InitialAS = initial(attack_speed)
+
 		//dual_wield_mult is funky, don't instantiate it
 		var/list/readout = list("<span class='notice'><u><b>MELEE STATISTICS</u></b>")
 		if(force_unwielded > 0)
@@ -367,7 +373,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		else
 			readout += "\nDAMAGE [InitialF] | (DPS [round(InitialF * (10/InitialAS), 0.1)])"
 			readout += "\nDUAL WIELD [InitialF * dual_wielded_mult] | (DPS [round((InitialF * dual_wielded_mult) * (10/(InitialAS / DUAL_WIELDING_SPEED_DIVIDER)), 0.1)])"
-		readout += "\nTHROW DAMAGE [throwforce]"
+		readout += "\nTHROW DAMAGE [(throwforce + throwforce_bonus) * DamMult]"
 		readout += "\nATTACKS / SECOND [round(10 / InitialAS, 0.1)] | DUAL WIELD [round(10/(InitialAS / DUAL_WIELDING_SPEED_DIVIDER), 0.1)]"
 		readout += "\nBLOCK CHANCE [block_chance]"
 		readout += "</span>"

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -20,7 +20,7 @@
 	var/awakened = FALSE
 	var/bloodthirst = HIS_GRACE_SATIATED
 	var/prev_bloodthirst = HIS_GRACE_SATIATED
-	var/force_bonus = 0
+	var/his_grace_force_bonus = 0
 	var/ascended = FALSE
 	var/victims_needed = 10 //Citadel change from 25 to 10
 	var/ascend_bonus = 15
@@ -131,7 +131,7 @@
 	desc = "A bloodthirsty artifact created by a profane rite."
 	gender = MALE
 	adjust_bloodthirst(1)
-	force_bonus = HIS_GRACE_FORCE_BONUS * LAZYLEN(contents)
+	his_grace_force_bonus = HIS_GRACE_FORCE_BONUS * LAZYLEN(contents)
 	playsound(user, 'sound/effects/pope_entry.ogg', 100)
 	icon_state = "his_grace_awakened"
 	move_gracefully()
@@ -168,7 +168,7 @@
 	animate(src, transform=matrix())
 	gender = initial(gender)
 	force = initial(force)
-	force_bonus = initial(force_bonus)
+	his_grace_force_bonus = initial(his_grace_force_bonus)
 	awakened = FALSE
 	bloodthirst = 0
 
@@ -181,7 +181,7 @@
 	playsound(meal, 'sound/misc/desceration-02.ogg', 75, 1)
 	playsound(src, 'sound/items/eatfood.ogg', 100, 1)
 	meal.forceMove(src)
-	force_bonus += HIS_GRACE_FORCE_BONUS
+	his_grace_force_bonus += HIS_GRACE_FORCE_BONUS
 	prev_bloodthirst = bloodthirst
 	if(prev_bloodthirst < HIS_GRACE_CONSUME_OWNER)
 		bloodthirst = max(LAZYLEN(contents), 1) //Never fully sated, and His hunger will only grow.
@@ -213,21 +213,21 @@
 			ADD_TRAIT(src, TRAIT_NODROP, HIS_GRACE_TRAIT)
 			if(HIS_GRACE_STARVING > prev_bloodthirst)
 				master.visible_message(span_boldwarning("[src] is starving!"), "<span class='his_grace big'>[src]'s bloodlust overcomes you. [src] must be fed, or you will become His meal.\
-				[force_bonus < 15 ? " And still, His power grows.":""]</span>")
-				force_bonus = max(force_bonus, 15)
+				[his_grace_force_bonus < 15 ? " And still, His power grows.":""]</span>")
+				his_grace_force_bonus = max(his_grace_force_bonus, 15)
 		if(HIS_GRACE_FAMISHED to HIS_GRACE_STARVING)
 			ADD_TRAIT(src, TRAIT_NODROP, HIS_GRACE_TRAIT)
 			if(HIS_GRACE_FAMISHED > prev_bloodthirst)
 				master.visible_message(span_warning("[src] is very hungry!"), "<span class='his_grace big'>Spines sink into your hand. [src] must feed immediately.\
-				[force_bonus < 10 ? " His power grows.":""]</span>")
-				force_bonus = max(force_bonus, 10)
+				[his_grace_force_bonus < 10 ? " His power grows.":""]</span>")
+				his_grace_force_bonus = max(his_grace_force_bonus, 10)
 			if(prev_bloodthirst >= HIS_GRACE_STARVING)
 				master.visible_message(span_warning("[src] is now only very hungry!"), "<span class='his_grace big'>Your bloodlust recedes.</span>")
 		if(HIS_GRACE_HUNGRY to HIS_GRACE_FAMISHED)
 			if(HIS_GRACE_HUNGRY > prev_bloodthirst)
 				master.visible_message(span_warning("[src] is getting hungry."), "<span class='his_grace big'>You feel [src]'s hunger within you.\
-				[force_bonus < 5 ? " His power grows.":""]</span>")
-				force_bonus = max(force_bonus, 5)
+				[his_grace_force_bonus < 5 ? " His power grows.":""]</span>")
+				his_grace_force_bonus = max(his_grace_force_bonus, 5)
 			if(prev_bloodthirst >= HIS_GRACE_FAMISHED)
 				master.visible_message(span_warning("[src] is now only somewhat hungry."), span_his_grace("[src]'s hunger recedes a little..."))
 		if(HIS_GRACE_PECKISH to HIS_GRACE_HUNGRY)
@@ -238,13 +238,13 @@
 		if(HIS_GRACE_SATIATED to HIS_GRACE_PECKISH)
 			if(prev_bloodthirst >= HIS_GRACE_PECKISH)
 				master.visible_message(span_warning("[src] is satiated."), "<span class='his_grace big'>[src]'s hunger recedes...</span>")
-	force = initial(force) + force_bonus
+	force = initial(force) + his_grace_force_bonus
 
 /obj/item/his_grace/proc/ascend()
 	if(ascended)
 		return
 	var/mob/living/carbon/human/master = loc
-	force_bonus += ascend_bonus
+	his_grace_force_bonus += ascend_bonus
 	desc = "A legendary toolbox and a distant artifact from The Age of Three Powers. On its three latches engraved are the words \"The Sun\", \"The Moon\", and \"The Stars\". The entire toolbox has the words \"The World\" engraved into its sides."
 	icon_state = "his_grace_ascended"
 	item_state = "toolbox_gold"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -10,6 +10,8 @@
 	var/damtype = BRUTE
 	var/force = 0
 
+	/// How much extra force does this item have over the base version of this item. Helps properly calculate damage and dps when examining weapons without relying on the force variable which changes frequently
+	var/force_bonus = 0
 	/// How good a given object is at causing wounds on carbons. Higher values equal better shots at creating serious wounds.
 	var/wound_bonus = 0
 	/// If this attacks a human with no wound armor on the affected body part, add this to the wound mod. Some attacks may be significantly worse at wounding if there's even a slight layer of armor to absorb some of it vs bare flesh

--- a/code/modules/smithing/finished_items.dm
+++ b/code/modules/smithing/finished_items.dm
@@ -53,11 +53,14 @@
 	I.force_wielded += 5
 	I.force_unwielded += 5
 	I.throwforce += 5
+	I.throwforce_bonus += 5
+	I.force_bonus += 5
 	I.is_sharpened = TRUE
 	I.desc = "[initial(I.desc)] It has been sharpened to a fine edge."
 	to_chat(user, span_notice("You sharpen the [I]!"))
 	qdel(src)
 	return ..()
+
 /obj/item/melee/smith/twohand
 	icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	lefthand_file = 'code/modules/smithing/icons/onmob/lefthand.dmi'

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -1,3 +1,18 @@
+/// Adds force to an item and updates the force_bonus variable
+/obj/item/proc/AddForce(forcetoadd, doforce = TRUE, dowielded = TRUE, dounwielded = TRUE, dothrowforce = FALSE)
+	if(!forcetoadd || !isnum(forcetoadd))
+		return
+	if(doforce)
+		force += forcetoadd
+		force_bonus += forcetoadd
+	if(dowielded)
+		force_wielded += forcetoadd
+	if(dounwielded)
+		force_unwielded += forcetoadd
+	if(dothrowforce)
+		throwforce += forcetoadd
+		throwforce_bonus += forcetoadd
+
 /obj/item/smithing
 	name = "base class /obj/item/smithing"
 	icon = 'code/modules/smithing/icons/blacksmith.dmi'
@@ -252,7 +267,7 @@
 
 /obj/item/smithing/hammerhead/startmasterworkfinish()
 	var/obj/item/melee/smith/hammer/finalforreal = new /obj/item/melee/smith/hammer(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalitem = finalforreal
 	..()
 
@@ -272,7 +287,7 @@
 
 /obj/item/smithing/shovelhead/startmasterworkfinish()
 	finalitem = new /obj/item/shovel/smithed(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	finalitem.toolspeed = 0.1
 	..()
 
@@ -353,7 +368,7 @@
 
 /obj/item/smithing/crowbar/startmasterworkfinish()
 	var/obj/item/crowbar/smithed/finalforreal = new /obj/item/crowbar/smithed(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalforreal.toolspeed = 0.1
 	finalitem = finalforreal
 	..()
@@ -374,7 +389,7 @@
 
 /obj/item/smithing/unitool/startmasterworkfinish()
 	var/obj/item/crowbar/smithedunitool/finalforreal = new /obj/item/crowbar/smithedunitool(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalitem = finalforreal
 	..()
 
@@ -404,7 +419,7 @@
 /obj/item/smithing/knifeblade/startmasterworkfinish()
 	var/obj/item/smithing/knifeblade/finalforreal = new /obj/item/smithing/knifeblade(src)
 	finalitem = new /obj/item/kitchen/knife(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalitem = finalforreal
 	finalitem.icon = 'code/modules/smithing/icons/blacksmith.dmi'
 	finalitem.icon_state = "knife_smith"
@@ -501,7 +516,7 @@
 /obj/item/smithing/ballandchain/startmasterworkfinish()
 	var/obj/item/smithing/ballandchain/finalforreal = new /obj/item/clothing/shoes/ballandchain(src)
 	finalitem = new /obj/item/clothing/shoes/ballandchain(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalitem.slowdown += 5
 	finalitem = finalforreal
 	finalitem.icon = 'code/modules/smithing/icons/blacksmith.dmi'
@@ -530,7 +545,7 @@
 
 /obj/item/smithing/swordblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/sword(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/sabreblade
@@ -547,7 +562,7 @@
 
 /obj/item/smithing/sabreblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/sword/sabre(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/spathablade
@@ -563,7 +578,7 @@
 
 /obj/item/smithing/spathablade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/sword/spatha(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/daggerblade
@@ -580,7 +595,7 @@
 
 /obj/item/smithing/daggerblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/dagger(src)
-	finalitem.force += 5 
+	finalitem.AddForce(5) 
 	..()
 
 /obj/item/smithing/macheteblade
@@ -596,7 +611,7 @@
 
 /obj/item/smithing/macheteblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/machete(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/gladiusblade
@@ -612,7 +627,7 @@
 
 /obj/item/smithing/gladiusblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/machete/gladius(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/macheterblade
@@ -628,7 +643,7 @@
 
 /obj/item/smithing/macheterblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/machete/reforged(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/macehead
@@ -645,7 +660,7 @@
 
 /obj/item/smithing/macehead/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/mace(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/wakiblade
@@ -661,7 +676,7 @@
 
 /obj/item/smithing/wakiblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/wakizashi(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/sawblade
@@ -677,7 +692,7 @@
 
 /obj/item/smithing/sawblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/saw(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/bowieblade
@@ -693,7 +708,7 @@
 
 /obj/item/smithing/bowieblade/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/dagger/bowie(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/unarmed/knuckles
@@ -709,7 +724,7 @@
 
 /obj/item/smithing/unarmed/knuckles/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/unarmed/knuckles(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 /obj/item/smithing/unarmed/claws
@@ -725,7 +740,7 @@
 
 /obj/item/smithing/unarmed/claws/startmasterworkfinish()
 	finalitem = new /obj/item/melee/smith/unarmed/claws(src)
-	finalitem.force += 5
+	finalitem.AddForce(5)
 	..()
 
 ////////////
@@ -769,7 +784,7 @@
 
 /obj/item/smithing/lancehead/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/spear/lance/finalforreal = new /obj/item/melee/smith/twohand/spear/lance(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalforreal.throwforce = finalforreal.force/10
 	finalitem = finalforreal
@@ -790,7 +805,7 @@
 
 /obj/item/smithing/tridenthead/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/spear/trident/finalforreal = new /obj/item/melee/smith/twohand/spear/trident(src)
-	finalforreal.force += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalforreal.throwforce = finalforreal.force/10
 	finalitem = finalforreal
@@ -811,9 +826,7 @@
 
 /obj/item/smithing/axehead/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/axe/finalforreal = new /obj/item/melee/smith/twohand/axe(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -832,9 +845,7 @@
 
 /obj/item/smithing/warhonedhead/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/axe/warhoned/finalforreal = new /obj/item/melee/smith/twohand/axe/warhoned(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -854,9 +865,7 @@
 
 /obj/item/smithing/scrapblade/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/axe/scrapblade/finalforreal = new /obj/item/melee/smith/twohand/axe/scrapblade(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -877,9 +886,7 @@
 
 /obj/item/smithing/katanablade/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/katana/finalforreal = new /obj/item/melee/smith/twohand/katana(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -898,9 +905,7 @@
 
 /obj/item/smithing/crusherhead/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/axe/crusher/finalforreal = new /obj/item/melee/smith/twohand/axe/crusher(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -920,9 +925,7 @@
 
 /obj/item/smithing/longswordblade/startmasterworkfinish()
 	var/obj/item/melee/smith/twohand/longsword/finalforreal = new /obj/item/melee/smith/twohand/longsword(src)
-	finalforreal.force += 5
-	finalforreal.force_wielded += 5
-	finalforreal.force_unwielded += 5
+	finalforreal.AddForce(5)
 	finalforreal.wielded_icon = "[icon_state]2"
 	finalitem = finalforreal
 	..()
@@ -943,8 +946,7 @@
 
 /obj/item/smithing/javelinhead/startmasterworkfinish()
 	var/obj/item/melee/smith/javelin/finalforreal = new /obj/item/melee/smith/javelin(src)
-	finalforreal.force += 5
-	finalforreal.throwforce += 5
+	finalforreal.AddForce(5,dothrowforce=TRUE)
 	finalitem = finalforreal
 	..()
 
@@ -965,9 +967,6 @@
 
 /obj/item/smithing/throwingknife/startmasterworkfinish()
 	var/obj/item/melee/smith/throwingknife/finalforreal = new /obj/item/melee/smith/throwingknife(src)
-	finalforreal.force += 5
-	finalforreal.throwforce += 5
+	finalforreal.AddForce(5,dothrowforce=TRUE)
 	finalitem = finalforreal
 	..()
-
-


### PR DESCRIPTION
- fixed a bug that made all smithing effects on weapons disappear if the player two-hand wielded it and then unwielded it (how long has this been the case lmfao)

-  fixed the DPS calculator so it takes extra damage from smithing and sharpening into account (the original scope of the PR)

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
