### PR TITLE
Adds normal lunchbox to defib recipe

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -359,6 +359,19 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/primitive_defib
+	name = "Improvised Defibrillator"
+	result = /obj/item/defibrillator/primitive
+	reqs = list(
+	/obj/item/wirecutters = 2,
+	/obj/item/stock_parts/cell = 6,
+	/obj/item/storage/bag/plants/lunchbox = 1,
+	/obj/item/stack/cable_coil = 30
+	)
+	time = 75
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_MEDICAL
+
 /datum/crafting_recipe/refill_chem_cartridge
 	name = "Refill chemical Cartridge"
 	result = /obj/item/stock_parts/chem_cartridge/crafted


### PR DESCRIPTION
## About The Pull Request
Adds normal lunchbox to be useable for the improvised defib recipe.
Felt silly that the recipe requires the custom lunchbox that fallout has while the base ss13 lunchboxes are useless

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Normal lunchbox to defib recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
