### PR TITLE
HOTFIX - Energy Weapon Wounding (Good to go if it passes checks)

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -17,6 +17,12 @@
 	wound_bonus = -20
 	bare_wound_bonus = 10
 	recoil = BULLET_RECOIL_LASER
+	sharpness = SHARP_POINTY // Temporary fix for the Wound system. Makes lasers/plasma bleed you out per hit.
+
+/obj/item/projectile/f13plasma
+	name = "plasma template"
+	icon_state = "laser"
+	sharpness = SHARP_POINTY // Temporary fix for the Wound system. Makes lasers/plasma bleed you out per hit.
 
 /obj/item/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -8,6 +8,7 @@
 	light_range = 3
 	light_color = LIGHT_COLOR_GREEN
 	recoil = BULLET_RECOIL_PLASMA
+	sharpness = SHARP_POINTY // Temporary fix for the Wound system. Makes lasers/plasma bleed you out per hit.
 
 /obj/item/projectile/energy/plasmabolt/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -262,7 +262,7 @@
 	*/
 
 	// what kind of wounds we're gonna roll for, take the greater between brute and burn, then if it's brute, we subdivide based on sharpness
-	var/wounding_type = (brute > burn ? WOUND_BLUNT : WOUND_BURN)
+	var/wounding_type = WOUND_BLUNT// (brute > burn ? WOUND_BLUNT : WOUND_BURN) is the old code here
 	var/wounding_dmg = max(brute, burn)
 	var/mangled_state = get_mangled_state()
 	var/bio_state = owner.get_biological_state()
@@ -302,7 +302,7 @@
 				return
 
 	// now we have our wounding_type and are ready to carry on with wounds and dealing the actual damage
-	
+
 	if(owner && wounding_dmg >= WOUND_MINIMUM_DAMAGE && wound_bonus != CANT_WOUND)
 		check_wounding(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus)
 
@@ -404,14 +404,14 @@
 			return // robot parts dont get wounded yet
 
 	damage = min(damage * CONFIG_GET(number/wound_damage_multiplier), WOUND_MAX_CONSIDERED_DAMAGE)
-	
+
 	if(HAS_TRAIT(owner, TRAIT_EASYLIMBDISABLE))
 		damage *= 1.5
 	if(woundtype == WOUND_BLUNT && HAS_TRAIT(owner, TRAIT_GLASS_BONES))
 		damage *= 1.5
 	if((woundtype in PAPER_SKIN_WOUNDS) && HAS_TRAIT(owner, TRAIT_PAPER_SKIN))
 		damage *= 1.5
-	
+
 	var/base_roll = rand(
 		min(damage * WOUND_DAMAGE_RANDOM_FLOOR_MULT, WOUND_MAX_CONSIDERED_DAMAGE),
 		min(damage * WOUND_DAMAGE_RANDOM_MAX_MULT, WOUND_MAX_CONSIDERED_DAMAGE)
@@ -1446,7 +1446,7 @@
 		if(istype(tat))
 			qdel(tat)
 			tattoos[location] = null
-			return TRUE	
+			return TRUE
 		if(ispath(tat))
 			var/datum/tattoo/tattie = tattoos[location]
 			if(tattie.type == tat)


### PR DESCRIPTION
## About The Pull Request
Title. Makes it so laser/plasma projectiles are considered 'sharp' and can cause bleeding. Temporary fix for lasers/plasma weapons not actually doing anything at high Wound levels. Should also indirectly fix some Wound issues with melee too.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Lasers are now sharp and pointy
- Plasma is now sharp and pointy
- Something changed in _bodyparts to make it so that burn-damage weapons can cut and bleed you

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
