### PR TITLE
House Wall Restoration

### DIFF
--- a/code/modules/fallout/turf/house_wall.dm
+++ b/code/modules/fallout/turf/house_wall.dm
@@ -1,0 +1,48 @@
+/turf/closed/wall/f13/wood/house
+	name = "weathered house wall"
+	desc = "A weathered pre-War house wall."
+	icon = 'icons/fallout/turfs/walls/house.dmi'
+	icon_state = "house"
+	icon_type_smooth = "house"
+	hardness = 50
+	smooth = SMOOTH_TRUE
+	canSmoothWith = list(/turf/closed/wall/f13/wood/house, /turf/closed/wall/f13/wood/house/broken, /turf/closed/wall, /turf/closed/wall/f13/wood/house/clean)
+
+/turf/closed/wall/f13/wood/house/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/toy/crayon/spraycan))
+		var/obj/item/toy/crayon/spraycan/sc = I
+		if(!sc.is_capped)
+			if(sc.use_charges(user, 3))
+				to_chat(user, span_warning("You painted the wall!"))
+				ChangeTurf(/turf/closed/wall/f13/wood/house/clean)
+
+/turf/closed/wall/f13/wood/house/broken
+	name = "broken house wall"
+	desc = "A badly damaged pre-war house wall."
+	icon = 'icons/fallout/turfs/walls/house-broken.dmi'
+	icon_state = "house-broken"
+	icon_type_smooth = "house-broken"
+	smooth = SMOOTH_TRUE
+	canSmoothWith = list(/turf/closed/wall/f13/wood/house, /turf/closed/wall/f13/wood/house/broken, /turf/closed/wall, /turf/closed/wall/f13/wood/house/clean)
+	opacity = 0
+
+/turf/closed/wall/f13/wood/house/broken/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/stack/sheet/mineral/wood))
+		var/obj/item/stack/sheet/mineral/wood/I = W
+		if(I.amount < 2)
+			return
+		if(!do_after(user, 5 SECONDS, FALSE, src))
+			to_chat(user, span_warning("You must stand still to fix the wall!"))
+			return
+		W.use(2)
+		ChangeTurf(/turf/closed/wall/f13/wood/house)
+	. = ..()
+
+/turf/closed/wall/f13/wood/house/clean
+	name = "house wall"
+	desc = "A newly painted house wall."
+	icon = 'icons/fallout/turfs/walls/house-clean.dmi'
+	icon_state = "house-clean"
+	icon_type_smooth = "house-clean"
+	smooth = SMOOTH_TRUE
+	canSmoothWith = list(/turf/closed/wall/f13/wood/house, /turf/closed/wall/f13/wood/house/broken, /turf/closed/wall, /turf/closed/wall/f13/wood/house/clean)

--- a/code/modules/fallout/turf/walls.dm
+++ b/code/modules/fallout/turf/walls.dm
@@ -41,58 +41,6 @@
 	girder_type = 0
 	canSmoothWith = list(/turf/closed/wall/f13/wood, /turf/closed/wall)
 
-/turf/closed/wall/f13/wood/house
-	name = "house wall"
-	desc = "A weathered pre-War house wall."
-	icon = 'icons/fallout/turfs/walls/house.dmi'
-	icon_state = "house0"
-	icon_type_smooth = "house"
-	hardness = 50
-	var/broken = 0
-	canSmoothWith = list(/turf/closed/wall/f13/wood/house, /turf/closed/wall/f13/wood/house/broken, /turf/closed/wall, /turf/closed/wall/f13/wood/house/clean)
-
-/turf/closed/wall/f13/wood/house/broken
-	broken = 1
-	damage = 21
-	icon_state = "house0-broken"
-
-/turf/closed/wall/f13/wood/house/broken/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/I = W
-		if(I.amount < 2)
-			return
-		if(!do_after(user, 5 SECONDS, FALSE, src))
-			to_chat(user, span_warning("You must stand still to fix the wall!"))
-			return
-		W.use(2)
-		ChangeTurf(/turf/closed/wall/f13/wood/house)
-	. = ..()
-
-
-/turf/closed/wall/f13/wood/house/take_damage(dam)
-	if(damage + dam > hardness/2)
-		broken = 1
-	..()
-
-/turf/closed/wall/f13/wood/house/relative()
-	icon_state = "[icon_type_smooth][junction][broken ? "-broken" : ""]"
-
-/turf/closed/wall/f13/wood/house/update_icon()
-	if(broken)
-		set_opacity(0)
-	..()
-
-turf/closed/wall/f13/wood/house/update_damage_overlay()
-	if(broken)
-		return
-	..()
-
-/turf/closed/wall/f13/wood/house/clean
-	icon_state = "house0-clean"
-
-/turf/closed/wall/f13/wood/house/clean/relative()
-	icon_state = "[icon_type_smooth][junction]-clean"
-
 /turf/closed/wall/f13/wood/interior
 	name = "interior wall"
 	desc = "Interesting, what kind of material they have used - these wallpapers still look good after all the centuries..."


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Allows you to apply a new paint to pre-war house walls to make it look brand new.

turn /turf/closed/wall/f13/wood/house to /turf/closed/wall/f13/wood/house/clean using "5 use" of spraycan.

also makes the wall use new smoothing because why not.

puts the house walls in it's own .dm to make wall.dm less cluttered.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->