### PR TITLE
Adjusts the Runechat timers/size and adds Bottom Text :tm:

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -147,10 +147,7 @@
 		var/combined_height = approx_lines
 		for(var/msg in owned_by.seen_messages[message_loc])
 			var/datum/chatmessage/m = msg
-			if(HAS_TRAIT(src, TRAIT_ERPBOTTOM))
-				animate(m.message, pixel_y = m.message.pixel_y*-1.5 + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
-			else
-				animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
+			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
 			var/sched_remaining = m.scheduled_destruction - world.time
 			if (sched_remaining > CHAT_MESSAGE_SPAWN_TIME)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -1,11 +1,11 @@
-#define CHAT_MESSAGE_SPAWN_TIME		0.2 SECONDS
-#define CHAT_MESSAGE_LIFESPAN		5 SECONDS
-#define CHAT_MESSAGE_EOL_FADE		0.7 SECONDS
-#define CHAT_MESSAGE_EXP_DECAY		0.7 // Messages decay at pow(factor, idx in stack)
-#define CHAT_MESSAGE_HEIGHT_DECAY	0.9 // Increase message decay based on the height of the message
+#define CHAT_MESSAGE_SPAWN_TIME		0.5 SECONDS
+#define CHAT_MESSAGE_LIFESPAN		12 SECONDS
+#define CHAT_MESSAGE_EOL_FADE		5.0 SECONDS
+#define CHAT_MESSAGE_EXP_DECAY		0.5 // Messages decay at pow(factor, idx in stack)
+#define CHAT_MESSAGE_HEIGHT_DECAY	0.4 // Increase message decay based on the height of the message
 #define CHAT_MESSAGE_APPROX_LHEIGHT	11 // Approximate height in pixels of an 'average' line, used for height decay
-#define CHAT_MESSAGE_WIDTH			96 // pixels
-#define CHAT_MESSAGE_MAX_LENGTH		110 // characters
+#define CHAT_MESSAGE_WIDTH			100 // pixels
+#define CHAT_MESSAGE_MAX_LENGTH		200 // characters
 #define WXH_TO_HEIGHT(x)			text2num(copytext((x), findtextEx((x), "x") + 1)) // thanks lummox
 
 /**
@@ -147,7 +147,10 @@
 		var/combined_height = approx_lines
 		for(var/msg in owned_by.seen_messages[message_loc])
 			var/datum/chatmessage/m = msg
-			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
+			if(HAS_TRAIT(src, TRAIT_ERPBOTTOM))
+				animate(m.message, pixel_y = m.message.pixel_y*-1.5 + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
+			else
+				animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
 			var/sched_remaining = m.scheduled_destruction - world.time
 			if (sched_remaining > CHAT_MESSAGE_SPAWN_TIME)
@@ -161,6 +164,7 @@
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
 	message.pixel_y = owner.bound_height * 0.95
+
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5


### PR DESCRIPTION
This increases the size of runechat messages to 200, and lengthens how long they're visible.  Yes, this does mean we could have someone spam them, but its a risk I think is worth taking for QOL.

I am also trying to make it so that it checks for the Trait ERPBOTTOM and places the runechat messages BELOW you, but haven't quite got that working yet.  Could use a real coder

@TalkingCactus
@Superlagg
@OverDriveZ

https://gyazo.com/a6117d31c916fcd37bdbb7a9a53c43d6

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
