### PR TITLE
Map Tweak: Ashdown Armory + Dog + Chikens

### DIFF
--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -850,10 +850,9 @@
 /area/f13/wasteland/ashdown)
 "gJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/ashdown)
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/wasteland/ashdown)
 "gL" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -2368,6 +2367,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"se" = (
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/wasteland/ashdown)
 "sn" = (
 /obj/structure/flora/branch_broken,
 /obj/effect/decal/cleanable/generic,
@@ -2979,6 +2982,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table,
 /obj/structure/destructible/tribal_torch/wall/lit,
+/obj/item/stack/sheet/plastic/five,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -4317,9 +4321,11 @@
 /turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
 "Ff" = (
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
-/area/f13/wasteland/ashdown)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/f13/wood,
+/area/f13/building/workshop/ashdown)
 "Fh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6347,11 +6353,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"SF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
-/area/f13/wasteland/ashdown)
 "SG" = (
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -63752,7 +63753,7 @@ tJ
 lP
 wS
 Cy
-gJ
+Ff
 Vl
 aH
 eM
@@ -68375,7 +68376,7 @@ pR
 iX
 eq
 Yf
-Ff
+se
 Tu
 jC
 lg
@@ -68633,7 +68634,7 @@ wx
 Ds
 Ql
 Mk
-SF
+gJ
 De
 RH
 vn

--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -849,21 +849,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ashdown)
 "gJ" = (
-/mob/living/simple_animal/hostile/wolf/alpha{
-	desc = "The Rottweiler is a robust dog breed of great strength descended from the mastiffs.This one smells of beans and sunflowers.";
-	faction = list("neutral");
-	health = 200;
-	icon_dead = "rottweiler_dead";
-	icon_living = "rottweiler";
-	icon_state = "rottweiler";
-	name = "Sunflower"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/cobble{
-	light_color = null;
-	color = "#777777"
-	},
-/area/f13/wasteland/ashdown)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/f13/wood,
+/area/f13/building/workshop/ashdown)
 "gL" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -1562,9 +1552,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lP" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet{
 	anchored = 1;
@@ -1574,10 +1561,6 @@
 /obj/item/clothing/suit/armor/light/kit/shoulder,
 /obj/item/clothing/suit/armor/light/kit/punk,
 /obj/item/clothing/suit/armor/light/kit,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
 /obj/item/clothing/suit/armor/light/leather/leather_jacket,
 /obj/item/clothing/suit/armor/light/duster/breastplate/khan,
 /obj/item/clothing/suit/armor/light/duster/breastplate/khan,
@@ -1586,6 +1569,8 @@
 	pixel_x = 1;
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/f13/common_armor,
+/obj/effect/spawner/lootdrop/f13/common_armor,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/ashdown)
 "lQ" = (
@@ -3100,11 +3085,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ashdown)
 "wF" = (
-/obj/machinery/autolathe,
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "red"
 	},
+/obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/ashdown)
 "wN" = (
@@ -4332,9 +4317,9 @@
 /turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
 "Ff" = (
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/ashdown)
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/wasteland/ashdown)
 "Fh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5759,6 +5744,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/abandoned)
 "OG" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -6359,6 +6347,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"SF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/wasteland/ashdown)
 "SG" = (
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -6469,6 +6462,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/wolf/alpha{
+	desc = "The Rottweiler is a robust dog breed of great strength descended from the mastiffs.This one smells of beans and sunflowers.";
+	faction = list("neutral");
+	health = 200;
+	icon_dead = "rottweiler_dead";
+	icon_living = "rottweiler";
+	icon_state = "rottweiler";
+	name = "Sunflower"
+	},
 /turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
 "Ty" = (
@@ -6804,9 +6806,9 @@
 	},
 /area/f13/building)
 "Vl" = (
-/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/ammo/unlocked_basic,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/ashdown)
 "Vp" = (
@@ -63236,7 +63238,7 @@ uv
 VX
 Ti
 lk
-Ff
+vt
 vJ
 Vc
 rf
@@ -63749,8 +63751,8 @@ Yf
 tJ
 lP
 wS
-vt
-Vl
+Cy
+gJ
 Vl
 aH
 eM
@@ -64004,7 +64006,7 @@ IA
 tc
 AN
 Yi
-Cy
+vt
 dY
 nU
 Qv
@@ -68373,7 +68375,7 @@ pR
 iX
 eq
 Yf
-zJ
+Ff
 Tu
 jC
 lg
@@ -68631,7 +68633,7 @@ wx
 Ds
 Ql
 Mk
-QB
+SF
 De
 RH
 vn
@@ -70687,7 +70689,7 @@ HZ
 py
 py
 py
-gJ
+Ym
 py
 nn
 iQ

--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -2367,10 +2367,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"se" = (
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
-/area/f13/wasteland/ashdown)
 "sn" = (
 /obj/structure/flora/branch_broken,
 /obj/effect/decal/cleanable/generic,
@@ -2982,7 +2978,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table,
 /obj/structure/destructible/tribal_torch/wall/lit,
-/obj/item/stack/sheet/plastic/five,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -6191,6 +6186,10 @@
 	},
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/ashdown)
+"RS" = (
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
 "RV" = (
 /obj/structure/fence/wooden{
@@ -68376,7 +68375,7 @@ pR
 iX
 eq
 Yf
-se
+RS
 Tu
 jC
 lg

--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -849,7 +849,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ashdown)
 "gJ" = (
-/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
@@ -2978,6 +2977,9 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table,
 /obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2-broken"
 	},
@@ -4892,6 +4894,11 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/ashdown)
+"IO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/chicken,
+/turf/open/floor/grass,
+/area/f13/wasteland/ashdown)
 "IP" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -6186,10 +6193,6 @@
 	},
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/ashdown)
-"RS" = (
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
 /area/f13/wasteland/ashdown)
 "RV" = (
 /obj/structure/fence/wooden{
@@ -68375,7 +68378,7 @@ pR
 iX
 eq
 Yf
-RS
+gJ
 Tu
 jC
 lg
@@ -68633,7 +68636,7 @@ wx
 Ds
 Ql
 Mk
-gJ
+IO
 De
 RH
 vn


### PR DESCRIPTION
## About The Pull Request
So what this PR basically does is maps in the armory a bit more life instead of having everyone pushed up towards the north. So that way if you are a ballistics user you arent crowded in the back of the area but instead crowded around the main parts. I also added five sheets of plastic into the armory. Also now Ashdown has chikens so bakers can get eggs if one of the ashdown / nomads want to do baking week without having to get a biogenerator. Also put sunflower in the pen instead of sunflower speedrunning into the recycler. Below is photos on the details. 

![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/5c374458-eddf-47b8-950a-1de81a07655d)

![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/ca3a422c-b3f1-43ca-88ca-f6125efc27e2)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: ashdown armory + animal pen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
