### PR TITLE
Adds Backstab Multiplier for one handed attacks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -189,7 +189,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/reskinnable_component
 
 	/// New variable for backstab multiplier
-	var/backstab_multiplier = 1.0 
+	var/backstab_multiplier = 1.15 
 
 /obj/item/Initialize()
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -188,6 +188,9 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	/// Reskinnable component
 	var/reskinnable_component
 
+	/// New variable for backstab multiplier
+	var/backstab_multiplier = 1.0 
+
 /obj/item/Initialize()
 
 	if(attack_verb)
@@ -1272,3 +1275,10 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/proc/refresh_upgrades()
 	return
 
+/obj/item/attack(mob/living/M, mob/living/user, attackchain_flags = NONE, damage_multiplier = 1, damage_override)
+	// Check if the user is behind the target
+	if(get_dir(user, M) == M.dir && isliving(M))
+		damage_multiplier = backstab_multiplier // Apply the backstab multiplier
+		playsound(user.loc, 'sound/effects/dismember.ogg', 50, 1, -1) // Play a backstab sound
+		to_chat(user, "<span class='notice'>You backstab [M]!</span>")
+	. = ..()


### PR DESCRIPTION
Doesn't work with Dans directional melee system, but does allow anything that can do force and is one handed (ie, not using wielded force) to have a backstab multiplier that we can dial in.

Backstabs only render their bonus damage when DIRECTLY behind the target.

Thanks Cactus!

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
