### PR TITLE
Fixing the character setup background not showing [ready to merge]

### DIFF
--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -55,12 +55,12 @@
 			mannequin.job = previewJob.title
 			previewJob.equip(mannequin, TRUE, preference_source = parent)
 
-	mannequin.cut_overlays()
 	mannequin.regenerate_icons()
 	COMPILE_OVERLAYS(mannequin)
 
 	parent.show_character_previews(new /mutable_appearance(mannequin))
 	SSdummy.return_dummy(mannequin)
+	mannequin.cut_overlays()
 
 /datum/preferences/proc/get_highest_job()
 	var/highest_pref = 0


### PR DESCRIPTION
## About The Pull Request
Fixes the character creator button to change background from complete void and black:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/ba38011b-bec3-4dc2-bce9-eb7dfbcf06ca)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/4058da24-553b-4a6c-abed-504187129d1b)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: fixed character setup "change background" button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
