### PR TITLE
minor fixes and adjustments to permanent tattoos

### DIFF
--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -2688,7 +2688,6 @@
 /obj/item/tattoo_holder/biker,
 /obj/item/tattoo_holder/biker,
 /obj/item/tattoo_gun,
-/obj/item/tattoo_remover,
 /obj/item/razor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,

--- a/code/datums/tattoo.dm
+++ b/code/datums/tattoo.dm
@@ -493,7 +493,7 @@
 /obj/item/tattoo_gun
 	name = "tattoo gun"
 	desc = "Some kind of artistic torture device designed to stab colors into someone's flesh. The needles are long \
-			enough to make your work visible, no matter how furry your victim is. Might want to keep some bandages handy. Use with no template loaded to remove tattoos."
+			enough to make your work visible, no matter how furry your victim is. Might want to keep some bandages handy."
 	icon = 'icons/obj/tattoo_gun.dmi'
 	icon_state = "tattoo_gun"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -536,7 +536,7 @@
 /obj/item/tattoo_gun/examine(mob/user)
 	. = ..()
 	if(!flash)
-		. += span_notice("The template slot is empty, load one in!")
+		. += span_notice("The template slot is empty. Use on someone to remove their tattoos.")
 		return
 	. += span_notice("It is loaded with \a [flash].")
 
@@ -750,8 +750,7 @@
 	if(engraving)
 		addtimer(CALLBACK(src, .proc/make_noises_and_pain, victim, user, tat_loc, part), next_time)
 
-/obj/item/tattoo_gun/proc/try_remove_tattoo(mob/living/carbon/human/victim, mob/living/user, bodyzone, /obj/item/bodypart/part)
-	. = ..()
+/obj/item/tattoo_gun/proc/try_remove_tattoo(mob/living/carbon/human/victim, mob/living/user, bodyzone, obj/item/bodypart/part)
 	if(!istype(victim) || !istype(user))
 		return
 	if(isnull(bodyzone) || !istype(part))
@@ -770,13 +769,17 @@
 	var/choice = input(user, "Which tattoo do you want to remove?", "Pick a tattoo!") as null|anything in tats
 	//attempt to remove it
 	playsound(get_turf(src), 'sound/weapons/drill.ogg', 50, 1)
-	if(do_after(user,30,target = victim))
+	if(do_after(user,50,target = victim))
 		//removal successful
 		part.remove_tattoo(part.tattoos[choice],choice)
 		if(victim.client?.prefs)
 			victim.client.prefs.permanent_tattoos = victim.format_tattoos()
 			victim.client.prefs.save_character()
 		playsound(get_turf(src), 'sound/weapons/circsawhit.ogg', 50, 1)
+		if(prob(scream_prob))
+			victim.emote("scream")
+		var/removaldam = rand(1,20)
+		part.receive_damage(brute = owie.brute_dam < 30 ? removaldam : 0, stamina = removaldam, wound_bonus = removaldam, sharpness = SHARP_EDGED, damage_coverings = FALSE)
 		to_chat(user, span_alert("You successfully remove the [tats[choice]]."))
 		to_chat(victim, span_alert("Your [tats[choice]] was successfully removed."))
 	else

--- a/code/datums/tattoo.dm
+++ b/code/datums/tattoo.dm
@@ -776,10 +776,10 @@
 			victim.client.prefs.permanent_tattoos = victim.format_tattoos()
 			victim.client.prefs.save_character()
 		playsound(get_turf(src), 'sound/weapons/circsawhit.ogg', 50, 1)
-		if(prob(scream_prob))
+		if(prob(60))
 			victim.emote("scream")
 		var/removaldam = rand(1,20)
-		part.receive_damage(brute = owie.brute_dam < 30 ? removaldam : 0, stamina = removaldam, wound_bonus = removaldam, sharpness = SHARP_EDGED, damage_coverings = FALSE)
+		part.receive_damage(brute = part.brute_dam < 30 ? removaldam : 0, stamina = removaldam, wound_bonus = removaldam, sharpness = SHARP_EDGED, damage_coverings = FALSE)
 		to_chat(user, span_alert("You successfully remove the [tats[choice]]."))
 		to_chat(victim, span_alert("Your [tats[choice]] was successfully removed."))
 	else

--- a/code/datums/tattoo.dm
+++ b/code/datums/tattoo.dm
@@ -493,7 +493,7 @@
 /obj/item/tattoo_gun
 	name = "tattoo gun"
 	desc = "Some kind of artistic torture device designed to stab colors into someone's flesh. The needles are long \
-			enough to make your work visible, no matter how furry your victim is. Might want to keep some bandages handy."
+			enough to make your work visible, no matter how furry your victim is. Might want to keep some bandages handy. Use with no template loaded to remove tattoos."
 	icon = 'icons/obj/tattoo_gun.dmi'
 	icon_state = "tattoo_gun"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -581,9 +581,6 @@
 	if(!ismob(user))
 		user.show_message(span_phobia("You don't exist!"))
 		return
-	if(!istype(flash))
-		user.show_message(span_alert("You don't have a tattoo template loaded!"))
-		return
 	if(!in_range(user, victim))
 		user.show_message(span_alert("They're too far away!"))
 		return // we'll have tattoo rifles, some day...
@@ -601,6 +598,9 @@
 	if(!istype(chunk))
 		user.show_message(span_alert("[victim] doesn't have one of those!"))
 		return // we dont decorate phantom limbs in THIS parlor
+	if(!istype(flash))
+		try_remove_tattoo(victim, user, put_it_there, chunk)
+		return
 	var/list/places_to_put_it = list()
 	for(var/key in GLOB.tattoo_locations[put_it_there])
 		if(GLOB.tattoo_locations[put_it_there][key] == TRUE)
@@ -750,19 +750,13 @@
 	if(engraving)
 		addtimer(CALLBACK(src, .proc/make_noises_and_pain, victim, user, tat_loc, part), next_time)
 
-/obj/item/tattoo_remover
-	name = "Tattoo Remover"
-	desc = "Useful for removing now-unwanted tattoos."
-	icon = 'icons/obj/tattoo_gun.dmi'
-	icon_state = "tattoo_gun"
-
-/obj/item/tattoo_remover/pre_attack(mob/living/carbon/human/victim, mob/living/user, params)
+/obj/item/tattoo_gun/proc/try_remove_tattoo(mob/living/carbon/human/victim, mob/living/user, bodyzone, /obj/item/bodypart/part)
 	. = ..()
-	if(isnull(victim) || !istype(victim, /mob/living/carbon/human))
+	if(!istype(victim) || !istype(user))
+		return
+	if(isnull(bodyzone) || !istype(part))
 		return
 	//find tattoos
-	var/bodyzone = check_zone(user.zone_selected)
-	var/obj/item/bodypart/part = victim.get_bodypart(bodyzone)
 	var/list/tats = list()
 	for(var/tatspot in GLOB.tattoo_locations[bodyzone])
 		if(!isnull(part.tattoos[tatspot]))
@@ -798,8 +792,6 @@
 	. = ..()
 	new /obj/item/tattoo_gun(src)
 	new /obj/item/tattoo_gun(src)
-	new /obj/item/tattoo_remover(src)
-	new /obj/item/tattoo_remover(src)
 	new /obj/item/tattoo_holder/blank(src)
 	new /obj/item/tattoo_holder/blank(src)
 	new /obj/item/tattoo_holder/blank/temporary(src)
@@ -814,7 +806,6 @@
 /obj/item/storage/box/tattoo_kit/PopulateContents()
 	. = ..()
 	new /obj/item/tattoo_gun(src)
-	new /obj/item/tattoo_remover(src)
 	new /obj/item/tattoo_holder/blank(src)
 	new /obj/item/tattoo_holder/blank(src)
 	new /obj/item/tattoo_holder/blank(src)

--- a/code/datums/tattoo.dm
+++ b/code/datums/tattoo.dm
@@ -754,9 +754,12 @@
 	name = "Tattoo Remover"
 	desc = "Useful for removing now-unwanted tattoos."
 	icon = 'icons/obj/tattoo_gun.dmi'
+	icon_state = "tattoo_gun"
 
 /obj/item/tattoo_remover/pre_attack(mob/living/carbon/human/victim, mob/living/user, params)
 	. = ..()
