### PR TITLE
Map Bugfix: Redwater Z Level

### DIFF
--- a/_maps/map_files/coyote_bayou/Redwater.dmm
+++ b/_maps/map_files/coyote_bayou/Redwater.dmm
@@ -24996,7 +24996,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/building)
 "iCl" = (
 /obj/effect/decal/marking{
@@ -62547,7 +62547,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/building)
 "vEW" = (
 /obj/structure/closet,
@@ -65611,7 +65611,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/building)
 "wGL" = (
 /obj/structure/flora/tree/jungle/small,


### PR DESCRIPTION
## About The Pull Request
There was a few rogue tiles they are gone now.
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/46e881eb-72c4-4c8b-a461-11b195d9cf30)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/907f77a1-dbfc-40ae-a77e-285185251482)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: redwoter z level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
