### PR TITLE
Expands room_sealers to include more doors

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -92,6 +92,7 @@ GLOBAL_LIST_INIT(room_sealers, typecacheof(list(
 	/obj/structure/window,
 	/obj/machinery/door,
 	/obj/structure/simple_door,
+	/obj/structure/mineral_door,
 	/obj/structure/fence,
 	/obj/structure/handrail,
 	/obj/structure/barricade,

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -93,6 +93,7 @@ GLOBAL_LIST_INIT(room_sealers, typecacheof(list(
 	/obj/machinery/door,
 	/obj/structure/simple_door,
 	/obj/structure/mineral_door,
+	/obj/structure/vaultdoor,
 	/obj/structure/fence,
 	/obj/structure/handrail,
 	/obj/structure/barricade,


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Resolves #429 by adding mineral doors and vault doors to the list of things that count as blockers when checking for sealed areas.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Added mineral doors and vault doors to the list of room sealing objects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
