### PR TITLE
Food Readdition: Cakes and Tarts

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -21,7 +21,6 @@
 
 /datum/crafting_recipe/food/clowncake
 	name = "Clown cake"
-	always_available = FALSE
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
 		/obj/item/reagent_containers/food/snacks/sundae = 2,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_donut.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_donut.dm
@@ -293,7 +293,6 @@
 
 /datum/crafting_recipe/food/dessert/vanillacake
 	name = "Vanilla cake"
-	always_available = FALSE
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
 		/obj/item/reagent_containers/food/snacks/grown/vanillapod = 2

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
@@ -200,9 +200,19 @@
 	result = /obj/item/reagent_containers/food/snacks/pie/amanita_pie
 	subcategory = CAT_PIE
 
+/datum/crafting_recipe/food/berrytart
+	name = "Berry tart"
+	reqs = list(
+			/datum/reagent/consumable/milk = 5,
+			/datum/reagent/consumable/sugar = 5,
+			/obj/item/reagent_containers/food/snacks/pie/plain = 1,
+			/obj/item/reagent_containers/food/snacks/grown/berries = 3
+			)
+	result = /obj/item/reagent_containers/food/snacks/pie/berrytart
+	subcategory = CAT_PIE
+
 /datum/crafting_recipe/food/cocolavatart
 	name = "Chocolate Lava tart"
-	always_available = FALSE
 	reqs = list(
 			/datum/reagent/consumable/milk = 5,
 			/datum/reagent/consumable/sugar = 5,


### PR DESCRIPTION
## About The Pull Request
What this PR does is finally readds vanilla cake, clown cake, chocolate lava tart and berry tart. Which was disabled for some reason I believe it was dr2 code back in the day. :D

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: a few food code that was always avaliable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
