### PR TITLE
silly little arrow crafting bug

### DIFF
--- a/code/game/objects/items/arrow_crafting.dm
+++ b/code/game/objects/items/arrow_crafting.dm
@@ -174,7 +174,7 @@
 	icon = 'icons/obj/arrow_crafting.dmi'
 	icon_state = "arrow_head_bodkin"
 	merge_type = /obj/item/stack/arrowhead/broadhead
-	result_arrow = /obj/item/ammo_casing/caseless/arrow/broadhead
+	result_arrow = /obj/item/ammo_casing/caseless/arrow/bodkin
 
 /obj/item/stack/arrowhead/explosive
 	name = "explosive arrow heads"


### PR DESCRIPTION
## About The Pull Request
bodkin arrows were making broadheads

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: arrow crafting should be okay again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
