### PR TITLE
Only compare against player mobs on their own Z

### DIFF
--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -292,8 +292,8 @@ GLOBAL_VAR_INIT(debug_spawner_turfs, FALSE)
 	if(!range)
 		return TRUE
 	var/atom/P = parent
-	for(var/mob/living/butt in GLOB.player_list) // client-containing mobs, NOT clients
-		if(butt.z == P.z && get_dist(P, butt) <= range)
+	for(var/mob/living/butt in LAZYACCESS(SSmobs.clients_by_zlevel, P?.z)) // client-containing mobs, NOT clients
+		if(get_dist(P, butt) <= range)
 			return TRUE
 
 /// first checks if anyone is in range, then if so, turns itself on for another 20ish seconds

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -298,12 +298,12 @@ GLOBAL_VAR_INIT(debug_spawner_turfs, FALSE)
 
 /// first checks if anyone is in range, then if so, turns itself on for another 20ish seconds
 /datum/component/spawner/proc/old_spawn()
-	if(should_destroy_spawner())
-		qdel(parent)
+	if(!COOLDOWN_FINISHED(src, spawner_cooldown))
 		return
 	if(COOLDOWN_FINISHED(src, spawn_until))
 		deactivate()
-	if(!COOLDOWN_FINISHED(src, spawner_cooldown))
+	if(should_destroy_spawner())
+		qdel(parent)
 		return
 	if(!active)
 		if(!something_in_range())

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -256,6 +256,9 @@ GLOBAL_VAR_INIT(debug_spawner_turfs, FALSE)
 		return FALSE
 	if(has_mobs_left())
 		return FALSE
+	if(QDELETED(parent))
+		qdel(src)
+		return FALSE // nothing to delete
 	if(ismob(parent))
 		qdel(src)
 		return FALSE // no more self-destructing ant queens


### PR DESCRIPTION
## About The Pull Request
Check only against player mobs on the spawner's Z to save cycles

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
