### PR TITLE
Fixes peanut butter brownie recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -214,7 +214,7 @@
 		/obj/item/reagent_containers/food/snacks/egg = 2,
 		/datum/reagent/consumable/coco = 5,
 		/obj/item/reagent_containers/food/snacks/butter = 1,
-		/obj/item/reagent_containers/food/condiment/peanut_butter = 5
+		/datum/reagent/consumable/peanut_butter = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/brownie_sheet_peanut
 	subcategory = CAT_PASTRY

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -223,7 +223,7 @@
 	name = "Crunchy peanut butter tart"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/pastrybase = 1,
-		/obj/item/reagent_containers/food/condiment/peanut_butter = 5,
+		/datum/reagent/consumable/peanut_butter = 5,
 		/datum/reagent/consumable/cream = 5,
 	)
 	result = /obj/item/reagent_containers/food/snacks/crunchy_peanut_butter_tart


### PR DESCRIPTION
## About The Pull Request
Peanut butter brownies required 5 of lower case peanut butter JARS instead of the reagent. Now it's happy with 5u of actual peanut butter.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Peanut butter brownie now makeable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
