### PR TITLE
automatic flora transparency

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -71,7 +71,6 @@
 
 /obj/structure/flora/tree/pine/Initialize()
 	. = ..()
-	AddComponent(/datum/component/largetransparency, y_size = 1, y_offset = 1)
 	if(length(icon_states))
 		icon_state = pick(icon_states)
 
@@ -129,8 +128,6 @@
 /obj/structure/flora/tree/tall/Initialize()
 	. = ..()
 	icon_state = "tree_[rand(1,3)]"
-	AddComponent(/datum/component/largetransparency, y_offset = 1, y_size = 2)
-
 
 /obj/structure/festivus
 	name = "festivus pole"
@@ -160,22 +157,15 @@
 /obj/structure/flora/tree/jungle/Initialize()
 	. = ..()
 	icon_state = "[icon_state][rand(1, 6)]"
-	setup_transparency()
 	color = random_foliage_color_greenbrown()
 
 /proc/random_foliage_color_greenbrown()
 	return "#[pick(GLOB.hex_6toc)][pick(GLOB.hex_6toc)][pick(GLOB.hex_6to9)][pick(GLOB.hex_6to9)]00"
 
-/obj/structure/flora/tree/jungle/proc/setup_transparency()
-	AddComponent(/datum/component/largetransparency, 1, 2, 1, 1)
-
 /obj/structure/flora/tree/jungle/small
 	pixel_y = 0
 	pixel_x = -32
 	icon = 'icons/obj/flora/jungletreesmall.dmi'
-
-/obj/structure/flora/tree/jungle/small/setup_transparency()
-	AddComponent(/datum/component/largetransparency, 1, 1, 0, 1)
 
 //grass
 /obj/structure/flora/grass

--- a/code/modules/fallout/obj/structures/wasteplants.dm
+++ b/code/modules/fallout/obj/structures/wasteplants.dm
@@ -37,8 +37,6 @@
 /obj/structure/flora/tree/wasteland/Initialize()
 	. = ..()
 	icon_state = "deadtree_[rand(1,6)]"
-	AddComponent(/datum/component/largetransparency, y_offset = 1)
-
 
 /obj/structure/flora/wasteplant
 	name = "wasteland plant"
@@ -206,7 +204,6 @@ obj/structure/flora/wasteplant/wild_punga
 /obj/structure/flora/tree/joshua/Initialize()
 	. = ..()
 	icon_state = "joshua_[rand(1,4)]"
-	AddComponent(/datum/component/largetransparency, y_offset = 1)
 	if(CHRISTMAS in SSevents.holidays)
 		if(prob(30))
 			icon_state = "joshua_xmas"

--- a/modular_coyote/code/flora_coyote.dm
+++ b/modular_coyote/code/flora_coyote.dm
@@ -62,6 +62,28 @@
 	anchored = TRUE
 
 //stuff from CIV 13
+/obj/structure/flora
+	/// Will auto-generate a transparency zone behind this plant when initialized.
+	var/do_transparency = TRUE
+
+/obj/structure/flora/Initialize()
+	. = ..()
+	if(icon && do_transparency == TRUE && ((layer > MOB_LAYER) || (layer == MOB_LAYER && plane >= ABOVE_ALL_MOB_LAYER)))
+		CreateTransparency()
+
+//Creates a generously sized transparency datum which covers the size of the sprite's icon + 1 tile around it.
+/obj/structure/flora/proc/CreateTransparency()
+	if(icon)
+		var/icon/i = icon(icon)
+		var/ih = i.Height()
+		var/iw = i.Width()
+		if(ih > 32 || iw > 32)
+			var/xsize = CEILING(iw/32, 1)
+			var/ysize = CEILING(ih/32, 1)
+			var/x_off = 0 //-(ih/2)/32 //Slide to the left (nvm it already slides automatically)
+			var/y_off = 1
+			AddComponent(/datum/component/largetransparency, x_off, y_off, xsize, ysize)
+
 /obj/structure/flora/tree/oak_one
 	name = "tree"
 	desc = "woody"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

Any flora object will now automatically generate a (roughly) correctly sized transparency zone so you can add as many trees as you want and we can still see.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
