### PR TITLE
Monophobia checks hands and backpack too; Animals can get up on their feet after getting tipped [ready to merge]

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -177,7 +177,6 @@
 		if(!isliving(M)) //ghosts ain't people
 			continue
 		if(M.is_monophobia_pet || M.ckey)
-			to_chat(world, span_clown("found in view!"))
 			return FALSE
 
 	//secondly let's check if our pet is actually in our backpack
@@ -187,13 +186,11 @@
 			if(storage.contents.len)  //if it has no items, don't even bother checking!
 				for(var/obj/item/I in storage.contents)  //Is an animal hiding in our backpack????
 					if(istype(I, /obj/item/clothing/head/mob_holder))
-						to_chat(world, span_clown("found in backpack!"))
 						return FALSE
 	
 	//thirdly let's actually check if the mob is being held in the hands
 	for(var/obj/item/I in owner.held_items)  //Is an animal hiding on our hands????
 		if(istype(I, /obj/item/clothing/head/mob_holder))
-			to_chat(world, span_clown("found in hands!"))
 			return FALSE
 
 	return TRUE

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -168,13 +168,34 @@
 		stress = max(stress - 4, 0)
 
 /datum/brain_trauma/severe/monophobia/proc/check_alone()
+	//is... the owner of the pet blind..? because if yes... then they may not see the pet.
 	if(HAS_TRAIT(owner, TRAIT_BLIND))
 		return TRUE
+
+	//firstly let's check if this pet is within our viewrange
 	for(var/mob/M in oview(owner, 7))
 		if(!isliving(M)) //ghosts ain't people
 			continue
 		if(M.is_monophobia_pet || M.ckey)
+			to_chat(world, span_clown("found in view!"))
 			return FALSE
+
+	//secondly let's check if our pet is actually in our backpack
+	var/obj/item/storage = owner.get_item_by_slot(SLOT_BACK)
+	if(storage)  //Are we actually wearing a backpack?
+		if(SEND_SIGNAL(storage, COMSIG_CONTAINS_STORAGE))  //Is the thing we are wearing on the back an actual storage item?
+			if(storage.contents.len)  //if it has no items, don't even bother checking!
+				for(var/obj/item/I in storage.contents)  //Is an animal hiding in our backpack????
+					if(istype(I, /obj/item/clothing/head/mob_holder))
+						to_chat(world, span_clown("found in backpack!"))
+						return FALSE
+	
+	//thirdly let's actually check if the mob is being held in the hands
+	for(var/obj/item/I in owner.held_items)  //Is an animal hiding on our hands????
+		if(istype(I, /obj/item/clothing/head/mob_holder))
+			to_chat(world, span_clown("found in hands!"))
+			return FALSE
+
 	return TRUE
 
 /datum/brain_trauma/severe/monophobia/proc/stress_reaction()

--- a/code/datums/elements/mob_holder.dm
+++ b/code/datums/elements/mob_holder.dm
@@ -203,7 +203,8 @@
 		L.forceMove(istype(here) && here != held_mob ? here : get_turf(L))
 		L.reset_perspective()
 		L.setDir(SOUTH)
-		L.SetAllImmobility(5 SECONDS, TRUE, TRUE)
+		if(!L.is_monophobia_pet)  //if it's a pet, don't stun it
+			L.SetAllImmobility(5 SECONDS, TRUE, TRUE)
 	if(!QDELETED(src))
 		qdel(src)
 

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -13,10 +13,24 @@
 	switch(M.a_intent)
 		if(INTENT_HELP)
 			if (health > 0)
-				visible_message(span_notice("[M] [response_help_continuous] [src]."), \
-								span_notice("[M] [response_help_continuous] you."), null, null, null,
-								M, span_notice("You [response_help_simple] [src]."))
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				if(!resting)
+					visible_message(span_notice("[M] [response_help_continuous] [src]."), \
+									span_notice("[M] [response_help_continuous] you."), null, null, null,
+									M, span_notice("You [response_help_simple] [src]."))
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				
+				else
+					M.visible_message(span_warning("[M] helps over [src]."),
+						span_notice("You help to get [src] back on its feet."))
+					to_chat(src, span_userdanger("You are being helped to get back up by [M]!"))
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+					icon = initial(icon)
+					icon_state = icon_living
+					density = initial(density)
+					lying = FALSE
+					set_resting(FALSE, silent = TRUE, updating = TRUE)
+					setMovetype(initial(movement_type))
 
 		if(INTENT_GRAB)
 			if(attacker_style && attacker_style.grab_act(M,src))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -363,24 +363,32 @@
 		M.visible_message(span_warning("[M] tips over [src]."),
 			span_notice("You tip over [src]."))
 		to_chat(src, span_userdanger("You are tipped over by [M]!"))
-		DefaultCombatKnockdown(60,ignore_canknockdown = TRUE)
+		DefaultCombatKnockdown(30, ignore_canknockdown = TRUE)
 		icon_state = icon_dead
-		spawn(rand(20,50))
-			if(!stat && M)
+
+		spawn(rand(40, 60))
+			if(!stat)
+				icon = initial(icon)
 				icon_state = icon_living
-				var/external
-				var/internal
-				switch(pick(1,2,3,4))
-					if(1,2,3)
-						var/text = pick("imploringly.", "pleadingly.",
-							"with a resigned expression.")
-						external = "[src] looks at [M] [text]"
-						internal = "You look at [M] [text]"
-					if(4)
-						external = "[src] seems resigned to its fate."
-						internal = "You resign yourself to your fate."
-				visible_message(span_notice("[external]"),
-					span_revennotice("[internal]"))
+				density = initial(density)
+				lying = FALSE
+				set_resting(FALSE, silent = TRUE, updating = TRUE)
+				setMovetype(initial(movement_type))
+
+				if(M)
+					var/external
+					var/internal
+					switch(pick(1,2,3,4))
+						if(1,2,3)
+							var/text = pick("imploringly.", "pleadingly.",
+								"with a resigned expression.")
+							external = "[src] looks at [M] [text]"
+							internal = "You look at [M] [text]"
+						if(4)
+							external = "[src] seems resigned to its fate."
+							internal = "You resign yourself to your fate."
+					visible_message(span_notice("[external]"),
+						span_revennotice("[internal]"))
 	else
 		..()
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,7 +17,7 @@ map pahrump-everything
 	adminonly
 endmap
 
-map pahrump-unit-test
+map pahrump-only
     default
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,7 +17,7 @@ map pahrump-everything
 	adminonly
 endmap
 
-map pahrump-only
+map pahrump-unit-test
     default
 endmap
 


### PR DESCRIPTION
## About The Pull Request
Monophobia, technically classified as severe brain injury in the code, actually gave me severe brain injury as well, while I was trying to fix it.
Now monophobia checks hands content and backpack contents as well! Meaning, you can carry your beloved pet in your bag and still feel their presence!

Edit: as someone pointed me out, pet animals were laying dead after being released on the ground, so I understood where the issue was and fixed it.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked monophobia to behave in a less dumb way.
fix: pet animals don't lay dead after being released.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
