### PR TITLE
Drink Machine Addition: Cucumber Juice & Amaretto

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -610,7 +610,8 @@
 		/datum/reagent/consumable/aloejuice,
 		/datum/reagent/consumable/peachjuice,
 		/datum/reagent/consumable/blumpkinjuice,
-		/datum/reagent/consumable/cherryjelly
+		/datum/reagent/consumable/cherryjelly,
+		/datum/reagent/consumable/cucumberjuice
 	)
 	upgrade_reagents2 = list(
 		/datum/reagent/consumable/vanilla,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -678,7 +678,8 @@
 		/datum/reagent/consumable/ethanol/sake,
 		/datum/reagent/consumable/ethanol/applejack,
 		/datum/reagent/consumable/ethanol/champagne,
-		/datum/reagent/consumable/ethanol/fernet
+		/datum/reagent/consumable/ethanol/fernet,
+		/datum/reagent/consumable/ethanol/amaretto
 	)
 	upgrade_reagents = list(
 		/datum/reagent/consumable/ethanol,


### PR DESCRIPTION
## About The Pull Request
This is basically adding cucumber juice to the drink dispenser, as it was forgotten long ago, so now you can come up to bar and ask for a cucumber lemonade or cucumber related drinks without waiting a year to get it. More for the roleplayers of the server instead of waiting a year for a singular drink. 😋 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Cucumber lemonade drink machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
