### PR TITLE
resolves two runtimes: looping sounds and projectiles

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -64,7 +64,7 @@
 /datum/looping_sound/proc/start(atom/add_thing)
 	if(add_thing)
 		output_atoms |= add_thing
-		RegisterSignal(add_thing, COMSIG_PARENT_PREQDELETED, .proc/remove_atom)
+		RegisterSignal(add_thing, COMSIG_PARENT_PREQDELETED, .proc/remove_atom, override = TRUE)
 	if(timerid || init_timerid) // already running, will pick them up on the next go
 		return
 	on_start()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -899,7 +899,7 @@
 			if(!hitscanning)
 				pixel_x = trajectory.return_px()
 				pixel_y = trajectory.return_py()
-		else if(T != loc && !isnull(loc))
+		else if(T != loc)
 			var/safety = CEILING(pixel_increment_amount / world.icon_size, 1) * 5 + 1
 			while(T != loc)
 				if(!--safety)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -860,7 +860,7 @@
  * It's complicated, so probably just don't mess with this unless you know what you're doing.
  */
 /obj/item/projectile/proc/pixel_move(times, hitscanning = FALSE, deciseconds_equivalent = world.tick_lag, trajectory_multiplier = 1, allow_animation = TRUE)
-	if(!loc || !trajectory)
+	if(!loc)
 		return
 	if(!nondirectional_sprite && !hitscanning)
 		var/matrix/M = new
@@ -879,6 +879,8 @@
 			var/max_turn = homing_turn_speed * deciseconds_equivalent * 0.1
 			setAngle(Angle + clamp(angle, -max_turn, max_turn))
 		// HOMING END
+		if(!trajectory)
+			return
 		trajectory.increment(trajectory_multiplier)
 		var/turf/T = trajectory.return_turf()
 		if(!istype(T))
@@ -897,13 +899,13 @@
 			if(!hitscanning)
 				pixel_x = trajectory.return_px()
 				pixel_y = trajectory.return_py()
-		else if(T != loc)
+		else if(T != loc && !isnull(loc))
 			var/safety = CEILING(pixel_increment_amount / world.icon_size, 1) * 5 + 1
 			while(T != loc)
 				if(!--safety)
 					CRASH("[type] took too long (allowed: [CEILING(pixel_increment_amount/world.icon_size,1)*2] moves) to get to its location.")
 				step_towards(src, T)
-				if(QDELETED(src) || pixel_move_interrupted)		// this doesn't take into account with pixel_move_interrupted the portion of the move cut off by any forcemoves, but we're opting to ignore that for now
+				if(isnull(loc) || pixel_move_interrupted)		// this doesn't take into account with pixel_move_interrupted the portion of the move cut off by any forcemoves, but we're opting to ignore that for now
 				// the reason is the entire point of moving to pixel speed rather than tile speed is smoothness, which will be crucial when pixel movement is done in the future
 				// reverting back to tile is more or less the only way of fixing this issue.
 					return


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
-Resolves a runtime involving multiple looping sounds attempting to register to the same signal upon starting. `RegisterSignal` has an `override` param specifically for this.
-Resolves a runtime involving projectiles having their location and trajectory nulled before attempting to run checks based on those two variables by running null checks at relevant times.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Fixed a runtime in looping sounds and one in projectile movement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