+	if(isnull(victim) || !istype(victim, /mob/living/carbon/human))
+		return
 	//find tattoos
 	var/bodyzone = check_zone(user.zone_selected)
 	var/obj/item/bodypart/part = victim.get_bodypart(bodyzone)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -187,7 +187,7 @@
 	for(var/obj/item/bodypart/i in bodyparts)
 		for(var/tatspot in i.tattoos)
 			var/datum/tattoo/tat = i.tattoos[tatspot]
-			if(tat.is_permanent == TRUE)
+			if(!isnull(tat) && tat.is_permanent == TRUE)
 				tats += "[tat.name]|[tat.desc]|[tat.extra_desc]|[tat.tat_location];"
 	return tats
 

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -6,7 +6,6 @@
 	product_slogans = "Dress for success!;Suited and booted!;It's show time!;Why leave style up to fate?"
 	vend_reply = "Thank you and have a spook-tastic Halloween!"
 	products = list(/obj/item/tattoo_gun = 5,
-					/obj/item/tattoo_remover = 5,
 					/obj/item/tattoo_holder/blank = 20,
 					/obj/item/tattoo_holder/blank/temporary = 20,
 					/obj/item/clothing/suit/chickensuit = 1,

--- a/code/modules/vending/brahminvendordm.dm
+++ b/code/modules/vending/brahminvendordm.dm
@@ -6,7 +6,6 @@
 	product_slogans = "Apply your brZZT- Giddeyup, yall!;Apply your brilliant deductiZZT-are better than one!;Apply your brilliant deductive methoZZT-your two-headed friends!;Apply your brilliant deductive methods in style! ...ZZT-ahmin, today!"
 	vend_reply = "Thank you for using the DetDroZZT-le Supply!"
 	products = list(/obj/item/tattoo_gun = 5,
-		/obj/item/tattoo_remover = 5,
 		/obj/item/tattoo_holder/blank = 20,
 		/obj/item/tattoo_holder/blank/temporary = 20,
 		///obj/item/brahminbags = 10,

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -231,7 +231,6 @@
 	product_slogans = "Do I look like your girlfriend?;I don't look like a ghost, do I?;Feel how warm I am?;It doesn't matter who I am.;Come and get me.;"
 	vend_reply = "Hurry back!"
 	products = list(/obj/item/tattoo_gun = 5,
-					/obj/item/tattoo_remover = 5,
 					/obj/item/tattoo_holder/blank = 20,
 					/obj/item/tattoo_holder/blank/temporary = 20,
 					/obj/item/clothing/under/f13/fprostitute = 5,

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -4,7 +4,6 @@
 	product_ads = "Escape to a fantasy world!;Fuel your gambling addiction!;Ruin your friendships!;Roll for initiative!;Elves and dwarves!;Paranoid computers!;Totally not satanic!;Fun times forever!"
 	icon_state = "games"
 	products = list(/obj/item/tattoo_gun = 5,
-					/obj/item/tattoo_remover = 5,
 					/obj/item/tattoo_holder/blank = 20,
 					/obj/item/tattoo_holder/blank/temporary = 20,
 					/obj/item/toy/cards/deck = 5,

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -7,7 +7,6 @@
 	vend_reply = "Come back for more!"
 	circuit = /obj/item/circuitboard/machine/vending/donksofttoyvendor
 	products = list(/obj/item/tattoo_gun = 5,
-		/obj/item/tattoo_remover = 5,
 		/obj/item/tattoo_holder/blank = 20,
 		/obj/item/tattoo_holder/blank/temporary = 20,
 		/obj/item/gun/ballistic/automatic/toy/unrestricted = 10,
@@ -70,7 +69,6 @@
 	icon_state = "kink"
 	vend_reply = "Have fun!"
 	products = list(/obj/item/tattoo_gun = 5,
-		/obj/item/tattoo_remover = 5,
 		/obj/item/tattoo_holder/blank = 20,
 		/obj/item/tattoo_holder/blank/temporary = 20,
 		/obj/item/storage/pill_bottle/breast_enlarger = 5,


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
- puts tattoo removal functionality into the tattoo gun itself to reduce clutter and adjusts its examine to reflect the change
- adds damage and a chance to scream on removal of a tattoo in order to make it feel more in line with tattoo application
- fixes two small errors with the code that was merged last night.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Tattoo removal is done with the tattoo gun
code: minor error correction with my previous tattoo code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
