### PR TITLE
fixes scarf-cape loadout names

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -175,73 +175,73 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/armor
 
 /obj/item/clothing/neck/laika
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze."
 	icon_state = "laika"
 	pocket_storage_component_path = /datum/component/storage/concrete/belt/specialized/gun // Laika uses gun(s) and there's not a visible holster on her. I assume it's a hidden shoulder holster. Also, why skip out on mechanics for drip?
 
 /obj/item/clothing/neck/laika/redder
-	name = "Blood Red Scarf-Cape + Holster"
+	name = "Blood Red Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is awfully Red."
 	icon_state = "laika_redder"
 
 /obj/item/clothing/neck/laika/blue
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is a dull shade of Blue."
 	icon_state = "laika_blue"
 
 /obj/item/clothing/neck/laika/bluer
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is a vibrant Blue."
 	icon_state = "laika_bluer"
 
 /obj/item/clothing/neck/laika/cyan
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is the color of coastal waters."
 	icon_state = "laika_cyan"
 
 /obj/item/clothing/neck/laika/tan
-	name = "Tactical Coyote Scarf-Cape + Holster"
+	name = "Tactical Coyote Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is a tacticool Coyote color."
 	icon_state = "laika_tan"
 
 /obj/item/clothing/neck/laika/brown
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is the color of dirt."
 	icon_state = "laika_brown"
 
 /obj/item/clothing/neck/laika/yellow
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is the color of.. Primula."
 	icon_state = "laika_yellow"
 
 /obj/item/clothing/neck/laika/olive
-	name = "Tactical OD Scarf-Cape + Holster"
+	name = "Tactical OD Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is in a tacticool drabby green."
 	icon_state = "laika_olive"
 
 /obj/item/clothing/neck/laika/white
-	name = "Chilly Scarf-Cape + Holster"
+	name = "Chilly Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is the color of snow."
 	icon_state = "laika_white"
 
 /obj/item/clothing/neck/laika/black
-	name = "Spooky Scarf-Cape + Holster"
+	name = "Spooky Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is the color of spilled ink."
 	icon_state = "laika_black"
 
 /obj/item/clothing/neck/laika/tricolor
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one smells of baguettes or vodka."
 	icon_state = "laika_tricolor"
 
 /obj/item/clothing/neck/laika/starspangledbanner
-	name = "Loud Scarf-Cape + Holster"
+	name = "Loud Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one smells of burgers, beer, and gunpowder."
 	icon_state = "laika_ssb"
 
 /obj/item/clothing/neck/laika/striped
-	name = "Striped Scarf-Cape + Holster"
+	name = "Striped Scarf-Cape w/ Holster"
 	desc = "A stylish scarf.. and cape? The perfect winter accessory for those who ride motorcycles and just can't handle the cold breeze. This one is striped."
 	icon_state = "laika_striped"
 

--- a/modular_citadel/code/modules/client/loadout/neck.dm
+++ b/modular_citadel/code/modules/client/loadout/neck.dm
@@ -135,60 +135,60 @@
 	path = /obj/item/clothing/neck/scarf/cptpatriot
 
 /datum/gear/neck/scarf/laika
-	name = "Scarf-Cape + Holster"
+	name = "Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika
 	cost = 2 // because it has a holster in it
 
 /datum/gear/neck/scarf/laika/redder
-	name = "Blood Red Scarf-Cape + Holster"
+	name = "Blood Red Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/redder
 
 /datum/gear/neck/scarf/laika/blue
-	name = "Blue Scarf-Cape + Holster"
+	name = "Blue Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/blue
 
 /datum/gear/neck/scarf/laika/bluer
-	name = "Vibrant Blue Scarf-Cape + Holster"
+	name = "Vibrant Blue Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/bluer
 
 /datum/gear/neck/scarf/laika/cyan
-	name = "Cyan Scarf-Cape + Holster"
+	name = "Cyan Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/cyan
 
 /datum/gear/neck/scarf/laika/tan
-	name = "Tactical Coyote Scarf-Cape + Holster"
+	name = "Tactical Coyote Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/tan
 
 /datum/gear/neck/scarf/laika/brown
-	name = "Brown Scarf-Cape + Holster"
+	name = "Brown Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/brown
 
 /datum/gear/neck/scarf/laika/yellow
-	name = "Yellow Scarf-Cape + Holster"
+	name = "Yellow Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/yellow
 
 /datum/gear/neck/scarf/laika/olive
-	name = "Tactical OD Scarf-Cape + Holster"
+	name = "Tactical OD Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/olive
 
 /datum/gear/neck/scarf/laika/white
-	name = "White Scarf-Cape + Holster"
+	name = "White Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/white
 
 /datum/gear/neck/scarf/laika/black
-	name = "Black Scarf-Cape + Holster"
+	name = "Black Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/black
 
 /datum/gear/neck/scarf/laika/tricolor
-	name = "Tricolor Scarf-Cape + Holster"
+	name = "Tricolor Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/tricolor
 
 /datum/gear/neck/scarf/laika/starspangledbanner
-	name = "Star Spangled Scarf-Cape + Holster"
+	name = "Star Spangled Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/starspangledbanner
 
 /datum/gear/neck/scarf/laika/striped
-	name = "Striped Scarf-Cape + Holster"
+	name = "Striped Scarf-Cape w/ Holster"
 	path = /obj/item/clothing/neck/laika/striped
 
 /datum/gear/neck/medolier


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
scarf-capes are unselectable because they have `+` in the name. i changed them all to `w/` and now they work.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
