### PR TITLE
Fixes those modular pizza crafting recipes

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -408,7 +408,7 @@
 		/obj/item/reagent_containers/food/snacks/pizzabread = 1,
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 4,
 	)
-	result = /obj/item/reagent_containers/food/snacks/pizzaslice/mothic_five_cheese
+	result = /obj/item/reagent_containers/food/snacks/pizza/mothic_five_cheese
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/mothic_white_pie
@@ -418,7 +418,7 @@
 		/obj/item/reagent_containers/food/snacks/cheesewedge = 2,
 		/obj/item/reagent_containers/food/snacks/grown/garlic = 1
 	)
-	result = /obj/item/reagent_containers/food/snacks/pizzaslice/mothic_white_pie
+	result = /obj/item/reagent_containers/food/snacks/pizza/mothic_white_pie
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/mothic_pesto
@@ -429,7 +429,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/garlic = 1,
 		/obj/item/reagent_containers/food/snacks/butter = 1
 	)
-	result = /obj/item/reagent_containers/food/snacks/pizzaslice/mothic_pesto
+	result = /obj/item/reagent_containers/food/snacks/pizza/mothic_pesto
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/mothic_garlic
@@ -440,7 +440,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/garlic = 2,
 		/obj/item/reagent_containers/food/snacks/butter = 1
 	)
-	result = /obj/item/reagent_containers/food/snacks/pizzaslice/mothic_garlic
+	result = /obj/item/reagent_containers/food/snacks/pizza/mothic_garlic
 	subcategory = CAT_BURGER
 
 /datum/crafting_recipe/food/sloppyjoe


### PR DESCRIPTION
## About The Pull Request
Craft the pizza instead of pizza slices.

## Pre-Merge Checklist
- [x] You notified staff that Fenny stinks.
- [ ] This code did wash Fenny during testing.
- [x] You documented all cats.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: When you make a pizza, 80% of it doesn't instantly vanish.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
