### PR TITLE
Fixes the fireball staff (Good to go if it passes checks)

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -464,17 +464,20 @@
 /obj/item/projectile/magic/aoe/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
+	flag = "bomb"
 	damage = 75
+	damage_low = 40
+	damage_high = 90
 	damage_type = BRUTE
 	nodamage = 0
-	supereffective_damage = BULLET_DAMAGE_RIFLE_50MG_MATCH
+	supereffective_damage = 200
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 	//explosion values
 	var/exp_heavy = 0
 	var/exp_light = 1
 	var/exp_flash = 1
-	var/exp_fire = 1
+	var/exp_fire = 2
 
 /obj/item/projectile/magic/aoe/fireball/on_hit(target)
 	. = ..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -470,7 +470,7 @@
 	damage_high = 90
 	damage_type = BRUTE
 	nodamage = 0
-	supereffective_damage = 200
+	supereffective_damage = 150
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 
 	//explosion values


### PR DESCRIPTION
## About The Pull Request
Title

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Fireball staff now checks Bomb-type armor, not Magic
- Fireball staff now does 40+10 to 90+10 damage vs players
- Fireball staff now has 200 base bane damage instead of 169 (200 to 250 NPC damage, except against Enclave)
- Fireball staff now has a more impressive fireball effect when it impacts

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
