### PR TITLE
Allow sleeping carp to auto-catch items, like all other martial arts can

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -147,6 +147,7 @@
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_MARTIAL_A, SLEEPING_CARP_TRAIT)
+	ADD_TRAIT(H, TRAIT_AUTO_CATCH_ITEM, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod *= 0.5 //You take less stamina damage overall, but you do not reduce the damage from stun batons
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	//H.physiology.pressure_mod *= 0.3 //go hang out with carp
@@ -161,6 +162,7 @@
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODRUGS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_MARTIAL_A, SLEEPING_CARP_TRAIT)
+	REMOVE_TRAIT(H, TRAIT_AUTO_CATCH_ITEM, SLEEPING_CARP_TRAIT)
 	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Makes sleeping carp able to auto catch items thrown at the user automatically, as well as deflect items thrown at the user if their hands are full. I'm not very good at coding, but I don't anticipate this to have any kind of issue that would require testing (I cant test on a local server due to lack of knowledge anyway)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: sleeping carp now auto-catches items like other martial arts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
