### PR TITLE
(MERGE WHEN POSSIBLE) Loadouts + Needler buff

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -28,6 +28,9 @@
 	icon_state = "needlecasing"
 	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	caliber = CALIBER_NEEDLE
+	force = 2
+	throwforce = 1
+	embedding = list("embed_chance"= 25)
 	projectile_type = /obj/item/projectile/bullet/needle
 	var/reagent_amount = 15
 

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -66,6 +66,18 @@
 	w_class = WEIGHT_CLASS_TINY
 	multiload = TRUE
 
+/obj/item/ammo_box/magazine/internal/needlesvd
+	name = "magazine filled with needlers"
+	icon = 'icons/fallout/objects/guns/ammo.dmi'
+	icon_state = "needlerpack"
+	ammo_type = /obj/item/ammo_casing/caseless/needle
+	caliber = list(CALIBER_NEEDLE)
+	max_ammo = 10
+	multiple_sprites = 2
+	custom_materials = list(/datum/material/iron = MATS_LIGHT_RIFLE_MAGAZINE)
+	w_class = WEIGHT_CLASS_TINY
+	multiload = TRUE
+
 /obj/item/ammo_box/magazine/internal/grenadeshotgun
 	name = "magazine filled with 40mm mike-mikes ouch ouchs"
 	ammo_type = /obj/item/ammo_casing/a40mm/buck

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -2797,6 +2797,30 @@
 	zoom_factor = 1.1
 	fire_sound = 'sound/f13weapons/automaticrifle_BAR.ogg'
 
+/obj/item/gun/ballistic/automatic/z34rifle/needlercustom
+	name = "The People's Rifle"
+	desc = "A Chinese-made Type 79 marksman rifle, a knockoff of the soviet Dragunov SVD produced for the PRC's army units and special forces. This one appears to be particularly weathered from time in the wastes, a faded red cloth wrapped around a scuffed stock, some scratches on the gun metal, and some text etched onto the PSO-1 scope in Chinese."
+	icon_state = "zastava"
+	item_state = "zastava"
+	icon = 'icons/fallout/objects/guns/ballistic.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
+	mag_type = /obj/item/ammo_box/magazine/internal/needlesvd
+	init_mag_type = /obj/item/ammo_box/magazine/internal/needlesvd
+	weapon_class = WEAPON_CLASS_RIFLE
+	weapon_weight = GUN_TWO_HAND_ONLY
+	damage_multiplier = GUN_EXTRA_DAMAGE_T5
+	cock_delay = GUN_COCK_RIFLE_BASE
+	init_recoil = AUTORIFLE_RECOIL(2, 1.9)
+	init_firemodes = list (
+		/datum/firemode/semi_auto/slower
+	)
+	can_scope = TRUE
+	can_suppress = TRUE
+	can_flashlight = FALSE
+	zoom_factor = 0.9
+	fire_sound = 'sound/f13weapons/automaticrifle_BAR.ogg'
+
 /obj/item/gun/ballistic/automatic/z34rifle/custom
 	name = "Z34 Battle Rifle"
 	desc = "The Soviet Z34 battle rifle. Based off the SLR or FN FAL, it is chambered in 7.62 Soviet. Now rechambered in .308, the weapon itself comes with a scope and seems to have a much heavier trigger than most rifles."
@@ -3027,8 +3051,8 @@
 
 // Custom rifle, loadout only. ETA to becoming a 5mm or 5.56 rifle TBA
 /obj/item/gun/ballistic/automatic/g36customtox //unused, note from Tox: Will redo entirely eventually
-	name = "Custom G36C Assault rifle"
-	desc = "A custom version of a G36C assault rifle. Chambered in 5.56 NATO, this customized G36C assault rifle is made from a more resistant and durable type of material. Sporting a black and white finish. Adorning the metal bits of the gun, including the exterior of the barrel, are engraved baroque motifs. The gun comes with a built in red dot sight manufactured into the carry handle. A reliable assault rifle that saw extensive use by West Germany. The charging handle can flip between left or right side. This one seems to be fitted to the right side for a more right-side handed charging handle."
+	name = " G36C Assault rifle"
+	desc = "A G36C base"
 	icon_state = "g36"
 	item_state = "g36"
 	icon = 'icons/fallout/objects/guns/ballistic.dmi'
