### PR TITLE
Map Bugfix: Ashdown Bar

### DIFF
--- a/_maps/map_files/coyote_bayou/Ashdown.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown.dmm
@@ -41352,6 +41352,8 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/storage/box/condimentbottles,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/ashdown)
 "sIa" = (
@@ -109942,7 +109944,7 @@ gRn
 gRn
 gRn
 gRn
-gRn
+wWK
 gRn
 gRn
 gRn
@@ -110198,7 +110200,7 @@ gMW
 gRn
 gRn
 gRn
-gRn
+wWK
 wWK
 wWK
 gRn
@@ -110969,7 +110971,7 @@ btP
 btP
 btP
 btP
-eHB
+btP
 wWK
 eHB
 tCq
@@ -111224,12 +111226,12 @@ eJW
 vtp
 eJW
 eJW
+eJW
 gFv
 btP
 wWK
 wWK
 wWK
-gRn
 gRn
 wWK
 wWK
@@ -111482,10 +111484,10 @@ eJW
 iXF
 rVB
 xwj
+eJW
 btP
-iRq
+eHB
 wWK
-gRn
 gRn
 gRn
 gRn
@@ -111739,10 +111741,10 @@ gAb
 iTj
 rVB
 gfO
+eJW
 btP
-gRn
-gRn
-gRn
+iRq
+wWK
 gRn
 gRn
 gRn
@@ -111995,9 +111997,9 @@ eJW
 vtp
 jZJ
 eJW
+eJW
 nsO
 btP
-gRn
 gRn
 gRn
 gRn
@@ -112253,8 +112255,8 @@ eJW
 iXF
 cXM
 xwj
+eJW
 btP
-gRn
 gRn
 gRn
 gRn
@@ -112510,8 +112512,8 @@ eJW
 iTj
 cXM
 gfO
+eJW
 btP
-gRn
 gRn
 gRn
 gRn
@@ -112766,9 +112768,9 @@ gAb
 eJW
 eJW
 eJW
+eJW
 gFv
 btP
-gRn
 gRn
 gRn
 gRn
@@ -113023,9 +113025,9 @@ eJW
 eJW
 eJW
 eJW
+eJW
 iZc
 btP
-gRn
 gRn
 gRn
 gRn


### PR DESCRIPTION
## About The Pull Request
What this PR does it basically expands the ashdown bar by a singular tile and making it where the potluck doesnt destory the wall anymore that leads to the mirelurk cave plus it also allows more walkroom on the back just incase if someone is rping in the middle and also this PR adds a salt and pepper to the Ashdown bar kitchen fridge.
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/f457f68a-95a0-4b6f-a941-4e3b71f2dd78)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/e005a5d3-c109-47d1-be8c-65c273251de2)
Salt and pepper in the fridge


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Ashdown Bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
