### PR TITLE
Prevents ghosts from spawning mobs in nullspace mid-disconnect.

### DIFF
--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -26,10 +26,11 @@
 	if(isturf(location))
 		M = new new_type( location )
 	else
-		M = new new_type( src.loc )
+		if(src.loc) // Prevents this from happening. https://media.discordapp.net/attachments/986782066886721597/1185769646981398568/image.png
+			M = new new_type( src.loc )
 
 	if(!M || !ismob(M))
-		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type(). Contact a coder.")
+		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type() or null. Contact a coder, or try again.")
 		qdel(M)
 		return
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

Unironically the first bug I've been really impressed by on this codebase, *hopefully* prevents this from happening again. 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/68038883/c7c89343-db91-4ef9-928c-6f2942965d12)
Love it. Simple basic network replication issues I encountered during all my uni work this semester simply showing up with BYOND's netcode! Though, it's not their code which is the issue, it's our codebase not being safe for concurrent issues such as that.

If anyone's wondering, basically when a observer leaves the game, the ghost they have is deleted. However with our changes to garbage collection, Fenny nullspaces it, so on that same tick now after the player disconnected on the same frame the spawn mob proc is called, that ghost is in nullspace, and it's src.loc is `null`, so that mob is now instantiated into nullspace.
Simple one line of code to make sure src.loc is never null would easily stop this from happening. (Unless it happens again :X then I'll be darn surprised!!)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
