### PR TITLE
Den QoL and Beautification

### DIFF
--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -54,6 +54,14 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"ay" = (
+/obj/structure/chair/right{
+	dir = 4
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "aA" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/locked_box/weapon/range/tier1_3,
@@ -315,6 +323,13 @@
 	dir = 5
 	},
 /turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"bD" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
 "bJ" = (
 /obj/machinery/power/tracker,
@@ -623,6 +638,15 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"cV" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "cW" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -1146,6 +1170,18 @@
 	smooth = 1
 	},
 /area/f13/building)
+"fy" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "fC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -2567,6 +2603,16 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
+"mw" = (
+/obj/structure/railing{
+	color = null;
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "mx" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3175,6 +3221,14 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"pk" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "pm" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -3381,6 +3435,15 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"qk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/transparent/openspace,
@@ -3424,6 +3487,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"qs" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "qt" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -3801,6 +3872,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"sd" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "se" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -4042,6 +4120,13 @@
 /obj/structure/flora/tree/cherryblossom4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tr" = (
+/obj/structure/window/fulltile/store,
+/obj/structure/barricade/bars,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ts" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4107,6 +4192,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark{
 	icon_state = "darkdirty"
 	},
+/area/f13/wasteland)
+"tE" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "tH" = (
 /obj/structure/cable{
@@ -4218,7 +4316,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "um" = (
-/obj/structure/chair/sofa/corner,
+/obj/structure/chair/right{
+	dir = 8
+	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -4478,6 +4578,19 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"vl" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "vo" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/indestructible/rock{
@@ -4502,6 +4615,15 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal/atonement)
+"vr" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tallgrass5,
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "vt" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -4891,8 +5013,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "xn" = (
-/turf/closed/wall/f13/coyote/fortress_brick,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "xo" = (
 /obj/structure/barricade/bars,
 /obj/structure/window/fulltile/store,
@@ -5000,10 +5125,12 @@
 "xJ" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 20
+	pixel_y = 0
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "xN" = (
 /obj/structure/simple_door/room{
@@ -5158,9 +5285,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
 "ym" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -6050,6 +6175,7 @@
 /obj/item/candle{
 	pixel_y = 5
 	},
+/obj/item/binoculars,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Cs" = (
@@ -6278,6 +6404,18 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"DE" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "DI" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -6669,7 +6807,9 @@
 	},
 /area/f13/wasteland)
 "Fs" = (
-/obj/structure/chair/sofa/right,
+/obj/structure/chair/left{
+	dir = 4
+	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -6721,6 +6861,18 @@
 	dir = 5
 	},
 /turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"FK" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "FL" = (
 /obj/structure/railing{
@@ -6979,11 +7131,15 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "GY" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Ha" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18";
@@ -7094,6 +7250,19 @@
 /obj/structure/flora/tree/oak_five,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"HA" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/tallgrass5,
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "HC" = (
 /turf/open/floor/plasteel/cult,
 /area/f13/wasteland)
@@ -7163,9 +7332,7 @@
 	},
 /area/f13/building)
 "HU" = (
-/obj/structure/chair/booth{
-	dir = 1
-	},
+/obj/structure/chair/bench,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -8103,10 +8270,12 @@
 "LW" = (
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 20
+	pixel_y = 0
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "LX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8344,6 +8513,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"Ng" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Nh" = (
 /turf/open/floor/grass{
 	color = "#225522"
@@ -8453,6 +8634,14 @@
 	dir = 2
 	},
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"ND" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
 "NH" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9021,6 +9210,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Qo" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "Qr" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -9316,6 +9514,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -9826,6 +10026,19 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Ta" = (
+/obj/structure/railing{
+	color = null;
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "Tc" = (
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior8"
@@ -10038,6 +10251,15 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal/atonement)
+"TJ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/wasteland)
 "TK" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -10598,6 +10820,13 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"We" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Wk" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/roof,
@@ -10694,7 +10923,7 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "WG" = (
-/obj/structure/chair/sofa/left{
+/obj/structure/chair/left{
 	dir = 8
 	},
 /turf/open/floor/wood_common{
@@ -10976,6 +11205,17 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/caves)
+"Yp" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Yr" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/planks{
@@ -11020,6 +11260,18 @@
 	dir = 4
 	},
 /turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"YF" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/booth,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing/blue,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "YJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42213,12 +42465,12 @@ hm
 hm
 jk
 jk
-xn
-xn
-xn
-xn
-ed
-ed
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
 hm
 hm
 hm
@@ -42472,11 +42724,11 @@ Ez
 Ez
 Ez
 VI
-pB
+qs
 xJ
 LW
 Ez
-hm
+Ez
 hm
 hm
 hm
@@ -42732,8 +42984,8 @@ Eq
 Eq
 Eq
 Eq
-Ez
-Ez
+rR
+tr
 hm
 hm
 hm
@@ -42989,7 +43241,7 @@ pB
 Eq
 Eq
 Eq
-rR
+Eq
 xo
 hm
 hm
@@ -44524,8 +44776,8 @@ Ez
 Ez
 Ez
 Fs
-dt
-HU
+ay
+Eq
 Eq
 Ez
 ed
@@ -44772,17 +45024,17 @@ Rx
 Eq
 xN
 Eq
+rR
+HU
+Eq
+HU
 Eq
 rR
-Eq
-Eq
-Eq
-Eq
 dv
 Ez
-GY
 dt
-HU
+dt
+Eq
 Eq
 Ez
 ed
@@ -45030,9 +45282,9 @@ Eq
 Ez
 Eq
 Eq
+HU
 Eq
-Eq
-Eq
+HU
 Eq
 Eq
 du
@@ -45282,7 +45534,7 @@ hm
 hm
 jk
 Ez
-Eq
+sL
 HT
 Ez
 XJ
@@ -45544,9 +45796,9 @@ JV
 Ez
 Eq
 Eq
+HU
 Eq
-Eq
-Eq
+HU
 Eq
 Eq
 du
@@ -45800,12 +46052,12 @@ ed
 Ez
 Ez
 Eq
+NZ
+HU
+Eq
+HU
 Eq
 NZ
-Eq
-Eq
-Eq
-Eq
 dv
 Ez
 Ez
@@ -51221,9 +51473,9 @@ gn
 gn
 gn
 Sp
-DY
-gn
-mb
+FK
+FK
+HA
 ez
 rj
 rj
@@ -51476,14 +51728,14 @@ tl
 oa
 ng
 gn
-gn
-gn
-Sp
-gn
-mb
-rj
+YF
+mw
+qk
+DE
+DE
+TJ
 Jv
-el
+ez
 ng
 gn
 ez
@@ -51733,13 +51985,13 @@ ez
 ez
 gn
 gn
-Sp
-gn
-gn
-Sp
+Yp
+Qo
+xn
+sd
 yl
-tl
-Sp
+bD
+Yp
 ez
 oa
 gn
@@ -51989,14 +52241,14 @@ hV
 cZ
 IY
 ez
-el
-gn
-Sp
 ez
-ez
-gn
-yr
-tl
+GY
+Qo
+xn
+xn
+xn
+ND
+pk
 gn
 tl
 gn
@@ -52247,13 +52499,13 @@ uq
 IY
 ez
 ez
-ez
-vg
-uX
-ez
-gn
-yr
-XH
+We
+vl
+yl
+xn
+xn
+bD
+vr
 gn
 tl
 Hm
@@ -52505,11 +52757,11 @@ IY
 yr
 gn
 SY
-gn
-ez
-tl
-gh
-ez
+Ta
+fy
+fy
+fy
+cV
 ez
 mb
 tl
@@ -52763,9 +53015,9 @@ ez
 yr
 dW
 ez
-gn
-DY
-Sp
+Ng
+Ng
+tE
 eX
 tl
 XH

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -685,6 +685,11 @@
 /obj/machinery/hydroponics/soil/pot,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"aqg" = (
+/turf/open/floor/grass{
+	color = "#225522"
+	},
+/area/f13/caves)
 "aqu" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -733,7 +738,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "arj" = (
-/obj/structure/flora/wasteplant/wild_feracactus,
+/obj/structure/legion_extractor,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/building)
 "arl" = (
@@ -1692,6 +1697,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"aOw" = (
+/obj/structure/sink/well{
+	pixel_x = 12;
+	pixel_y = -8
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "aOy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/black,
@@ -1865,10 +1877,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
-"aUJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "aUQ" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -2134,10 +2142,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"bcZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "bdf" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -3391,6 +3395,13 @@
 	color = "#779999"
 	},
 /area/f13/wasteland/nash)
+"bHQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "bIj" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -3543,6 +3554,10 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
+"bNL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "bNT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -4079,6 +4094,10 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"ccP" = (
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ccR" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -4478,10 +4497,6 @@
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
-"com" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "cop" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4533,13 +4548,6 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/building/abandoned)
-"cpB" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "cpF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5267,16 +5275,6 @@
 	color = "#779999"
 	},
 /area/f13/wasteland/nash)
-"cKX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "cLm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5413,10 +5411,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"cPr" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "cPA" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
@@ -5429,6 +5423,7 @@
 /area/f13/building/abandoned)
 "cQl" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
 	},
@@ -5633,7 +5628,8 @@
 	},
 /area/f13/wasteland/nash)
 "cUY" = (
-/turf/closed/indestructible/rock,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "cVc" = (
 /obj/structure/railing/corner,
@@ -6363,10 +6359,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"dpA" = (
-/obj/item/shovel/spade,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "dpB" = (
 /turf/open/floor/plating/snowed/colder,
 /area/f13/wasteland)
@@ -8202,7 +8194,7 @@
 /area/f13/wasteland)
 "emQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/cultivator/rake,
+/obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "enl" = (
@@ -8391,6 +8383,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bar/heaven)
+"etA" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "etE" = (
 /obj/machinery/light{
 	dir = 8
@@ -8477,20 +8477,16 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
+"evM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "evN" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/repaired,
 /obj/item/lock_bolt,
 /turf/open/floor/wood_wide,
-/area/f13/building)
-"evP" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
 /area/f13/building)
 "evQ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -8625,6 +8621,10 @@
 	icon_state = "bluerustychess"
 	},
 /area/f13/building)
+"eAC" = (
+/obj/structure/bed/dogbed,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eAD" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/inside/subway,
@@ -9643,6 +9643,11 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"eZA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "eZQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10143,12 +10148,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
-"fnE" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/caves)
 "fnX" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -10273,6 +10272,11 @@
 	initial_gas_mix = "o2=22;n2=82;miasma=44;TEMP=293.15"
 	},
 /area/f13/building/abandoned)
+"fqF" = (
+/obj/structure/flora/tallgrass5,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "frq" = (
 /obj/structure/fence/door{
 	dir = 4
@@ -10890,6 +10894,9 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"fFE" = (
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "fFL" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -10967,6 +10974,16 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"fHZ" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fIs" = (
 /obj/structure/chair/stool{
 	dir = 4;
@@ -11945,10 +11962,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/mall)
-"gjo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+"gjl" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "gjF" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -12228,6 +12246,10 @@
 	light_range = 2
 	},
 /area/f13/wasteland)
+"gpQ" = (
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "gpR" = (
 /obj/structure/flora/rock/pile/largejungle{
 	icon_state = "bush3"
@@ -12997,6 +13019,10 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gHd" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "gHi" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -13705,11 +13731,6 @@
 /obj/item/reagent_containers/food/snacks/meat/steak/gondola,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
-"gZl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "gZp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -14023,6 +14044,11 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"hhi" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "hhu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -14364,7 +14390,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/hydroponics/soil,
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/building)
 "hnn" = (
@@ -14376,13 +14402,6 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/building/abandoned)
-"hno" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "hnv" = (
 /obj/structure/closet/crate/footlocker,
 /obj/item/broom,
@@ -14418,15 +14437,13 @@
 	},
 /area/f13/bar/nash)
 "hnO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c"
+/turf/open/floor/grass{
+	color = "#225522"
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/area/f13/caves)
 "hnP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -14461,6 +14478,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building/hospital/clinic/nash)
+"hpE" = (
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "hpS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14663,6 +14684,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"hto" = (
+/obj/structure/flora/tallgrass5,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "htF" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -14841,7 +14866,12 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "hyz" = (
-/turf/open/floor/plating/dirt,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
 /area/f13/caves)
 "hyM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15099,11 +15129,6 @@
 /area/f13/building)
 "hFx" = (
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"hFD" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/closed/indestructible/rock,
 /area/f13/caves)
 "hFG" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -15470,6 +15495,10 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"hQS" = (
+/obj/effect/landmark/start/f13/wastelander/den,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "hRp" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -15534,9 +15563,6 @@
 	color = "#b2b2b2"
 	},
 /area/f13/building/mall)
-"hSJ" = (
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "hSQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -15627,6 +15653,14 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"hWr" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hWC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15751,6 +15785,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"hZf" = (
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "hZm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -16329,6 +16366,14 @@
 	sunlight_state = 1
 	},
 /area/f13/building/mall)
+"ipE" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#9c9c9c"
+	},
+/area/f13/caves)
 "ipJ" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -19383,10 +19428,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"jRz" = (
-/obj/structure/barricade/wooden,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
 "jRL" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -20148,6 +20189,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"kmf" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "kms" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20845,10 +20892,6 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
-"kCs" = (
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "kCu" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -20965,6 +21008,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"kDo" = (
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "kDu" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -21166,10 +21216,9 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"kHk" = (
-/turf/open/floor/grass{
-	color = "#225522"
-	},
+"kHz" = (
+/obj/structure/barricade/wooden,
+/turf/closed/indestructible/rock,
 /area/f13/caves)
 "kHO" = (
 /obj/structure/table/reinforced{
@@ -21272,7 +21321,7 @@
 /area/f13/building/hospital)
 "kJq" = (
 /obj/effect/landmark/start/f13/wastelander/den,
-/turf/open/floor/plating/dirt,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/caves)
 "kKc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21334,12 +21383,6 @@
 	icon_state = "wide-broken6"
 	},
 /area/f13/wasteland)
-"kKR" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "kLl" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -21512,9 +21555,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/floor/grass{
-	color = "#225522"
-	},
+/turf/open/floor/plating/dirt,
 /area/f13/caves)
 "kRD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -21558,6 +21599,11 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"kSG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "kTe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21690,6 +21736,11 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/wood_common,
 /area/f13/caves)
+"kVE" = (
+/obj/structure/flora/tallgrass5,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "kWr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rug/big/rug_yellow{
@@ -21989,6 +22040,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
+"leP" = (
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "lfe" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22097,9 +22152,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"lib" = (
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "lig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/fulltile/house,
@@ -22266,6 +22318,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"lnA" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lnM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -22372,17 +22428,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/wall/f13/store,
 /area/f13/building/hospital)
-"lqm" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/turf/closed/indestructible/rock,
-/area/f13/caves)
 "lqs" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/blood/drip,
@@ -22559,8 +22604,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "lvv" = (
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
+"lvD" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lvE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -23007,6 +23060,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"lFv" = (
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "lFw" = (
 /mob/living/simple_animal/hostile/renegade,
 /turf/open/indestructible/ground/outside/roof,
@@ -23948,7 +24004,7 @@
 "mdU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "mdW" = (
 /obj/structure/spacevine,
@@ -24543,6 +24599,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/f13/bar/heaven)
+"mvO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "mvR" = (
 /obj/structure/table/glass,
 /turf/open/floor/wood_common,
@@ -24785,6 +24848,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"mBe" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "mBg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25029,6 +25097,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"mHN" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "mIa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -25161,8 +25233,10 @@
 /area/f13/wasteland)
 "mJY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "mKa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25312,13 +25386,6 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
-"mMQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "mNn" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -27045,6 +27112,10 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
+"nEF" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "nEG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -27211,12 +27282,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
-"nKj" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "nKk" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13{
@@ -27644,12 +27709,6 @@
 /obj/structure/flora/tree/oak_four,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"nRk" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "nRq" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -28431,6 +28490,12 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building)
+"omN" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "omQ" = (
 /obj/structure/dresser{
 	pixel_y = 10
@@ -28523,6 +28588,12 @@
 "oqG" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
+"orb" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/caves)
 "org" = (
 /obj/structure/fluff/hedge,
@@ -28637,11 +28708,6 @@
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
 	},
-/area/f13/wasteland)
-"otx" = (
-/obj/structure/flora/tallgrass5,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "otX" = (
 /obj/structure/window/fulltile/store{
@@ -29294,14 +29360,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"oMd" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/turf/closed/indestructible/rock,
-/area/f13/caves)
 "oMf" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -30145,7 +30203,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
+/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "plV" = (
@@ -30162,10 +30220,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"pnK" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "pog" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
@@ -30211,6 +30265,10 @@
 	icon_state = "wide-broken5"
 	},
 /area/f13/wasteland)
+"ppP" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "ppS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/concrete,
@@ -30412,6 +30470,10 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"puH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "puJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -30438,6 +30500,17 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"pwl" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 5
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
+	},
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "pws" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -31195,10 +31268,6 @@
 	color = "#779999"
 	},
 /area/f13/wasteland/nash)
-"pOZ" = (
-/obj/effect/landmark/start/f13/wastelander/den,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/caves)
 "pPv" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gatehouse";
@@ -31435,6 +31504,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pWq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "pWr" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -31878,10 +31957,6 @@
 	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
-"qhd" = (
-/obj/structure/bed/dogbed,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "qhe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -32191,6 +32266,15 @@
 /obj/structure/spacevine,
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
+"qqe" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "qqh" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -32482,17 +32566,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
-"quQ" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/caves)
 "quR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33211,6 +33284,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/wasteplant/wild_xander,
+/obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "qSl" = (
@@ -33335,8 +33409,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qYc" = (
-/obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/building)
 "qYp" = (
@@ -33662,14 +33736,6 @@
 /obj/structure/fluff/hedge,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"rhj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/structure/flora/wasteplant/wild_feracactus,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "rhl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33907,11 +33973,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
-"rlB" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "rlI" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -33999,10 +34060,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"rmd" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "rmk" = (
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic/nash)
@@ -34071,6 +34128,12 @@
 	color = "#11ff11"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"rpe" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "rpk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -35042,6 +35105,7 @@
 	color = "#a98c5d";
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "rOK" = (
@@ -35643,13 +35707,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"shh" = (
+"sgY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "shp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -35703,11 +35767,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
-"siA" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "sjo" = (
 /mob/living/simple_animal/hostile/wolf/alpha{
 	name = "Terror"
@@ -35803,14 +35862,6 @@
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
-"skW" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#9c9c9c"
-	},
-/area/f13/caves)
 "slj" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
@@ -35938,6 +35989,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"sqM" = (
+/obj/structure/flora/tallgrass5,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "sqS" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -36345,12 +36402,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"sET" = (
-/obj/structure/simple_door/metal/fence/wooden{
-	dir = 2
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "sFc" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/f13/wood{
@@ -36649,11 +36700,6 @@
 /obj/structure/table/plasmaglass,
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
-"sOf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "sOp" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -37165,10 +37211,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
-"tbB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
 "tbR" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -37537,14 +37579,6 @@
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"tkl" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 6
-	},
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "tkm" = (
 /mob/living/simple_animal/hostile/renegade,
 /obj/structure/chair,
@@ -37824,13 +37858,6 @@
 	color = "#775555"
 	},
 /area/f13/building)
-"tpI" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "tpK" = (
 /turf/closed/wall/f13/store,
 /area/f13/building)
@@ -37935,6 +37962,11 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"trg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/cultivator/rake,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "tsD" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -38178,6 +38210,10 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"tzz" = (
+/obj/item/shovel/spade,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "tzG" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/f13{
@@ -38326,10 +38362,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tDg" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "tDj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /mob/living/simple_animal/hostile/radroach/strongradroach,
@@ -39237,6 +39269,17 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
+"tZo" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
+/area/f13/caves)
 "tZQ" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -39315,6 +39358,14 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"udw" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
+	},
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "udH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -39330,10 +39381,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
 /area/f13/caves)
-"udM" = (
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "udQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge/standard,
@@ -39717,9 +39764,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"uoL" = (
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/caves)
 "uoR" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -39752,12 +39796,6 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"upF" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
 "uqj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -40312,16 +40350,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
-"uDo" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "uEj" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -40654,20 +40682,6 @@
 	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland)
-"uOB" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
-"uOF" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "uOS" = (
 /obj/machinery/light/small{
@@ -41573,6 +41587,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/mall)
+"vld" = (
+/obj/structure/chair/bench,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "vlj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -41769,13 +41787,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vqd" = (
-/obj/structure/sink/well{
-	pixel_x = 12;
-	pixel_y = -8
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
 "vqf" = (
 /obj/structure/campfire/stove{
 	pixel_y = 10
@@ -41856,10 +41867,6 @@
 	},
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"vrM" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "vrR" = (
 /obj/structure/spacevine{
@@ -42047,10 +42054,6 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"vzK" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "vzN" = (
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/shoes/sneakers/orange,
@@ -42375,7 +42378,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "vFL" = (
 /obj/structure/window/fulltile/house{
@@ -43732,6 +43735,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"wsr" = (
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
+/area/f13/wasteland)
 "wss" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -43748,10 +43757,8 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "wtB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "wtF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/wood,
@@ -43869,6 +43876,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bar/heaven)
+"wvK" = (
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "wvT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44276,10 +44290,6 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"wHC" = (
-/obj/structure/flora/wasteplant/wild_broc,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
 "wHI" = (
 /obj/effect/turf_decal/trimline/neutral{
 	dir = 4;
@@ -45038,6 +45048,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"xdp" = (
+/obj/structure/simple_door/metal/fence/wooden{
+	dir = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "xdJ" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -45048,6 +45064,11 @@
 	dir = 1
 	},
 /area/f13/building/hospital)
+"xed" = (
+/obj/effect/temp_visual/steam,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "xel" = (
 /obj/structure/spacevine,
 /turf/open/floor/wood_wide{
@@ -45340,14 +45361,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
-"xoV" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/caves)
 "xpm" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
@@ -45418,6 +45431,13 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"xsB" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xsC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -46260,12 +46280,6 @@
 	color = "#11ff11"
 	},
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"xNF" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "xNW" = (
 /obj/structure/barricade/wooden/planks{
@@ -80645,7 +80659,7 @@ lyA
 jgn
 hMq
 vfT
-evP
+qqe
 lXs
 hMq
 rfh
@@ -80902,7 +80916,7 @@ jgn
 iXk
 tyE
 gig
-uOB
+etA
 xAb
 hMq
 qOx
@@ -81925,8 +81939,8 @@ iEJ
 dxi
 hMq
 vje
-hSJ
-lib
+fFE
+wtB
 oDY
 xAb
 hya
@@ -82169,20 +82183,20 @@ cjA
 cjA
 cjA
 oFf
-hSJ
-hSJ
-lib
-lib
-lib
-hSJ
-hSJ
-hSJ
-lib
-hSJ
-lib
-lib
-nRk
-hSJ
+fFE
+fFE
+wtB
+wtB
+wtB
+fFE
+fFE
+fFE
+wtB
+fFE
+wtB
+wtB
+gjl
+fFE
 hfs
 nWw
 xAb
@@ -82424,9 +82438,9 @@ iRb
 vje
 cjA
 qtg
-pOZ
-uoL
-lib
+kJq
+lFv
+wtB
 ryv
 ryv
 xJi
@@ -82439,7 +82453,7 @@ lyA
 mlA
 xJi
 bkG
-hSJ
+fFE
 jgn
 dMq
 vsz
@@ -82681,9 +82695,9 @@ iRb
 vje
 cjA
 qtg
-pOZ
-hyz
-lib
+kJq
+hZf
+wtB
 lyA
 lyR
 owA
@@ -82696,7 +82710,7 @@ lyA
 owA
 lyA
 wZa
-hSJ
+fFE
 jgn
 iEJ
 iEJ
@@ -82938,9 +82952,9 @@ iRb
 vje
 cjA
 qtg
-kJq
-hyz
-lib
+hQS
+hZf
+wtB
 hfs
 lyA
 owA
@@ -82953,7 +82967,7 @@ lTF
 tQp
 jgn
 pIp
-lib
+wtB
 lyA
 aht
 lyA
@@ -83195,25 +83209,25 @@ iRb
 vje
 cjA
 qtg
-pOZ
-uoL
-lib
+kJq
+lFv
+wtB
 ryv
 mlA
 jgn
 ryv
-hSJ
-hSJ
+fFE
+fFE
 owA
 jgn
 mlA
 wCP
 wCP
 otu
-tbB
-xNF
-bcZ
-mMQ
+puH
+kmf
+cUY
+mvO
 dze
 tpg
 tcm
@@ -83452,25 +83466,25 @@ iRb
 vje
 cjA
 qtg
-kJq
-uoL
-lib
+hQS
+lFv
+wtB
 jgn
 fwT
 lyA
-hSJ
+fFE
 ccE
-nKj
-nKj
-lib
+rpe
+rpe
+wtB
 lyA
 eQv
 wCP
 pIp
-lib
-tbB
-shh
-cKX
+wtB
+puH
+bHQ
+pWq
 nZK
 qLq
 tcm
@@ -83715,19 +83729,19 @@ wdc
 jgn
 lyA
 lyA
-pnK
-hSJ
-vqd
-lib
-lib
+vld
+fFE
+aOw
+wtB
+wtB
 lyA
 lyA
 lyA
 otu
-mMQ
-mdU
-mdU
-mMQ
+mvO
+eZA
+eZA
+mvO
 kDC
 xku
 tcm
@@ -83972,16 +83986,16 @@ vje
 lyA
 ryv
 lyR
-pnK
-hSJ
-hSJ
-vrM
-lib
-lib
-lib
-lib
-lib
-lib
+vld
+fFE
+fFE
+nEF
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
 hqF
 xUt
 vVm
@@ -84229,16 +84243,16 @@ vje
 lyA
 ryv
 pIV
-pnK
-mJY
-gZl
-lib
-lib
+vld
+evM
+kSG
+wtB
+wtB
 rMp
 heq
 ryv
 lyA
-lib
+wtB
 lyA
 jgn
 lyA
@@ -84486,16 +84500,16 @@ uwq
 lgs
 mzZ
 ryv
-lib
-hno
-hno
+wtB
+mJY
+mJY
 aOb
-hSJ
+fFE
 aFK
 wZa
 lyA
 heq
-shh
+bHQ
 lyA
 tpK
 qSt
@@ -84736,7 +84750,7 @@ vje
 iRb
 gJP
 gJP
-kKR
+omN
 jzb
 mnU
 txV
@@ -84744,15 +84758,15 @@ acG
 xma
 lyA
 tcN
-vrM
-udM
+nEF
+hto
 bEe
 qiY
 tcN
 wZa
 lyA
 wUY
-gjo
+mdU
 lyA
 tpK
 kcn
@@ -84991,9 +85005,9 @@ oez
 oez
 oez
 iRb
-tDg
-tpI
-tkl
+lvD
+xsB
+hWr
 mnU
 mnU
 txV
@@ -85009,7 +85023,7 @@ qiY
 otu
 lyA
 otu
-tbB
+puH
 lyA
 qSt
 qDJ
@@ -85249,7 +85263,7 @@ oez
 oez
 iRb
 gJP
-uDo
+fHZ
 wCn
 pte
 cnH
@@ -85266,7 +85280,7 @@ otu
 ipP
 lyA
 hqF
-lib
+wtB
 lyA
 qSt
 tpK
@@ -85506,7 +85520,7 @@ oez
 oez
 iRb
 gJP
-vzK
+lnA
 fSd
 dIW
 haD
@@ -85520,10 +85534,10 @@ tpK
 lyA
 lyA
 qls
-mdU
-tbB
-bcZ
-bcZ
+eZA
+puH
+cUY
+cUY
 lyA
 cLD
 sbk
@@ -85761,8 +85775,8 @@ oez
 oez
 oez
 oez
-oMd
-tDg
+udw
+lvD
 gJP
 fSd
 lbc
@@ -85771,16 +85785,16 @@ qtT
 rhW
 uBg
 dik
-cPr
-cpB
+gHd
+lvv
 oLF
 lyA
 lyA
 tAR
-mdU
+eZA
 wCP
 nxF
-lib
+wtB
 lyA
 tpK
 kES
@@ -86018,26 +86032,26 @@ oez
 oez
 oez
 oez
-hFD
+mBe
 gJP
-kCs
-sET
+ccP
+xdp
 evy
-vFD
+sgY
 hFG
 rSL
 beR
 jXS
-arj
-dpA
+leP
+tzz
 oLF
 lyA
 hfs
 lyA
-tbB
+puH
 otu
 otu
-mdU
+eZA
 dfD
 tpK
 vui
@@ -86275,11 +86289,11 @@ oez
 oez
 oez
 oez
-jRz
-vzK
+kHz
+lnA
 gJP
 fSd
-com
+kDo
 qSg
 lnp
 wql
@@ -86291,11 +86305,11 @@ oLF
 qNW
 qNW
 otu
-mdU
+eZA
 lyA
 wCP
-bcZ
-lib
+cUY
+wtB
 men
 xDk
 xDk
@@ -86305,7 +86319,7 @@ xDk
 xDk
 xDk
 men
-kRq
+hnO
 oOB
 pUj
 pUj
@@ -86532,26 +86546,26 @@ oez
 oez
 oez
 oez
-lqm
-tDg
+pwl
+lvD
 gJP
 wAl
-wtB
-sOf
-rhj
+dYn
+emQ
+vFD
 kaD
 rOb
-emQ
+trg
 cFh
-wHC
+ppP
 oLF
 jgn
 ryv
 otu
-gjo
+mdU
 ryv
 qls
-aUJ
+bNL
 lyA
 dZt
 qgO
@@ -86562,7 +86576,7 @@ lqv
 nlQ
 alP
 tpK
-skW
+ipE
 oOB
 jxp
 jxp
@@ -86788,27 +86802,27 @@ mbu
 mbu
 mbu
 mbu
-cUY
 iRb
-kCs
+iRb
+ccP
 gJP
 fSd
 plz
 lvv
-hnO
+vFD
 yiT
 hnm
-dik
+arj
 qYc
-cpB
+hpE
 fSd
-lyA
+wsr
 ryv
 wUY
-gjo
+mdU
 wZa
 lyA
-rlB
+kVE
 fwT
 qSt
 nof
@@ -86819,7 +86833,7 @@ otX
 tpK
 dZt
 oga
-skW
+ipE
 tpK
 hbz
 jxp
@@ -87045,10 +87059,10 @@ mbu
 mbu
 mbu
 mbu
-cUY
-qhd
+iRb
+eAC
 gJP
-kCs
+ccP
 fSd
 fSd
 iMa
@@ -87062,21 +87076,21 @@ lKt
 lyA
 lyA
 ryv
-gjo
+mdU
 pLU
-otx
-bcZ
-rmd
-rmd
+fqF
+cUY
+mHN
+mHN
+hZf
+hZf
+lFv
+lFv
 hyz
-hyz
-uoL
-uoL
-xoV
 gpe
-kRq
-kRq
-kRq
+hnO
+hnO
+hnO
 tpK
 fpX
 jxp
@@ -87302,8 +87316,8 @@ mbu
 mbu
 mbu
 mbu
-cUY
-qhd
+iRb
+eAC
 gJP
 vje
 fSd
@@ -87314,26 +87328,26 @@ aFC
 tBF
 haY
 cdN
-siA
+hhi
 fSd
 hfs
 jgn
 nxF
-tbB
+puH
 mky
-uOF
+sqM
 xnJ
 fSd
 qAP
 fSd
 qAP
 dIW
+hZf
+hZf
+hnO
 hyz
 hyz
-kRq
-xoV
-xoV
-kRq
+hnO
 tpK
 wZx
 jxp
@@ -87559,7 +87573,7 @@ mbu
 mbu
 mbu
 mbu
-cUY
+iRb
 iRb
 vje
 vje
@@ -87576,21 +87590,21 @@ tke
 jgn
 qNW
 wCP
-mdU
+eZA
 bkG
-bcZ
+cUY
 amX
 iok
 iok
 icJ
 jGi
 fSd
+hnO
 kRq
-upF
-hyz
-kRq
-kRq
-kRq
+hZf
+hnO
+hnO
+hnO
 tpK
 vNA
 jxp
@@ -87816,7 +87830,7 @@ mbu
 mbu
 mbu
 mbu
-cUY
+iRb
 spb
 spb
 oSM
@@ -87830,10 +87844,10 @@ oxM
 cdN
 cdN
 lnR
-lib
-bcZ
-gjo
-tbB
+wtB
+cUY
+mdU
+puH
 wZa
 lyA
 fSd
@@ -87842,12 +87856,12 @@ lxD
 vFs
 fSd
 fSd
-kRq
-xoV
-uoL
-fnE
-xoV
-kRq
+hnO
+hyz
+lFv
+orb
+hyz
+hnO
 tpK
 wZx
 jxp
@@ -88099,12 +88113,12 @@ nkJ
 agm
 rmt
 fSd
-xoV
-kRq
-kRq
 hyz
-xoV
-kRq
+hnO
+hnO
+hZf
+hyz
+hnO
 tpK
 tpK
 tpK
@@ -88356,12 +88370,12 @@ nkJ
 akk
 ehZ
 fSd
-xoV
-quQ
-kHk
 hyz
-kRq
-kRq
+tZo
+aqg
+hZf
+hnO
+hnO
 tpK
 pdm
 fIs
@@ -88613,12 +88627,12 @@ fSd
 fSd
 dDO
 dIW
-kRq
-quQ
-xoV
+hnO
+tZo
 hyz
-uoL
-upF
+hZf
+lFv
+kRq
 rwS
 jxp
 jxp
@@ -88873,7 +88887,7 @@ vje
 vje
 vje
 vje
-kRq
+hnO
 gpe
 gpe
 tpK
@@ -89365,7 +89379,7 @@ oez
 oez
 oez
 oez
-ueB
+xed
 ueB
 oez
 ueB
@@ -90133,7 +90147,7 @@ oez
 oez
 oez
 oez
-oez
+wvK
 oez
 oez
 oez
@@ -92451,7 +92465,7 @@ oez
 oez
 vje
 vje
-vje
+gpQ
 vje
 vje
 vje

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -733,12 +733,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "arj" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "arl" = (
 /obj/structure/flora/grass/coyote/four,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1662,11 +1659,10 @@
 	},
 /area/f13/building/massfusion)
 "aOb" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/tallgrass5,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/chair/bench{
+	dir = 4
 	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "aOf" = (
 /obj/machinery/light/small{
@@ -1784,7 +1780,7 @@
 	color = "#a98c5d"
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/area/f13/building)
 "aRy" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag,
@@ -1869,6 +1865,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
+"aUJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "aUQ" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -2134,6 +2134,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"bcZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "bdf" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -2195,12 +2199,9 @@
 	color = "#a98c5d";
 	dir = 1
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "beW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3094,7 +3095,7 @@
 "bCe" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/item/defibrillator,
+/obj/item/defibrillator/primitive,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -3218,9 +3219,7 @@
 "bEe" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tallgrass5,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "bEr" = (
 /obj/structure/closet/secure_closet/medical1{
@@ -3471,7 +3470,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "bLU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -4059,12 +4058,10 @@
 /area/f13/caves)
 "ccE" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/tree/jungle{
-	color = "#999999"
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "ccJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4481,6 +4478,10 @@
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"com" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "cop" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4532,6 +4533,13 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/building/abandoned)
+"cpB" = (
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "cpF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5076,8 +5084,8 @@
 /area/f13/wasteland)
 "cFh" = (
 /obj/structure/flora/wasteplant/wild_xander,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "cFp" = (
 /obj/item/mine/shrapnel,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -5259,6 +5267,16 @@
 	color = "#779999"
 	},
 /area/f13/wasteland/nash)
+"cKX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "cLm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5394,6 +5412,10 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
+/area/f13/building)
+"cPr" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "cPA" = (
 /obj/structure/railing/corner,
@@ -6073,9 +6095,12 @@
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
 "dik" = (
-/obj/structure/flora/wasteplant/wild_broc,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "din" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6338,6 +6363,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"dpA" = (
+/obj/item/shovel/spade,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "dpB" = (
 /turf/open/floor/plating/snowed/colder,
 /area/f13/wasteland)
@@ -6446,9 +6475,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "dse" = (
-/obj/structure/flora/wasteplant/wild_feracactus,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "dsG" = (
 /obj/machinery/button/door{
 	id = "knowledgeking";
@@ -6709,7 +6739,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "dzz" = (
 /obj/machinery/vending/cola/red,
@@ -6781,6 +6811,8 @@
 	dir = 8
 	},
 /obj/structure/anvil/obtainable/basic,
+/obj/item/twohanded/sledgehammer/simple,
+/obj/item/clothing/gloves/f13/blacksmith,
 /turf/open/indestructible/cobble{
 	color = "#777777";
 	light_color = null
@@ -7886,7 +7918,7 @@
 "edZ" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "eed" = (
 /obj/structure/simple_door/room/dirty,
 /turf/open/floor/f13/wood,
@@ -8170,8 +8202,9 @@
 /area/f13/wasteland)
 "emQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/item/cultivator/rake,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "enl" = (
 /obj/structure/filingcabinet{
 	pixel_x = -8
@@ -8430,7 +8463,7 @@
 	pixel_x = -16
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "evC" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/poddoor/shutters{
@@ -8449,6 +8482,15 @@
 /obj/structure/simple_door/repaired,
 /obj/item/lock_bolt,
 /turf/open/floor/wood_wide,
+/area/f13/building)
+"evP" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "evQ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -10101,6 +10143,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
+"fnE" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "fnX" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -10230,7 +10278,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "frs" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11897,6 +11945,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/mall)
+"gjo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "gjF" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -12795,7 +12848,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "gDs" = (
-/obj/structure/curtain,
+/obj/structure/curtain{
+	color = "#845f58";
+	open = 0
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
 	},
@@ -12938,6 +12994,7 @@
 "gGq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/shelf_wood,
+/obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gHi" = (
@@ -13648,6 +13705,11 @@
 /obj/item/reagent_containers/food/snacks/meat/steak/gondola,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
+"gZl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "gZp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -14302,12 +14364,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "hnn" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -14317,6 +14376,13 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/building/abandoned)
+"hno" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "hnv" = (
 /obj/structure/closet/crate/footlocker,
 /obj/item/broom,
@@ -14359,8 +14425,8 @@
 /obj/machinery/hydroponics/soil{
 	color = "#9c9c9c"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "hnP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -14775,16 +14841,8 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "hyz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink/well{
-	pixel_x = 12;
-	pixel_y = -8
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "hyM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -15042,13 +15100,18 @@
 "hFx" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"hFD" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "hFG" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
 	dir = 5
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "hGb" = (
 /obj/structure/bed/old,
 /obj/item/blanket/blanketalt,
@@ -15471,6 +15534,9 @@
 	color = "#b2b2b2"
 	},
 /area/f13/building/mall)
+"hSJ" = (
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "hSQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16156,10 +16222,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "inU" = (
-/obj/structure/flora/wasteplant/wild_broc,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "iok" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -17138,8 +17204,11 @@
 "iMa" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
-/obj/structure/curtain,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#845f58";
+	open = 0
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iMn" = (
@@ -17962,11 +18031,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "jhc" = (
+/obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/tree/pink_tree{
 	pixel_x = -35;
 	pixel_y = 5
 	},
-/obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "jhe" = (
@@ -18568,8 +18637,12 @@
 /area/f13/ruins)
 "jvR" = (
 /obj/item/clothing/gloves/botanic_leather,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "jvX" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-02"
@@ -19310,6 +19383,10 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"jRz" = (
+/obj/structure/barricade/wooden,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "jRL" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -19529,9 +19606,8 @@
 	},
 /area/f13/wasteland)
 "jXS" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "jYv" = (
 /obj/structure/sink/greyscale{
 	color = "#715030";
@@ -19662,9 +19738,11 @@
 	density = 0;
 	pixel_y = -12
 	},
-/obj/structure/barricade/wooden/planks,
+/obj/structure/barricade/wooden/planks{
+	density = 0
+	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "kaR" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -20767,6 +20845,10 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"kCs" = (
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kCu" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -20927,7 +21009,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "kDD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -21084,6 +21166,11 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"kHk" = (
+/turf/open/floor/grass{
+	color = "#225522"
+	},
+/area/f13/caves)
 "kHO" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -21185,7 +21272,7 @@
 /area/f13/building/hospital)
 "kJq" = (
 /obj/effect/landmark/start/f13/wastelander/den,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/caves)
 "kKc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21247,6 +21334,12 @@
 	icon_state = "wide-broken6"
 	},
 /area/f13/wasteland)
+"kKR" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kLl" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -21419,7 +21512,9 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/grass{
+	color = "#225522"
+	},
 /area/f13/caves)
 "kRD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -21743,7 +21838,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "lbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -22002,6 +22097,9 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"lib" = (
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "lig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/fulltile/house,
@@ -22160,8 +22258,8 @@
 	color = "#9c9c9c";
 	pixel_y = 7
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "lnw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -22274,6 +22372,17 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/wall/f13/store,
 /area/f13/building/hospital)
+"lqm" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 5
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
+	},
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "lqs" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/blood/drip,
@@ -22450,8 +22559,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "lvv" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "lvE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -23839,7 +23948,7 @@
 "mdU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "mdW" = (
 /obj/structure/spacevine,
@@ -24030,8 +24139,12 @@
 	color = "#a98c5d";
 	dir = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "mkp" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25049,9 +25162,7 @@
 "mJY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "mKa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25201,6 +25312,13 @@
 	icon_state = "neutralrustyfull"
 	},
 /area/f13/building)
+"mMQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "mNn" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -25441,7 +25559,9 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mTt" = (
@@ -27091,6 +27211,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"nKj" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "nKk" = (
 /obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13{
@@ -27518,6 +27644,12 @@
 /obj/structure/flora/tree/oak_four,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"nRk" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "nRq" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -27803,7 +27935,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "oab" = (
 /obj/effect/decal/cleanable/dirt{
@@ -28506,6 +28638,11 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"otx" = (
+/obj/structure/flora/tallgrass5,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "otX" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -28944,7 +29081,7 @@
 /area/f13/building)
 "oFf" = (
 /obj/machinery/gear_painter,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/caves)
 "oGd" = (
 /obj/machinery/light{
@@ -29133,7 +29270,7 @@
 	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "oLL" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -29157,6 +29294,14 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"oMd" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
+	},
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "oMf" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -30000,11 +30145,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "plV" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -30019,6 +30162,10 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
+"pnK" = (
+/obj/structure/chair/bench,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "pog" = (
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
@@ -31048,6 +31195,10 @@
 	color = "#779999"
 	},
 /area/f13/wasteland/nash)
+"pOZ" = (
+/obj/effect/landmark/start/f13/wastelander/den,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "pPv" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gatehouse";
@@ -31727,6 +31878,10 @@
 	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
+"qhd" = (
+/obj/structure/bed/dogbed,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qhe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -32259,7 +32414,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "qtY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -32327,6 +32482,17 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
+"quQ" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
+/area/f13/caves)
 "quR" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -32785,7 +32951,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "qLD" = (
 /turf/open/floor/carpet/black,
@@ -33044,8 +33210,9 @@
 "qSg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "qSl" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -33170,8 +33337,8 @@
 "qYc" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "qYp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33495,6 +33662,14 @@
 /obj/structure/fluff/hedge,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"rhj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "rhl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33526,8 +33701,12 @@
 	color = "#a98c5d";
 	dir = 5
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil{
+	color = "#9c9c9c";
+	pixel_y = 7
+	},
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "rhY" = (
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -33728,6 +33907,11 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
+"rlB" = (
+/obj/structure/flora/tallgrass5,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "rlI" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -33814,6 +33998,10 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/f13/wood,
+/area/f13/wasteland)
+"rmd" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "rmk" = (
 /turf/open/floor/carpet/blue,
@@ -34854,8 +35042,8 @@
 	color = "#a98c5d";
 	dir = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "rOK" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/roof,
@@ -34987,7 +35175,7 @@
 	dir = 10
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "rSX" = (
 /obj/structure/window{
 	dir = 4;
@@ -35455,6 +35643,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"shh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "shp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -35508,6 +35703,11 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
+"siA" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sjo" = (
 /mob/living/simple_animal/hostile/wolf/alpha{
 	name = "Terror"
@@ -35603,6 +35803,14 @@
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
+"skW" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#9c9c9c"
+	},
+/area/f13/caves)
 "slj" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
@@ -36137,6 +36345,12 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"sET" = (
+/obj/structure/simple_door/metal/fence/wooden{
+	dir = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "sFc" = (
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/f13/wood{
@@ -36435,6 +36649,11 @@
 /obj/structure/table/plasmaglass,
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
+"sOf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "sOp" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -36946,6 +37165,10 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
+"tbB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "tbR" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -37304,13 +37527,24 @@
 "tke" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
-/obj/structure/curtain,
+/obj/structure/curtain{
+	color = "#845f58";
+	open = 0
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tkk" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"tkl" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tkm" = (
 /mob/living/simple_animal/hostile/renegade,
 /obj/structure/chair,
@@ -37577,7 +37811,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "tpu" = (
 /obj/structure/closet/cabinet,
@@ -37590,6 +37824,13 @@
 	color = "#775555"
 	},
 /area/f13/building)
+"tpI" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tpK" = (
 /turf/closed/wall/f13/store,
 /area/f13/building)
@@ -38085,6 +38326,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tDg" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tDj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /mob/living/simple_animal/hostile/radroach/strongradroach,
@@ -39085,6 +39330,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/rock,
 /area/f13/caves)
+"udM" = (
+/obj/structure/flora/tallgrass5,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "udQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge/standard,
@@ -39468,6 +39717,9 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"uoL" = (
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "uoR" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/dirt,
@@ -39500,6 +39752,12 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"upF" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "uqj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -40040,8 +40298,9 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "uBj" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -40053,6 +40312,16 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
+"uDo" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uEj" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -40385,6 +40654,20 @@
 	dir = 8
 	},
 /turf/open/floor/wood_common,
+/area/f13/wasteland)
+"uOB" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"uOF" = (
+/obj/structure/flora/tallgrass5,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "uOS" = (
 /obj/machinery/light/small{
@@ -41486,6 +41769,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"vqd" = (
+/obj/structure/sink/well{
+	pixel_x = 12;
+	pixel_y = -8
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "vqf" = (
 /obj/structure/campfire/stove{
 	pixel_y = 10
@@ -41566,6 +41856,10 @@
 	},
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vrM" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "vrR" = (
 /obj/structure/spacevine{
@@ -41753,6 +42047,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"vzK" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vzN" = (
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/shoes/sneakers/orange,
@@ -42078,7 +42376,7 @@
 	color = "#a98c5d"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "vFL" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -43323,7 +43621,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "wqo" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -43451,8 +43749,9 @@
 /area/f13/wasteland/nash)
 "wtB" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/area/f13/building)
 "wtF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/wood,
@@ -43977,6 +44276,10 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"wHC" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "wHI" = (
 /obj/effect/turf_decal/trimline/neutral{
 	dir = 4;
@@ -44908,7 +45211,7 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "xkz" = (
 /obj/structure/dresser,
@@ -45037,6 +45340,14 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"xoV" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
+/area/f13/caves)
 "xpm" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
@@ -45950,6 +46261,12 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"xNF" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "xNW" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -46742,7 +47059,7 @@
 	pixel_y = -6
 	},
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/area/f13/building)
 "ykd" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -80328,7 +80645,7 @@ lyA
 jgn
 hMq
 vfT
-xAb
+evP
 lXs
 hMq
 rfh
@@ -80585,7 +80902,7 @@ jgn
 iXk
 tyE
 gig
-xAb
+uOB
 xAb
 hMq
 qOx
@@ -80821,7 +81138,7 @@ iRb
 iRb
 vje
 hMq
-cdN
+wtK
 eed
 cdN
 cdN
@@ -81608,8 +81925,8 @@ iEJ
 dxi
 hMq
 vje
-aKa
-aKa
+hSJ
+lib
 oDY
 xAb
 hya
@@ -81852,20 +82169,20 @@ cjA
 cjA
 cjA
 oFf
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-tcm
-aKa
+hSJ
+hSJ
+lib
+lib
+lib
+hSJ
+hSJ
+hSJ
+lib
+hSJ
+lib
+lib
+nRk
+hSJ
 hfs
 nWw
 xAb
@@ -82107,9 +82424,9 @@ iRb
 vje
 cjA
 qtg
-kJq
-aRD
-aKa
+pOZ
+uoL
+lib
 ryv
 ryv
 xJi
@@ -82122,7 +82439,7 @@ lyA
 mlA
 xJi
 bkG
-aKa
+hSJ
 jgn
 dMq
 vsz
@@ -82364,9 +82681,9 @@ iRb
 vje
 cjA
 qtg
-kJq
-aRD
-aKa
+pOZ
+hyz
+lib
 lyA
 lyR
 owA
@@ -82379,7 +82696,7 @@ lyA
 owA
 lyA
 wZa
-aKa
+hSJ
 jgn
 iEJ
 iEJ
@@ -82622,8 +82939,8 @@ vje
 cjA
 qtg
 kJq
-aRD
-aKa
+hyz
+lib
 hfs
 lyA
 owA
@@ -82636,7 +82953,7 @@ lTF
 tQp
 jgn
 pIp
-aKa
+lib
 lyA
 aht
 lyA
@@ -82878,25 +83195,25 @@ iRb
 vje
 cjA
 qtg
-kJq
-aRD
-aKa
+pOZ
+uoL
+lib
 ryv
 mlA
 jgn
 ryv
-lyA
-lyA
+hSJ
+hSJ
 owA
 jgn
 mlA
 wCP
-hyz
+wCP
 otu
-srk
-tcm
-srk
-gud
+tbB
+xNF
+bcZ
+mMQ
 dze
 tpg
 tcm
@@ -83136,24 +83453,24 @@ vje
 cjA
 qtg
 kJq
-aRD
-aKa
+uoL
+lib
 jgn
 fwT
 lyA
-lyA
+hSJ
 ccE
-lyA
-mlA
-lyA
+nKj
+nKj
+lib
 lyA
 eQv
 wCP
 pIp
-aKa
-srk
-gud
-pEE
+lib
+tbB
+shh
+cKX
 nZK
 qLq
 tcm
@@ -83398,19 +83715,19 @@ wdc
 jgn
 lyA
 lyA
-lyA
-lyA
-lyA
-xJi
-lyA
+pnK
+hSJ
+vqd
+lib
+lib
 lyA
 lyA
 lyA
 otu
-gud
+mMQ
 mdU
 mdU
-gud
+mMQ
 kDC
 xku
 tcm
@@ -83655,16 +83972,16 @@ vje
 lyA
 ryv
 lyR
-qNW
-ryv
-ryv
-ryv
-lyA
-tcN
-ryv
-ryv
-lyA
-aKa
+pnK
+hSJ
+hSJ
+vrM
+lib
+lib
+lib
+lib
+lib
+lib
 hqF
 xUt
 vVm
@@ -83912,16 +84229,16 @@ vje
 lyA
 ryv
 pIV
-lyA
+pnK
 mJY
-aFK
-tcN
-ryv
+gZl
+lib
+lib
 rMp
 heq
 ryv
 lyA
-aKa
+lib
 lyA
 jgn
 lyA
@@ -84169,16 +84486,16 @@ uwq
 lgs
 mzZ
 ryv
-owA
-otq
-mJY
+lib
+hno
+hno
 aOb
-lyA
+hSJ
 aFK
 wZa
 lyA
 heq
-gud
+shh
 lyA
 tpK
 qSt
@@ -84417,9 +84734,9 @@ oez
 vje
 vje
 iRb
-vje
-vje
-vje
+gJP
+gJP
+kKR
 jzb
 mnU
 txV
@@ -84427,15 +84744,15 @@ acG
 xma
 lyA
 tcN
-heq
-mlA
+vrM
+udM
 bEe
 qiY
 tcN
 wZa
 lyA
 wUY
-mdU
+gjo
 lyA
 tpK
 kcn
@@ -84674,9 +84991,9 @@ oez
 oez
 oez
 iRb
-vje
-vje
-vje
+tDg
+tpI
+tkl
 mnU
 mnU
 txV
@@ -84692,7 +85009,7 @@ qiY
 otu
 lyA
 otu
-srk
+tbB
 lyA
 qSt
 qDJ
@@ -84931,8 +85248,8 @@ oez
 oez
 oez
 iRb
-vje
-vje
+gJP
+uDo
 wCn
 pte
 cnH
@@ -84949,7 +85266,7 @@ otu
 ipP
 lyA
 hqF
-aKa
+lib
 lyA
 qSt
 tpK
@@ -85188,8 +85505,8 @@ oez
 oez
 oez
 iRb
-vje
-vje
+gJP
+vzK
 fSd
 dIW
 haD
@@ -85204,9 +85521,9 @@ lyA
 lyA
 qls
 mdU
-srk
-srk
-srk
+tbB
+bcZ
+bcZ
 lyA
 cLD
 sbk
@@ -85444,9 +85761,9 @@ oez
 oez
 oez
 oez
-iRb
-vje
-vje
+oMd
+tDg
+gJP
 fSd
 lbc
 bLP
@@ -85454,8 +85771,8 @@ qtT
 rhW
 uBg
 dik
-lvv
-cFh
+cPr
+cpB
 oLF
 lyA
 lyA
@@ -85463,7 +85780,7 @@ tAR
 mdU
 wCP
 nxF
-aKa
+lib
 lyA
 tpK
 kES
@@ -85701,10 +86018,10 @@ oez
 oez
 oez
 oez
-iRb
-vje
-vje
-wAl
+hFD
+gJP
+kCs
+sET
 evy
 vFD
 hFG
@@ -85712,12 +86029,12 @@ rSL
 beR
 jXS
 arj
-jXS
+dpA
 oLF
 lyA
 hfs
 lyA
-srk
+tbB
 otu
 otu
 mdU
@@ -85958,11 +86275,11 @@ oez
 oez
 oez
 oez
-iRb
-vje
-vje
+jRz
+vzK
+gJP
 fSd
-lvv
+com
 qSg
 lnp
 wql
@@ -85977,8 +86294,8 @@ otu
 mdU
 lyA
 wCP
-srk
-aKa
+bcZ
+lib
 men
 xDk
 xDk
@@ -86215,26 +86532,26 @@ oez
 oez
 oez
 oez
-iRb
-vje
-vje
+lqm
+tDg
+gJP
 wAl
 wtB
-emQ
-vFD
+sOf
+rhj
 kaD
 rOb
 emQ
 cFh
-jXS
+wHC
 oLF
 jgn
 ryv
 otu
-mdU
+gjo
 ryv
 qls
-qNW
+aUJ
 lyA
 dZt
 qgO
@@ -86245,7 +86562,7 @@ lqv
 nlQ
 alP
 tpK
-kRq
+skW
 oOB
 jxp
 jxp
@@ -86471,27 +86788,27 @@ mbu
 mbu
 mbu
 mbu
-mbu
+cUY
 iRb
-vje
-vje
+kCs
+gJP
 fSd
 plz
 lvv
 hnO
 yiT
 hnm
-arj
+dik
 qYc
-dse
+cpB
 fSd
 lyA
-pIV
+ryv
 wUY
-mdU
+gjo
 wZa
 lyA
-mky
+rlB
 fwT
 qSt
 nof
@@ -86502,7 +86819,7 @@ otX
 tpK
 dZt
 oga
-kRq
+skW
 tpK
 hbz
 jxp
@@ -86728,10 +87045,10 @@ mbu
 mbu
 mbu
 mbu
-mbu
-iRb
-vje
-vje
+cUY
+qhd
+gJP
+kCs
 fSd
 fSd
 iMa
@@ -86745,18 +87062,18 @@ lKt
 lyA
 lyA
 ryv
-mdU
+gjo
 pLU
-vVm
-otu
-jgn
-jgn
+otx
+bcZ
+rmd
+rmd
+hyz
+hyz
+uoL
+uoL
+xoV
 gpe
-gpe
-gpe
-gpe
-kRq
-kRq
 kRq
 kRq
 kRq
@@ -86985,9 +87302,9 @@ mbu
 mbu
 mbu
 mbu
-mbu
-iRb
-vje
+cUY
+qhd
+gJP
 vje
 fSd
 cdN
@@ -86997,25 +87314,25 @@ aFC
 tBF
 haY
 cdN
-cdN
+siA
 fSd
 hfs
 jgn
 nxF
-srk
+tbB
 mky
-xUt
+uOF
 xnJ
 fSd
 qAP
 fSd
 qAP
 dIW
-gpe
-gpe
+hyz
+hyz
 kRq
-kRq
-kRq
+xoV
+xoV
 kRq
 tpK
 wZx
@@ -87242,7 +87559,7 @@ mbu
 mbu
 mbu
 mbu
-mbu
+cUY
 iRb
 vje
 vje
@@ -87261,7 +87578,7 @@ qNW
 wCP
 mdU
 bkG
-otu
+bcZ
 amX
 iok
 iok
@@ -87269,8 +87586,8 @@ icJ
 jGi
 fSd
 kRq
-kRq
-gpe
+upF
+hyz
 kRq
 kRq
 kRq
@@ -87513,10 +87830,10 @@ oxM
 cdN
 cdN
 lnR
-aKa
-srk
-mdU
-srk
+lib
+bcZ
+gjo
+tbB
 wZa
 lyA
 fSd
@@ -87526,10 +87843,10 @@ vFs
 fSd
 fSd
 kRq
-kRq
-gpe
-kRq
-kRq
+xoV
+uoL
+fnE
+xoV
 kRq
 tpK
 wZx
@@ -87782,11 +88099,11 @@ nkJ
 agm
 rmt
 fSd
+xoV
 kRq
 kRq
-kRq
-gpe
-kRq
+hyz
+xoV
 kRq
 tpK
 tpK
@@ -88039,10 +88356,10 @@ nkJ
 akk
 ehZ
 fSd
-kRq
-kRq
-gpe
-gpe
+xoV
+quQ
+kHk
+hyz
 kRq
 kRq
 tpK
@@ -88297,11 +88614,11 @@ fSd
 dDO
 dIW
 kRq
-kRq
-kRq
-gpe
-gpe
-kRq
+quQ
+xoV
+hyz
+uoL
+upF
 rwS
 jxp
 jxp
@@ -98469,7 +98786,7 @@ oez
 oez
 oez
 oez
-oez
+aKa
 aKa
 aKa
 aKa


### PR DESCRIPTION
## About The Pull Request
Adds a few quality of life bits to the Den, reworks a few of the parts of the map, and adds some materials to bring it up to basic par with a few other settlements.

Behold, grassification and a central park with benches:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/709347d5-d3e9-4009-b5ee-b3260014b1b2)

Adds a blender and a primitive defib instead of a regular defib to the Den clinic: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/d2a6bba5-6880-48a2-abef-3242ec248ec0)

Reorganzies the garden, adds a compost bin, harvest bin, seed extractor and seed bin, as well as an animal pen and tools! (And fixes the bridge having collision):
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/8f67cbb0-b41f-441b-aa0f-60e96091b9a1)

Adds 50 metal, 50 glass, and 50 blackpowder, and a toolbox to the workshop, as well as a sledge and a set of smithing gloves to the anvil room to bring the Den up to par with other map-spawn workshops:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/c5f65012-f630-45b2-b90f-4f0d2f1282f7)

Adds a boxing ring to the upper floor, complete with a pair of gloves for good old fashioned fisticuffs: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/cb0a898d-335e-4386-b5f0-5cd6af20a979)

Adds benches to the meeting room, changes the orientation of the loungeroom booth, makes the bar a bit wider (not to the point it pokes out into any other areas) with some drinking glass boxes, and decorates the leadership bedroom: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/311d39fb-d2b3-484e-aa78-8bc00c8004b3)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Public park, seating, animal pen, more plots, garden tools, chem-room blender, boxing ring, drinking glasses, a fresh lawn!
balance: Removed the uncommon loot spawns from the workshop, replaced with 50 metal/glass/bp and a sledge/glove combo for the anvil room
fix: Bridge Collision in Den Garden
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
