### PR TITLE
Fixes the bluespace paint stats

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(trash_attachment, list(
 	/obj/item/tool_upgrade/refinement/stabilized_grip = 1,
 	/obj/item/tool_upgrade/refinement/laserguide = 1,
 	/obj/item/tool_upgrade/productivity/booster = 1,
-	/obj/item/tool_upgrade/augment/randomizer/ballistic = 1,
+	/obj/item/tool_upgrade/augment/randomizer = 1,
 //	/obj/item/tool_upgrade/productivity/red_paint = 2
 ))
 
@@ -962,7 +962,7 @@ GLOBAL_LIST_INIT(loot_attachment, list(
 	/obj/item/tool_upgrade/refinement/stabilized_grip = 1,
 	/obj/item/tool_upgrade/refinement/laserguide = 1,
 	/obj/item/tool_upgrade/productivity/booster = 1,
-	/obj/item/tool_upgrade/augment/randomizer/energy = 1,
+	/obj/item/tool_upgrade/augment/randomizer = 1,
 //	/obj/item/tool_upgrade/productivity/red_paint = 1
 ))
 

--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -1223,8 +1223,7 @@
 		/obj/item/tool_upgrade/refinement/laserguide = 1,
 		/obj/item/tool_upgrade/reinforcement/heatsink = 1,
 		/obj/item/gun_upgrade/trigger/raidertrigger = 1,
-		/obj/item/tool_upgrade/augment/randomizer/energy = 1,
-		/obj/item/tool_upgrade/augment/randomizer/ballistic = 1,
+		/obj/item/tool_upgrade/augment/randomizer = 1,
 		/obj/item/gun_upgrade/cosmetic/gold = 1,
 		/obj/item/gun_upgrade/trigger/boom = 1,
 

--- a/modular_coyote/eris/code/mods/mod_types.dm
+++ b/modular_coyote/eris/code/mods/mod_types.dm
@@ -334,12 +334,12 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL_1H = rand(-4,4) * 0.001,
-		GUN_UPGRADE_RECOIL_2H = rand(-4,4) * 0.001,
-		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-4,4) * 0.001,
-		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-4,4) * 0.001,
-		GUN_UPGRADE_CHARGECOST = rand(-2,2) * 0.001,
-		GUN_UPGRADE_DAMAGE_MULT = rand(-4,4) * 0.001,
+		GUN_UPGRADE_RECOIL_1H =1 + rand(-35,45) * 0.01,
+		GUN_UPGRADE_RECOIL_2H =1 + rand(-35,45) * 0.01,
+		GUN_UPGRADE_FIRE_DELAY_MULT =1 + rand(-35,45) * 0.01,
+		GUN_UPGRADE_PROJ_SPEED_MULT =1 + rand(-35,45) * 0.01,
+		GUN_UPGRADE_CHARGECOST =1 + rand(-15,25) * 0.01,
+		GUN_UPGRADE_DAMAGE_MULT =1 + rand(-35,45) * 0.01,
 		UPGRADE_COLOR = "#59788E"
 	)
 	I.prefix = "blue"

--- a/modular_coyote/eris/code/mods/mod_types.dm
+++ b/modular_coyote/eris/code/mods/mod_types.dm
@@ -334,12 +334,12 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL_1H = rand(-10,10) * 0.01,
-		GUN_UPGRADE_RECOIL_2H = rand(-10,10) * 0.01,
-		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-10,10) * 0.01,
-		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-10,10) * 0.01,
-		GUN_UPGRADE_CHARGECOST = rand(-5,5) * 0.01,
-		GUN_UPGRADE_DAMAGE_MULT = rand(-10,10) * 0.01,
+		GUN_UPGRADE_RECOIL_1H = rand(-4,4) * 0.01,
+		GUN_UPGRADE_RECOIL_2H = rand(-4,4) * 0.01,
+		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-4,4) * 0.01,
+		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-4,4) * 0.01,
+		GUN_UPGRADE_CHARGECOST = rand(-2,2) * 0.01,
+		GUN_UPGRADE_DAMAGE_MULT = rand(-4,4) * 0.01,
 		UPGRADE_COLOR = "#59788E"
 	)
 	I.prefix = "blue"

--- a/modular_coyote/eris/code/mods/mod_types.dm
+++ b/modular_coyote/eris/code/mods/mod_types.dm
@@ -334,12 +334,12 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL_1H = rand(-4,4) * 0.01,
-		GUN_UPGRADE_RECOIL_2H = rand(-4,4) * 0.01,
-		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-4,4) * 0.01,
-		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-4,4) * 0.01,
-		GUN_UPGRADE_CHARGECOST = rand(-2,2) * 0.01,
-		GUN_UPGRADE_DAMAGE_MULT = rand(-4,4) * 0.01,
+		GUN_UPGRADE_RECOIL_1H = rand(-4,4) * 0.001,
+		GUN_UPGRADE_RECOIL_2H = rand(-4,4) * 0.001,
+		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-4,4) * 0.001,
+		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-4,4) * 0.001,
+		GUN_UPGRADE_CHARGECOST = rand(-2,2) * 0.001,
+		GUN_UPGRADE_DAMAGE_MULT = rand(-4,4) * 0.001,
 		UPGRADE_COLOR = "#59788E"
 	)
 	I.prefix = "blue"

--- a/modular_coyote/eris/code/mods/mod_types.dm
+++ b/modular_coyote/eris/code/mods/mod_types.dm
@@ -325,40 +325,21 @@
 	I.prefix = "intelligent"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
 
-/obj/item/tool_upgrade/augment/randomizer/ballistic
+/obj/item/tool_upgrade/augment/randomizer
 	name = "Bluespace Paint"
 	desc = "A mysterious blue and ever shifting liquid paint. Anything that it's put on seems to meld and change instantly to be better...or worse!"
 	icon_state = "randomizer"
 
-/obj/item/tool_upgrade/augment/randomizer/ballistic/New()
+/obj/item/tool_upgrade/augment/randomizer/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL_1H = rand(-40,40) * 0.01,
-		GUN_UPGRADE_RECOIL_2H = rand(-40,40) * 0.01,
-		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-40,40) * 0.01,
-		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-40,40) * 0.01,
-		GUN_UPGRADE_DAMAGE_MULT = rand(-40,40) * 0.01,
+		GUN_UPGRADE_RECOIL_1H = rand(-10,10) * 0.01,
+		GUN_UPGRADE_RECOIL_2H = rand(-10,10) * 0.01,
+		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-10,10) * 0.01,
+		GUN_UPGRADE_PROJ_SPEED_MULT = rand(-10,10) * 0.01,
+		GUN_UPGRADE_CHARGECOST = rand(-5,5) * 0.01,
+		GUN_UPGRADE_DAMAGE_MULT = rand(-10,10) * 0.01,
 		UPGRADE_COLOR = "#59788E"
 	)
 	I.prefix = "blue"
-	I.req_gun_tags = list(GUN_PROJECTILE)
-
-/obj/item/tool_upgrade/augment/randomizer/energy
-	name = "Bluespace Paint"
-	desc = "A mysterious blue and ever shifting liquid paint. Anything that it's put on seems to meld and change instantly to be better...or worse!"
-	icon_state = "randomizer"
-
-/obj/item/tool_upgrade/augment/randomizer/energy/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.weapon_upgrades = list(
-		GUN_UPGRADE_RECOIL_1H = rand(-40,40) * 0.01,
-		GUN_UPGRADE_RECOIL_2H = rand(-40,40) * 0.01,
-		GUN_UPGRADE_FIRE_DELAY_MULT = rand(-40,40) * 0.01,
-		GUN_UPGRADE_CHARGECOST = rand(-20,20) * 0.01,
-		GUN_UPGRADE_DAMAGE_MULT = rand (-40, 40) * 0.01,
-		UPGRADE_COLOR = "#59788E"
-	)
-	I.prefix = "blue"
-	I.req_fuel_cell = REQ_CELL


### PR DESCRIPTION
Thanks to other devs, this actually works how it should now!

Random stats from -35% to 45%. Might get the best mod or trash, good luck!

Also removed the second bluespace paint. It was brought to my attention that two separate ones were unneeded due to the random variety. They can go on any gun, but some might be better on a specific gun type (for obvious reasons).