### PR TITLE
Lets you tuck yourself in underneath blankets, because blankets exist separately from bedsheets for some reason

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -7,7 +7,7 @@ LINEN BINS
 
 /obj/item/blanket
 	name = "blanket"
-	desc = "A undyed rough blanket."
+	desc = "A undyed rough blanket. <span class='bold'>Use in hand to tuck yourself in.</span>"
 	icon = 'icons/obj/bedsheets.dmi'
 	icon_state = "blanket1"
 	item_state = "bedsheet"
@@ -40,7 +40,7 @@ LINEN BINS
 
 /obj/item/bedsheet
 	name = "bedsheet"
-	desc = "A surprisingly soft linen bedsheet."
+	desc = "A surprisingly soft linen bedsheet. <span class='bold'>Use in hand to tuck yourself in.</span>"
 	icon = 'icons/obj/bedsheets.dmi'
 	icon_state = "sheetwhite"
 	item_state = "bedsheet"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -18,6 +18,23 @@ LINEN BINS
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
+/obj/item/blanket/attack_self(mob/user)
+	if(!user.can_reach(src))		//No telekenetic grabbing.
+		return
+	if(!user.dropItemToGround(src))
+		return
+	if(layer == initial(layer))
+		plane = MOB_PLANE // makes it render on the mob plane to overlay the mobs.
+		layer = ABOVE_MOB_LAYER
+		to_chat(user, span_notice("You cover yourself with [src]."))
+	else
+		plane = initial(plane) // sets it back!
+		layer = initial(layer)
+		to_chat(user, span_notice("You smooth [src] out beneath you."))
+	add_fingerprint(user)
+	return
+// Want something to do? Refactor blankets into bedsheets.
+
 /obj/item/blanket/blanketalt
 	icon_state = "blanket2"
 


### PR DESCRIPTION
## About The Pull Request
• Adds the code-block for setting down 
• Changes desc of blankets and bedsheets to inform players how to tuck in.
![image](https://github.com/ARF-SS13/coyote-bayou/assets/53862927/ff659610-d2e0-458e-8c25-974e29c698da)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
qol: You can now tuck yourself into bed by using the bedsheets in your hand.
/:cl: