### PR TITLE
Map Bug Fixs: Garland

### DIFF
--- a/_maps/map_files/coyote_bayou/Garland-City.dmm
+++ b/_maps/map_files/coyote_bayou/Garland-City.dmm
@@ -370,6 +370,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "apB" = (
+/obj/structure/window/fulltile/house,
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -1920,10 +1921,10 @@
 	},
 /area/f13/building)
 "bEe" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/window/fulltile/house/broken,
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13,
 /area/f13/city)
 "bEo" = (
 /obj/structure/spacevine{
@@ -3946,9 +3947,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dei" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain,
-/turf/closed/wall/f13/wood/house,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13,
 /area/f13/city)
 "deJ" = (
 /obj/structure/chair/wood{
@@ -4401,11 +4403,6 @@
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
-"dxI" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/window/fulltile/house/broken,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "dxY" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/blood,
@@ -6012,13 +6009,6 @@
 /obj/effect/spawner/lootdrop/ammo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eKy" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "eKB" = (
 /obj/structure/chair/sofa,
 /obj/structure/curtain{
@@ -7938,12 +7928,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"gpq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "gpO" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -9371,13 +9355,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"hwE" = (
-/obj/structure/bed/roller,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "hwY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -10830,9 +10807,11 @@
 	},
 /area/f13/building)
 "iwg" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/window/fulltile/house,
+/obj/structure/spacevine{
+	name = "vines"
 	},
+/obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iwp" = (
@@ -11390,9 +11369,8 @@
 /area/f13/building)
 "iSN" = (
 /obj/structure/window/fulltile/house,
-/obj/structure/spacevine{
-	name = "vines"
-	},
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iTc" = (
@@ -12531,12 +12509,12 @@
 	},
 /area/f13/building)
 "jMt" = (
-/obj/structure/window/fulltile/house/broken{
-	color = "#7777FF"
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/machinery/vending/cola/random,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "jMN" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/turf_decal/weather/dirt{
@@ -15137,12 +15115,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"lJp" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13,
-/area/f13/city)
 "lJH" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -16292,12 +16264,6 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mxB" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/holofloor,
-/area/f13/city)
 "mxS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -19454,7 +19420,7 @@
 /area/f13/building)
 "oNc" = (
 /obj/structure/window/fulltile/house/broken,
-/turf/open/floor/f13,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "oNn" = (
 /obj/structure/sink{
@@ -22400,9 +22366,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qXg" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "qXl" = (
 /obj/item/reagent_containers/spray/pestspray,
 /obj/effect/decal/cleanable/dirt,
@@ -23869,6 +23838,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"siX" = (
+/obj/structure/window/fulltile/house/broken{
+	color = "#7777FF"
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/city)
 "siY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -24783,6 +24759,12 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building)
+"sTI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "sUu" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -25485,7 +25467,7 @@
 	color = "#7777FF"
 	},
 /obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "tyF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25705,7 +25687,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/open/floor/f13,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "tHr" = (
 /turf/open/floor/plasteel/f13{
@@ -26119,6 +26101,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"tTU" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tTY" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/indestructible/ground/outside/ruins,
@@ -26391,7 +26377,6 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "udS" = (
@@ -28409,6 +28394,13 @@
 /obj/effect/overlay/desert_side,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/radiation)
+"vCA" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13,
+/area/f13/city)
 "vCF" = (
 /obj/item/storage/pill_bottle/stimulant,
 /obj/structure/rack/shelf_metal,
@@ -30636,9 +30628,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "xoG" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/bed/roller,
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/f13,
 /area/f13/city)
@@ -31137,12 +31129,11 @@
 	},
 /area/f13/wasteland)
 "xKa" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/holofloor,
+/area/f13/city)
 "xKH" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/spacevine{
@@ -59367,7 +59358,7 @@ hiK
 muN
 qzn
 hiK
-qXg
+tTU
 rUq
 rUq
 rUq
@@ -61429,7 +61420,7 @@ ehT
 vUr
 meM
 nOw
-xKa
+jMt
 sed
 cON
 nVG
@@ -61677,7 +61668,7 @@ nOw
 nOw
 fmQ
 asm
-mxB
+xKa
 nqO
 tBp
 hlM
@@ -61940,7 +61931,7 @@ tBp
 ivi
 hMV
 cLW
-apB
+oNc
 xkw
 xkw
 ozH
@@ -62197,7 +62188,7 @@ tBp
 ivi
 tZF
 tZF
-iSN
+udF
 bpx
 xkw
 ozH
@@ -63481,7 +63472,7 @@ tBp
 dZV
 ivi
 oNv
-eKy
+qXg
 ehT
 jsK
 jsK
@@ -64017,7 +64008,7 @@ eCy
 nOw
 nOw
 ehT
-jMt
+txN
 ehT
 ehT
 wKl
@@ -64764,7 +64755,7 @@ mqX
 oQy
 tBp
 sHV
-iwg
+sTI
 tZF
 tZF
 ehT
@@ -65791,11 +65782,11 @@ nOw
 nOw
 tng
 gyK
-gpq
+bEe
 toV
 ehT
 gnq
-hwE
+xoG
 ehT
 naG
 qPg
@@ -66330,11 +66321,11 @@ meM
 nOw
 nOw
 ehT
-txN
+siX
 gsV
 iTn
 ehT
-jMt
+txN
 ehT
 ehT
 lDx
@@ -67847,11 +67838,11 @@ nOw
 nOw
 wKl
 tdh
-lJp
+dei
 ial
 ehT
 toV
-xoG
+vCA
 wKl
 naG
 hfu
@@ -68882,7 +68873,7 @@ iTn
 wKl
 wKl
 ehT
-dei
+gwJ
 wKl
 ehT
 cON
@@ -69135,7 +69126,7 @@ nOw
 nOw
 nOw
 nOw
-bEe
+iSN
 fFO
 xJb
 ehT
@@ -69151,7 +69142,7 @@ cON
 cON
 cON
 qTT
-iSN
+udF
 ipX
 ivi
 ehT
@@ -69408,7 +69399,7 @@ cON
 cON
 cON
 qTT
-dxI
+apB
 lZk
 ivi
 pPa
@@ -70436,7 +70427,7 @@ nVG
 cON
 cON
 qTT
-iSN
+udF
 lZk
 ivi
 iaU
@@ -72476,7 +72467,7 @@ nOw
 nOw
 nOw
 nOw
-udF
+iwg
 fFO
 ivi
 vtw

--- a/_maps/map_files/coyote_bayou/Garland-City.dmm
+++ b/_maps/map_files/coyote_bayou/Garland-City.dmm
@@ -370,9 +370,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "apB" = (
-/obj/structure/window/fulltile/house,
 /obj/structure/window/fulltile/house/broken,
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "aqs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1518,7 +1517,7 @@
 /area/f13/building)
 "bhU" = (
 /obj/structure/window/fulltile/house,
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "bia" = (
 /obj/structure/spacevine{
@@ -1921,7 +1920,9 @@
 	},
 /area/f13/building)
 "bEe" = (
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/structure/window/fulltile/house,
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/curtain,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bEo" = (
@@ -2621,11 +2622,11 @@
 "chH" = (
 /obj/structure/rack,
 /obj/item/cultivator,
-/obj/item/shovel,
 /obj/item/shovel/spade,
 /obj/item/hatchet,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/storage/bag/plants/portaseeder,
+/obj/item/shovel/spade,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/city)
 "chK" = (
@@ -4400,6 +4401,11 @@
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
+"dxI" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/window/fulltile/house/broken,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "dxY" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/blood,
@@ -6006,6 +6012,13 @@
 /obj/effect/spawner/lootdrop/ammo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eKy" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "eKB" = (
 /obj/structure/chair/sofa,
 /obj/structure/curtain{
@@ -7925,6 +7938,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"gpq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13,
+/area/f13/city)
 "gpO" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -8112,9 +8131,8 @@
 /area/f13/wasteland)
 "gwJ" = (
 /obj/structure/window/fulltile/house,
-/turf/closed/wall/f13/wood/house/clean{
-	color = "#7777FF"
-	},
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "gxB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9353,6 +9371,13 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
+"hwE" = (
+/obj/structure/bed/roller,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13,
+/area/f13/city)
 "hwY" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -10805,10 +10830,10 @@
 	},
 /area/f13/building)
 "iwg" = (
-/obj/structure/dresser,
-/turf/closed/wall/f13/wood/house/clean{
-	color = "#7777FF"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "iwp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11364,9 +11389,10 @@
 	},
 /area/f13/building)
 "iSN" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/structure/window/fulltile/house,
+/obj/structure/spacevine{
+	name = "vines"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "iTc" = (
@@ -12505,9 +12531,12 @@
 	},
 /area/f13/building)
 "jMt" = (
-/obj/machinery/vending/cola/random,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/house/broken{
+	color = "#7777FF"
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "jMN" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/turf_decal/weather/dirt{
@@ -14814,9 +14843,7 @@
 "ltG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/grey,
-/turf/closed/wall/f13/wood/house/clean{
-	color = "#7777FF"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "luU" = (
 /obj/structure/sign/warning/enginesafety,
@@ -15110,6 +15137,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"lJp" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13,
+/area/f13/city)
 "lJH" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/barber{
@@ -15277,7 +15310,6 @@
 "lPf" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/closed/wall/f13/wood/house/clean{
 	color = "#7777FF"
 	},
@@ -16260,6 +16292,12 @@
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mxB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/holofloor,
+/area/f13/city)
 "mxS" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -16679,7 +16717,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "mOn" = (
 /obj/structure/table,
@@ -18726,7 +18764,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "omN" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/effect/spawner/lootdrop/f13/common_armor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "omR" = (
@@ -19416,7 +19454,7 @@
 /area/f13/building)
 "oNc" = (
 /obj/structure/window/fulltile/house/broken,
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13,
 /area/f13/city)
 "oNn" = (
 /obj/structure/sink{
@@ -19784,7 +19822,6 @@
 "pbt" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_middle,
-/obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "pbw" = (
@@ -20078,17 +20115,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "pkC" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/structure/chair/bench,
-/obj/structure/nest/randomized{
-	randomizer_difficulty = 3;
-	randomizer_kind = "low level raider";
-	randomizer_tag = "bridge gang"
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "pkE" = (
 /obj/effect/spawner/lootdrop/wmelee_high,
 /obj/effect/decal/cleanable/dirt,
@@ -21345,7 +21374,6 @@
 "qhc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
-/obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "qhj" = (
@@ -21785,7 +21813,7 @@
 /area/f13/wasteland)
 "qxU" = (
 /obj/structure/table,
-/obj/item/reagent_containers/blood/radaway,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/f13,
 /area/f13/city)
 "qxW" = (
@@ -22372,11 +22400,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qXg" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/city)
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qXl" = (
 /obj/item/reagent_containers/spray/pestspray,
 /obj/effect/decal/cleanable/dirt,
@@ -24941,6 +24967,7 @@
 /area/f13/wasteland)
 "tdh" = (
 /obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13,
 /area/f13/city)
 "teg" = (
@@ -25458,10 +25485,7 @@
 	color = "#7777FF"
 	},
 /obj/structure/curtain,
-/obj/structure/window/fulltile/house/broken{
-	color = "#7777FF"
-	},
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/city)
 "tyF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25681,7 +25705,7 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/closed/wall/f13/wood/house,
+/turf/open/floor/f13,
 /area/f13/city)
 "tHr" = (
 /turf/open/floor/plasteel/f13{
@@ -25863,6 +25887,9 @@
 /area/f13/building)
 "tLJ" = (
 /obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "tMh" = (
@@ -26364,7 +26391,8 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/closed/wall/f13/wood/house,
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "udS" = (
 /turf/open/floor/f13{
@@ -28163,13 +28191,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "vuN" = (
-/obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	damage_deflection = 28;
-	max_integrity = 400;
-	obj_integrity = 400;
-	req_access_txt = "123"
-	},
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
@@ -29543,6 +29565,9 @@
 "wyb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "wyc" = (
@@ -30611,12 +30636,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "xoG" = (
-/obj/effect/spawner/lootdrop/f13/rare_weps,
-/obj/effect/spawner/lootdrop/f13/rare_weps,
-/obj/effect/spawner/lootdrop/f13/rare_armor,
-/obj/effect/spawner/lootdrop/f13/rare_armor,
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13,
 /area/f13/city)
 "xoP" = (
 /obj/machinery/vending/engivend,
@@ -31113,15 +31137,12 @@
 	},
 /area/f13/wasteland)
 "xKa" = (
-/obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	damage_deflection = 28;
-	max_integrity = 400;
-	obj_integrity = 400;
-	req_access_txt = "123"
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/vending/cola/random,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "xKH" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/spacevine{
@@ -57948,7 +57969,7 @@ inE
 kCH
 dID
 dID
-xKa
+sYk
 sQM
 vmF
 xdN
@@ -58062,7 +58083,7 @@ eyZ
 eyZ
 eyZ
 eyZ
-nro
+eyZ
 eyZ
 eyZ
 eyZ
@@ -58832,7 +58853,7 @@ hiK
 chH
 qzn
 hiK
-rUq
+bNi
 rUq
 cnn
 cnn
@@ -59346,10 +59367,10 @@ hiK
 muN
 qzn
 hiK
+qXg
 rUq
 rUq
 rUq
-dMp
 xMo
 xMo
 jQi
@@ -59603,12 +59624,12 @@ hiK
 hiK
 hiK
 hiK
+dMp
 rUq
 rUq
 rUq
-bNi
-xMo
-xaf
+rUq
+rUq
 jQi
 sed
 cON
@@ -59864,8 +59885,8 @@ rUq
 rUq
 rUq
 rUq
-xMo
-xaf
+rUq
+rUq
 jQi
 sed
 cON
@@ -60634,10 +60655,10 @@ nOw
 nOw
 nOw
 rUq
+rUq
+rUq
 nOw
-nOw
-nOw
-uOS
+aGk
 sed
 cON
 cON
@@ -60890,7 +60911,7 @@ nOw
 nOw
 nOw
 nOw
-rUq
+nOw
 nOw
 nOw
 nOw
@@ -61147,7 +61168,7 @@ nOw
 nOw
 tcb
 nOw
-rUq
+nOw
 nOw
 nOw
 nOw
@@ -61408,7 +61429,7 @@ ehT
 vUr
 meM
 nOw
-aGk
+xKa
 sed
 cON
 nVG
@@ -61656,16 +61677,16 @@ nOw
 nOw
 fmQ
 asm
-nqO
+mxB
 nqO
 tBp
-ivi
+hlM
 oNv
 oNv
 wKl
 meM
 meM
-jMt
+uOS
 sed
 cON
 nVG
@@ -62176,10 +62197,10 @@ tBp
 ivi
 tZF
 tZF
-udF
+iSN
 bpx
 xkw
-pkC
+ozH
 bSp
 ycA
 cON
@@ -62689,7 +62710,7 @@ lUT
 tBp
 gtd
 ivi
-ivi
+pkC
 ehT
 oJR
 oJR
@@ -63201,7 +63222,7 @@ rHX
 ovV
 ctQ
 kZC
-ivi
+nOy
 ivi
 ivi
 nJc
@@ -63460,7 +63481,7 @@ tBp
 dZV
 ivi
 oNv
-oNv
+eKy
 ehT
 jsK
 jsK
@@ -63996,7 +64017,7 @@ eCy
 nOw
 nOw
 ehT
-txN
+jMt
 ehT
 ehT
 wKl
@@ -64743,7 +64764,7 @@ mqX
 oQy
 tBp
 sHV
-ivi
+iwg
 tZF
 tZF
 ehT
@@ -65770,11 +65791,11 @@ nOw
 nOw
 tng
 gyK
-toV
+gpq
 toV
 ehT
 gnq
-gnq
+hwE
 ehT
 naG
 qPg
@@ -66313,7 +66334,7 @@ txN
 gsV
 iTn
 ehT
-txN
+jMt
 ehT
 ehT
 lDx
@@ -67826,11 +67847,11 @@ nOw
 nOw
 wKl
 tdh
-toV
+lJp
 ial
 ehT
 toV
-ial
+xoG
 wKl
 naG
 hfu
@@ -69114,7 +69135,7 @@ nOw
 nOw
 nOw
 nOw
-apB
+bEe
 fFO
 xJb
 ehT
@@ -69130,7 +69151,7 @@ cON
 cON
 cON
 qTT
-udF
+iSN
 ipX
 ivi
 ehT
@@ -69387,7 +69408,7 @@ cON
 cON
 cON
 qTT
-apB
+dxI
 lZk
 ivi
 pPa
@@ -70400,7 +70421,7 @@ nOw
 nOw
 nOw
 ehT
-iSN
+fpi
 ivi
 ehT
 ivi
@@ -70415,7 +70436,7 @@ nVG
 cON
 cON
 qTT
-udF
+iSN
 lZk
 ivi
 iaU
@@ -70657,7 +70678,7 @@ nOw
 nOw
 nOw
 gwJ
-iwg
+fFO
 ltG
 ehT
 aOh
@@ -71427,7 +71448,7 @@ nOw
 nOw
 nOw
 nOw
-bhU
+gwJ
 fFO
 ivi
 vtw
@@ -71685,8 +71706,8 @@ nOw
 nOw
 nOw
 ehT
-xoG
-bEe
+fpi
+ivi
 ehT
 ivi
 wKl
@@ -72198,7 +72219,7 @@ nOw
 nOw
 nOw
 nOw
-qXg
+wKl
 fpi
 ivi
 ehT
@@ -72457,7 +72478,7 @@ nOw
 nOw
 udF
 fFO
-bEe
+ivi
 vtw
 ivi
 aQp
@@ -92042,7 +92063,7 @@ qYj
 buI
 etP
 vIC
-xKa
+sYk
 jfa
 rUq
 rUq
@@ -92293,7 +92314,7 @@ cON
 cON
 qTT
 jQi
-xKa
+sYk
 lHy
 vmF
 wzr


### PR DESCRIPTION
## About The Pull Request
Majority of these changes are putting floors instead of walls on the windows, and bringing the farm up to a more farming standard then having the silly shovel that removes plots, and removes a rogue mob spawner in the town and removes a loot drop that was in the town and shouldnt of been there, as it was free rare items and to the east of the town and also added a few lights too, so it should be as bright as someone smiling instead of darkness. There was a few rogue little caesers doors around and they were zapped into oblivion below is the major changes. 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/ef16e6a7-bc16-4dd0-8327-f2ba87372d7c)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/d4a772a5-d22c-4a73-be99-7a1b10c6324f)


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: garland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
