### PR TITLE
Map Tweak + Bugfix: Garland

### DIFF
--- a/_maps/map_files/coyote_bayou/Garland-City.dmm
+++ b/_maps/map_files/coyote_bayou/Garland-City.dmm
@@ -409,10 +409,7 @@
 	},
 /area/f13/building)
 "asm" = (
-/obj/structure/closet/crate/bin,
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
-/turf/open/floor/holofloor,
+/turf/open/floor/plasteel/freezer,
 /area/f13/city)
 "asx" = (
 /obj/structure/spacevine{
@@ -668,7 +665,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aBl" = (
-/turf/open/transparent/openspace,
+/turf/open/floor/wood_wide{
+	color = "#777777"
+	},
 /area/f13/building)
 "aBz" = (
 /obj/effect/decal/marking{
@@ -739,9 +738,6 @@
 	},
 /area/f13/building)
 "aGk" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -1114,14 +1110,11 @@
 	},
 /area/f13/building)
 "aSg" = (
-/obj/structure/fence/handrail{
-	pixel_y = -8
+/obj/structure/spacevine{
+	name = "vines"
 	},
 /obj/structure/wreck/car/bike{
 	dir = 8
-	},
-/obj/structure/spacevine{
-	name = "vines"
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -2946,6 +2939,20 @@
 "cuG" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
+"cvf" = (
+/obj/structure/fence/wooden{
+	pixel_x = -16
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "cvw" = (
@@ -3435,7 +3442,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/cola/red,
+/obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
@@ -3947,10 +3954,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dei" = (
-/obj/structure/chair/booth{
+/obj/structure/chair/right{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "deJ" = (
@@ -4471,11 +4477,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"dAk" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "dAO" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "dBe" = (
 /obj/structure/bed,
@@ -5131,8 +5148,8 @@
 	},
 /area/f13/building)
 "dZV" = (
-/obj/machinery/vending/games,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "eac" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -5170,6 +5187,12 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"ecM" = (
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ecN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5257,6 +5280,16 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"egH" = (
+/obj/structure/lattice,
+/obj/structure/fence/wooden{
+	pixel_x = 16
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "egO" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood,
@@ -5293,13 +5326,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eiu" = (
-/obj/machinery/workbench/bottler,
-/turf/open/floor/holofloor,
-/area/f13/city)
-"eiw" = (
 /obj/structure/fence/handrail{
 	pixel_y = 16
 	},
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
+"eiw" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -8326,6 +8358,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gGo" = (
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/obj/structure/fence/wooden{
+	pixel_x = 16
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "gGr" = (
 /obj/item/stack/ore/iron,
 /obj/effect/decal/cleanable/dirt,
@@ -8578,10 +8621,11 @@
 	},
 /area/f13/wasteland)
 "gRD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "gRK" = (
 /obj/vehicle/ridden/lavaboat,
 /turf/open/indestructible/ground/outside/water,
@@ -8896,9 +8940,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hfu" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9472,9 +9513,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hCc" = (
-/obj/machinery/smartfridge/bottlerack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/obj/structure/car/rubbish3{
+	pixel_x = -4;
+	pixel_y = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
 "hCs" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/blood/radaway,
@@ -9726,7 +9770,6 @@
 "hMV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "hNc" = (
@@ -10055,6 +10098,12 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"hXi" = (
+/obj/structure/chair/left{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "hYq" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -10732,14 +10781,13 @@
 	},
 /area/f13/building)
 "iuq" = (
-/obj/structure/fence/handrail{
-	pixel_y = -8
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "iur" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -10895,11 +10943,10 @@
 	},
 /area/f13/building)
 "izX" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "iAC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11629,6 +11676,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"jbK" = (
+/obj/structure/chair/right{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "jbV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/crafts,
@@ -11972,6 +12025,19 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"jrY" = (
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "jsb" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14597,7 +14663,7 @@
 "lmI" = (
 /obj/structure/simple_door/wood/alt,
 /obj/item/lock_bolt{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -15443,7 +15509,12 @@
 /area/f13/building)
 "lUT" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/drinkingglasses,
+/obj/machinery/processor/chopping_block,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife/butcher{
+	name = "Mama's cleaver"
+	},
+/obj/item/kitchen/knife,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "lUY" = (
@@ -16330,6 +16401,12 @@
 /obj/item/clothing/under/pants/f13/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mzh" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "mzj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -16538,6 +16615,9 @@
 /obj/structure/spacevine{
 	name = "vines"
 	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "mGM" = (
@@ -16621,6 +16701,17 @@
 	icon_state = "goo11"
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
+/area/f13/wasteland)
+"mId" = (
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/obj/structure/barricade/wooden/planks,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "mIf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16786,7 +16877,9 @@
 /area/f13/wasteland)
 "mTY" = (
 /obj/structure/bus_door,
-/turf/open/indestructible/ground/outside/road,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
 /area/f13/wasteland)
 "mUg" = (
 /obj/structure/rack,
@@ -16948,6 +17041,9 @@
 /area/f13/building)
 "naG" = (
 /obj/effect/decal/fakelattice,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "naO" = (
@@ -17353,7 +17449,10 @@
 	},
 /area/f13/building)
 "nqO" = (
-/turf/open/floor/holofloor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
 /area/f13/city)
 "nqV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17879,8 +17978,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "nIz" = (
-/obj/structure/closet/fridge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "nJc" = (
 /obj/machinery/door/unpowered/securedoor,
@@ -17896,7 +18003,9 @@
 /area/f13/wasteland)
 "nJi" = (
 /obj/structure/cargocrate,
-/turf/open/indestructible/ground/outside/road,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
 /area/f13/wasteland)
 "nJl" = (
 /obj/structure/table/reinforced,
@@ -18360,9 +18469,6 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "nWY" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -18673,6 +18779,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"okH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "okY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19031,9 +19142,6 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "ozH" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -19185,7 +19293,9 @@
 /area/f13/wasteland)
 "oFb" = (
 /obj/structure/noticeboard,
-/turf/open/space/basic,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
 /area/f13/wasteland)
 "oFj" = (
 /obj/structure/closet/secure_closet/medical2,
@@ -19305,6 +19415,7 @@
 /area/f13/building)
 "oID" = (
 /obj/machinery/gear_painter,
+/obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "oIV" = (
@@ -19333,10 +19444,10 @@
 	},
 /area/f13/building)
 "oJR" = (
+/obj/structure/lattice,
 /obj/structure/fence/wooden{
 	pixel_x = 16
 	},
-/obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -19511,9 +19622,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oQy" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "oQz" = (
 /obj/structure/bed/mattress,
 /turf/open/indestructible/ground/inside/dirt,
@@ -20084,10 +20197,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "pkC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/holofloor,
+/obj/machinery/workbench/bottler,
+/turf/open/floor/plasteel/freezer,
 /area/f13/city)
 "pkE" = (
 /obj/effect/spawner/lootdrop/wmelee_high,
@@ -20397,6 +20508,12 @@
 	icon_state = "bluechess2"
 	},
 /area/f13/building)
+"pxO" = (
+/obj/structure/chair/left{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "pxP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -20666,11 +20783,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pIp" = (
-/obj/structure/fence/handrail{
-	pixel_y = -8
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/obj/structure/barricade/wooden/planks,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "pIT" = (
 /obj/structure/nest/randomized{
@@ -20710,6 +20826,13 @@
 	icon_state = "shadowleft"
 	},
 /area/f13/wasteland)
+"pKd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge/meat{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "pKh" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20853,12 +20976,13 @@
 	},
 /area/f13/building)
 "pPa" = (
-/obj/machinery/door/unpowered/securedoor,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = -12
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "pPi" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -21599,8 +21723,10 @@
 	},
 /area/f13/wasteland)
 "qrD" = (
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/holofloor,
+/obj/structure/rack,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/plasteel/freezer,
 /area/f13/city)
 "qrM" = (
 /obj/structure/simple_door/house{
@@ -21684,6 +21810,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"qup" = (
+/obj/structure/lattice,
+/obj/structure/fence/wooden{
+	pixel_x = -16
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "qux" = (
 /obj/structure/flora/tree/joshua{
 	pixel_x = -21;
@@ -22074,6 +22210,11 @@
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
+"qJc" = (
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "qJu" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -22200,10 +22341,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "qPg" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
+/obj/structure/wreck/trash/machinepiletwo{
+	pixel_x = 5;
+	pixel_y = 10
 	},
-/obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "qPk" = (
@@ -22451,6 +22592,9 @@
 	},
 /obj/structure/spacevine{
 	name = "vines"
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -23600,7 +23744,9 @@
 /area/f13/wasteland)
 "rZK" = (
 /obj/machinery/vending/cola/starkist,
-/turf/open/indestructible/ground/outside/road,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
 /area/f13/wasteland)
 "rZW" = (
 /turf/open/floor/plating/f13/outside/road,
@@ -23722,6 +23868,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"sez" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innercornerpieceright"
+	},
+/area/f13/wasteland)
 "seA" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -23870,6 +24021,13 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
+/area/f13/wasteland)
+"sjf" = (
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sjt" = (
 /obj/structure/chair/stool,
@@ -24186,7 +24344,7 @@
 /area/f13/wasteland)
 "sxg" = (
 /obj/structure/simple_door/tent,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/city)
 "sxv" = (
 /obj/structure/spider/stickyweb,
@@ -24753,6 +24911,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sSJ" = (
+/obj/structure/wreck/trash/three_barrels{
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "sSN" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/airless/bar,
@@ -24916,8 +25080,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tcb" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -26114,6 +26279,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"tUf" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "tUM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -27794,13 +27963,19 @@
 	},
 /area/f13/building)
 "veD" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "vfr" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "vfs" = (
@@ -28063,6 +28238,13 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/building)
+"vpr" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "vpU" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -28169,6 +28351,14 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"vuF" = (
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "vuN" = (
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood{
@@ -28214,9 +28404,8 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "vvC" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/holofloor,
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "vvZ" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -29004,8 +29193,8 @@
 	},
 /area/f13/building)
 "wcP" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/holofloor,
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "wcY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29092,6 +29281,32 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"whm" = (
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/quality_oil,
+/obj/item/reagent_containers/food/condiment/mustard,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/peanut_butter,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/bbqsauce,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "wht" = (
 /obj/structure/table/wood/settler,
 /obj/item/mining_scanner,
@@ -29542,12 +29757,11 @@
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland)
 "wyb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/light{
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "wyc" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -30232,9 +30446,24 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wYC" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"wZw" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/ywflowers{
+	light_power = 3;
+	light_range = 2;
+	light_color = "#EBAF4C"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "wZE" = (
 /obj/machinery/light{
 	dir = 1
@@ -30479,6 +30708,9 @@
 	},
 /obj/structure/spacevine{
 	name = "vines"
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -30946,8 +31178,11 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "xAK" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/road,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xBc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31119,9 +31354,6 @@
 	},
 /area/f13/wasteland)
 "xKa" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
 /obj/machinery/vending/cola/random,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -31412,6 +31644,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"xXk" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "xXl" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -31456,6 +31695,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"xZY" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "yah" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -50876,7 +51119,7 @@ rUq
 rUq
 rUq
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -51133,7 +51376,7 @@ pcs
 bVX
 ldN
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -51390,7 +51633,7 @@ sed
 bVX
 ixY
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -51647,7 +51890,7 @@ sXV
 bVX
 ixY
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -51904,7 +52147,7 @@ sed
 bVX
 coR
 sed
-cON
+vsj
 cON
 cON
 cON
@@ -52161,7 +52404,7 @@ sed
 bVX
 bdC
 sed
-cON
+vsj
 cON
 snq
 cON
@@ -52418,7 +52661,7 @@ sed
 iHz
 smg
 sed
-cON
+vsj
 cON
 cON
 cON
@@ -52675,7 +52918,7 @@ sed
 pzM
 smg
 sed
-cON
+iHz
 cON
 cON
 cON
@@ -52932,7 +53175,7 @@ ugt
 bVX
 mge
 sed
-cON
+vsj
 cON
 cON
 cON
@@ -53189,7 +53432,7 @@ ugt
 bVX
 mge
 sed
-cON
+pzM
 cON
 cON
 cON
@@ -53446,8 +53689,8 @@ ugt
 iHz
 mge
 sed
+bVX
 snq
-cON
 cON
 cON
 cON
@@ -53703,7 +53946,7 @@ ugt
 vsj
 ixY
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -53960,7 +54203,7 @@ ugt
 vsj
 ldN
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -54217,7 +54460,7 @@ rUq
 rUq
 rUq
 sed
-cON
+bVX
 cON
 cON
 nVG
@@ -54474,7 +54717,7 @@ rUq
 rUq
 rUq
 sed
-cON
+bVX
 cON
 cON
 ewm
@@ -54731,7 +54974,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -54988,8 +55231,8 @@ rUq
 rUq
 qTT
 sed
-cON
-cON
+bVX
+snq
 cON
 cON
 cON
@@ -55502,7 +55745,7 @@ kTa
 rUq
 qTT
 sed
-cON
+bVX
 nVG
 cON
 cON
@@ -55759,7 +56002,7 @@ kTa
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -56016,7 +56259,7 @@ kTa
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -56273,7 +56516,7 @@ kTa
 rUq
 qTT
 sed
-cON
+bVX
 snq
 cON
 snq
@@ -56530,7 +56773,7 @@ kTa
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -56787,7 +57030,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 nVG
@@ -57044,7 +57287,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -57301,7 +57544,7 @@ rUq
 rUq
 qTT
 sed
-cON
+snq
 cON
 qYn
 cON
@@ -57558,7 +57801,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 tut
 cON
 cON
@@ -57815,7 +58058,7 @@ goh
 goh
 rYf
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -58072,7 +58315,7 @@ eyZ
 vAx
 rYf
 aBf
-rGs
+izX
 cON
 cON
 cON
@@ -58321,7 +58564,7 @@ hiK
 hiK
 hiK
 hiK
-dAO
+bNi
 rUq
 cnn
 cnn
@@ -58329,7 +58572,7 @@ cnn
 kcS
 rOC
 baM
-rGs
+izX
 rGs
 rGs
 rGs
@@ -58586,7 +58829,7 @@ cnn
 kcS
 jQi
 sed
-cON
+bVX
 cON
 etl
 cON
@@ -58835,7 +59078,7 @@ hiK
 chH
 qzn
 hiK
-bNi
+xAK
 rUq
 cnn
 cnn
@@ -58843,7 +59086,7 @@ cnn
 kQK
 pwg
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -58853,7 +59096,7 @@ cON
 cON
 giR
 qTT
-pnc
+hCc
 rUq
 rUq
 haz
@@ -59100,7 +59343,7 @@ cnn
 xMo
 jQi
 uUN
-cON
+bVX
 cON
 cON
 nVG
@@ -59108,10 +59351,10 @@ cON
 cON
 cON
 cON
-xAK
+cON
 qTT
-fTh
-xMo
+jQi
+eiu
 xMo
 rUq
 rUq
@@ -59357,7 +59600,7 @@ xMo
 xMo
 jQi
 sed
-rvC
+mzh
 cON
 cON
 nVG
@@ -59365,7 +59608,7 @@ cON
 cON
 cON
 cON
-cON
+sSJ
 qTT
 jQi
 xaf
@@ -59614,7 +59857,7 @@ rUq
 rUq
 jQi
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -59871,7 +60114,7 @@ rUq
 rUq
 jQi
 sed
-cON
+bVX
 cON
 cON
 snq
@@ -59881,8 +60124,8 @@ bkT
 bkT
 bkT
 lju
-iuq
-xMo
+dyB
+eiu
 xMo
 nOw
 nOw
@@ -60128,7 +60371,7 @@ xMo
 xMo
 uuk
 sed
-cON
+bVX
 nVG
 cON
 snq
@@ -60138,8 +60381,8 @@ ezY
 nGp
 bkT
 qTT
-fTh
-eCy
+jQi
+dAO
 scI
 nOw
 nOw
@@ -60382,10 +60625,10 @@ rUq
 rUq
 rUq
 rUq
-rUq
-uOS
+ecM
+jQi
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -60395,8 +60638,8 @@ ydT
 iLw
 xkR
 qTT
-iuq
-meM
+dyB
+veD
 meM
 nOw
 nOw
@@ -60639,10 +60882,10 @@ nOw
 rUq
 rUq
 rUq
-nOw
+gRD
 aGk
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -60652,8 +60895,8 @@ ydT
 iLw
 fjl
 qTT
-iuq
-xkw
+dyB
+tcb
 xkw
 nOw
 nOw
@@ -60896,10 +61139,10 @@ nOw
 nOw
 nOw
 nOw
-nOw
-izX
+gRD
+gEB
 sed
-cON
+bVX
 cON
 bGy
 nVG
@@ -60909,8 +61152,8 @@ ydT
 iLw
 xjZ
 qTT
-fTh
-eCy
+jQi
+dAO
 eCy
 nOw
 nOw
@@ -61142,21 +61385,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
-nOw
-tvN
-nOw
-nOw
-nOw
-tcb
-nOw
-nOw
-nOw
-nOw
-nOw
-izX
+clr
+fmQ
+fmQ
+fmQ
+tBp
+ehT
+ehT
+ehT
+ehT
+vUr
+meM
+gRD
+gEB
 sed
-cON
+bVX
 izw
 nVG
 cON
@@ -61166,8 +61409,8 @@ ydT
 kYU
 bkT
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 nOw
 nOw
@@ -61399,21 +61642,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
-clr
 fmQ
-fmQ
-fmQ
+pKd
+nqO
+tUf
 tBp
-ehT
-ehT
-ehT
-vUr
+hlM
+ivi
+hXi
+dei
+wKl
 meM
-nOw
+pPa
 xKa
 sed
-cON
+bVX
 nVG
 nVG
 cON
@@ -61656,21 +61899,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
+qrD
 asm
 pkC
-nqO
 tBp
-hlM
-oNv
-oNv
-wKl
-meM
-meM
-uOS
+ivi
+ivi
+hMV
+nIz
+vpr
+xkw
+sjf
+jQi
 sed
-cON
+bVX
 nVG
 bGy
 cON
@@ -61913,21 +62156,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
+tBp
 vvC
-qrD
-eiu
+tBp
 tBp
 ivi
-hMV
-cLW
-oNc
-xkw
-xkw
+ivi
+jbK
+pxO
+xXk
+bpx
+sjf
 ozH
 bSp
-ycA
+pIp
 cON
 nVG
 cON
@@ -62170,21 +62413,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
-tBp
-wcP
-tBp
-tBp
+whm
+ovV
+ovV
+cbT
 ivi
-tZF
-tZF
-udF
-bpx
+ivi
+ivi
+oNv
+ehT
 xkw
+sjf
 ozH
 bSp
-ycA
+pIp
 cON
 nVG
 cON
@@ -62195,7 +62438,7 @@ ivi
 ivi
 ivi
 ivi
-ivi
+vuk
 oID
 tng
 eCy
@@ -62427,21 +62670,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
-nIz
+vuF
 ovV
-ovV
-cbT
+dZV
+tBp
+gtd
 ivi
 ivi
-ivi
+jrY
 ehT
 xkw
-xkw
+sjf
 ozH
 bSp
-ycA
+pIp
 cON
 cON
 cON
@@ -62451,7 +62694,7 @@ wKl
 mqu
 ivi
 ivi
-vuk
+ivi
 ivi
 ivi
 ehT
@@ -62684,21 +62927,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
-fmQ
-nIz
+tBp
+xZY
 ovV
 lUT
 tBp
 gtd
 ivi
-wYC
+ivi
+tZF
 ehT
 oJR
-oJR
+gGo
 eiw
 hWU
-cON
+bVX
 nVG
 qYn
 nVG
@@ -62941,7 +63184,6 @@ kCH
 nOw
 nOw
 nOw
-nOw
 tBp
 tLJ
 ovV
@@ -62950,12 +63192,13 @@ tBp
 gtd
 ivi
 ivi
+ivi
 nJc
 lCT
 lCT
 edq
 sed
-cON
+bVX
 bGy
 nVG
 cON
@@ -63198,7 +63441,6 @@ kCH
 nOw
 nOw
 nOw
-nOw
 tBp
 rHX
 ovV
@@ -63207,12 +63449,13 @@ kZC
 nOy
 ivi
 ivi
+ivi
 nJc
 eup
 coq
 lCT
 qRZ
-nVG
+gpO
 cON
 bGy
 nVG
@@ -63455,21 +63698,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 mAa
 ovV
 ovV
 tBp
-dZV
+wcP
 ivi
-oNv
+ivi
+hXi
 dei
 ehT
 jsK
-jsK
+cvf
 eiw
-hHa
-cON
+sed
+bVX
 cON
 cON
 nVG
@@ -63712,21 +63955,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 tBp
-gRD
+okH
 ovV
 fXO
 egO
 ivi
+ivi
 hMV
-cLW
+nIz
 ehT
 xkw
-xkw
-izX
+sjf
+gEB
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -63736,7 +63979,7 @@ cON
 cON
 cON
 qTT
-fTh
+jQi
 vfr
 xkw
 nOw
@@ -63969,21 +64212,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 tBp
-wyb
+iuq
 ovV
-veD
+fXO
 ehR
 ivi
-tZF
-tZF
-bhU
+ivi
+jbK
+pxO
+xXk
 xkw
-xkw
-uOS
-etJ
-cON
+sjf
+jQi
+sed
+bVX
 cON
 cON
 cON
@@ -63993,8 +64236,8 @@ cON
 cON
 cON
 qTT
-iuq
-eCy
+dyB
+dAO
 eCy
 nOw
 nOw
@@ -64226,21 +64469,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
-hCc
+dAk
 ovV
 fXO
 egO
 ivi
-oNv
-oNv
-bhU
+ivi
+hXi
+dei
+xXk
 xkw
-xkw
-uOS
-sed
-cON
+sjf
+jQi
+hHa
+bVX
 ycA
 cON
 cON
@@ -64250,8 +64493,8 @@ cON
 ycA
 cON
 lju
-fTh
-meM
+jQi
+veD
 meM
 nOw
 nOw
@@ -64483,21 +64726,21 @@ kCH
 nOw
 nOw
 nOw
-nOw
 fmQ
-hCc
+qJc
 ovV
 fXO
 egO
 ivi
+ivi
 cLW
-sMl
+nIz
 ehT
 xkw
-xkw
-uOS
-sed
-cON
+sjf
+jQi
+wYC
+bVX
 ycA
 cON
 cON
@@ -64507,8 +64750,8 @@ cON
 ntt
 izw
 qTT
-iuq
-eCy
+dyB
+dAO
 eCy
 nOw
 nOw
@@ -64740,21 +64983,21 @@ kCH
 kCH
 nOw
 nOw
-nOw
 fmQ
 mqX
-oQy
+ovV
 tBp
 sHV
 xoG
-tZF
-tZF
+ivi
+jbK
+pxO
 ehT
 meM
-meM
-uOS
-sed
-cON
+pPa
+jQi
+etJ
+bVX
 ycA
 cON
 cON
@@ -64764,7 +65007,7 @@ nVG
 ycA
 cON
 qTT
-fTh
+jQi
 xje
 cxO
 sBu
@@ -64997,21 +65240,21 @@ kCH
 kCH
 nOw
 nOw
-nOw
 clr
 fmQ
 fmQ
 fmQ
 fmQ
-pAz
+iTn
+ehT
 ehT
 ehT
 ehT
 meM
-nOw
-uOS
+gRD
+jQi
 sed
-cON
+bVX
 cON
 nVG
 nVG
@@ -65265,10 +65508,10 @@ tGe
 nOw
 nOw
 nOw
-nOw
-uOS
+gRD
+jQi
 sed
-cON
+bVX
 ycA
 nVG
 cON
@@ -65523,9 +65766,9 @@ oNc
 ehT
 ehT
 cuG
-uOS
+jQi
 sed
-cON
+bVX
 ycA
 cON
 nVG
@@ -65535,8 +65778,8 @@ cON
 ycA
 cON
 qTT
-iuq
-gSQ
+dyB
+qup
 gSQ
 vcC
 vcC
@@ -65782,7 +66025,7 @@ ehT
 naG
 qPg
 sed
-cON
+bVX
 ycA
 cON
 cON
@@ -65792,8 +66035,8 @@ cON
 ycA
 cON
 qTT
-iuq
-eCy
+dyB
+dAO
 eCy
 nOw
 nOw
@@ -66039,7 +66282,7 @@ ehT
 ehT
 dVW
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -66049,8 +66292,8 @@ cON
 cON
 cON
 qTT
-iuq
-xkw
+dyB
+tcb
 xkw
 nOw
 nOw
@@ -66296,7 +66539,7 @@ aYk
 aYk
 oNc
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -66553,7 +66796,7 @@ toV
 toV
 ehT
 cKC
-cON
+bVX
 cON
 cON
 cON
@@ -66563,8 +66806,8 @@ cON
 cON
 cON
 lju
-iuq
-eCy
+dyB
+dAO
 xkw
 nOw
 nOw
@@ -66810,7 +67053,7 @@ toV
 toV
 eHp
 qRZ
-cON
+bVX
 cON
 cON
 nVG
@@ -67067,7 +67310,7 @@ toV
 toV
 wKl
 pMy
-izw
+wZw
 cON
 cON
 nVG
@@ -67324,7 +67567,7 @@ aYk
 aYk
 tHg
 sed
-cON
+bVX
 nVG
 cON
 cON
@@ -67581,7 +67824,7 @@ ehT
 ehT
 dVW
 sed
-cON
+bVX
 cON
 cKH
 nVG
@@ -67838,7 +68081,7 @@ wKl
 naG
 hfu
 sed
-cON
+bVX
 cON
 nVG
 nVG
@@ -68093,9 +68336,9 @@ oNc
 ehT
 wKl
 cuG
-uOS
+jQi
 sed
-cON
+bVX
 cON
 cON
 nVG
@@ -68349,10 +68592,10 @@ nOw
 nOw
 nOw
 nOw
-nOw
-uOS
+gRD
+jQi
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -68606,10 +68849,10 @@ nOw
 nOw
 nOw
 nOw
-nOw
-izX
+gRD
+gEB
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -68619,8 +68862,8 @@ cON
 cON
 cON
 qTT
-pIp
-xkw
+jQi
+mId
 xkw
 nOw
 tGe
@@ -69393,9 +69636,9 @@ qTT
 jMt
 lZk
 ivi
-pPa
+vtw
 ivi
-pPa
+vtw
 ivi
 sGI
 aoN
@@ -69633,9 +69876,9 @@ nOw
 nOw
 wKl
 ehT
-cXY
+jEN
 ehT
-cXY
+jEN
 ehT
 wKl
 cON
@@ -70147,9 +70390,9 @@ nOw
 nOw
 ehT
 ehT
-jEN
+cXY
 ehT
-jEN
+cXY
 ehT
 wKl
 cON
@@ -71189,8 +71432,8 @@ cON
 cON
 cON
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 nOw
 tGe
@@ -71433,7 +71676,7 @@ nOw
 gwJ
 fFO
 ivi
-vtw
+wyb
 ivi
 ehT
 hAg
@@ -71446,8 +71689,8 @@ cON
 cON
 cON
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 rPm
 rPm
@@ -71703,8 +71946,8 @@ nVG
 cON
 cON
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 gBW
 nWL
@@ -71960,8 +72203,8 @@ cON
 nVG
 cON
 qTT
-fTh
-cxO
+jQi
+egH
 cxO
 rPm
 rPm
@@ -72217,8 +72460,8 @@ cON
 cON
 qYn
 qTT
-fTh
-cxO
+jQi
+egH
 cxO
 sUu
 xFi
@@ -72461,7 +72704,7 @@ nOw
 iSN
 fFO
 ivi
-vtw
+wyb
 ivi
 aQp
 ycA
@@ -72474,7 +72717,7 @@ cON
 cON
 nVG
 mlN
-fTh
+jQi
 ram
 gSQ
 rPm
@@ -72731,8 +72974,8 @@ xSJ
 cON
 cON
 lju
-iuq
-xkw
+dyB
+tcb
 xkw
 sUu
 wte
@@ -72988,8 +73231,8 @@ cON
 cON
 cON
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 sUu
 vqx
@@ -73232,10 +73475,10 @@ nOw
 nOw
 nOw
 nOw
-nOw
+gRD
 aGk
 fEj
-cON
+bVX
 cON
 cON
 cON
@@ -73245,8 +73488,8 @@ xSJ
 cON
 cON
 qTT
-fTh
-xkw
+jQi
+tcb
 xkw
 rPm
 rPm
@@ -73489,8 +73732,8 @@ nOw
 nOw
 nOw
 nOw
-nOw
-uOS
+gRD
+jQi
 gHu
 mTY
 cON
@@ -73502,8 +73745,8 @@ cON
 cON
 cON
 qTT
-fTh
-meM
+jQi
+veD
 meM
 rPm
 rPm
@@ -73746,8 +73989,8 @@ nOw
 nOw
 nOw
 nOw
-nOw
-uOS
+gRD
+jQi
 sed
 rZK
 cON
@@ -74003,7 +74246,7 @@ nOw
 nOw
 nOw
 xMo
-xMo
+oQy
 nWY
 sed
 nJi
@@ -74016,8 +74259,8 @@ cON
 cON
 cON
 nQe
-fTh
-xMo
+jQi
+eiu
 oEA
 nOw
 nOw
@@ -74520,7 +74763,7 @@ xMo
 xaf
 jQi
 sed
-cON
+bVX
 cON
 cON
 nVG
@@ -74774,10 +75017,10 @@ rUq
 rUq
 rUq
 xMo
-xMo
-uOS
+oQy
+jQi
 fEj
-cON
+bVX
 cON
 cON
 cON
@@ -74787,8 +75030,8 @@ nVG
 cON
 giR
 bIn
-fTh
-xMo
+jQi
+eiu
 xMo
 rUq
 pDB
@@ -75034,7 +75277,7 @@ goh
 rUq
 eXP
 sed
-rvC
+mzh
 cON
 cON
 cON
@@ -75291,7 +75534,7 @@ goh
 rUq
 qTT
 uUN
-cON
+bVX
 cON
 cON
 cON
@@ -75548,7 +75791,7 @@ goh
 rUq
 qTT
 sed
-rGs
+izX
 rGs
 rGs
 rGs
@@ -75805,7 +76048,7 @@ goh
 goh
 rYf
 aBf
-rGs
+izX
 cON
 cON
 cON
@@ -76062,7 +76305,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -76319,7 +76562,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -76576,7 +76819,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 snq
 cON
 qYn
@@ -76833,7 +77076,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -77090,7 +77333,7 @@ rUq
 rUq
 qTT
 cVO
-cON
+bVX
 cON
 cON
 nVG
@@ -77347,7 +77590,7 @@ sZw
 rUq
 qTT
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -77604,7 +77847,7 @@ sZw
 rUq
 qTT
 sed
-trU
+iaD
 cON
 cON
 cON
@@ -77861,7 +78104,7 @@ sZw
 rUq
 qTT
 sed
-cON
+bVX
 nVG
 cON
 cON
@@ -78118,7 +78361,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 nVG
 cON
 cON
@@ -78375,7 +78618,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 cON
@@ -78632,7 +78875,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 nVG
 cON
 trU
@@ -78889,7 +79132,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 izw
 cON
 cON
@@ -79146,7 +79389,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -79403,7 +79646,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 nVG
 cON
@@ -79660,7 +79903,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 cON
 cON
 izw
@@ -79917,7 +80160,7 @@ rUq
 rUq
 qTT
 sed
-cON
+bVX
 oOi
 cON
 cON
@@ -80174,7 +80417,7 @@ rUq
 rUq
 qTT
 sed
-cON
+iHz
 cON
 cON
 qYn
@@ -80431,7 +80674,7 @@ aWQ
 aWQ
 mtN
 sed
-cON
+pzM
 snq
 cON
 cON
@@ -80688,7 +80931,7 @@ pbn
 pbn
 pbn
 rKA
-cON
+sez
 cON
 cON
 nVG

--- a/_maps/map_files/coyote_bayou/Garland-City.dmm
+++ b/_maps/map_files/coyote_bayou/Garland-City.dmm
@@ -279,6 +279,11 @@
 	icon_state = "outermaincornerinner - E"
 	},
 /area/f13/wasteland)
+"amB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innercornerpieceright"
+	},
+/area/f13/wasteland)
 "amG" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags,
@@ -2944,17 +2949,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"cvf" = (
-/obj/structure/fence/wooden{
-	pixel_x = -16
-	},
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
-/obj/structure/fence/handrail{
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "cvw" = (
 /turf/closed/indestructible/rock,
 /area/f13/caves)
@@ -3345,6 +3339,12 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
+"cHE" = (
+/obj/structure/chair/right{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "cHI" = (
 /obj/effect/decal/fakelattice{
 	pixel_y = -17
@@ -4477,18 +4477,8 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"dAk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "dAO" = (
 /obj/structure/lattice,
-/obj/structure/spacevine{
-	name = "vines"
-	},
 /obj/structure/fence/handrail{
 	pixel_y = 16
 	},
@@ -4663,6 +4653,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
+"dHu" = (
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "dHI" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/spacevine{
@@ -5148,8 +5146,17 @@
 	},
 /area/f13/building)
 "dZV" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "eac" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -5187,12 +5194,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"ecM" = (
-/obj/structure/fence/handrail{
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "ecN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5280,16 +5281,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"egH" = (
-/obj/structure/lattice,
-/obj/structure/fence/wooden{
-	pixel_x = 16
-	},
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "egO" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/f13/wood,
@@ -5326,11 +5317,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eiu" = (
-/obj/structure/fence/handrail{
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge/meat{
+	anchored = 1
 	},
-/turf/closed/indestructible/rock,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "eiw" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -5844,6 +5836,10 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"eBh" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "eBH" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -8194,6 +8190,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/caves)
+"gye" = (
+/obj/structure/chair/left{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "gyK" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper{
@@ -8259,6 +8261,17 @@
 "gBG" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"gBL" = (
+/obj/structure/fence/wooden{
+	pixel_x = -16
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "gBW" = (
 /obj/structure/rug/mat{
@@ -8358,17 +8371,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"gGo" = (
-/obj/structure/lattice,
-/obj/structure/fence/handrail{
-	pixel_y = -12
-	},
-/obj/structure/fence/wooden{
-	pixel_x = 16
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "gGr" = (
 /obj/item/stack/ore/iron,
 /obj/effect/decal/cleanable/dirt,
@@ -9513,11 +9515,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hCc" = (
-/obj/structure/car/rubbish3{
-	pixel_x = -4;
-	pixel_y = 17
+/obj/structure/lattice,
+/obj/structure/spacevine{
+	name = "vines"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hCs" = (
 /obj/structure/closet/crate/medical,
@@ -10098,12 +10103,6 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hXi" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "hYq" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -10539,6 +10538,10 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
+"ilv" = (
+/obj/machinery/vending/games,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "ilO" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -10781,13 +10784,11 @@
 	},
 /area/f13/building)
 "iuq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/fence/handrail{
+	pixel_y = 16
 	},
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "iur" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -10943,11 +10944,11 @@
 	},
 /area/f13/building)
 "izX" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "iAC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/frog,
@@ -11310,6 +11311,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"iOF" = (
+/obj/structure/lattice,
+/obj/structure/fence/wooden{
+	pixel_x = 16
+	},
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "iOT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -11676,12 +11687,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"jbK" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "jbV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/crafts,
@@ -12025,19 +12030,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"jrY" = (
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 4;
-	pixel_y = 8
+"jqW" = (
+/obj/structure/wreck/trash/three_barrels{
+	pixel_y = -11
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "jsb" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13215,6 +13213,18 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/building)
+"kjY" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "kkl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -14070,6 +14080,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kSK" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/flora/ausbushes/ywflowers{
+	light_power = 3;
+	light_range = 2;
+	light_color = "#EBAF4C"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "kSY" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -14181,6 +14204,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"kWV" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "kWY" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14474,6 +14504,13 @@
 	},
 /turf/closed/wall/f13/store,
 /area/f13/building)
+"lgw" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "lhq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -14660,6 +14697,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"lmn" = (
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "lmI" = (
 /obj/structure/simple_door/wood/alt,
 /obj/item/lock_bolt{
@@ -14920,6 +14964,11 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"lwG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "lwL" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/closed/indestructible/f13vaultrusted,
@@ -15508,13 +15557,8 @@
 /turf/open/water,
 /area/f13/building)
 "lUT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/processor/chopping_block,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher{
-	name = "Mama's cleaver"
-	},
-/obj/item/kitchen/knife,
+/obj/machinery/smartfridge/bottlerack,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "lUY" = (
@@ -16401,12 +16445,6 @@
 /obj/item/clothing/under/pants/f13/ghoul,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mzh" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland)
 "mzj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
@@ -16702,17 +16740,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
-"mId" = (
-/obj/structure/lattice,
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/obj/structure/barricade/wooden/planks,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "mIf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -16956,6 +16983,17 @@
 /obj/machinery/door/airlock/medical,
 /turf/open/floor/f13,
 /area/f13/city)
+"mXx" = (
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/obj/structure/fence/wooden{
+	pixel_x = 16
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "mXL" = (
 /obj/structure/table/wood/bar,
 /obj/item/trash/plate,
@@ -17418,6 +17456,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"npu" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland)
 "npw" = (
 /obj/item/target,
 /obj/effect/decal/cleanable/dirt,
@@ -17449,11 +17493,15 @@
 	},
 /area/f13/building)
 "nqO" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/fence/wooden{
+	pixel_x = -16
 	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/city)
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "nqV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -17978,17 +18026,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "nIz" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nJc" = (
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood,
@@ -18779,11 +18822,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"okH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "okY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19622,10 +19660,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oQy" = (
-/obj/structure/fence/handrail{
-	pixel_y = -12
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/closed/indestructible/rock,
 /area/f13/wasteland)
 "oQz" = (
 /obj/structure/bed/mattress,
@@ -19664,6 +19702,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/wasteland)
+"oSF" = (
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "oSI" = (
@@ -20508,12 +20552,6 @@
 	icon_state = "bluechess2"
 	},
 /area/f13/building)
-"pxO" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "pxP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -20783,10 +20821,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pIp" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment,
+/obj/structure/fence/handrail{
+	pixel_y = -12
 	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "pIT" = (
 /obj/structure/nest/randomized{
@@ -20826,13 +20866,6 @@
 	icon_state = "shadowleft"
 	},
 /area/f13/wasteland)
-"pKd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge/meat{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/f13/city)
 "pKh" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -20979,7 +21012,7 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /obj/structure/fence/handrail{
-	pixel_y = -12
+	pixel_y = 16
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -21723,10 +21756,10 @@
 	},
 /area/f13/wasteland)
 "qrD" = (
-/obj/structure/rack,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/chair/left{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/city)
 "qrM" = (
 /obj/structure/simple_door/house{
@@ -21810,16 +21843,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"qup" = (
-/obj/structure/lattice,
-/obj/structure/fence/wooden{
-	pixel_x = -16
-	},
-/obj/structure/fence/handrail{
-	pixel_y = 16
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "qux" = (
 /obj/structure/flora/tree/joshua{
 	pixel_x = -21;
@@ -22210,11 +22233,6 @@
 	},
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
-"qJc" = (
-/obj/machinery/smartfridge/bottlerack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "qJu" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -23868,11 +23886,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"sez" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "innercornerpieceright"
-	},
-/area/f13/wasteland)
 "seA" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/curtain{
@@ -24021,13 +24034,6 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
 	},
-/area/f13/wasteland)
-"sjf" = (
-/obj/structure/lattice,
-/obj/structure/fence/handrail{
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sjt" = (
 /obj/structure/chair/stool,
@@ -24382,6 +24388,17 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"syL" = (
+/obj/structure/lattice,
+/obj/structure/fence/handrail{
+	pixel_y = 16
+	},
+/obj/structure/barricade/wooden/planks,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "szd" = (
 /obj/structure/chair/stool,
 /turf/open/floor/f13{
@@ -24911,12 +24928,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"sSJ" = (
-/obj/structure/wreck/trash/three_barrels{
-	pixel_y = -11
-	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
 "sSN" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/airless/bar,
@@ -25080,11 +25091,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tcb" = (
-/obj/structure/lattice,
-/obj/structure/fence/handrail{
-	pixel_y = 16
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "tce" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26083,6 +26093,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"tNo" = (
+/obj/structure/fence/handrail{
+	pixel_y = -12
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tNp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -26279,10 +26295,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"tUf" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/freezer,
-/area/f13/city)
 "tUM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/water,
@@ -27606,6 +27618,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"uTM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "uTY" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -27964,9 +27982,8 @@
 /area/f13/building)
 "veD" = (
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
 /obj/structure/fence/handrail{
-	pixel_y = 16
+	pixel_y = -12
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -28238,13 +28255,6 @@
 	icon_state = "greendirtysolid"
 	},
 /area/f13/building)
-"vpr" = (
-/obj/structure/window/fulltile/house/broken,
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vpU" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -28351,14 +28361,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"vuF" = (
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "vuN" = (
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood{
@@ -28378,6 +28380,10 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"vuV" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "vva" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -29193,8 +29199,30 @@
 	},
 /area/f13/building)
 "wcP" = (
-/obj/machinery/vending/games,
-/turf/open/floor/f13/wood,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/item/reagent_containers/food/condiment/quality_oil,
+/obj/item/reagent_containers/food/condiment/mustard,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/peanut_butter,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/bbqsauce,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city)
 "wcY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29281,32 +29309,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"whm" = (
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/quality_oil,
-/obj/item/reagent_containers/food/condiment/mustard,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/peanut_butter,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/bbqsauce,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "wht" = (
 /obj/structure/table/wood/settler,
 /obj/item/mining_scanner,
@@ -29657,6 +29659,10 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"wsV" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/freezer,
+/area/f13/city)
 "wsZ" = (
 /obj/effect/decal/marking,
 /obj/structure/spacevine{
@@ -29757,9 +29763,9 @@
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland)
 "wyb" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/structure/window/fulltile/house,
+/obj/structure/curtain{
+	color = "#363636"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -30213,6 +30219,14 @@
 /obj/item/twohanded/fireaxe,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
+"wQM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/processor/chopping_block,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/knife/butcher,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "wQO" = (
 /obj/structure/chair{
 	icon_state = "chair";
@@ -30446,23 +30460,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wYC" = (
-/obj/structure/table/wood/junk,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/structure/fence/handrail{
+	pixel_y = -12
 	},
-/area/f13/wasteland)
-"wZw" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_power = 3;
-	light_range = 2;
-	light_color = "#EBAF4C"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
+/turf/closed/indestructible/rock,
 /area/f13/wasteland)
 "wZE" = (
 /obj/machinery/light{
@@ -31178,11 +31179,11 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "xAK" = (
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/effect/spawner/lootdrop/f13/seedspawner,
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/car/rubbish3{
+	pixel_x = -4;
+	pixel_y = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "xBc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31644,13 +31645,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"xXk" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "xXl" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -31695,10 +31689,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"xZY" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/city)
 "yah" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -31770,6 +31760,14 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"ycQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/city)
 "ydT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
@@ -58315,7 +58313,7 @@ eyZ
 vAx
 rYf
 aBf
-izX
+oQy
 cON
 cON
 cON
@@ -58572,7 +58570,7 @@ cnn
 kcS
 rOC
 baM
-izX
+oQy
 rGs
 rGs
 rGs
@@ -59078,7 +59076,7 @@ hiK
 chH
 qzn
 hiK
-xAK
+nIz
 rUq
 cnn
 cnn
@@ -59096,7 +59094,7 @@ cON
 cON
 giR
 qTT
-hCc
+xAK
 rUq
 rUq
 haz
@@ -59354,7 +59352,7 @@ cON
 cON
 qTT
 jQi
-eiu
+iuq
 xMo
 rUq
 rUq
@@ -59600,7 +59598,7 @@ xMo
 xMo
 jQi
 sed
-mzh
+npu
 cON
 cON
 nVG
@@ -59608,7 +59606,7 @@ cON
 cON
 cON
 cON
-sSJ
+jqW
 qTT
 jQi
 xaf
@@ -60125,7 +60123,7 @@ bkT
 bkT
 lju
 dyB
-eiu
+iuq
 xMo
 nOw
 nOw
@@ -60382,7 +60380,7 @@ nGp
 bkT
 qTT
 jQi
-dAO
+hCc
 scI
 nOw
 nOw
@@ -60625,7 +60623,7 @@ rUq
 rUq
 rUq
 rUq
-ecM
+tNo
 jQi
 sed
 bVX
@@ -60639,7 +60637,7 @@ iLw
 xkR
 qTT
 dyB
-veD
+pPa
 meM
 nOw
 nOw
@@ -60896,7 +60894,7 @@ iLw
 fjl
 qTT
 dyB
-tcb
+dAO
 xkw
 nOw
 nOw
@@ -61153,7 +61151,7 @@ iLw
 xjZ
 qTT
 jQi
-dAO
+hCc
 eCy
 nOw
 nOw
@@ -61410,7 +61408,7 @@ kYU
 bkT
 qTT
 jQi
-tcb
+dAO
 xkw
 nOw
 nOw
@@ -61643,17 +61641,17 @@ nOw
 nOw
 nOw
 fmQ
-pKd
-nqO
-tUf
+eiu
+uTM
+wsV
 tBp
 hlM
 ivi
-hXi
+gye
 dei
 wKl
 meM
-pPa
+pIp
 xKa
 sed
 bVX
@@ -61900,17 +61898,17 @@ nOw
 nOw
 nOw
 fmQ
-qrD
+izX
 asm
 pkC
 tBp
 ivi
 ivi
 hMV
-nIz
-vpr
+kjY
+kWV
 xkw
-sjf
+veD
 jQi
 sed
 bVX
@@ -62163,14 +62161,14 @@ tBp
 tBp
 ivi
 ivi
-jbK
-pxO
-xXk
+cHE
+qrD
+wyb
 bpx
-sjf
+veD
 ozH
 bSp
-pIp
+tcb
 cON
 nVG
 cON
@@ -62414,7 +62412,7 @@ nOw
 nOw
 nOw
 fmQ
-whm
+wcP
 ovV
 ovV
 cbT
@@ -62424,10 +62422,10 @@ ivi
 oNv
 ehT
 xkw
-sjf
+veD
 ozH
 bSp
-pIp
+tcb
 cON
 nVG
 cON
@@ -62671,20 +62669,20 @@ nOw
 nOw
 nOw
 fmQ
-vuF
+dHu
 ovV
-dZV
+vuV
 tBp
 gtd
 ivi
 ivi
-jrY
+dZV
 ehT
 xkw
-sjf
+veD
 ozH
 bSp
-pIp
+tcb
 cON
 cON
 cON
@@ -62928,9 +62926,9 @@ nOw
 nOw
 nOw
 tBp
-xZY
+eBh
 ovV
-lUT
+wQM
 tBp
 gtd
 ivi
@@ -62938,7 +62936,7 @@ ivi
 tZF
 ehT
 oJR
-gGo
+mXx
 eiw
 hWU
 bVX
@@ -63702,14 +63700,14 @@ mAa
 ovV
 ovV
 tBp
-wcP
+ilv
 ivi
 ivi
-hXi
+gye
 dei
 ehT
 jsK
-cvf
+gBL
 eiw
 sed
 bVX
@@ -63956,17 +63954,17 @@ nOw
 nOw
 nOw
 tBp
-okH
+lwG
 ovV
 fXO
 egO
 ivi
 ivi
 hMV
-nIz
+kjY
 ehT
 xkw
-sjf
+veD
 gEB
 sed
 bVX
@@ -64213,17 +64211,17 @@ nOw
 nOw
 nOw
 tBp
-iuq
+ycQ
 ovV
 fXO
 ehR
 ivi
 ivi
-jbK
-pxO
-xXk
+cHE
+qrD
+wyb
 xkw
-sjf
+veD
 jQi
 sed
 bVX
@@ -64237,7 +64235,7 @@ cON
 cON
 qTT
 dyB
-dAO
+hCc
 eCy
 nOw
 nOw
@@ -64470,17 +64468,17 @@ nOw
 nOw
 nOw
 fmQ
-dAk
+lgw
 ovV
 fXO
 egO
 ivi
 ivi
-hXi
+gye
 dei
-xXk
+wyb
 xkw
-sjf
+veD
 jQi
 hHa
 bVX
@@ -64494,7 +64492,7 @@ ycA
 cON
 lju
 jQi
-veD
+pPa
 meM
 nOw
 nOw
@@ -64727,19 +64725,19 @@ nOw
 nOw
 nOw
 fmQ
-qJc
+lUT
 ovV
 fXO
 egO
 ivi
 ivi
 cLW
-nIz
+kjY
 ehT
 xkw
-sjf
+veD
 jQi
-wYC
+oSF
 bVX
 ycA
 cON
@@ -64751,7 +64749,7 @@ ntt
 izw
 qTT
 dyB
-dAO
+hCc
 eCy
 nOw
 nOw
@@ -64990,11 +64988,11 @@ tBp
 sHV
 xoG
 ivi
-jbK
-pxO
+cHE
+qrD
 ehT
 meM
-pPa
+pIp
 jQi
 etJ
 bVX
@@ -65779,7 +65777,7 @@ ycA
 cON
 qTT
 dyB
-qup
+nqO
 gSQ
 vcC
 vcC
@@ -66036,7 +66034,7 @@ ycA
 cON
 qTT
 dyB
-dAO
+hCc
 eCy
 nOw
 nOw
@@ -66293,7 +66291,7 @@ cON
 cON
 qTT
 dyB
-tcb
+dAO
 xkw
 nOw
 nOw
@@ -66807,7 +66805,7 @@ cON
 cON
 lju
 dyB
-dAO
+hCc
 xkw
 nOw
 nOw
@@ -67310,7 +67308,7 @@ toV
 toV
 wKl
 pMy
-wZw
+kSK
 cON
 cON
 nVG
@@ -68863,7 +68861,7 @@ cON
 cON
 qTT
 jQi
-mId
+syL
 xkw
 nOw
 tGe
@@ -71433,7 +71431,7 @@ cON
 cON
 qTT
 jQi
-tcb
+dAO
 xkw
 nOw
 tGe
@@ -71676,7 +71674,7 @@ nOw
 gwJ
 fFO
 ivi
-wyb
+lmn
 ivi
 ehT
 hAg
@@ -71690,7 +71688,7 @@ cON
 cON
 qTT
 jQi
-tcb
+dAO
 xkw
 rPm
 rPm
@@ -71947,7 +71945,7 @@ cON
 cON
 qTT
 jQi
-tcb
+dAO
 xkw
 gBW
 nWL
@@ -72204,7 +72202,7 @@ nVG
 cON
 qTT
 jQi
-egH
+iOF
 cxO
 rPm
 rPm
@@ -72461,7 +72459,7 @@ cON
 qYn
 qTT
 jQi
-egH
+iOF
 cxO
 sUu
 xFi
@@ -72704,7 +72702,7 @@ nOw
 iSN
 fFO
 ivi
-wyb
+lmn
 ivi
 aQp
 ycA
@@ -72975,7 +72973,7 @@ cON
 cON
 lju
 dyB
-tcb
+dAO
 xkw
 sUu
 wte
@@ -73232,7 +73230,7 @@ cON
 cON
 qTT
 jQi
-tcb
+dAO
 xkw
 sUu
 vqx
@@ -73489,7 +73487,7 @@ cON
 cON
 qTT
 jQi
-tcb
+dAO
 xkw
 rPm
 rPm
@@ -73746,7 +73744,7 @@ cON
 cON
 qTT
 jQi
-veD
+pPa
 meM
 rPm
 rPm
@@ -74246,7 +74244,7 @@ nOw
 nOw
 nOw
 xMo
-oQy
+wYC
 nWY
 sed
 nJi
@@ -74260,7 +74258,7 @@ cON
 cON
 nQe
 jQi
-eiu
+iuq
 oEA
 nOw
 nOw
@@ -75017,7 +75015,7 @@ rUq
 rUq
 rUq
 xMo
-oQy
+wYC
 jQi
 fEj
 bVX
@@ -75031,7 +75029,7 @@ cON
 giR
 bIn
 jQi
-eiu
+iuq
 xMo
 rUq
 pDB
@@ -75277,7 +75275,7 @@ goh
 rUq
 eXP
 sed
-mzh
+npu
 cON
 cON
 cON
@@ -75791,7 +75789,7 @@ goh
 rUq
 qTT
 sed
-izX
+oQy
 rGs
 rGs
 rGs
@@ -76048,7 +76046,7 @@ goh
 goh
 rYf
 aBf
-izX
+oQy
 cON
 cON
 cON
@@ -80931,7 +80929,7 @@ pbn
 pbn
 pbn
 rKA
-sez
+amB
 cON
 cON
 nVG


### PR DESCRIPTION
## About The Pull Request
What this PR does is basically makes the diner in garland relevant. It has cleaned up into more of a modern style instead of what it used to be and expands it a little bit so you have more room and gives it food inside so you can already eat. Also there has been added upgraded drink machines. This feels like it brings more of that classy diner vibe and some candles in the freezer area just incase if someone wants to buy out the diner for a romantic dinner or two. Below photo is how it looks now
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/53bef197-9392-4657-8549-70db7af55a53)
Also what else is added is a seed extractor with a little tweak of moving the compost off to the side
![image](https://github.com/ARF-SS13/coyote-bayou/assets/29418371/fb835ece-b3b3-4f25-86de-0e2127787f7f)
Also most of the railing has been fixed and deadbolts so people can actually walk by the railing instead of avoiding it completely. 


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
Tweak: Gaaarland Texarkana
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
