### PR TITLE
Attempt to fix autolathe logic

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -162,8 +162,13 @@ GLOBAL_VAR_INIT(lathe_reports_done, 0)
 				if(!disabled && can_build(D, 10))
 					m10 = TRUE
 				var/datum/component/material_container/mats = GetComponent(/datum/component/material_container)
+				var/iter_max_multiplier = 50
 				for(var/datum/material/mat in D.materials)
-					max_multiplier = min(50, round(mats.get_material_amount(mat)/(D.materials[mat] * prod_coeff)))
+					if (D.materials[mat] == 0)
+						continue // We aren't actually using the material, let's skip the divide by zero error and get on with our lives
+					var/local_max_multiplier = min(50, round(mats.get_material_amount(mat)/(D.materials[mat] * prod_coeff)))
+					iter_max_multiplier = min(local_max_multiplier, iter_max_multiplier) // Use the lesser of the two since there is a limiting factor
+				max_multiplier = iter_max_multiplier
 
 		var/list/design = list(
 			name = D.name,


### PR DESCRIPTION
## About The Pull Request
This PR aims to fix a fundamental logic error in the auto lathe. When attempting to capture the largest quantity of an object that it can print, the lathe experiences two different types of mathematical error:

1. The lathe does not handle if any materials in the recipe require a zero quantity. Due to a bug that I cannot find, some materials list a requirement of 0 black powder, which causes a divide by zero error and breaks the UI.

2. The lathe incorrectly shows the total quantity that can be printed as limited by only the last material checked. Therefore, it may display a number that is impossible to print with the provided materials.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
