### PR TITLE
Loadout Healstaff and some minor heal magic balances (Good to go if it passes checks)

### DIFF
--- a/code/game/objects/items/loadout_beacons.dm
+++ b/code/game/objects/items/loadout_beacons.dm
@@ -2960,7 +2960,7 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	spawn_thing = /obj/item/storage/box/magic/bonewands
 
 /obj/item/storage/box/magic/bonewands
-	name = "Wand storage case"
+	name = "wand storage case"
 
 /obj/item/storage/box/magic/bonewands/PopulateContents()
 	new /obj/item/gun/magic/wand/kelpmagic/magicmissile(src)
@@ -2973,11 +2973,23 @@ GLOBAL_LIST_EMPTY(loadout_boxes)
 	spawn_thing = /obj/item/storage/box/magic/rodwands
 
 /obj/item/storage/box/magic/rodwands
-	name = "Wand storage case"
+	name = "wand storage case"
 
 /obj/item/storage/box/magic/rodwands/PopulateContents()
 	new /obj/item/gun/magic/wand/kelpmagic/basiczappies(src)
 	new /obj/item/gun/magic/wand/kelpmagic/basiczappies(src)
+
+/datum/loadout_box/healstaff
+	entry_tag = "Staff of Lesser Healing"
+	entry_flags = LOADOUT_FLAG_WASTER | LOADOUT_FLAG_TRIBAL
+	entry_class = LOADOUT_CAT_MAGIC
+	spawn_thing = /obj/item/storage/box/magic/healstaff
+
+/obj/item/storage/box/magic/healstaff
+	name = "staff storage case"
+
+/obj/item/storage/box/magic/healstaff/PopulateContents()
+	new /obj/item/gun/magic/staff/healing/triheal(src)
 
 // Putting this down here because it refuses to work. Needs to be fixed later.
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -51,14 +51,18 @@
 
 /obj/item/gun/magic/staff/healing/triheal
 	name = "staff of unstable blessings"
-	desc = "An artefact that spits bolts of restorative magic. This one has three spells echanted into its crystal. One to heal simple bruises, one that soothes burns, and the other that can heal even the most complex of toxins and cellular damage."
+	desc = "An artefact that spits bolts of restorative magic. This one has three spells of healing enchanted into its crystal, however the wielder cannot choose which shall be cast due to the artefact's wild nature."
 	fire_sound = 'sound/magic/mystical.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/chaos
 	icon_state = "triheal"
 	item_state = "broom"
-	max_charges = 3
-	recharge_rate = 30 SECONDS
+	max_charges = 30
+	recharge_rate = 6 SECONDS
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/healbrute, /obj/item/projectile/magic/healburn, /obj/item/projectile/magic/healtoxin)
+	init_firemodes = list(
+		/datum/firemode/automatic/rpm100,
+		/datum/firemode/semi_auto/faster
+	)
 
 /obj/item/gun/magic/staff/healing/triheal/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0, stam_cost = 0)
 	chambered.projectile_type = pick(allowed_projectile_types)
@@ -109,7 +113,7 @@
 	//righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	//hitsound = 'sound/weapons/rapierhit.ogg'
 	//force_unwielded = 25
-	//force_wielded = 40 
+	//force_wielded = 40
 	//block_parry_data = /datum/block_parry_data/bokken
 	//item_flags = ITEM_CAN_PARRY
 	//weapon_special_component = /datum/component/weapon_special/single_turf
@@ -258,7 +262,7 @@
 	icon_state = "medstaff"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/mending
 	max_charges = 25 // 5x the capacity than the wand, but it is Bulky; heals 15/10/20/20/20/5 Bru/Brn/Tox/Oxy/Stm/Cln damage per shot; as a projectile it CAN miss and heal an enemy instead
-	recharge_rate = 60 SECONDS
+	recharge_rate = 30 SECONDS
 
 /****************/
 //Upgraded Staff of Healing//

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -399,7 +399,7 @@
 	w_class = WEIGHT_CLASS_NORMAL // It's a source of infinite healing, it needs a downside; can carry two wands in a shoulder holster (~100 healing every 5 minutes)
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/mending
 	max_charges = 5
-	recharge_rate = 60 SECONDS
+	recharge_rate = 30 SECONDS
 
 /obj/item/ammo_casing/magic/kelpmagic/mending // Because the projectile isn't here, heals 15 brute + 10 burn damage and 20 tox/oxy, along with a pittance of clone.
 		projectile_type = /obj/item/projectile/magic/tenderwand

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -547,13 +547,12 @@
 			return BULLET_ACT_BLOCK
 	if(iscarbon(target))
 		M.visible_message(span_warning("[src] mends [target]!"))
-		M.adjustBruteLoss(-35) //HEALS
-		M.adjustOxyLoss(-20)
-		M.adjustBruteLoss(-15)
-		M.adjustFireLoss(-5)
-		M.adjustToxLoss(-0, TRUE) //heals TOXINLOVERs
+		M.adjustBruteLoss(-3) //HEALS
+		M.adjustOxyLoss(-10)
+		M.adjustFireLoss(-1)
+		M.adjustToxLoss(-1, TRUE) //heals TOXINLOVERs
 		M.adjustCloneLoss(-5)
-		M.adjustStaminaLoss(-20)
+		M.adjustStaminaLoss(-10)
 		return
 
 /obj/item/projectile/magic/healburn
@@ -570,14 +569,14 @@
 			return BULLET_ACT_BLOCK
 	if(iscarbon(target))
 		M.visible_message(span_warning("[src] mends [target]!"))
-		M.adjustBruteLoss(-5) //HEALS
-		M.adjustOxyLoss(-20)
-		M.adjustBruteLoss(-35)
-		M.adjustFireLoss(-35)
-		M.adjustToxLoss(-0, TRUE) //heals TOXINLOVERs
+		M.adjustBruteLoss(-1) //HEALS
+		M.adjustOxyLoss(-10)
+		M.adjustFireLoss(-3)
+		M.adjustToxLoss(-1, TRUE) //heals TOXINLOVERs
 		M.adjustCloneLoss(-5)
 		M.adjustStaminaLoss(-10)
 		return
+
 /obj/item/projectile/magic/healtoxin
 	icon_state = "toxinheal"
 	damage = 0
@@ -592,13 +591,12 @@
 			return BULLET_ACT_BLOCK
 	if(iscarbon(target))
 		M.visible_message(span_warning("[src] mends [target]!"))
-		M.adjustBruteLoss(-5) //HEALS
+		M.adjustBruteLoss(-1) //HEALS
 		M.adjustOxyLoss(-50)
-		M.adjustBruteLoss(-15)
-		M.adjustFireLoss(-5)
-		M.adjustToxLoss(-50, TRUE) //heals TOXINLOVERs
-		M.adjustCloneLoss(-50)
-		M.adjustStaminaLoss(-0)
+		M.adjustFireLoss(-1)
+		M.adjustToxLoss(-5, TRUE) //heals TOXINLOVERs
+		M.adjustCloneLoss(-25)
+		M.adjustStaminaLoss(-50)
 		return
 
 /obj/item/projectile/magic/tenderwand


### PR DESCRIPTION
## About The Pull Request
Adds a new staff to the spawn loadouts per fenny's request and some minor balance tweaks with magic things.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Added the triheal staff to loadout
- Changed the triheal staff to basically be a healing RCW
- Buffed the healing wand/staff so that the triheal staff isn't just outright better. May need to go back and raise their recharge time a little in the future?

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
