### PR TITLE
Applying Superglue to the bottom of Rechargers

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -69,8 +69,8 @@
 			return
 		if(default_deconstruction_crowbar(W))
 			return
-		if(!charging && default_unfasten_wrench(user, W))
-			return
+//		if(!charging && default_unfasten_wrench(user, W))
+//			return
 		return ..()
 
 /obj/machinery/cell_charger/deconstruct()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -71,9 +71,12 @@
 		if(charging)
 			to_chat(user, span_notice("Remove the charging item first!"))
 			return
+/*
+// Till FIAT Power is fixed, no movin these around willy nilly. Put some effort into it and work for the milage of your 'non battery replacable' firearms. You can still full dissasemble after all
 		setAnchored(!anchored)
 		power_change()
-		to_chat(user, span_notice("You [anchored ? "attached" : "detached"] [src]."))
+*/
+		to_chat(user, span_notice("[src] seems to be stuck in place, it will need further disassembly to move."))
 		G.play_tool_sound(src)
 		return
 


### PR DESCRIPTION
## About The Pull Request
Simply put, you can still smack wrenches against rechargers, but they don't unanchor them anymore, to move them you now have to fully disassemble them. Workaround for FIAT power and TG styled recharging guns with non-replacable cells

PS. Staff requested the WHOLE energy weapons idea get kneecapped instead of the 'replaceless cells' TG guns, sorry folks!

## Pre-Merge Checklist
- [ X] You tested this on a local server.
- [ X] This code did not runtime during testing.
- [ X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked a few things
balance: rebalanced something
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
