### PR TITLE
Multichance projectile hit behaviour v1 (MCPHB v1) [ready to merge]

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -1620,7 +1620,9 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	desc = "When you hit your target, you frequently hit your target's vital points more often than not."
 	value = 65
 	category = "Ranged Quirks"
-	mechanics = "You have advantage on all random ranged damage rolls. (roll twice and take the highest)"
+	mechanics = "You have advantage on all random ranged damage rolls. (roll twice and take the highest). \
+				On top of that your shots have better chances of hitting simple mobs on their vital spots, aiming your shots on the head, arms and legs trigger gimmicks \
+				more often. Gimmicks that vary between stunning a mob temporarely to dealing more damage."
 	conflicts = list(
 		/datum/quirk/clumsy,
 		/datum/quirk/straightshooter,

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,7 +17,7 @@ map pahrump-everything
 	adminonly
 endmap
 
-map pahrump-unit-test
+map pahrump-only
     default
 endmap
 


### PR DESCRIPTION
## About The Pull Request
Headshot:
-50% prob of landing a headshot --> +50% raw damage on the projectile;
-25% prob of dealing regular damage and not triggering any gimmick;
-25% prob of completely missing the shot.

Shoulders hit:
-75% prob of landing the shot --> mob deals -25% damage for 3 seconds;
-25% prob of dealing regular damage and not triggering any gimmick;
-Bullet always deals -15% damage, no matter what;
-If the hit is successful then timeout of 6 seconds total, in which this gimmick can't be triggered again (so it can't be stacked more than once at the same time).
-If the hit is successful, a chance of stunning the mob will be calculated, the percentage of this event triggering is function of projectile damage and damage threshold of the mob. (Basically, high damage projectiles have higher chances of stunning and knocking the mob on the ground for 3 seconds).

Legs hit:
-50% prob of hitting the legs --> mob speed -50% for 6 sec;
-25% prob of dealing regular damage and not triggering any gimmick;
-25% prob of completely missing the shot;
-Bullet always deals -15% damage, no matter what;
-If the hit is successful then timeout of 12 seconds total, in which this gimmick can't be triggered again (so it can't be stacked more than once at the same time).

Chest hit:
A regular shot, no gimmick 


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