@@ -3234,6 +3258,26 @@
 	slowdown = GUN_SLOWDOWN_RIFLE_LMG * 1.5
 	init_firemodes = list(
 		/datum/firemode/automatic/rpm200
+	)
+
+/obj/item/gun/ballistic/automatic/bren/custom
+	name = "Custom Bren gun"
+	desc = "A rather heavy gun that served as the primary British infantry LMG throughout the second world war."
+	icon = 'icons/fallout/objects/guns/longguns.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/64x64_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/64x64_righthand.dmi'
+	icon_state = "bren"
+	item_state = "bren"
+	mag_type = /obj/item/ammo_box/magazine/bren
+	init_mag_type = /obj/item/ammo_box/magazine/bren
+	weapon_class = WEAPON_CLASS_RIFLE
+	weapon_weight = GUN_TWO_HAND_ONLY
+	damage_multiplier = GUN_LESS_DAMAGE_T3
+	init_recoil = LMG_RECOIL(1.2, 1.2)
+	slowdown = GUN_SLOWDOWN_RIFLE_LMG * 1.5
+	init_firemodes = list(
+		/datum/firemode/automatic/rpm75 ,
+		/datum/firemode/semi_auto/slower
 	)
 
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -406,16 +406,15 @@
 /obj/item/projectile/bullet/needle
 	name = "needle"
 	icon_state = "needle"
-	damage_list = list("14" = 5 , "16" = 40, "18" = 20, "20" = 10)
+	damage_list = list("16" = 80, "18" = 20, "20" = 5)
 	damage = BULLET_DAMAGE_PISTOL_NEEDLE
 	stamina = BULLET_STAMINA_PISTOL_NEEDLE
 	spread = BULLET_SPREAD_SURPLUS
 	recoil = BULLET_RECOIL_PISTOL_NEEDLE
 
 	wound_bonus = BULLET_WOUND_PISTOL_NEEDLE
-	bare_wound_bonus = BULLET_WOUND_PISTOL_NEEDLE_NAKED_MULT
+	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-
 	pixels_per_second = BULLET_SPEED_PISTOL_NEEDLE
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 	supereffective_damage = 11

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -377,6 +377,16 @@
 	new /obj/item/ammo_box/a50MGbox(src)
 	new /obj/item/ammo_box/a50MGbox(src)
 
+/datum/gear/donator/kits/calebc7892
+	name = "The Liberation"
+	path = /obj/item/storage/box/large/custom_kit/calebc7892
+	ckeywhitelist = list("calebc789")
+
+/obj/item/storage/box/large/custom_kit/calebc7892/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/z34rifle/needlercustom(src)
+	new /obj/item/ammo_box/needlercapsule(src)
+	new /obj/item/ammo_box/needlercapsule(src) //provided two given when I spawned some in for testing, some came empty or half of their capsule. Needs fixing when possible.
+
 // D
 
 /datum/gear/donator/kits/dameonowen
@@ -1489,6 +1499,18 @@
 
 /obj/item/storage/box/large/custom_kit/tk420634_4/PopulateContents()
 	new /obj/item/gun/magic/staff/healing/triheal(src)
+
+/datum/gear/donator/kits/thelasthosea2
+	name = "Bren loadout"
+	path = /obj/item/storage/box/large/custom_kit/thelasthosea2
+	ckeywhitelist = list("The lastHoesa2")
+
+/obj/item/storage/box/large/custom_kit/thelasthosea2/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/bren/custom(src)
+	new /obj/item/ammo_box/magazine/bren(src)
+	new /obj/item/ammo_box/a308box(src)
+
+
 
 /datum/gear/donator/kits/tonyburritos
 	name = "NCR Scout"


### PR DESCRIPTION
Buffs wounding of the needler projectile.  Adds two custom loadouts. Needler projectile can embed at a 25 percent chance, subject to change. Needler now has 10mm wounding, making it more dangerous to be shot by despite having very low damage.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
