### PR TITLE
Job Equipment Tweak: Nomad Sunnies + Datapal

### DIFF
--- a/code/modules/jobs/job_types/hells_nomads.dm
+++ b/code/modules/jobs/job_types/hells_nomads.dm
@@ -32,6 +32,7 @@
 	jobtype = /datum/job/biker
 	suit = /obj/item/clothing/suit/armor/light/duster/brahmin/biker
 	ears = /obj/item/radio/headset/headset_biker
+	glasses = /obj/item/clothing/glasses/sunglasses
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	shoes = /obj/item/clothing/shoes/f13/cowboy
 	backpack = /obj/item/storage/backpack/satchel/explorer
@@ -42,6 +43,7 @@
 	box = /obj/item/storage/survivalkit
 	box_two = /obj/item/storage/survivalkit/medical
 	backpack_contents = list(
+		/obj/item/pda = 1,
 		/obj/item/storage/wallet/stash/low = 1,
 		/obj/item/kit_spawner/tools = 1,
 		/obj/item/cool_book/ashdowncit = 1

--- a/code/modules/jobs/job_types/hells_nomads.dm
+++ b/code/modules/jobs/job_types/hells_nomads.dm
@@ -32,7 +32,6 @@
 	jobtype = /datum/job/biker
 	suit = /obj/item/clothing/suit/armor/light/duster/brahmin/biker
 	ears = /obj/item/radio/headset/headset_biker
-	glasses = /obj/item/clothing/glasses/sunglasses
 	head = /obj/item/clothing/head/helmet/f13/khan/bandana
 	shoes = /obj/item/clothing/shoes/f13/cowboy
 	backpack = /obj/item/storage/backpack/satchel/explorer


### PR DESCRIPTION
## About The Pull Request
What this PR does is adds sunnies and datapal to the most baddest toughest biker gang that eats nails for breakfast, and now they just gotten cooler then what they were before. Finally coming in with sunnies and datapal in the beginning as it seemed like everyone else gotten one but them. 😎 

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: sunglasses + datapal to Nomads 
/:cl: