### PR TITLE
Den and Nash Upper 2 Facelift

### DIFF
--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -86,6 +86,16 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"az" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/mob/living/simple_animal/advanced/dog{
+	name = "Buddy"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "aA" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/locked_box/weapon/range/tier1_3,
@@ -180,6 +190,14 @@
 	color = "#11ff11"
 	},
 /obj/effect/validball_spawner,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"aQ" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/item/razor,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "aR" = (
@@ -629,6 +647,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood/junk,
+/obj/effect/validball_spawner,
 /turf/open/floor/wood_common,
 /area/f13/caves)
 "cv" = (
@@ -3143,6 +3162,11 @@
 	color = "#888888"
 	},
 /area/f13/building)
+"me" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/validball_spawner,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "mf" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4592,6 +4616,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
+	},
+/area/f13/building)
+"rQ" = (
+/obj/effect/validball_spawner,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "rR" = (
@@ -6216,6 +6246,7 @@
 /area/f13/building)
 "xO" = (
 /obj/machinery/workbench,
+/obj/effect/validball_spawner,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xQ" = (
@@ -10504,7 +10535,7 @@
 /area/f13/wasteland)
 "NJ" = (
 /obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/validball_spawner,
 /turf/open/floor/wood_common,
 /area/f13/caves)
 "NM" = (
@@ -11109,6 +11140,11 @@
 	color = "#845f58";
 	layer = 5
 	},
+/turf/open/floor/wood_common,
+/area/f13/building)
+"PU" = (
+/obj/structure/table/wood,
+/obj/effect/validball_spawner,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "PW" = (
@@ -12438,6 +12474,10 @@
 /obj/structure/spacevine,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"TY" = (
+/obj/effect/validball_spawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Uc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50035,8 +50075,8 @@ YS
 Ez
 gn
 lM
-lN
-sy
+aQ
+az
 fh
 hm
 hm
@@ -65133,7 +65173,7 @@ bS
 oJ
 bS
 bS
-Va
+PU
 mR
 jk
 "}
@@ -74383,7 +74423,7 @@ hm
 hm
 jk
 su
-FS
+TY
 zY
 zY
 kS
@@ -76425,7 +76465,7 @@ hm
 hm
 YM
 kR
-kR
+me
 kR
 kR
 kR
@@ -76440,7 +76480,7 @@ hm
 tR
 mx
 yZ
-mx
+rQ
 VB
 tR
 jk
@@ -77723,7 +77763,7 @@ mx
 mx
 bd
 qp
-mx
+rQ
 mx
 mx
 sZ
@@ -77846,7 +77886,7 @@ FS
 FS
 EB
 FS
-FS
+TY
 ed
 ed
 Xr
@@ -78234,7 +78274,7 @@ tR
 Qz
 mx
 mx
-mx
+rQ
 dd
 ST
 jk

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -825,8 +825,10 @@
 	},
 /area/f13/building)
 "da" = (
-/obj/machinery/door/poddoor/gate/bunker{
-	id = TexGarageSouth
+/obj/machinery/door/poddoor/shutters{
+	id = TexGarageSouth;
+	name = "Garage";
+	max_integrity = 999999
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -4216,6 +4218,11 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "qp" = (
+/obj/machinery/door/poddoor/shutters{
+	id = TexGarageSouth;
+	name = "Garage";
+	max_integrity = 999999
+	},
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -5876,8 +5883,9 @@
 "wE" = (
 /obj/machinery/button/door{
 	name = "Machine-Shop Door";
-	pixel_y = -27;
-	pixel_x = 8
+	id = TexGarageSouth;
+	pixel_x = 9;
+	pixel_y = -25
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
@@ -10265,10 +10273,12 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "MX" = (
-/obj/machinery/door/poddoor/gate/bunker{
-	id = TexGarageSouth
-	},
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/door/poddoor/shutters{
+	id = TexGarageSouth;
+	name = "Garage";
+	max_integrity = 999999
+	},
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -73089,7 +73099,7 @@ hm
 hm
 hm
 FS
-FS
+da
 FS
 oS
 jk

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -420,7 +420,7 @@
 "bJ" = (
 /obj/machinery/button/door{
 	name = "Machine-Shop Door";
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	pixel_y = 25;
 	pixel_x = 9
 	},
@@ -826,7 +826,7 @@
 /area/f13/building)
 "da" = (
 /obj/machinery/door/poddoor/shutters{
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	name = "Garage";
 	max_integrity = 999999
 	},
@@ -1195,7 +1195,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	name = "Machine-Shop Door";
-	id = TexGarageSouth
+	id = "TexGarageSouth"
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -4219,7 +4219,7 @@
 /area/f13/wasteland)
 "qp" = (
 /obj/machinery/door/poddoor/shutters{
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	name = "Garage";
 	max_integrity = 999999
 	},
@@ -5883,7 +5883,7 @@
 "wE" = (
 /obj/machinery/button/door{
 	name = "Machine-Shop Door";
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	pixel_x = 9;
 	pixel_y = -25
 	},
@@ -9401,7 +9401,7 @@
 "JQ" = (
 /obj/machinery/button/door{
 	name = "Machine-Shop Door";
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	pixel_x = -23;
 	pixel_y = 7
 	},
@@ -10275,7 +10275,7 @@
 "MX" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/door/poddoor/shutters{
-	id = TexGarageSouth;
+	id = "TexGarageSouth";
 	name = "Garage";
 	max_integrity = 999999
 	},

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ac" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -7,6 +11,22 @@
 /turf/open/floor/f13/wood{
 	color = "#999999"
 	},
+/area/f13/wasteland)
+"ad" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ae" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "af" = (
 /obj/structure/railing{
@@ -19,11 +39,8 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/ruins)
 "ai" = (
-/obj/machinery/light,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "aj" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -38,12 +55,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"an" = (
+/obj/structure/railing,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "aq" = (
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"at" = (
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "av" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -108,6 +132,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"aH" = (
+/mob/living/simple_animal/hostile/raider/junker,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -155,20 +183,14 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "aR" = (
-/obj/structure/ladder/unbreakable{
-	id = "bunnyden";
-	level = 1;
-	height = 2;
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster81{
+	pixel_y = 33
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "aS" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass{
@@ -176,10 +198,13 @@
 	},
 /area/f13/building/tribal)
 "aT" = (
-/obj/machinery/vending/boozeomat{
-	pixel_y = -5
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
 /area/f13/building)
 "aU" = (
 /obj/structure/spacevine,
@@ -208,6 +233,30 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"aZ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"bb" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "bc" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -215,6 +264,30 @@
 /obj/machinery/power/solar,
 /turf/open/floor/plasteel/solarpanel,
 /area/f13/wasteland)
+"bd" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"be" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"bg" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "bi" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/dirt{
@@ -338,13 +411,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
-"bJ" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-4"
+"bF" = (
+/obj/structure/cargocrate{
+	icon_state = "cargocrate3"
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"bJ" = (
+/obj/machinery/button/door{
+	name = "Machine-Shop Door";
+	id = TexGarageSouth;
+	pixel_y = 25;
+	pixel_x = 9
+	},
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"bM" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"bN" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "bP" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -412,6 +508,17 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"ca" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "cb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/decal/cleanable/dirt,
@@ -463,6 +570,10 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"cg" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "ch" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -504,6 +615,22 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"cs" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"cu" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/structure/table/wood/junk,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "cv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor{
@@ -515,6 +642,17 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cy" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "cz" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -594,6 +732,15 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"cL" = (
+/obj/structure/table/wood/bar,
+/obj/structure/fence/pole_t{
+	layer = 3.0
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "cP" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/fence/end/wooden{
@@ -672,11 +819,22 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "cZ" = (
-/obj/structure/simple_door/room/dirty,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/f13/wood,
+/area/f13/building)
+"da" = (
+/obj/machinery/door/poddoor/gate/bunker{
+	id = TexGarageSouth
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"dd" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
 /area/f13/building)
 "dj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -704,6 +862,10 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"do" = (
+/obj/structure/debris/v4,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "dp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -715,25 +877,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "dt" = (
-/obj/structure/table/booth,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "du" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/wreck/trash/machinepiletwo{
+	icon_state = "technical_pile1"
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dv" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/obj/structure/bonfire/prelit,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"dw" = (
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "dz" = (
 /obj/structure/campfire{
@@ -835,6 +1007,19 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"dR" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-17"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"dT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "dV" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -853,23 +1038,24 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "dW" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tallgrass5,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dX" = (
 /obj/structure/flora/tree/cherryblossom2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dY" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ea" = (
 /obj/structure/bonfire/prelit,
 /obj/structure/spacevine,
@@ -878,6 +1064,14 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"eb" = (
+/obj/effect/fake_stairs/south{
+	color = "#A47449"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ec" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/interior,
@@ -917,6 +1111,12 @@
 /obj/structure/flora/tree/oak_five,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ep" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -931,13 +1131,9 @@
 	},
 /area/f13/wasteland)
 "er" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/nest/molerat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "es" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -960,16 +1156,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ev" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
+"ew" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "ex" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -990,6 +1189,16 @@
 /obj/item/locked_box/weapon/range/tier3,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"eB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	name = "Machine-Shop Door";
+	id = TexGarageSouth
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "eC" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
@@ -999,6 +1208,12 @@
 	color = "#FFFF44"
 	},
 /area/f13/wasteland)
+"eE" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eH" = (
 /obj/structure/fence/wooden,
 /turf/open/floor/grass{
@@ -1030,14 +1245,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/wasteland)
 "eT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_blue_shag,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "eU" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -1123,15 +1336,10 @@
 /area/f13/wasteland)
 "fh" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+	color = "#A47449"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
@@ -1160,13 +1368,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"fq" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/machinery/light/small/broken,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "fr" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fs" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -1212,6 +1423,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"fz" = (
+/obj/structure/cargocrate{
+	icon_state = "cargocrate4"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"fA" = (
+/turf/open/floor/wood_common{
+	icon_state = "common-broken3"
+	},
+/area/f13/caves)
 "fC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -1299,6 +1521,17 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"fM" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "fN" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -1310,6 +1543,17 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"fO" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "fP" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -1332,6 +1576,16 @@
 	color = "#6D6D6D"
 	},
 /area/f13/caves)
+"gd" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "gf" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	pixel_y = 6
@@ -1395,6 +1649,10 @@
 	color = "#FFFF44"
 	},
 /area/f13/wasteland)
+"gj" = (
+/obj/machinery/workbench,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "gl" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -1423,6 +1681,19 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"go" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_x = -8;
+	pixel_y = 29
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "gr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/shelf_metal,
@@ -1445,6 +1716,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"gA" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "gC" = (
 /obj/effect/decal/cleanable/glitter/blue{
 	color = "#444499";
@@ -1452,6 +1729,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"gD" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "gE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -1532,6 +1820,19 @@
 	color = "#555555"
 	},
 /area/f13/building)
+"gO" = (
+/obj/structure/wreck/trash/machinepiletwo{
+	icon_state = "technical_pile3"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"gP" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "gS" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -1564,6 +1865,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"gY" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hb" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -1579,6 +1884,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"hd" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	doc_content_1 = "I'd like to report a crime happening at your house, Officer Mack. Your house is about to burn for the crimes you committed against the People's Republic of China! I hope your sleeping family wakes up in time.. GLORY TO CHINA.";
+	doc_title_1 = "Crime Report."
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "hf" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -1588,6 +1902,17 @@
 	color = "#779999"
 	},
 /area/f13/wasteland)
+"hg" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/curtain,
+/obj/machinery/pool/drain,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "hi" = (
 /obj/item/binoculars,
 /obj/structure/table/wood,
@@ -1612,6 +1937,10 @@
 "hm" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"ho" = (
+/obj/machinery/autolathe,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "hp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/drip,
@@ -1627,6 +1956,10 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"hw" = (
+/obj/structure/tires/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hy" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1700,6 +2033,22 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hL" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/prewar/poster73{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "hM" = (
 /obj/structure/lattice,
 /turf/open/floor/wood_wide,
@@ -1729,10 +2078,11 @@
 	},
 /area/f13/bar/heaven)
 "hV" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/item/kirbyplants{
+	icon_state = "plant-17"
 	},
-/turf/closed/wall/f13/wood/house/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hX" = (
 /obj/structure/spacevine{
@@ -1746,6 +2096,14 @@
 	name = "temple wall"
 	},
 /area/f13/building/tribal/atonement)
+"hY" = (
+/obj/structure/wreck/trash/machinepiletwo{
+	icon_state = "technical_pile1"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "hZ" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/f13{
@@ -1799,6 +2157,18 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ih" = (
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to the Den's Nightclub, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ij" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1806,11 +2176,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "im" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "in" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1857,6 +2225,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"it" = (
+/obj/structure/nest/scorpion,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iv" = (
 /obj/structure/flora/tree/cherryblossom,
 /turf/open/floor/grass,
@@ -1889,6 +2261,12 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"iB" = (
+/obj/structure/closet,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "iE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -1907,6 +2285,13 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
+/area/f13/wasteland)
+"iI" = (
+/obj/structure/campfire/barrel,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "iJ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -1952,6 +2337,20 @@
 "iW" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
+/area/f13/wasteland)
+"iX" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/tallgrass5,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ja" = (
 /obj/structure/barricade/sandbags,
@@ -2086,6 +2485,15 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"jr" = (
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ju" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/tree/cherryblossom4{
@@ -2118,6 +2526,12 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"jA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "jE" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/decal/cleanable/dirt,
@@ -2135,6 +2549,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"jG" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jJ" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -2198,6 +2616,17 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"jQ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10;
+	pixel_y = -4
+	},
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "jT" = (
 /obj/item/binoculars,
 /turf/open/floor/f13/wood,
@@ -2208,6 +2637,20 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"jV" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
+"jW" = (
+/obj/machinery/computer/arcade/battle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "jX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2257,13 +2700,16 @@
 	},
 /area/f13/wasteland)
 "km" = (
-/obj/structure/simple_door/room{
-	pixel_y = 5
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = 0;
+	pixel_x = 0
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "kn" = (
 /mob/living/simple_animal/hostile/gecko/legacy/alpha,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -2278,6 +2724,17 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"kp" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"kr" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kt" = (
 /obj/structure/spacevine,
 /turf/closed/indestructible/riveted/boss{
@@ -2302,6 +2759,26 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"ky" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/binoculars,
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
+"kB" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "kC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -2310,6 +2787,14 @@
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"kE" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "kH" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken6"
@@ -2342,6 +2827,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"kQ" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood_common,
+/area/f13/caves)
+"kR" = (
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
+"kS" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kT" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -2379,12 +2876,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "le" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/microwave,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "lf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -2419,11 +2916,22 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ll" = (
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "lp" = (
 /obj/structure/closet/crate/wicker,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
+/area/f13/building)
+"lq" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building)
 "ls" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -2458,16 +2966,22 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"lA" = (
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house/broken,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/building)
 "lC" = (
-/obj/machinery/vending/bigredvend{
-	pixel_y = -5
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "lD" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -2484,6 +2998,18 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"lE" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "lF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/roof,
@@ -2529,6 +3055,23 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"lM" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"lN" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "lO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2550,6 +3093,10 @@
 /obj/structure/flora/tree/cherryblossom,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lT" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lU" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -2566,6 +3113,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lY" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ma" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -2578,15 +3135,19 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "mb" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/area/f13/building)
+"mf" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
 	},
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "mk" = (
 /obj/structure/cable,
 /obj/machinery/power/solar,
@@ -2604,11 +3165,24 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal/atonement)
+"mn" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "mo" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
 /turf/open/floor/carpet/red,
+/area/f13/building)
+"mp" = (
+/obj/structure/chair/right{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "mq" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -2645,13 +3219,12 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "mv" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -1
+/obj/structure/flora/wasteplant/wild_fungus{
+	pixel_y = 16
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mw" = (
 /obj/structure/railing{
 	color = null;
@@ -2663,29 +3236,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
 "mx" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/obj/item/toy/plush/lizardplushie/kobold{
-	pixel_y = 10
-	},
-/obj/item/toy/plush/carpplushie,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "mz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/dresser,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mA" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -2709,6 +3267,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mD" = (
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mE" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common{
@@ -2726,6 +3288,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"mH" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "mJ" = (
 /obj/structure/flora/tree/jungle{
 	color = "#999999"
@@ -2734,6 +3302,12 @@
 	color = "#777777"
 	},
 /area/f13/building/tribal)
+"mK" = (
+/obj/structure/bed/mattress,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2"
+	},
+/area/f13/caves)
 "mL" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -2757,11 +3331,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "mR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/closed/wall/mineral/wood,
+/area/f13/building)
 "mS" = (
 /obj/item/gun/ballistic/automatic/marksman/sniper,
 /turf/open/floor/f13/wood,
@@ -2806,6 +3377,16 @@
 /obj/structure/spacevine,
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"mZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
+"nc" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nf" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -2845,6 +3426,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"nk" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2880,37 +3465,26 @@
 "nq" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/chair/stool/retro/tan,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ns" = (
+/obj/structure/nest/raider/melee,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "nt" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/structure/simple_door/metal/barred,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "nw" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -2973,6 +3547,14 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"nM" = (
+/obj/structure/window/fulltile/ruins,
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "nO" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -3053,10 +3635,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nW" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nX" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "nY" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -3081,6 +3667,13 @@
 	color = "#777777"
 	},
 /area/f13/building/tribal)
+"ok" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -3110,6 +3703,14 @@
 	color = "#C2B280"
 	},
 /area/f13/building)
+"or" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "ot" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/f13{
@@ -3132,6 +3733,15 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"ox" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "oy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3160,6 +3770,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"oB" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -3168,6 +3784,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"oJ" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "oK" = (
 /obj/structure/sink/deep_water{
 	pixel_x = 1;
@@ -3205,14 +3825,14 @@
 	},
 /area/f13/wasteland)
 "oS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"oT" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "oU" = (
@@ -3224,14 +3844,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "oW" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -3263,6 +3878,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"pd" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "pf" = (
 /obj/structure/chair/sofa{
 	color = "red"
@@ -3319,6 +3938,20 @@
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
 	},
+/area/f13/wasteland)
+"po" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "pp" = (
 /obj/item/stock_parts/cell/super/empty,
@@ -3399,6 +4032,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"pD" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "pE" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/blood/drip,
@@ -3407,6 +4047,16 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"pF" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pG" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	pixel_y = 6
@@ -3444,6 +4094,17 @@
 "pT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
+/area/f13/building)
+"pW" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	termtag = "Public"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "pY" = (
 /obj/structure/cable{
@@ -3554,19 +4215,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"qp" = (
+/turf/open/floor/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building)
 "qq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "qs" = (
-/obj/structure/table/wood/bar,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "qt" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill";
@@ -3582,6 +4247,13 @@
 	name = "temple wall"
 	},
 /area/f13/building/tribal)
+"qw" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "qx" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3597,6 +4269,12 @@
 /turf/open/floor/f13/wood{
 	color = "#999999"
 	},
+/area/f13/wasteland)
+"qC" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "qD" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3647,6 +4325,15 @@
 	smooth = 1
 	},
 /area/f13/building)
+"qM" = (
+/obj/structure/chair/left{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "qN" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3655,6 +4342,28 @@
 /obj/structure/flora/chomp/thicket5,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
+"qT" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"qU" = (
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "qV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -3717,6 +4426,10 @@
 	icon_state = "interior2"
 	},
 /area/f13/building)
+"rd" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "rg" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -3757,29 +4470,23 @@
 	},
 /area/f13/wasteland)
 "ro" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "rq" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "rt" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3803,6 +4510,12 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"rw" = (
+/obj/structure/rug/big/rug_fancy{
+	pixel_x = 16
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "rz" = (
 /obj/structure/flora/ausbushes/brflowers{
 	light_power = 3;
@@ -3852,11 +4565,11 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "rH" = (
-/obj/machinery/microwave/stove,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "rK" = (
 /obj/structure/railing{
@@ -3866,20 +4579,17 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "rM" = (
-/obj/machinery/power/solar,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"rR" = (
-/obj/machinery/light{
+/obj/structure/chair/folding{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
+"rR" = (
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "rS" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -3897,6 +4607,13 @@
 	color = "#AA5555"
 	},
 /area/f13/building)
+"rU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "rW" = (
 /obj/structure/table/wood,
 /obj/item/candle/infinite{
@@ -3922,8 +4639,9 @@
 	},
 /area/f13/wasteland)
 "rZ" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -3931,7 +4649,6 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/obj/structure/flora/ausbushes/genericbush,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "sb" = (
@@ -3989,6 +4706,10 @@
 /obj/structure/bed/double,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sl" = (
+/obj/machinery/autolathe,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sn" = (
 /turf/open/transparent/openspace{
 	name = "air";
@@ -4007,6 +4728,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
+"ss" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "st" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4017,6 +4744,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"su" = (
+/obj/structure/nest/protectron,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sx" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -4025,6 +4756,13 @@
 /turf/open/floor/f13/wood{
 	color = "#999999"
 	},
+/area/f13/wasteland)
+"sy" = (
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "sA" = (
 /obj/structure/railing{
@@ -4041,6 +4779,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"sC" = (
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sE" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/validball_spawner,
@@ -4048,8 +4791,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "sF" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_fancy,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "sG" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -4107,10 +4855,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "sP" = (
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/obj/structure/nest/raider,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "sQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4122,6 +4869,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"sT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/mat/welcome,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "sU" = (
@@ -4144,11 +4898,19 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "sZ" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"te" = (
+/obj/structure/cargocrate{
+	icon_state = "cargocrate1"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tf" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4165,6 +4927,14 @@
 "tg" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"th" = (
+/obj/structure/closet/fridge,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/vegetarian,
+/turf/open/floor/wood_common,
 /area/f13/building)
 "tl" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -4198,8 +4968,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tr" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/bars,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -4229,6 +5002,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"tw" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "tx" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4270,6 +5054,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"tD" = (
+/obj/structure/dresser,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "tE" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -4284,11 +5072,17 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "tH" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/junk/small/prewartv{
+	pixel_x = 16;
+	pixel_y = -11
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tI" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4307,9 +5101,24 @@
 	color = "#992222"
 	},
 /area/f13/building)
+"tL" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "tM" = (
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
+"tO" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = -22;
+	pixel_x = 12
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "tP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4321,16 +5130,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tR" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/ausbushes/genericbush,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/closed/wall/f13/ruins,
+/area/f13/building)
 "tS" = (
 /obj/structure/chair/sofa{
 	dir = 4;
@@ -4344,6 +5145,14 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"tW" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 2;
+	pixel_y = 0;
+	color = "pink"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tY" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -4358,12 +5167,9 @@
 	},
 /area/f13/wasteland)
 "ub" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/dresser,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "uf" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -4381,13 +5187,29 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
-"uj" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+"uh" = (
+/obj/structure/sign/poster/prewar/poster82{
+	pixel_y = 32
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"ui" = (
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
+"uj" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "uk" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -4511,6 +5333,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"uF" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "uG" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4573,17 +5402,26 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "uO" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"uP" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "uQ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/locked_box/weapon/range/tier4,
@@ -4618,14 +5456,18 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "uX" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/glowshroom/single,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"uY" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/chair/folding{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/wood_common,
 /area/f13/wasteland)
 "uZ" = (
 /turf/open/floor/f13/wood,
@@ -4642,12 +5484,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "vg" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "vh" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -4668,6 +5510,14 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"vn" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 2;
+	color = "pink"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vo" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/indestructible/rock{
@@ -4752,12 +5602,40 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"vG" = (
-/obj/structure/chair/stool/retro/tan,
-/turf/open/floor/wood_common{
-	color = "#779999"
+"vC" = (
+/obj/structure/furnace,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vD" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vF" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 16;
+	pixel_x = 11
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vG" = (
+/obj/structure/flora/wasteplant/wild_fungus{
+	pixel_x = -16
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vH" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "vI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4769,17 +5647,24 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "vJ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood_common,
+/area/f13/building)
+"vK" = (
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"vM" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vN" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4795,6 +5680,25 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vP" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vQ" = (
+/obj/machinery/vending/games,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "vR" = (
 /obj/structure/fence{
 	icon_state = "end";
@@ -4811,14 +5715,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "vU" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/mattress,
+/obj/item/bedsheet/black,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "vV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -4826,6 +5730,13 @@
 	color = "#11ff11"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"vW" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "vY" = (
@@ -4841,6 +5752,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"vZ" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "wd" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/carpet/red,
@@ -4868,20 +5783,29 @@
 	},
 /turf/open/floor/plasteel/solarpanel,
 /area/f13/wasteland)
+"wj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "wl" = (
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "wm" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = -4
+/obj/item/kirbyplants{
+	icon_state = "plant-02"
 	},
-/turf/closed/wall/f13/coyote/fortress_brick,
+/turf/open/floor/wood_common,
 /area/f13/building)
 "wo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"wr" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "wt" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -4896,12 +5820,19 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"wx" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+"wv" = (
+/obj/structure/window/fulltile/ruins,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
+"wx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "wy" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/f13{
@@ -4924,6 +5855,10 @@
 	icon_state = "wide-broken3"
 	},
 /area/f13/wasteland)
+"wC" = (
+/obj/machinery/microwave/stove,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wD" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -4938,6 +5873,14 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"wE" = (
+/obj/machinery/button/door{
+	name = "Machine-Shop Door";
+	pixel_y = -27;
+	pixel_x = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4951,6 +5894,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"wH" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/drawer,
@@ -4997,6 +5944,15 @@
 	smooth = 1
 	},
 /area/f13/building)
+"wP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "wR" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5020,6 +5976,14 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wW" = (
+/obj/structure/sign/poster/prewar/poster93{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "wX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -5029,6 +5993,10 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"wY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "xa" = (
 /obj/structure/closet/crate/wooden{
 	pixel_y = 12
@@ -5052,6 +6020,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"xg" = (
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9;
+	density = 0
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	pixel_y = 14;
+	pixel_x = 18
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xh" = (
 /obj/item/reagent_containers/food/snacks/butteredtoast{
 	desc = "That's a very stale piece of toast, Peabus had it in his mouth.";
@@ -5085,6 +6067,13 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"xl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xm" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/outside/roof,
@@ -5096,12 +6085,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
 "xo" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/closed/wall/mineral/wood,
+/area/f13/caves)
 "xp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rug/carpet,
@@ -5200,23 +6185,31 @@
 	},
 /area/f13/wasteland)
 "xJ" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#888888"
 	},
 /area/f13/building)
 "xN" = (
-/obj/structure/simple_door/room{
-	pixel_y = 0
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/sign/poster/prewar/poster65{
+	pixel_x = -32
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
+"xO" = (
+/obj/machinery/workbench,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xQ" = (
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -5337,6 +6330,10 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"yh" = (
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "yi" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -5380,12 +6377,9 @@
 	},
 /area/f13/wasteland)
 "yr" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "yt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/repaired,
@@ -5434,11 +6428,30 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"yE" = (
+/obj/structure/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair_settler"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "yG" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/locked_box/weapon/range/tier1_3,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"yH" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "yJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -5450,15 +6463,22 @@
 	},
 /area/f13/wasteland)
 "yK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/wood/bar,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/area/f13/building)
+"yN" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/structure/flora/tallgrass5,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "yP" = (
@@ -5483,11 +6503,34 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"yS" = (
+/obj/structure/junk/small/prewartv{
+	pixel_x = 16;
+	pixel_y = -11
+	},
+/obj/structure/table/wood,
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "yT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"yV" = (
+/obj/structure/simple_door/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"yW" = (
+/obj/structure/car/rubbish2{
+	icon_state = "car_rubish3";
+	layer = 5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "yY" = (
 /obj/structure/railing{
 	dir = 6;
@@ -5498,6 +6541,26 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"yZ" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"za" = (
+/obj/structure/chair/comfy/throne{
+	pixel_x = 16
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 0;
+	pixel_x = 16
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "zc" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/decal/cleanable/glitter/blue{
@@ -5532,6 +6595,15 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"zh" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "zi" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -5559,6 +6631,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building/tribal)
+"zk" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"zl" = (
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "zm" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -5598,6 +6694,13 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"zu" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/transparent/openspace,
+/area/f13/building)
 "zx" = (
 /obj/structure/railing{
 	dir = 4
@@ -5639,6 +6742,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"zE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "zF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5648,6 +6762,17 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"zI" = (
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "zJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5694,6 +6819,11 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"zQ" = (
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4"
+	},
+/area/f13/caves)
 "zS" = (
 /obj/structure/bed/wooden{
 	pixel_y = 17
@@ -5732,6 +6862,16 @@
 /obj/structure/simple_door/house,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/hospital)
+"zU" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "zW" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -5748,13 +6888,9 @@
 	},
 /area/f13/building)
 "zY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Aa" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -5785,6 +6921,12 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Ah" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Ar" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -5919,14 +7061,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "AQ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "AR" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -5935,13 +7075,27 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "AS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+/obj/structure/table/wood/bar,
+/obj/structure/mirror{
+	pixel_x = -26;
+	pixel_y = 0
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/item/lipstick/jade,
+/obj/item/lipstick/purple,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"AT" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "AU" = (
 /obj/structure/fence{
 	dir = 4;
@@ -6032,6 +7186,15 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
+"Bo" = (
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Bq" = (
 /obj/structure/bonfire/prelit,
 /obj/effect/decal/cleanable/blood,
@@ -6092,6 +7255,12 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"BB" = (
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building)
 "BD" = (
 /obj/structure/fence{
 	dir = 4;
@@ -6198,6 +7367,14 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Ce" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Cf" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
@@ -6219,6 +7396,14 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Cm" = (
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "Cn" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -6238,27 +7423,16 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Cq" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/table/booth,
-/obj/item/candle{
-	pixel_y = 5
-	},
-/obj/item/binoculars,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "Cs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6304,6 +7478,10 @@
 	icon_state = "interior9"
 	},
 /area/f13/building)
+"Cy" = (
+/obj/machinery/light,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Cz" = (
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior3"
@@ -6329,6 +7507,24 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"CH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"CJ" = (
+/obj/structure/sign/poster/prewar/poster66{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "CL" = (
 /obj/item/binoculars,
 /obj/structure/table/wood,
@@ -6342,15 +7538,15 @@
 	},
 /area/f13/building)
 "CO" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/blood,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"CP" = (
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_6"
 	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/smoke_machine{
-	name = "HVAC Machine"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "CQ" = (
 /obj/effect/landmark/vertibird{
 	id = "Nash - Christus Saint Michaels Hospital - Rooftop";
@@ -6436,18 +7632,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "Du" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Dv" = (
+/obj/structure/closet/cabinet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Dw" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -6468,6 +7662,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"Dy" = (
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "DB" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6497,6 +7695,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"DG" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "DI" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -6505,6 +7707,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"DK" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "DL" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -6520,6 +7726,19 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
+"DO" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 27;
+	pixel_x = -5
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "DP" = (
 /obj/effect/spawner/lootdrop/f13/common,
@@ -6557,6 +7776,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"DX" = (
+/obj/structure/simple_door/interior,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "DY" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -6579,8 +7805,15 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building)
 "Eb" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Ec" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -6608,17 +7841,34 @@
 	color = "#225522"
 	},
 /area/f13/wasteland)
-"Eo" = (
-/obj/structure/railing{
-	color = "#A47449";
+"Ej" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"Ek" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
+"Em" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Eo" = (
+/obj/structure/window/fulltile/ruins,
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Eq" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -6661,6 +7911,10 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"Eu" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Ev" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -6704,6 +7958,12 @@
 "Ez" = (
 /turf/closed/wall/f13/coyote/fortress_brick,
 /area/f13/building)
+"EB" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor6"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "EC" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -6734,16 +7994,46 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"EF" = (
+/obj/structure/window/fulltile/ruins,
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "EG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/bunker,
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"EH" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/caves)
+"EJ" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "EK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"EN" = (
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "EO" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -6765,6 +8055,15 @@
 	},
 /turf/open/floor/f13/wood{
 	color = "#C2B280"
+	},
+/area/f13/building)
+"EQ" = (
+/mob/living/simple_animal/hostile/raider/junker/boss,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "ER" = (
@@ -6811,6 +8110,22 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"EY" = (
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/cigarette/cigar,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = -3;
+	pixel_x = 4
+	},
+/obj/item/storage/box/matches{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "EZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/pet/dog/corgi/puppy{
@@ -6819,13 +8134,16 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "Fe" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/transparent/glass/reinforced,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Ff" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -6861,19 +8179,37 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/indestructible,
 /area/f13/tcoms)
-"Fn" = (
-/obj/structure/railing{
-	color = "#A47449";
+"Fk" = (
+/obj/structure/flora/wasteplant/wild_fungus{
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"Fl" = (
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Fm" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
 	dir = 4
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
+"Fn" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood_common,
+/area/f13/caves)
+"Fp" = (
+/obj/structure/closet/cabinet/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "Fr" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -6895,6 +8231,10 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"Fu" = (
+/obj/structure/debris/v4,
+/turf/closed/wall/mineral/wood,
+/area/f13/caves)
 "Fv" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -6917,6 +8257,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Fx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "FC" = (
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
@@ -6992,14 +8339,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "FV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/clown,
+/obj/item/clothing/under/pants/chaps,
+/obj/item/clothing/under/pants/jeanshort,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
+"FX" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "FY" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -7033,6 +8389,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"Gc" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Ge" = (
 /obj/item/shovel/spade,
 /obj/structure/rack/shelf_metal,
@@ -7057,6 +8422,14 @@
 	color = "#779999"
 	},
 /area/f13/building/abandoned)
+"Gh" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_rubber,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Gn" = (
 /obj/structure/fireplace{
 	pixel_x = -15
@@ -7093,6 +8466,11 @@
 	},
 /turf/open/floor/plasteel/solarpanel,
 /area/f13/wasteland)
+"Gu" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Gv" = (
 /obj/structure/sink/deep_water{
 	pixel_x = 1
@@ -7114,6 +8492,13 @@
 "Gy" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/building/massfusion)
+"GB" = (
+/obj/structure/flora/wasteplant/wild_fungus{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "GC" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -7131,6 +8516,10 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"GE" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "GG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/floor,
@@ -7156,6 +8545,18 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"GJ" = (
+/obj/structure/table/wood/bar,
+/obj/structure/mirror{
+	pixel_x = -26;
+	pixel_y = 0
+	},
+/obj/item/lipstick,
+/obj/item/lipstick/black,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "GK" = (
 /obj/structure/rack/shelf_metal,
 /obj/structure/spacevine,
@@ -7180,9 +8581,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "GP" = (
-/obj/machinery/power/solar,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "GQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -7196,21 +8601,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "GR" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "GU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -7219,6 +8614,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"GX" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "GY" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -7274,19 +8675,22 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"Hm" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+"Hk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Hm" = (
+/obj/structure/table/wood,
+/obj/item/export/bottle/applejack,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "Hn" = (
-/turf/closed/wall/f13/wood/interior,
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "Ho" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7339,16 +8743,10 @@
 	},
 /area/f13/wasteland)
 "Hy" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tree/oak_five,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "HA" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -7394,6 +8792,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"HJ" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "HM" = (
 /obj/structure/railing/corner{
 	color = null
@@ -7429,20 +8838,19 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "HT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos{
-	name = "crimson bedsheet"
-	},
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
 "HU" = (
-/obj/structure/chair/bench,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	icon_state = "common-broken5"
 	},
-/area/f13/building)
+/area/f13/caves)
 "HV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7513,6 +8921,10 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"Id" = (
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Ie" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -7694,6 +9106,13 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"IJ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "IM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7735,6 +9154,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"IQ" = (
+/obj/structure/tires/half,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"IU" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "IV" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -7779,13 +9207,13 @@
 	},
 /area/f13/wasteland)
 "Jk" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/obj/structure/flora/tree/oak_five,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Jm" = (
 /obj/item/flashlight/oldlamp{
 	light_on = 1;
@@ -7822,6 +9250,13 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Jp" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Jr" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -7855,6 +9290,16 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Jz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/brflowers{
@@ -7903,18 +9348,15 @@
 	},
 /area/f13/wasteland)
 "JF" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster70{
+	pixel_x = 32
 	},
-/obj/structure/chair/comfy/plywood,
-/obj/structure/fluff/beach_umbrella{
-	pixel_y = 11
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/transparent/glass/reinforced,
-/area/f13/wasteland)
+/area/f13/building)
 "JG" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -7930,14 +9372,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "JM" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowvertical"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "JP" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary{
 	desc = "That is fucking PEABUS!";
@@ -7951,13 +9390,27 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"JR" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -3
+"JQ" = (
+/obj/machinery/button/door{
+	name = "Machine-Shop Door";
+	id = TexGarageSouth;
+	pixel_x = -23;
+	pixel_y = 7
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"JR" = (
+/obj/structure/sink/greyscale{
+	dir = 1
+	},
+/obj/structure/mirror{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "JS" = (
 /obj/structure/rack{
@@ -7974,10 +9427,29 @@
 /obj/item/binoculars,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/massfusion)
-"JV" = (
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/f13/coyote/fortress_brick,
+"JT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
 /area/f13/building)
+"JV" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "JW" = (
 /obj/structure/railing/corner{
 	dir = 8;
@@ -8045,6 +9517,14 @@
 "Kj" = (
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned)
+"Kq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/mattress,
+/obj/item/bedsheet/black,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "Kr" = (
 /obj/structure/spacevine{
 	color = "#225522"
@@ -8063,13 +9543,30 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"Kv" = (
-/obj/structure/railing{
-	color = "#A47449";
+"Ku" = (
+/obj/structure/sink/greyscale{
 	dir = 1
 	},
-/turf/open/transparent/glass/reinforced,
-/area/f13/wasteland)
+/obj/structure/mirror{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"Kv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/prewar/poster79{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Kx" = (
 /obj/structure/rug/mat{
 	color = "#CC4444";
@@ -8081,6 +9578,10 @@
 	color = "#992222"
 	},
 /area/f13/building)
+"Ky" = (
+/obj/structure/debris/v3,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "Kz" = (
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
@@ -8108,12 +9609,29 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"KH" = (
-/obj/structure/spacevine{
-	name = "vines"
+"KG" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
 	},
-/turf/closed/wall/f13/wood/interior,
-/area/f13/building)
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/caves)
+"KH" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "KI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -8124,12 +9642,35 @@
 	},
 /area/f13/wasteland)
 "KK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/area/f13/building)
+"KM" = (
+/obj/structure/curtain{
+	color = "#363636";
+	layer = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"KO" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/wood/junk,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "KS" = (
@@ -8150,16 +9691,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "KU" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "KV" = (
 /obj/structure/cable{
@@ -8176,6 +9708,16 @@
 	},
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
+"KY" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "KZ" = (
 /obj/structure/nest/gecko,
@@ -8283,6 +9825,25 @@
 	},
 /turf/open/floor/grass/fakebasalt,
 /area/f13/building)
+"Lw" = (
+/obj/structure/chair/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"Lz" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 2;
+	pixel_y = 0;
+	color = "pink"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "LB" = (
 /obj/structure/rack/shelf_metal,
 /obj/machinery/light/broken{
@@ -8338,6 +9899,25 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"LL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
+"LP" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "LQ" = (
 /obj/structure/fence{
 	icon_state = "corner";
@@ -8361,6 +9941,16 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"LS" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "LT" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -8383,15 +9973,12 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "LW" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 4;
-	pixel_y = 0
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
 	},
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "LX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/table,
@@ -8417,14 +10004,20 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
-"Mh" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
+"Mf" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
+"Mh" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Mk" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
@@ -8469,6 +10062,26 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"Ms" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Mu" = (
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"Mv" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "Mw" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -8487,6 +10100,37 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"My" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Mz" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"MD" = (
+/obj/structure/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair_settler"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ME" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -8520,6 +10164,14 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
+"MF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "MH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -8554,12 +10206,41 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"MQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"MN" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
+"MP" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"MQ" = (
+/obj/structure/sign/poster/prewar/poster61{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"MR" = (
+/obj/item/bikehorn/rubberducky,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "MS" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/decal/cleanable/glitter/blue{
@@ -8583,6 +10264,15 @@
 /obj/structure/flora/tree/oak_five,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"MX" = (
+/obj/machinery/door/poddoor/gate/bunker{
+	id = TexGarageSouth
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building)
 "MY" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -8669,12 +10359,10 @@
 /turf/open/floor/plasteel/solarpanel,
 /area/f13/wasteland)
 "Nk" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Nn" = (
 /obj/structure/chair/office/dark,
@@ -8689,6 +10377,15 @@
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"Nq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table/wood/junk,
+/obj/item/binoculars,
+/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Nr" = (
 /obj/structure/flora/chomp/bones/lribs1{
@@ -8712,6 +10409,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"Ny" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Nz" = (
 /obj/structure/flora/chomp/bones/lribs1{
 	pixel_y = 0;
@@ -8758,6 +10465,16 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"NE" = (
+/obj/structure/table/wood,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"NF" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "NH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
@@ -8775,6 +10492,11 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"NJ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "NM" = (
 /obj/structure/closet/locker/fridge{
 	pixel_x = -11;
@@ -8820,6 +10542,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"NS" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "NT" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -8847,11 +10578,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "NZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/filingcabinet,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "Oa" = (
@@ -8886,16 +10615,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "Oh" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
 	},
-/obj/structure/table/wood,
-/obj/item/binoculars,
-/turf/open/transparent/glass/reinforced,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Oi" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -8919,6 +10644,13 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"Ol" = (
+/obj/item/kirbyplants{
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Om" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/cleanable/glitter/blue{
@@ -8932,19 +10664,29 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"Oq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/chair/stool/retro/black,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Or" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/wasteland)
 "Os" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/wood/junk,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Ot" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed/old,
@@ -8978,6 +10720,14 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/wasteland)
+"OD" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "OE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/campfire/stove{
@@ -8985,6 +10735,16 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
+/area/f13/building)
+"OF" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "OI" = (
 /obj/structure/railing/corner{
@@ -9001,6 +10761,19 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned)
+"OL" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "OM" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -9032,6 +10805,15 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"OS" = (
+/obj/structure/chair/left{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "OV" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -9069,6 +10851,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Pd" = (
+/obj/structure/table/wood/bar,
+/obj/structure/fence/pole_b,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"Pe" = (
+/obj/structure/anvil/obtainable/basic,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Pf" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -9096,6 +10889,14 @@
 /obj/item/paper/monitorkey,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/massfusion)
+"Pl" = (
+/obj/structure/car/rubbish2{
+	icon_state = "car_rubish3";
+	layer = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
 "Pn" = (
 /obj/structure/fence{
 	icon_state = "end";
@@ -9120,8 +10921,26 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"Ps" = (
+/obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Pv" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Pw" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/table/wood/junk,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Px" = (
@@ -9182,6 +11001,13 @@
 	name = "Fruit Gang Strongarm"
 	},
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"PD" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
 /area/f13/building)
 "PE" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -9268,6 +11094,13 @@
 	opacity = 1
 	},
 /area/f13/building)
+"PR" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "PW" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	icon_state = "technical_pile3"
@@ -9291,6 +11124,16 @@
 /obj/structure/fluff/beach_umbrella/cap,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"Qe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "Qg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/right{
@@ -9302,6 +11145,22 @@
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Qi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
+"Qj" = (
+/obj/structure/flora/rock/pile/largejungle{
+	icon_state = "bush3";
+	pixel_y = 0;
+	layer = 5
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Ql" = (
 /mob/living/simple_animal/hostile/gecko/fire,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -9334,11 +11193,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"Qq" = (
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Qr" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Qt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "Qu" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -9364,6 +11237,13 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"Qz" = (
+/obj/effect/spawner/lootdrop/f13/bounty/med_to_high,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "QA" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -9483,6 +11363,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"QP" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "QQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -9493,11 +11383,25 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"QR" = (
+/obj/structure/simple_door/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "QS" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table/wood/bar,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "QV" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 4
@@ -9506,48 +11410,46 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "QX" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowtop"
-	},
+/obj/item/lock_bolt,
+/obj/structure/simple_door/wood,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
 "QZ" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Rb" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant{
 	faction = list("raider")
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"Re" = (
+/obj/structure/rug/big/rug_blue{
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Rg" = (
-/obj/machinery/door/unpowered/securedoor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Rk" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 1
+	dir = 9
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/roof,
+/turf/open/floor/wood_common,
 /area/f13/wasteland)
 "Rl" = (
 /obj/structure/railing/corner{
@@ -9572,6 +11474,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Ro" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Rq" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -9618,6 +11525,16 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"Ru" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Rw" = (
 /obj/structure/flora/tree/cherryblossom3{
 	layer = 6
@@ -9626,14 +11543,18 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "Rx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
+/area/f13/building)
+"Ry" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Rz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9659,6 +11580,15 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"RD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster69{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "RE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9670,6 +11600,12 @@
 "RF" = (
 /turf/closed/indestructible/rock,
 /area/f13/wasteland)
+"RG" = (
+/obj/structure/table/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "RH" = (
 /obj/effect/decal/cleanable/glitter/blue{
 	color = "#444499";
@@ -9690,6 +11626,15 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal/atonement)
+"RL" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9;
+	pixel_y = 4
+	},
+/obj/item/chair/folding,
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "RM" = (
 /obj/structure/flora/chomp/bones/lbone{
 	icon_state = "lribs";
@@ -9779,6 +11724,19 @@
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"Sa" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "Sb" = (
 /obj/structure/flora/chomp/bones/lskull{
 	pixel_y = -10;
@@ -9798,6 +11756,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"Sd" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Se" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -9839,6 +11803,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"Sk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "Sl" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -9865,6 +11835,22 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"So" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/obj/structure/flora/rock/pile/largejungle{
+	icon_state = "bush3";
+	pixel_y = 0;
+	layer = 5
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Sp" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -9901,6 +11887,10 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Sv" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Sw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10027,6 +12017,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"SH" = (
+/obj/structure/simple_door/interior,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "SI" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10053,6 +12049,20 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"SM" = (
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9;
+	density = 0
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_x = -18;
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "SN" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -10096,13 +12106,7 @@
 	},
 /area/f13/building/tribal/atonement)
 "ST" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/store{
-	icon_state = "storewindowbottom"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/closed/wall/f13/tunnel,
 /area/f13/building)
 "SU" = (
 /obj/structure/flora/tree/jungle/small{
@@ -10154,6 +12158,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/wasteland)
+"Tb" = (
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Tc" = (
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior8"
@@ -10197,20 +12205,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "Tj" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+/obj/structure/rug/big/rug_red{
+	pixel_x = -16
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Tl" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -10260,6 +12263,13 @@
 /obj/item/lock_construct,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Ts" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/rare,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "Tt" = (
 /mob/living/simple_animal/hostile/raider/ranged/sulphiteranged,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -10382,6 +12392,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"TM" = (
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/obj/effect/spawner/lootdrop/f13/seedspawner,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "TN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -10444,10 +12460,15 @@
 /area/f13/caves)
 "Uh" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+	color = "#A47449"
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Uj" = (
 /obj/item/stock_parts/cell/super/empty,
@@ -10458,6 +12479,14 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Uk" = (
+/obj/structure/nest/raider/melee,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Um" = (
 /mob/living/simple_animal/hostile/raider/tribal,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -10475,6 +12504,13 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Up" = (
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Uq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/binoculars,
@@ -10484,11 +12520,28 @@
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/obj/machinery/smoke_machine{
-	name = "HVAC Machine"
+/obj/structure/railing{
+	color = "#A47449"
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Us" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/terminal{
+	dir = 8;
+	doc_content_1 = "The Chryslus in stall two is leaking its miserable green coolant all over my pristine dock.  I'm going to be here all night, going to send the boys home and ring up my wife.  ~October 22nd, 2077";
+	doc_content_2 = "Alright, I got the mess cleaned up, going to give my key to Joe and go home.  I cant wait to-  The message seems to end there.";
+	doc_content_3 = "I managed to tear the battery out of that fuckn old car the sorry son of a bitch whose bones I'm stepping on right now was trying to fix.  I might be able to find a use for it if I can only not fucking fry myself. Here's hoping, right?";
+	doc_title_1 = "Dawsons Note: #1";
+	doc_title_2 = "Dawsons Note: #2";
+	doc_title_3 = "Robinson wuz here";
+	termtag = "Secret"
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "Ut" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -10498,6 +12551,14 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"Uu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Ux" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -10534,14 +12595,12 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "UI" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/railing{
+	dir = 6;
+	pixel_y = -4
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "UL" = (
 /obj/structure/bed/mattress{
 	pixel_y = 12
@@ -10562,6 +12621,15 @@
 /obj/effect/validball_spawner,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"UQ" = (
+/obj/structure/sign/poster/prewar/poster93{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
 /area/f13/building)
 "UR" = (
 /obj/structure/rack/shelf_metal,
@@ -10591,6 +12659,27 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"UV" = (
+/obj/structure/curtain{
+	color = "#845f58";
+	layer = 5
+	},
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"UY" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10
+	},
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "UZ" = (
 /obj/structure/fence{
 	icon_state = "end";
@@ -10598,6 +12687,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Va" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Vb" = (
 /obj/structure/rack/shelf_metal,
 /obj/machinery/light{
@@ -10650,21 +12743,15 @@
 	},
 /area/f13/building/tribal/atonement)
 "Vk" = (
+/obj/structure/table/wood/bar,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/chair/stool/retro/tan,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "Vl" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -10777,6 +12864,13 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
+"VB" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "VC" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -10808,15 +12902,13 @@
 	},
 /area/f13/wasteland)
 "VI" = (
-/obj/structure/table/wood/bar,
-/obj/item/reagent_containers/food/drinks/shaker{
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8;
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "VJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -10874,6 +12966,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common,
+/area/f13/building)
+"VR" = (
+/obj/structure/car/rubbish2,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/building)
+"VS" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "VW" = (
 /obj/structure/cable{
@@ -10942,6 +13043,23 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Wg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"Wh" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10";
+	layer = 2.9
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
+"Wj" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Wk" = (
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/roof,
@@ -11013,6 +13131,12 @@
 	color = "#777777"
 	},
 /area/f13/building/tribal)
+"Wz" = (
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = 0
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "WA" = (
 /obj/structure/railing{
 	dir = 4
@@ -11084,6 +13208,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"WY" = (
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "WZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -11091,17 +13222,30 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"Xc" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
+"Xb" = (
+/obj/structure/simple_door/repaired,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
+/area/f13/building)
+"Xc" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
+/obj/structure/flora/ausbushes/fullgrass{
+	pixel_x = -2;
+	pixel_y = -3
+	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Xd" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Xj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -11134,9 +13278,22 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"Xp" = (
+/obj/structure/table/booth,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
+"Xq" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Xr" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/wasteland)
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "Xv" = (
 /obj/effect/turf_decal/trimline/neutral{
 	icon_state = "trimline_fill"
@@ -11156,22 +13313,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "Xx" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/floor/wood_common,
+/area/f13/caves)
 "Xy" = (
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"XB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/fortress_brick,
+/area/f13/building)
 "XC" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/white,
@@ -11202,13 +13352,17 @@
 	},
 /area/f13/wasteland)
 "XH" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "red"
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "XI" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/validball_spawner,
@@ -11216,7 +13370,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "XJ" = (
-/obj/structure/chair/comfy/throne,
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -11229,6 +13385,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"XQ" = (
+/obj/effect/spawner/lootdrop/f13/rare,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "XU" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -11250,6 +13413,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"XY" = (
+/obj/structure/table/wood,
+/obj/structure/junk/small/prewartv,
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/turf/open/floor/wood_common,
+/area/f13/building)
 "Yb" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -11279,6 +13450,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"Yf" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Yg" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -11315,6 +13490,18 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
+"Ym" = (
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Yn" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -11337,12 +13524,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "Yr" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 1
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
 	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/building)
 "Yw" = (
 /obj/structure/railing/corner{
@@ -11381,6 +13569,15 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"YE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/building)
 "YF" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -11393,6 +13590,21 @@
 /obj/item/clothing/gloves/boxing/blue,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"YG" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
+	},
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
+"YH" = (
+/obj/structure/wreck/trash/halftire,
+/obj/effect/spawner/lootdrop/f13/uncommon,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "YJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
@@ -11416,6 +13628,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"YM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "YN" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -11453,23 +13672,19 @@
 /obj/structure/bonfire/dense/prelit/grill,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
+"YS" = (
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "YU" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "YV" = (
 /obj/structure/stone_tile/surrounding/burnt,
 /obj/structure/stone_tile/center,
@@ -11539,11 +13754,35 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Zl" = (
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
+"Zm" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "Zn" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Zo" = (
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Zt" = (
 /turf/closed/wall/mineral/brick,
 /area/f13/building)
@@ -11557,6 +13796,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Zw" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "Zx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -11652,6 +13898,26 @@
 	smooth = 1
 	},
 /area/f13/building)
+"ZK" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/curtain,
+/obj/machinery/pool/drain,
+/obj/item/soap,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"ZL" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ZM" = (
 /obj/structure/flora/ausbushes/brflowers{
 	light_power = 3;
@@ -11684,6 +13950,12 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ZT" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "ZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -11700,6 +13972,17 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building/massfusion)
+"ZZ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 
 (1,1,1) = {"
 jk
@@ -11966,37 +14249,37 @@ tM
 tM
 tM
 RF
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -12223,37 +14506,37 @@ bo
 bo
 tM
 RF
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -12480,37 +14763,37 @@ Fj
 bo
 tM
 RF
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+Xr
+Xr
+ed
+Xr
+ed
 hm
 hm
 yP
@@ -12737,37 +15020,37 @@ bo
 bo
 tM
 RF
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
 hm
 hm
 yP
@@ -12994,37 +15277,37 @@ tM
 tM
 tM
 RF
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -13251,6 +15534,21 @@ RF
 RF
 RF
 RF
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -13263,25 +15561,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -13502,21 +15785,21 @@ jk
 "}
 (8,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -13759,21 +16042,21 @@ jk
 "}
 (9,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -14016,20 +16299,20 @@ jk
 "}
 (10,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -14273,20 +16556,20 @@ jk
 "}
 (11,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -14530,12 +16813,12 @@ jk
 "}
 (12,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -14787,12 +17070,12 @@ jk
 "}
 (13,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -15044,12 +17327,12 @@ jk
 "}
 (14,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -15301,12 +17584,12 @@ jk
 "}
 (15,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -15558,12 +17841,12 @@ jk
 "}
 (16,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -15815,12 +18098,12 @@ jk
 "}
 (17,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -16072,9 +18355,9 @@ jk
 "}
 (18,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -16329,9 +18612,9 @@ jk
 "}
 (19,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -16586,9 +18869,9 @@ jk
 "}
 (20,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -16843,9 +19126,9 @@ jk
 "}
 (21,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -17100,9 +19383,9 @@ jk
 "}
 (22,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -17357,9 +19640,9 @@ jk
 "}
 (23,1,1) = {"
 jk
-hm
-hm
-hm
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -17614,8 +19897,8 @@ jk
 "}
 (24,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -17871,8 +20154,8 @@ jk
 "}
 (25,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -18128,8 +20411,8 @@ jk
 "}
 (26,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -18385,8 +20668,8 @@ jk
 "}
 (27,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -18642,8 +20925,8 @@ jk
 "}
 (28,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -18899,8 +21182,8 @@ jk
 "}
 (29,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -19156,8 +21439,8 @@ jk
 "}
 (30,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -19413,8 +21696,8 @@ jk
 "}
 (31,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -19670,8 +21953,8 @@ jk
 "}
 (32,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -19927,8 +22210,8 @@ jk
 "}
 (33,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -20184,8 +22467,8 @@ jk
 "}
 (34,1,1) = {"
 jk
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -20441,12 +22724,12 @@ jk
 "}
 (35,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -20698,12 +22981,12 @@ jk
 "}
 (36,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -20955,12 +23238,12 @@ jk
 "}
 (37,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -21212,12 +23495,12 @@ jk
 "}
 (38,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+Xr
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -21469,12 +23752,12 @@ jk
 "}
 (39,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+Xr
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -21726,12 +24009,12 @@ jk
 "}
 (40,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -21983,12 +24266,12 @@ jk
 "}
 (41,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -22240,12 +24523,12 @@ jk
 "}
 (42,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -22497,12 +24780,12 @@ jk
 "}
 (43,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -22754,12 +25037,12 @@ jk
 "}
 (44,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -23011,13 +25294,13 @@ jk
 "}
 (45,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -23268,10 +25551,10 @@ jk
 "}
 (46,1,1) = {"
 jk
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -23525,10 +25808,10 @@ jk
 "}
 (47,1,1) = {"
 jk
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -23782,10 +26065,10 @@ jk
 "}
 (48,1,1) = {"
 jk
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -24039,10 +26322,10 @@ jk
 "}
 (49,1,1) = {"
 jk
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 yP
@@ -24296,12 +26579,12 @@ jk
 "}
 (50,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -24553,12 +26836,12 @@ jk
 "}
 (51,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
+Xr
+ed
+ed
+ed
 yP
 yP
 yP
@@ -24576,9 +26859,9 @@ yP
 yP
 yP
 yP
-hm
-hm
-hm
+ed
+ed
+ed
 hm
 hm
 hm
@@ -24810,12 +27093,12 @@ jk
 "}
 (52,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
 yP
 yP
 yP
@@ -24833,8 +27116,8 @@ yP
 yP
 yP
 yP
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -25067,12 +27350,12 @@ jk
 "}
 (53,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
 yP
 yP
 yP
@@ -25090,8 +27373,8 @@ yP
 yP
 yP
 yP
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -25324,31 +27607,31 @@ jk
 "}
 (54,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -25581,31 +27864,31 @@ jk
 "}
 (55,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -25838,32 +28121,32 @@ jk
 "}
 (56,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -26095,29 +28378,29 @@ jk
 "}
 (57,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -26352,29 +28635,29 @@ jk
 "}
 (58,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -26609,19 +28892,19 @@ jk
 "}
 (59,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+jk
+jk
+jk
+ed
+ed
+ed
 hm
 hm
 hm
@@ -26866,17 +29149,17 @@ jk
 "}
 (60,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+ed
+ed
+ed
 hm
 hm
 hm
@@ -27123,15 +29406,15 @@ jk
 "}
 (61,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+ed
+ed
 hm
 hm
 hm
@@ -27380,14 +29663,14 @@ jk
 "}
 (62,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+jk
+jk
+jk
+ed
+ed
 hm
 hm
 hm
@@ -27637,14 +29920,14 @@ jk
 "}
 (63,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+jk
+jk
+jk
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -27894,13 +30177,13 @@ jk
 "}
 (64,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -28151,10 +30434,10 @@ jk
 "}
 (65,1,1) = {"
 jk
-hm
-hm
-hm
-hm
+jk
+jk
+ed
+ed
 hm
 hm
 hm
@@ -28408,9 +30691,9 @@ jk
 "}
 (66,1,1) = {"
 jk
-hm
-hm
-hm
+jk
+jk
+jk
 hm
 hm
 hm
@@ -28665,9 +30948,9 @@ jk
 "}
 (67,1,1) = {"
 jk
-hm
-hm
-hm
+jk
+jk
+jk
 hm
 hm
 hm
@@ -28922,8 +31205,8 @@ jk
 "}
 (68,1,1) = {"
 jk
-hm
-hm
+jk
+jk
 hm
 hm
 hm
@@ -29179,8 +31462,8 @@ jk
 "}
 (69,1,1) = {"
 jk
-hm
-hm
+jk
+jk
 hm
 hm
 hm
@@ -29436,8 +31719,8 @@ jk
 "}
 (70,1,1) = {"
 jk
-hm
-hm
+jk
+jk
 hm
 hm
 hm
@@ -29693,8 +31976,8 @@ jk
 "}
 (71,1,1) = {"
 jk
-hm
-hm
+ed
+jk
 hm
 hm
 hm
@@ -29950,25 +32233,25 @@ jk
 "}
 (72,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -30207,25 +32490,25 @@ jk
 "}
 (73,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -30464,6 +32747,25 @@ jk
 "}
 (74,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
 hm
 hm
 hm
@@ -30485,29 +32787,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -30721,6 +33004,25 @@ jk
 "}
 (75,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
 hm
 hm
 hm
@@ -30741,30 +33043,11 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+ed
+ed
+jk
 hm
 hm
 hm
@@ -30978,6 +33261,25 @@ jk
 "}
 (76,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -30995,38 +33297,19 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
 zC
 zC
 Oz
@@ -31235,6 +33518,25 @@ jk
 "}
 (77,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -31248,42 +33550,23 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 zC
 zC
 Oz
@@ -31492,55 +33775,55 @@ jk
 "}
 (78,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+RF
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 zC
 zC
 zC
@@ -31749,55 +34032,55 @@ jk
 "}
 (79,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+it
+ed
+ed
+Xr
+Xr
+ed
+Xr
+ed
+ed
+jk
 zC
 zC
 zC
@@ -32006,55 +34289,55 @@ jk
 "}
 (80,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+uP
+Fk
+FS
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
+jk
 zC
 zC
 zC
@@ -32263,55 +34546,55 @@ jk
 "}
 (81,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+le
+Ym
+uX
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
+jk
 zC
 zC
 zC
@@ -32520,55 +34803,55 @@ jk
 "}
 (82,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+FS
+ed
+ed
+Xr
+Xr
+ed
+ed
+jk
+jk
 zC
 zC
 zC
@@ -32777,55 +35060,55 @@ jk
 "}
 (83,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+jk
+jk
 zC
 zC
 zC
@@ -33034,54 +35317,54 @@ jk
 "}
 (84,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
 zC
 zC
 zC
@@ -33291,54 +35574,54 @@ jk
 "}
 (85,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
 zC
 zC
 zC
@@ -33548,54 +35831,54 @@ jk
 "}
 (86,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+jk
+jk
 zC
 zC
 zC
@@ -33805,53 +36088,53 @@ jk
 "}
 (87,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+jk
 ah
 VC
 uZ
@@ -34062,54 +36345,54 @@ jk
 "}
 (88,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-VC
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+FS
+uX
+lC
+km
+gY
+FS
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+ah
 CV
 uZ
 Ti
@@ -34319,54 +36602,54 @@ jk
 "}
 (89,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-VC
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+dv
+Ej
+mH
+ed
+FS
+zY
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+ah
 uZ
 uZ
 uZ
@@ -34576,54 +36859,54 @@ jk
 "}
 (90,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-VC
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+zY
+ro
+ed
+it
+uX
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+ah
 uZ
 uZ
 AV
@@ -34833,54 +37116,54 @@ jk
 "}
 (91,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-VC
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Fk
+FS
+oS
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+ah
 WK
 uZ
 uZ
@@ -35090,54 +37373,54 @@ jk
 "}
 (92,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-VC
+ah
 xV
 uZ
 uZ
@@ -35347,51 +37630,51 @@ jk
 "}
 (93,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+Xr
+Xr
+ed
+ed
+jk
 hm
 hm
 ah
@@ -35604,51 +37887,51 @@ jk
 "}
 (94,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+jk
+jk
 hm
 hm
 hm
@@ -35861,50 +38144,50 @@ jk
 "}
 (95,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -36118,43 +38401,43 @@ jk
 "}
 (96,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+jk
+jk
 hm
 hm
 hm
 hm
 hm
+RF
+RF
+RF
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+RF
+RF
+RF
 hm
 hm
 hm
@@ -36375,30 +38658,30 @@ jk
 "}
 (97,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+jk
 hm
 hm
 hm
@@ -36632,6 +38915,30 @@ jk
 "}
 (98,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+jk
 hm
 hm
 hm
@@ -36652,33 +38959,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
 hm
 hm
 hm
@@ -36889,6 +39172,30 @@ jk
 "}
 (99,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+jk
 hm
 hm
 hm
@@ -36909,33 +39216,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
 hm
 hm
 hm
@@ -37146,6 +39429,30 @@ jk
 "}
 (100,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+jk
 hm
 hm
 hm
@@ -37166,33 +39473,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
 hm
 hm
 hm
@@ -37403,6 +39686,30 @@ jk
 "}
 (101,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+jk
 hm
 hm
 hm
@@ -37422,36 +39729,12 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -37660,6 +39943,30 @@ jk
 "}
 (102,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+jk
 hm
 hm
 hm
@@ -37678,37 +39985,13 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -37917,6 +40200,30 @@ jk
 "}
 (103,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -37934,39 +40241,15 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -38174,6 +40457,31 @@ jk
 "}
 (104,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
 hm
 hm
 hm
@@ -38190,41 +40498,16 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -38421,7 +40704,7 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -38431,6 +40714,31 @@ jk
 "}
 (105,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -38447,42 +40755,17 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -38679,7 +40962,7 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -38688,6 +40971,31 @@ jk
 "}
 (106,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -38704,42 +41012,17 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -38936,7 +41219,7 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -38945,6 +41228,31 @@ jk
 "}
 (107,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -38961,42 +41269,17 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -39194,14 +41477,39 @@ hm
 ed
 ed
 ed
-ed
-ed
+Xr
+Xr
 ed
 ed
 jk
 "}
 (108,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -39218,42 +41526,17 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -39450,15 +41733,40 @@ hm
 hm
 ed
 ed
+Xr
 ed
-ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (109,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -39475,41 +41783,16 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -39707,15 +41990,40 @@ hm
 hm
 ed
 ed
+Xr
 ed
-ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (110,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+lC
+qs
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+jk
 hm
 hm
 hm
@@ -39732,42 +42040,17 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -39966,13 +42249,38 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (111,1,1) = {"
 jk
+ed
+ed
+ed
+Xr
+ed
+ed
+dv
+Ej
+Ej
+qs
+ed
+zY
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
 hm
 hm
 hm
@@ -39989,42 +42297,17 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
 hm
 hm
 hm
@@ -40223,13 +42506,38 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (112,1,1) = {"
 jk
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+FS
+GB
+ro
+FS
+FS
+oS
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
 hm
 hm
 hm
@@ -40247,41 +42555,16 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
 hm
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -40480,38 +42763,38 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (113,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+zY
+ed
+it
+uX
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
 hm
 hm
 hm
@@ -40737,39 +43020,39 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (114,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+oS
+FS
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+jk
+jk
 hm
 hm
 hm
@@ -40994,41 +43277,41 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (115,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+jk
+jk
+RF
 hm
 hm
 hm
@@ -41251,42 +43534,42 @@ ed
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (116,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+jk
+jk
 hm
 hm
 hm
@@ -41508,55 +43791,55 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (117,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -41763,8 +44046,8 @@ hm
 hm
 hm
 ed
-ed
-ed
+Xr
+Xr
 ed
 ed
 ed
@@ -41772,44 +44055,44 @@ jk
 "}
 (118,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+AF
+FS
+bN
+LW
+So
+jk
+jk
 hm
 hm
 hm
@@ -42020,7 +44303,7 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -42029,44 +44312,44 @@ jk
 "}
 (119,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+jk
+ab
+FS
+lC
+rR
+mH
+FS
+gY
+jk
 hm
 hm
 hm
@@ -42074,8 +44357,8 @@ hm
 hm
 hm
 jk
-ed
-ed
+jk
+jk
 hm
 hm
 hm
@@ -42277,7 +44560,7 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -42286,54 +44569,54 @@ jk
 "}
 (120,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+jk
+jk
+ab
+FS
+mf
+rR
+Wz
+qs
+FS
+jk
 hm
 hm
 hm
 hm
 jk
 jk
-ed
-ed
-ed
-ed
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -42534,7 +44817,7 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -42543,54 +44826,54 @@ jk
 "}
 (121,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+jk
+FS
+vG
+FS
+mf
+rR
+Fm
+Mh
+FS
 jk
 jk
-Ez
-Ez
-Ez
-Ez
-Ez
-Ez
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -42791,64 +45074,64 @@ hm
 hm
 hm
 ed
+Xr
+Xr
 ed
-ed
-ed
-ed
+Xr
 ed
 jk
 "}
 (122,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
 jk
 jk
-Ez
-Ez
-Ez
+FS
+FS
+mf
+Mh
+Fk
+FS
+AF
+jk
+jk
+jk
+FS
+FS
+Zm
 VI
 qs
-xJ
-LW
-Ez
-Ez
+jk
+jk
+jk
+hm
 hm
 hm
 hm
@@ -43049,63 +45332,63 @@ hm
 hm
 ed
 ed
-ed
-ed
+Xr
+Xr
 ed
 ed
 jk
 "}
 (123,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
 jk
-Ez
-Ez
-Eq
+FS
+FS
+lE
+FS
+FS
+FS
+jk
+jk
+jk
+FS
+AF
+lC
 rR
-Eq
-Eq
-Eq
-Eq
 rR
-tr
+bM
+cy
+ab
+jk
+jk
 hm
 hm
 hm
@@ -43115,9 +45398,9 @@ hm
 hm
 hm
 hm
-Rk
-AS
-mx
+hm
+hm
+hm
 hm
 hm
 hm
@@ -43314,55 +45597,55 @@ jk
 "}
 (124,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 jk
-wm
-Eq
-Eq
-vG
-pB
-Eq
-Eq
-Eq
-Eq
-xo
+jk
+FS
+FS
+FS
+jk
+jk
+jk
+jk
+jk
+FS
+lC
+rd
+rR
+rR
+Mh
+FS
+gY
+jk
+jk
 hm
 hm
 hm
@@ -43372,9 +45655,9 @@ hm
 hm
 hm
 hm
-ub
-yP
-oW
+hm
+hm
+hm
 hm
 hm
 hm
@@ -43571,56 +45854,56 @@ jk
 "}
 (125,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+FS
+Oh
+gD
+jk
+jk
 jk
 lC
-Eq
-Eq
-vG
-pB
-pB
-pB
-pB
-pB
-Ez
-Ez
+rR
+rR
+rR
+mH
+oS
+FS
+ab
+at
+jk
+jk
 hm
 hm
 hm
@@ -43629,9 +45912,9 @@ hm
 hm
 hm
 hm
-ub
-yP
-oW
+hm
+hm
+hm
 hm
 hm
 hm
@@ -43828,56 +46111,56 @@ jk
 "}
 (126,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 jk
-aT
-Eq
-Eq
-Eq
+jk
+jk
+jk
+le
+fO
+fO
+fO
+rR
+rR
+nX
+rR
+Mh
+FS
 vG
-vG
-vG
-vG
-vG
-Eq
-xo
+at
+at
+jk
+jk
 hm
 hm
 hm
@@ -43886,9 +46169,9 @@ hm
 hm
 hm
 hm
-ub
-yP
-oW
+hm
+hm
+hm
 hm
 hm
 hm
@@ -44085,67 +46368,67 @@ jk
 "}
 (127,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 jk
 jk
-Ez
-pB
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Ez
-Ez
+jk
+jk
+jk
+jk
+Uu
+rR
+rR
+Mh
+FS
+FS
+FS
+Oh
+ez
+ez
+ez
+uO
+uO
+uO
+uO
+LP
+LP
+nq
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-oS
-uj
-Fn
 hm
 hm
 hm
@@ -44342,63 +46625,63 @@ jk
 "}
 (128,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-jk
 ed
-Ez
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 le
-Eq
-Eq
-Eq
-Eq
-NZ
-Eq
-Eq
-Eq
-Eq
-xo
-hm
-hm
-hm
-hm
-hm
-hm
+Mh
+mv
+FS
+EJ
+FS
+Oh
+ez
+ez
+ez
+gn
+gn
+gn
+gn
+gn
+ez
+fh
 hm
 hm
 hm
@@ -44599,31 +46882,31 @@ jk
 "}
 (129,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 jk
 jk
 jk
@@ -44637,25 +46920,25 @@ jk
 jk
 jk
 jk
+jk
+jk
+jk
+jk
+jk
+at
+Oh
+Oh
+at
+ez
+ez
 Ez
 Ez
 Ez
 Ez
-sZ
 Ez
 Ez
-Ez
-Ez
-sZ
-Ez
-Ez
-Ez
-hm
-hm
-hm
-hm
-hm
-hm
+ez
+fh
 hm
 hm
 hm
@@ -44856,31 +47139,31 @@ jk
 "}
 (130,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+jk
 jk
 Ez
 Ez
@@ -44895,23 +47178,23 @@ Ez
 Ez
 Ez
 Ez
-Fs
-ay
-Eq
-Eq
 Ez
-ed
-ed
-hm
-oS
-yP
-yP
-yP
+Ez
+Ez
+Ez
+ez
+ez
+ez
+ez
+ez
+ez
+Ez
+Sd
+AT
+GJ
 AS
-AS
-AS
-AS
-AS
+Ez
+gn
 fh
 hm
 hm
@@ -45113,65 +47396,65 @@ jk
 "}
 (131,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 jk
 Ez
 Rx
-Eq
+wx
 xN
-Eq
-rR
-HU
-Eq
-HU
-Eq
-rR
-dv
+AQ
+vQ
 Ez
-dt
-dt
-Eq
-Eq
+Fp
+wx
+wx
+bb
 Ez
-ed
-ed
-hm
-hm
-yP
-bJ
-yP
-yP
-yP
-hH
-hH
-hH
-oW
-hm
-hm
+Fp
+Eq
+wx
+bb
+Ez
+ez
+ez
+ez
+ez
+ez
+vW
+Ez
+OL
+wx
+HT
+Gh
+Ez
+gn
+gn
+uO
+nq
 hm
 hm
 hm
@@ -45370,65 +47653,65 @@ jk
 "}
 (132,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+jk
 jk
 Ez
-Eq
-Eq
+AQ
+wx
+Zw
+AQ
+wx
 Ez
+aR
 Eq
 Eq
-HU
-Eq
-HU
-Eq
-Eq
-du
+Xd
 Ez
-um
-WG
+wW
 Eq
-Eq
+wx
+bg
 Ez
-ed
-hm
-hm
-hm
-tH
-rq
+ez
+ez
+Ez
+Ez
+Ez
+Ez
+Ez
 FV
+wx
 MQ
-MQ
-MQ
-mR
-yP
-oW
-hm
-hm
+wx
+Ez
+gn
+gn
+ez
+fh
 hm
 hm
 hm
@@ -45627,65 +47910,65 @@ jk
 "}
 (133,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+jk
 jk
 Ez
-sL
+AQ
 HT
-Ez
+EY
 XJ
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-km
-Eq
-Eq
-Eq
-ai
+wx
 Ez
-ed
-hm
-hm
-rM
-KK
-yP
-eT
-QS
-yP
-rM
-yK
-QS
-oW
-hm
-hm
+uF
+Eq
+Eq
+yE
+Ez
+mE
+Eq
+wx
+MD
+Ez
+ez
+ez
+Ez
+wx
+HJ
+sF
+Ez
+XB
+QR
+Ez
+Ez
+Ez
+Ez
+Ez
+ez
+fh
 hm
 hm
 hm
@@ -45884,65 +48167,65 @@ jk
 "}
 (134,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+jk
 jk
 Ez
+wP
+XJ
+Zo
+XJ
+ev
 Ez
-JV
-Ez
-Eq
-Eq
-HU
-Eq
-HU
-Eq
-Eq
-du
-Ez
-Eq
+qw
 Eq
 Eq
 Eq
 Ez
-ed
-hm
-hm
-rM
-KK
-yP
-eT
-QS
-yP
-rM
-yK
-QS
-oW
-hm
-hm
+qw
+Eq
+Eq
+AQ
+Ez
+ez
+ez
+Ez
+uh
+tr
+wx
+Ez
+wx
+wx
+eb
+pB
+LS
+pB
+Ez
+gn
+Uh
 hm
 hm
 hm
@@ -46141,67 +48424,67 @@ jk
 "}
 (135,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 jk
-ed
-ed
+jk
 Ez
+wx
+XJ
+ZL
+XJ
+wx
 Ez
-Eq
-NZ
-HU
-Eq
-HU
-Eq
-NZ
-dv
 Ez
 Ez
 QX
-ST
 Ez
 Ez
-ed
-hm
-hm
-rM
+Ez
+Ez
+QX
+Ez
+Ez
+ez
+ez
+Ez
+wx
+pW
 KK
-yP
+Ez
 AQ
-QS
-yP
-rM
-yK
-QS
-oW
-hm
-hm
-hm
-hm
+wx
+jQ
+cL
+Pd
+pB
+Ez
+gn
+ez
+uO
+nq
 hm
 hm
 hm
@@ -46398,68 +48681,68 @@ jk
 "}
 (136,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 jk
 ed
 ed
-Ez
-Ez
-Ez
-Ez
-Ez
-QX
-JM
-ST
-Ez
-Ez
-Ez
-ed
-sF
-sF
 ed
 ed
 ed
-hm
-hm
-GP
-mz
-yP
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+Ez
+wx
+AQ
+XJ
+AQ
+wx
+Ez
+gn
+gn
+ez
+ez
+ez
+ez
+gn
+gn
+gn
+gn
+gn
+ez
+mr
+sT
+wx
+wx
+ih
 eT
-GP
-yP
-rM
+wx
+WY
+Vk
 yK
 QS
-oW
-hm
-hm
-hm
-hm
-hm
+Ez
+gn
+ez
+ez
+ez
+ZZ
 hm
 hm
 hm
@@ -46655,68 +48938,68 @@ jk
 "}
 (137,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
 jk
 ed
-Eb
-Eb
-Eb
-Eb
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
+jk
+Ez
+wx
+wx
+wx
+AQ
+wx
+Bo
+gn
+Fe
+ez
+ez
+ez
+gn
+Sp
+gn
+gn
+gn
+ez
+ez
+Ez
 rM
-KK
-yP
-eT
-GP
-yP
 rM
-yK
-QS
-oW
-hm
-hm
-hm
-hm
-hm
+wx
+ih
+wx
+AQ
+wx
+WY
+WY
+WY
+Ez
+ez
+lM
+KY
+sy
+fh
 hm
 hm
 hm
@@ -46912,68 +49195,68 @@ jk
 "}
 (138,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+jk
+jk
+jk
 jk
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+Ez
+RD
+wx
+AQ
+AQ
+AQ
 Eb
-Eb
-Eb
-Eb
+gn
+ez
+ez
+ez
+ez
+ez
+gn
+tO
+fh
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-rM
-KK
-yP
+Ez
+Ez
+Ez
+Ez
+Ez
 wx
 GP
-yP
-rM
-yK
-QS
-oW
-hm
-hm
-hm
-hm
-hm
+wx
+wx
+wx
+wx
+Ez
+ez
+lM
+lN
+sy
+fh
 hm
 hm
 hm
@@ -47169,68 +49452,68 @@ jk
 "}
 (139,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+jk
+jk
+jk
+jk
+jk
 jk
 ed
-Eb
-Eb
-Eb
-Eb
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+jk
+Ez
+wx
+AQ
+AQ
+jW
+JF
+Ez
+gn
+gn
+gn
+ez
+ez
+ez
+ez
+ez
+fh
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-rM
+Ez
+Fs
+ay
 dY
-yP
-yP
-er
-yP
-rM
-yK
-QS
-oW
-hm
-hm
-hm
-hm
-hm
+wx
+AQ
+AQ
+wx
+wx
+wx
+Eq
+Ez
+ez
+gn
+iI
+ez
+fh
 hm
 hm
 hm
@@ -47421,73 +49704,73 @@ hm
 hm
 hm
 ed
-ed
+Xr
 jk
 "}
 (140,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
 jk
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+lA
+jk
+Ez
+Bo
 Eb
-Eb
-Eb
-Eb
+Ez
+Ez
+Ez
+Ez
+MP
+gn
+ez
+ez
+MP
+gn
+vF
+ez
+yH
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-Uh
-vU
-hm
-oS
+Ez
+Xp
+rq
+KM
+AQ
+GP
+AQ
+wx
+wx
+AQ
 uj
-uj
-uj
-Fn
-hm
-hm
-hm
-hm
-hm
+Ez
+gn
+lM
+lN
+sy
+fh
 hm
 hm
 hm
@@ -47677,74 +49960,74 @@ hm
 ed
 ed
 ed
-ed
-ed
+Xr
+Xr
 jk
 "}
 (141,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
 jk
 ed
-Eb
-Eb
-Eb
-Eb
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+FS
+FS
+jk
+Ez
+wx
+AQ
+WH
+WH
+WH
+Ez
+Os
+ez
+vW
+go
+Os
+gn
+Sa
+gn
+qT
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-Kv
-Oh
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ez
+mp
+OS
+jr
+wx
+wx
+wx
+WY
+WY
+WY
+YS
+Ez
+gn
+lM
+lN
+sy
+fh
 hm
 hm
 hm
@@ -47934,74 +50217,74 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 jk
 "}
 (142,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
 jk
 ed
-Eb
-Eb
-Eb
-Eb
+ed
+ed
+ed
+ed
+Xr
+FS
+FS
+gY
+lA
+Ez
+wx
+wx
+zu
+WH
+WH
+Ez
+be
+ez
+ez
+ez
+MP
+gn
+gh
+gn
+yH
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ez
+Ez
+Ez
+Ez
 Kv
-JF
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+wx
+WY
+pB
+pD
+pD
+pD
+Ez
+ez
+gn
+ez
+ez
+kB
 hm
 hm
 hm
@@ -48191,73 +50474,73 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 jk
 "}
 (143,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 jk
 ed
-Eb
-Eb
-Eb
-Eb
+ep
+FS
+FS
+FS
+FS
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+gn
+Xc
+ez
+ez
+ez
+gn
+zk
+gn
+ae
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-Kv
-Fe
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ez
+qM
+Lw
+jr
+wx
+GP
+WY
+pB
+wx
+wx
+wx
+Ez
+ez
+gn
+rZ
+vP
 hm
 hm
 hm
@@ -48447,72 +50730,72 @@ hm
 hm
 ed
 ed
-ed
-ed
+Xr
+Xr
 ed
 jk
 "}
 (144,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+jk
+jk
+jk
+NE
+GB
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+Ez
+MP
+Os
+MP
+ez
+be
+Pw
+be
+ae
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ez
+Xp
+rq
+KM
+GP
+AQ
+wx
+wx
+wx
+wx
+wx
+Ez
+ez
 Uh
-vU
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -48704,72 +50987,72 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (145,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+jk
+jk
+FS
+FS
+FS
+vG
+FS
+FS
+FS
+FS
+FS
+Ez
+po
+aZ
+po
+rZ
+fM
+KO
+My
 hm
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ez
+um
+WG
+jr
+Eq
+wx
+wx
+wv
+ox
+hL
+Mz
+Ez
+ez
 Uh
-aR
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -48961,31 +51244,24 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (146,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -48995,9 +51271,16 @@ hm
 hm
 hm
 jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+FS
+FS
 ed
-ed
-ed
 hm
 hm
 hm
@@ -49013,20 +51296,20 @@ hm
 hm
 hm
 hm
-hm
-hm
-Tj
-Xc
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
 ez
-ez
-Xc
-Xc
-Xc
-Xc
-YU
-hm
-hm
-hm
+fh
 hm
 hm
 hm
@@ -49218,26 +51501,24 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (147,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -49252,9 +51533,14 @@ hm
 hm
 hm
 jk
+jk
+jk
+FS
 ed
 ed
-ed
+hm
+hm
+hm
 hm
 hm
 hm
@@ -49273,17 +51559,14 @@ hm
 hm
 hm
 jq
-fr
+gn
+gn
+gn
 ez
-tl
-rj
-CO
-rj
-Ur
-vJ
-hm
-hm
-hm
+ez
+ez
+ez
+fh
 hm
 hm
 hm
@@ -49475,22 +51758,22 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (148,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -49529,18 +51812,18 @@ hm
 hm
 hm
 hm
-jq
+hm
+hm
+hm
+KH
+gn
+gn
+gn
 ez
-gn
-Sp
-gn
-yr
-yr
-yr
-vJ
-hm
-hm
-hm
+pb
+pb
+rZ
+vP
 hm
 hm
 hm
@@ -49732,22 +52015,22 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (149,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -49770,8 +52053,6 @@ ed
 ed
 ed
 ed
-ed
-ed
 hm
 hm
 hm
@@ -49786,15 +52067,17 @@ hm
 hm
 hm
 hm
-jq
-oa
-gn
+Ru
+ca
+uO
+iX
+uO
 ez
-tl
+ez
+ez
+ez
 Ur
-gn
-Ur
-vJ
+hm
 hm
 hm
 hm
@@ -49990,21 +52273,21 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 jk
 "}
 (150,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -50027,14 +52310,6 @@ ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-ed
 hm
 hm
 hm
@@ -50043,15 +52318,23 @@ hm
 hm
 hm
 hm
-jq
-tl
-gn
-gn
-vg
+hm
+hm
+hm
+hm
+hm
+hm
+tw
 ez
-gn
-el
-vJ
+QP
+Sp
+FK
+FK
+HA
+ez
+Gc
+fh
+hm
 hm
 hm
 hm
@@ -50253,15 +52536,15 @@ jk
 "}
 (151,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -50283,9 +52566,7 @@ jk
 ed
 ed
 ed
-hm
-hm
-hm
+ed
 hm
 hm
 hm
@@ -50301,14 +52582,16 @@ hm
 hm
 hm
 jq
-ez
-oa
 gn
-SY
-yr
-gn
-ez
-vJ
+YF
+mw
+qk
+DE
+DE
+TJ
+Jv
+fh
+hm
 hm
 hm
 hm
@@ -50504,21 +52787,21 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 jk
 "}
 (152,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -50540,9 +52823,7 @@ jk
 ed
 ed
 ed
-hm
-hm
-hm
+ed
 hm
 hm
 hm
@@ -50559,16 +52840,18 @@ hm
 hm
 jq
 ez
-oa
-Jk
-ez
-yr
-gn
+Yp
+Qo
+xn
+sd
+yl
+bD
+Yp
 ez
 uO
-Xc
+uO
 nq
-Cq
+hm
 hm
 hm
 hm
@@ -50761,24 +53044,24 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 jk
 "}
 (153,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -50797,10 +53080,8 @@ jk
 ed
 ed
 ed
-hm
-hm
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -50816,16 +53097,18 @@ hm
 hm
 jq
 gn
-Sp
-Jv
-Du
-Du
-QZ
-QZ
-rZ
+GY
+Qo
+xn
+xn
+xn
+ND
+pk
 gn
-ez
-Vk
+gn
+gn
+Uh
+hm
 hm
 hm
 hm
@@ -51018,24 +53301,23 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 jk
 "}
 (154,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -51051,9 +53333,12 @@ hm
 hm
 hm
 jk
+jk
 ed
 ed
 ed
+ed
+ed
 hm
 hm
 hm
@@ -51067,27 +53352,25 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-Hy
+jq
+go
+We
+vl
+yl
+xn
+xn
+bD
+vr
 gn
 gn
-Sp
-gh
-Du
-gh
-gh
-gh
-gn
-ez
-vJ
-hm
-hm
-hm
-hm
-hm
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
 hm
 hm
 hm
@@ -51281,18 +53564,17 @@ jk
 "}
 (155,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -51308,17 +53590,10 @@ hm
 hm
 hm
 jk
+jk
 ed
 ed
 ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 hm
 hm
@@ -51328,29 +53603,37 @@ hm
 hm
 hm
 hm
-Xx
-rj
-rj
-vg
-Sp
+hm
+hm
+hm
+hm
+hm
+hm
+jq
 gn
-Jv
+SY
+Ta
+fy
+fy
+fy
+cV
+ez
 gn
-uX
 gn
-gn
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-YU
+Qt
+xJ
+xJ
+xJ
+xJ
+YE
+zh
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -51538,18 +53821,17 @@ jk
 "}
 (156,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -51565,15 +53847,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 ed
 ed
@@ -51586,28 +53860,37 @@ hm
 hm
 hm
 hm
-tR
-rj
-rj
+hm
+hm
+hm
+hm
+hm
+hm
 gn
-gn
-gn
-Sp
-FK
-FK
-HA
+gh
+yN
 ez
-rj
-rj
-Jv
-yr
+Ng
+Ng
+tE
+eX
+Zl
 ez
-IY
-cH
-IY
-hV
-cZ
-IY
+gn
+Qt
+Qi
+xJ
+PD
+xJ
+xJ
+gP
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -51789,23 +54072,22 @@ hm
 hm
 hm
 ed
-ed
+jk
 ed
 jk
 "}
 (157,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -51822,16 +54104,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 ed
 hm
@@ -51840,31 +54113,41 @@ hm
 hm
 hm
 hm
-ro
-Xc
-Xc
-ez
-tl
-oa
-ng
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 gn
-YF
-mw
-qk
-DE
-DE
-TJ
-Jv
-ez
-ng
+gn
+Xc
+gh
+gh
+oT
 gn
 ez
-nD
-ev
-KH
-DD
-uq
-Os
+ez
+ez
+gn
+Ez
+mb
+mb
+PD
+aT
+Us
+PD
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -52045,23 +54328,22 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
+jk
+jk
+jk
 jk
 "}
 (158,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -52079,17 +54361,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 hm
 hm
@@ -52097,31 +54369,42 @@ hm
 hm
 hm
 hm
-jq
-fr
-ez
-ez
-ez
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+JV
+pb
 ez
 gn
 gn
-Yp
-Qo
-xn
-sd
-yl
-bD
-Yp
 ez
-oa
 gn
-fr
-IY
-sP
-Hn
-zY
-uq
-Mh
+gn
+ez
+ez
+gn
+Ez
+xJ
+Qi
+mb
+xJ
+xJ
+xJ
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -52302,23 +54585,22 @@ hm
 hm
 hm
 hm
-ed
-ed
+jk
+jk
 ed
 jk
 "}
 (159,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -52336,17 +54618,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 hm
 hm
@@ -52354,31 +54626,42 @@ hm
 hm
 hm
 hm
-IY
-cH
-IY
-hV
-cZ
-IY
-ez
-ez
-GY
-Qo
-xn
-xn
-xn
-ND
-pk
-gn
-tl
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+KH
 gn
 ez
-IY
-KU
-Rg
-uq
-uq
-mv
+ez
+ez
+gn
+ng
+ez
+gn
+Ez
+xJ
+xJ
+mb
+xJ
+xJ
+xJ
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -52559,23 +54842,22 @@ hm
 hm
 hm
 hm
-ed
-ed
+jk
+jk
 ed
 jk
 "}
 (160,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -52593,17 +54875,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 hm
 hm
@@ -52611,31 +54883,42 @@ hm
 hm
 hm
 hm
-nD
-ev
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 KH
-DD
-uq
-IY
-ez
-ez
-We
-vl
-yl
-xn
-xn
-bD
-vr
+DO
 gn
-tl
-Hm
+Sp
+CH
 ez
-nD
-UI
-Hn
-rH
-nW
-Mh
+gn
+ez
+gn
+Ez
+nt
+ui
+ui
+ui
+nt
+Ez
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -52823,16 +55106,15 @@ jk
 "}
 (161,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -52850,17 +55132,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 hm
 hm
@@ -52868,31 +55140,42 @@ hm
 hm
 hm
 hm
-IY
-sP
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+KU
 Hn
-zY
-uq
-IY
-yr
-gn
-SY
-Ta
-fy
-fy
-fy
-cV
+Hn
+KU
+KU
+KU
+yV
+yV
+KU
 ez
+Ez
+xJ
+xJ
+ui
 mb
-tl
-rj
-rj
-lB
-IY
-hV
-cH
-IY
-IY
+xJ
+Ez
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -53073,23 +55356,22 @@ hm
 hm
 hm
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (162,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -53107,17 +55389,7 @@ hm
 hm
 hm
 jk
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+jk
 ed
 hm
 hm
@@ -53125,27 +55397,38 @@ hm
 hm
 hm
 hm
-IY
+KU
+lY
+pF
+lY
+KU
+vM
+UV
+UV
+KU
+pF
+lY
+lY
 KU
 Rg
+yr
+yr
+zI
 uq
-uq
-IY
-ez
 yr
 dW
-ez
-Ng
-Ng
-tE
-eX
-tl
+Hn
+Jx
+Ez
+Kq
+zE
+ui
 XH
-gn
-ez
-rj
-ez
-vJ
+vU
+Ez
+hm
+hm
+hm
 hm
 hm
 hm
@@ -53330,25 +55613,25 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (163,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -53365,44 +55648,44 @@ hm
 hm
 jk
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
 hm
 hm
 hm
 hm
 hm
 hm
-nD
-UI
-Hn
+KU
+Ny
+yr
+DD
+KU
+Ry
+yr
+Dv
+KU
+Ry
+yr
+DD
+KU
+CJ
 rH
 nW
-IY
-rj
-rj
-pb
+xg
+nW
+dW
+qQ
 Eo
-pb
-pb
-gh
-gn
-tl
-tl
-gn
-DY
-rj
-rj
-vJ
+hm
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+Ez
+hm
+hm
+hm
 hm
 hm
 hm
@@ -53560,7 +55843,7 @@ hm
 hm
 hm
 hm
-hm
+ed
 hm
 hm
 hm
@@ -53587,79 +55870,79 @@ hm
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (164,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
 ed
 ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-lB
-IY
-hV
-Mh
-Nk
-IY
-ez
-pb
-rK
 hm
 hm
 hm
-jq
-fr
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+EF
+IU
 yr
-ez
-ez
-mb
-ez
-pb
-GR
+Sk
+KU
+mz
+yr
+tL
+KU
+mz
+yr
+lB
+KU
+hV
+yr
+Nk
+dW
+nW
+dW
+yr
+Eo
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -53817,10 +56100,8 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -53845,76 +56126,78 @@ ed
 ed
 ed
 ed
+ed
+Xr
 ed
 ed
 jk
 "}
 (165,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
 ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-im
-im
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+jk
 ed
 hm
 hm
 hm
 hm
 hm
-jq
-rj
+hm
+Eo
+Lz
 dW
+tH
+KU
+tW
+yr
+yS
+KU
+tW
+yr
+yS
+KU
+za
+im
 yr
 yr
-ez
-nt
+yr
+yr
+yr
+Eo
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -54074,12 +56357,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -54102,49 +56383,14 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
 jk
 "}
 (166,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
@@ -54154,24 +56400,61 @@ ed
 ed
 ed
 ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+jk
 ed
 ed
+hm
+hm
+hm
+hm
+hm
+QZ
+vn
+dW
 im
-im
-ed
+KU
+vn
+qQ
+VS
+KU
+vn
+yr
+VS
+KU
+yr
+VS
+dW
+yr
+qQ
+yr
+dW
+QZ
 hm
 hm
 hm
 hm
 hm
 hm
-IY
-cH
-IY
-hV
-cZ
-IY
-ez
+hm
+hm
+hm
 hm
 hm
 hm
@@ -54331,6 +56614,10 @@ hm
 hm
 hm
 hm
+Xr
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -54348,13 +56635,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
 ed
 ed
 ed
@@ -54365,50 +56648,14 @@ jk
 "}
 (167,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
+ed
+ed
+ed
+Xr
+Xr
 ed
 hm
 hm
@@ -54422,13 +56669,49 @@ hm
 hm
 hm
 hm
-nD
-ev
-KH
-DD
-uq
-Mh
-ez
+hm
+hm
+hm
+hm
+jk
+jk
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+EF
+rH
+dW
+yr
+KU
+yr
+yr
+dW
+KU
+LL
+yr
+yr
+KU
+dR
+dW
+Nk
+yr
+Nk
+dW
+yr
+EF
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -54588,6 +56871,12 @@ hm
 hm
 hm
 hm
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -54601,17 +56890,11 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
 ed
 ed
 ed
@@ -54622,6 +56905,15 @@ jk
 "}
 (168,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
 hm
 hm
 hm
@@ -54639,6 +56931,35 @@ hm
 hm
 hm
 hm
+jk
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+KU
+wC
+VS
+qQ
+KU
+Up
+RG
+yr
+KU
+wC
+im
+Sk
+KU
+UQ
+dW
+nW
+SM
+Nk
+dW
+yr
+EF
 hm
 hm
 hm
@@ -54648,44 +56969,6 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-IY
-sP
-Hn
-zY
-uq
-Yr
-ez
 hm
 hm
 hm
@@ -54845,30 +57128,30 @@ hm
 hm
 hm
 hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
 ed
 ed
 ed
@@ -54879,6 +57162,16 @@ jk
 "}
 (169,1,1) = {"
 jk
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -54894,55 +57187,45 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-IY
+jk
+jk
+ed
+ed
+ed
+ed
+ed
 KU
-Rg
-uq
-uq
-Mh
-ez
+KU
+KU
+KU
+KU
+Fl
+KU
+KU
+KU
+Fl
+KU
+KU
+KU
+Fl
+wY
+yr
+yr
+yr
+yr
+yr
+mZ
+yr
+KU
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 hm
 hm
 hm
@@ -55105,27 +57388,27 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
 ed
 ed
 ed
@@ -55136,6 +57419,16 @@ jk
 "}
 (170,1,1) = {"
 jk
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -55150,6 +57443,37 @@ hm
 hm
 hm
 hm
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+KU
+yr
+dW
+dW
+yr
+mZ
+dW
+yr
+yr
+dW
+yr
+yr
+yr
+yr
+Sk
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+KU
 hm
 hm
 hm
@@ -55159,47 +57483,6 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-nD
-UI
-Hn
-rH
-nW
-JR
-ez
 hm
 hm
 hm
@@ -55364,25 +57647,25 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+Xr
+Xr
+ed
+ed
 ed
 ed
 ed
@@ -55393,6 +57676,16 @@ jk
 "}
 (171,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -55407,6 +57700,37 @@ hm
 hm
 hm
 hm
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+KU
+yr
+gd
+Ms
+Ms
+yr
+MF
+Sk
+yr
+yr
+yr
+qQ
+xl
+yr
+uq
+yr
+Ol
+Mf
+OF
+Em
+Ol
+VS
+KU
 hm
 hm
 hm
@@ -55416,47 +57740,6 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-lB
-IY
-hV
-cH
-IY
-IY
-ez
 hm
 hm
 hm
@@ -55622,24 +57905,24 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
 hm
 hm
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 ed
 ed
 ed
@@ -55650,6 +57933,16 @@ jk
 "}
 (172,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -55665,46 +57958,36 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+KU
+dW
+ok
+WH
+WH
+KU
+KU
+KU
+SH
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+KU
+Hn
+Hn
+KU
+KU
+KU
 hm
 hm
 hm
@@ -55889,24 +58172,34 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
+ed
+ed
+hm
+hm
+ed
+ed
+Xr
+Xr
 ed
 ed
 jk
 "}
 (173,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+Xr
+ed
+ed
 hm
 hm
 hm
@@ -55924,44 +58217,34 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
+jk
+KU
+JT
+Jk
+WH
+WH
+KU
+zl
+DX
+jA
+Ku
+KU
+jk
+jk
+jk
+jk
+jk
+jk
+yP
+yP
+yP
+yP
+yP
+yP
 hm
 hm
 hm
@@ -56157,13 +58440,23 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (174,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -56184,41 +58477,31 @@ hm
 hm
 hm
 hm
+jk
+jk
+KU
+yr
+dW
+dW
+yr
+KU
+KU
+KU
+jA
+Fx
+KU
+jk
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+yP
+yP
+yP
+yP
+yP
+yP
 hm
 hm
 hm
@@ -56414,13 +58697,23 @@ hm
 ed
 ed
 ed
-ed
+Xr
 ed
 ed
 jk
 "}
 (175,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -56441,41 +58734,31 @@ hm
 hm
 hm
 hm
+jk
+jk
+KU
+yr
+yr
+Du
+yr
+KU
+Cq
+ll
+jA
+JR
+KU
+jk
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+yP
+yP
+yP
+yP
+yP
+yP
 hm
 hm
 hm
@@ -56665,19 +58948,29 @@ hm
 hm
 hm
 hm
+ed
 hm
 hm
-hm
 ed
 ed
-ed
-ed
+Xr
+Xr
 ed
 ed
 jk
 "}
 (176,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -56698,41 +58991,31 @@ hm
 hm
 hm
 hm
+jk
+jk
+KU
+yr
+Yr
+eE
+OD
+KU
+KU
+KU
+Xb
+KU
+KU
+jk
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+yP
+yP
+yP
+yP
+yP
+yP
 hm
 hm
 hm
@@ -56922,12 +59205,12 @@ hm
 hm
 hm
 hm
-hm
-hm
+ed
+ed
 hm
 ed
 ed
-ed
+Xr
 ed
 ed
 ed
@@ -56935,6 +59218,16 @@ jk
 "}
 (177,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -56955,36 +59248,26 @@ hm
 hm
 hm
 hm
+jk
+jk
+KU
+KU
+KU
+KU
+KU
+KU
+ZK
+jA
+jA
+KU
+jk
+jk
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
 hm
 hm
 hm
@@ -57179,11 +59462,11 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
 ed
 ed
+ed
+ed
+Xr
 ed
 ed
 ed
@@ -57192,6 +59475,16 @@ jk
 "}
 (178,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -57213,35 +59506,25 @@ hm
 hm
 hm
 hm
+jk
+jk
+jk
+jk
+jk
+jk
+KU
+MR
+vg
+vg
+KU
+jk
 hm
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
 hm
 hm
 hm
@@ -57436,11 +59719,11 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
 ed
 ed
+ed
+ed
+Xr
 ed
 ed
 ed
@@ -57449,16 +59732,16 @@ jk
 "}
 (179,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -57485,13 +59768,13 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+KU
+hg
+jA
+jA
+KU
+jk
 hm
 hm
 hm
@@ -57693,11 +59976,11 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
 ed
 ed
+ed
+ed
+Xr
 ed
 ed
 ed
@@ -57706,16 +59989,16 @@ jk
 "}
 (180,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -57742,13 +60025,13 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+KU
+KU
+KU
+KU
+KU
+jk
 hm
 hm
 hm
@@ -57950,9 +60233,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
+ed
+ed
+ed
 ed
 ed
 ed
@@ -57963,21 +60246,21 @@ jk
 "}
 (181,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -57999,13 +60282,13 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+jk
+jk
+jk
+jk
+jk
+jk
+jk
 hm
 hm
 hm
@@ -58207,9 +60490,9 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
+ed
+ed
+ed
 ed
 ed
 ed
@@ -58220,21 +60503,21 @@ jk
 "}
 (182,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -58464,34 +60747,34 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
+Eu
+Eu
+Eu
 ed
 jk
 "}
 (183,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -58717,34 +61000,34 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+uP
+FS
+oS
+FS
+FS
 jk
 "}
 (184,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -58970,38 +61253,38 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Ps
+Eu
+Eu
+Ro
 ed
 jk
 "}
 (185,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -59223,42 +61506,42 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+kE
+Mh
+sC
+FS
+FS
+wH
 jk
 "}
 (186,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -59480,42 +61763,42 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+dt
+TM
+Eu
+Eu
+Eu
+Wj
 jk
 "}
 (187,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -59737,42 +62020,42 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+JH
+mD
+FS
+oS
 fd
 jk
 "}
 (188,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -59988,48 +62271,48 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+FS
+FS
+FS
 ed
 jk
 "}
 (189,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -60160,132 +62443,132 @@ hm
 hm
 hm
 hm
+ed
+ed
+hm
+ed
+Yk
+Yk
+Yk
+Yk
+Yk
+Yk
+Yk
+Yk
+Yk
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Xr
+ed
 Xr
-hm
+ed
+ed
+ed
 Xr
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
-Yk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
-ed
-ed
-ed
-ed
-ed
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+GE
+mR
+mR
 jk
 "}
 (190,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -60415,12 +62698,12 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
+ed
 Yk
 Yk
 fv
@@ -60430,119 +62713,119 @@ Yk
 fv
 Yk
 Yk
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Xr
+ed
+ed
+ed
 Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+Xr
 ed
 ed
-ed
-ed
-ed
-ed
+mR
+tD
+vJ
+Jp
+hd
+Va
+mR
+ho
+bS
+ZT
+mR
 jk
 "}
 (191,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -60672,12 +62955,12 @@ hm
 hm
 hm
 hm
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
 Yk
 Yk
 Yk
@@ -60687,119 +62970,119 @@ zp
 Yk
 Yk
 Yk
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 Xr
 Xr
 Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
-ed
-ed
-ed
-ed
+mR
+bS
+bS
+bS
+Ah
+Re
+mR
+yh
+bS
+Xq
+mR
 jk
 "}
 (192,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -60929,12 +63212,12 @@ hm
 hm
 hm
 hm
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
 Yk
 Yk
 Yk
@@ -60944,120 +63227,120 @@ zp
 zp
 Yk
 Yk
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+ed
 Xr
 Xr
 Xr
 Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+mR
+or
+bS
+bS
+bS
+bS
+mR
+gj
+bS
+Cy
+mR
 jk
 "}
 (193,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -61185,13 +63468,13 @@ hm
 hm
 hm
 hm
+ed
+ed
 Xr
 Xr
 Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
 Yk
 zp
 zp
@@ -61201,120 +63484,120 @@ Yk
 Yk
 Yk
 Yk
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+mR
+mR
+mR
+mR
+bS
+bS
+mR
+bS
+bS
+bS
+mR
 jk
 "}
 (194,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -61442,13 +63725,13 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Yk
 Yk
 sV
@@ -61457,12 +63740,12 @@ Yk
 Yk
 fv
 Yk
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -61523,28 +63806,6 @@ yP
 yP
 yP
 yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -61557,19 +63818,41 @@ ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+mR
+Wh
+bS
+mR
+vZ
+bS
+mR
+mR
 jk
 "}
 (195,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -61698,14 +63981,14 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
 Xr
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
 Yk
 Yk
 Yk
@@ -61714,13 +63997,13 @@ zp
 Yk
 Yk
 Yk
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -61786,20 +64069,7 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
 hm
 hm
 hm
@@ -61810,23 +64080,36 @@ hm
 hm
 ed
 ed
-ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+mR
+mR
+GE
+mR
+mR
+GE
+mR
 ed
 jk
 "}
 (196,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -61955,29 +64238,29 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
+ed
 Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -62043,20 +64326,7 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
 hm
 hm
 hm
@@ -62067,23 +64337,36 @@ hm
 hm
 ed
 ed
-ed
-ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+Rk
+ew
+mR
+NS
+bS
+bS
+bS
+Cy
+mR
+mR
 jk
 "}
 (197,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -62212,29 +64495,29 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
 Xr
 Xr
 Xr
 Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -62294,28 +64577,6 @@ yP
 yP
 yP
 yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -62323,24 +64584,46 @@ hm
 hm
 hm
 ed
-ed
-ed
-ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+uY
+ai
+ai
+PR
+bS
+bS
+DK
+bS
+rw
+Va
+mR
 jk
 "}
 (198,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -62469,30 +64752,30 @@ hm
 hm
 hm
 hm
+ed
+ed
 Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -62551,28 +64834,6 @@ yP
 yP
 yP
 yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -62580,24 +64841,46 @@ hm
 hm
 hm
 ed
-ed
-ed
-ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ky
+ai
+ai
+Tj
+bS
+bS
+mn
+bS
+bS
+XY
+mR
 jk
 "}
 (199,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -62725,136 +65008,136 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 Xr
 Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
 Xr
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+YG
+ai
+ai
+PR
+bS
+bS
+oJ
+bS
+bS
+Va
+mR
 jk
 "}
 (200,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -62982,136 +65265,136 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+ed
+Xr
+ed
+ed
+ed
+ed
 Xr
 Xr
 Xr
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+IJ
+jV
+mR
+NS
+bS
+bS
+bS
+bS
+mR
+mR
 jk
 "}
 (201,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -63239,138 +65522,138 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
 Xr
+ed
+ed
+ed
+ed
 Xr
+ed
 Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+mR
+mR
+mR
+bS
+bS
+bS
+mR
 ed
 jk
 "}
 (202,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -63495,139 +65778,139 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+mR
+bS
+bS
+bS
+mR
+mR
 jk
 "}
 (203,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -63752,138 +66035,138 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+nM
+bS
+bS
+bS
+wm
+mR
 jk
 "}
 (204,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -64015,132 +66298,132 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+nM
+Hy
+bS
+bS
+Cy
+mR
 jk
 "}
 (205,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -64272,132 +66555,132 @@ zC
 zC
 zC
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+nM
+YU
+Gu
+bS
+th
+mR
 jk
 "}
 (206,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -64529,133 +66812,133 @@ zC
 zC
 zC
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+mR
+mR
+mR
+GE
+mR
+mR
 jk
 "}
 (207,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -64787,19 +67070,19 @@ zC
 zC
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -64894,25 +67177,25 @@ hm
 hm
 ed
 ed
-ed
-ed
-ed
+FS
+FS
+FS
 ed
 jk
 "}
 (208,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -65046,11 +67329,11 @@ hm
 hm
 hm
 hm
-Xr
-Xr
-Xr
-Xr
-Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -65152,24 +67435,24 @@ hm
 ed
 ed
 ed
-ed
-ed
+oS
+FS
 ed
 jk
 "}
 (209,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -65409,24 +67692,24 @@ hm
 ed
 ed
 ed
-ed
-ed
+FS
+FS
 ed
 jk
 "}
 (210,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -65667,23 +67950,23 @@ ed
 ed
 ed
 ed
-ed
+FS
 ed
 jk
 "}
 (211,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -65924,23 +68207,23 @@ hm
 hm
 ed
 ed
-ed
+FS
 ed
 jk
 "}
 (212,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -66180,24 +68463,24 @@ hm
 hm
 hm
 ed
-ed
-ed
+FS
+FS
 ed
 jk
 "}
 (213,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -66437,24 +68720,24 @@ hm
 hm
 hm
 ed
-ed
-ed
-ed
+FS
+FS
+FS
 jk
 "}
 (214,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -66694,24 +68977,24 @@ hm
 hm
 hm
 ed
-ed
-ed
-ed
+FS
+FS
+oS
 jk
 "}
 (215,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -66951,24 +69234,24 @@ hm
 hm
 hm
 ed
-ed
-ed
+FS
+FS
 ed
 jk
 "}
 (216,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -67208,24 +69491,24 @@ hm
 hm
 hm
 ed
-ed
-ed
+Xr
+FS
 ed
 jk
 "}
 (217,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -67465,24 +69748,24 @@ hm
 hm
 hm
 ed
-ed
-ed
+Xr
+FS
 ed
 jk
 "}
 (218,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -67722,23 +70005,23 @@ hm
 hm
 hm
 ed
-ed
-ed
+Xr
+FS
 ed
 jk
 "}
 (219,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -67979,23 +70262,23 @@ hm
 hm
 hm
 ed
-ed
-ed
+Xr
+FS
 ed
 jk
 "}
 (220,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -68237,22 +70520,22 @@ hm
 hm
 ed
 ed
-ed
+FS
 ed
 jk
 "}
 (221,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -68493,23 +70776,23 @@ hm
 hm
 hm
 ed
-ed
-ed
+oS
+FS
 ed
 jk
 "}
 (222,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -68751,22 +71034,22 @@ hm
 hm
 ed
 ed
-ed
+FS
 ed
 jk
 "}
 (223,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -69008,22 +71291,22 @@ hm
 hm
 ed
 ed
-ed
+FS
 ed
 jk
 "}
 (224,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -69264,24 +71547,24 @@ hm
 hm
 hm
 ed
-ed
-ed
-ed
+FS
+FS
+FS
 jk
 "}
 (225,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -69520,25 +71803,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+FS
+fr
+FS
+jk
 jk
 "}
 (226,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -69777,25 +72060,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+FS
+FS
+jk
+jk
 jk
 "}
 (227,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -70034,25 +72317,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+FS
+FS
+jk
+jk
 jk
 "}
 (228,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -70291,25 +72574,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+wE
+jk
+jk
+jk
 jk
 "}
 (229,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -70548,25 +72831,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+FS
+da
+JQ
+FS
 jk
 "}
 (230,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -70805,25 +73088,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+FS
+FS
+FS
+oS
 jk
 "}
 (231,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -71062,25 +73345,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+jk
+jk
+yW
+FS
 jk
 "}
 (232,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -71319,25 +73602,25 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
+jk
+jk
+jk
+FS
 jk
 "}
 (233,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -71574,27 +73857,27 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+jk
+jk
+jk
+jG
+FS
 jk
 "}
 (234,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -71831,27 +74114,27 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+jk
+Tb
+IQ
+FS
+FS
 jk
 "}
 (235,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -72088,27 +74371,27 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+su
+FS
+zY
+zY
+kS
 jk
 "}
 (236,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -72345,1301 +74628,1313 @@ hm
 hm
 hm
 hm
-ed
-ed
-ed
-ed
-ed
-ed
+jk
+nk
+ad
+FS
+kp
+FS
 jk
 "}
 (237,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+FS
+oS
+Qq
+FS
+FS
 jk
 "}
 (238,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
 ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+su
+JM
+FS
+FS
+zY
 jk
 "}
 (239,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+Xr
+Xr
+ed
+Xr
 ed
 ed
 ed
 ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+jk
+jk
+zY
+FS
+oW
+hw
 jk
 "}
 (240,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
 ed
-ed
-ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ST
+ST
+Ek
+tR
+ST
+ST
 jk
 "}
 (241,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
 ed
 ed
 ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+Ce
+Nq
+Oq
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ST
+mx
+MN
+dw
+Pl
+ST
 jk
 "}
 (242,1,1) = {"
 jk
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -73673,23 +75968,11 @@ hm
 hm
 hm
 hm
+ed
+ed
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -73874,6 +76157,11 @@ hm
 hm
 hm
 hm
+YM
+kR
+kR
+kR
+rU
 hm
 hm
 hm
@@ -73882,21 +76170,30 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
+tR
+mx
+dw
+dw
+dw
+tR
 jk
 "}
 (243,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -73928,26 +76225,12 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74121,6 +76404,8 @@ hm
 hm
 hm
 hm
+qC
+ss
 hm
 hm
 hm
@@ -74128,6 +76413,13 @@ hm
 hm
 hm
 hm
+YM
+kR
+kR
+kR
+kR
+kR
+rU
 hm
 hm
 hm
@@ -74135,25 +76427,30 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
+tR
+mx
+yZ
+mx
+VB
+tR
 jk
 "}
 (244,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74185,27 +76482,13 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74378,6 +76661,8 @@ hm
 hm
 hm
 hm
+yP
+an
 hm
 hm
 hm
@@ -74385,187 +76670,30 @@ hm
 hm
 hm
 hm
+Hk
+wj
+kR
+kR
+kR
+kR
+kR
+rU
 hm
 hm
 hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
+ST
+mx
+mx
+cs
+Ts
+tR
 jk
 "}
 (245,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-hm
-hm
-hm
-hm
-ed
-hm
-hm
-hm
-hm
-hm
-ed
 ed
 ed
 ed
@@ -74613,6 +76741,11 @@ hm
 hm
 hm
 hm
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74620,18 +76753,8 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
 hm
 hm
 hm
@@ -74654,6 +76777,77 @@ ed
 ed
 ed
 ed
+FS
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+RL
+cu
+UY
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+hm
+hm
+hm
+hm
+ed
+hm
+hm
+hm
+hm
+hm
 ed
 ed
 ed
@@ -74664,10 +76858,112 @@ ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+yP
+an
+hm
+hm
+hm
+hm
+hm
+hm
+UI
+kR
+FS
+FS
+FS
+FS
+FS
+FS
+oS
+ST
+ST
+tR
+tR
+tR
+ST
+ST
+mx
+lq
+dw
+VR
+tR
 jk
 "}
 (246,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74682,6 +76978,150 @@ hm
 hm
 hm
 hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+Xr
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+yP
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+er
+FS
+FS
+FS
+FS
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+xo
+Xx
+zQ
+Xx
+xo
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+ed
+ed
+ed
+hm
+hm
+ed
+ed
+ed
+hm
+hm
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74737,194 +77177,50 @@ hm
 hm
 yP
 yP
-yP
-yP
-yP
-yP
-yP
-yP
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-hm
-hm
-ed
-ed
-ed
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+dT
+dT
+dT
+dT
+dT
+dT
+kR
+kR
+du
+FS
+FS
+FS
+ad
+zY
+JM
+ST
+hY
+Mv
+Qe
+Wg
+iB
+ST
+bJ
+dw
+dw
+dw
+tR
 jk
 "}
 (247,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -74959,35 +77255,22 @@ hm
 hm
 hm
 hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75005,6 +77288,35 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+ed
+zY
+FS
+fr
+FS
+FS
+FS
+ed
+ed
+ed
+hm
+hm
+hm
+ed
+xo
+xo
+Xx
+Xx
+vH
+xo
+ed
+hm
+hm
+hm
+hm
+ed
+ed
 ed
 ed
 ed
@@ -75028,92 +77340,11 @@ ed
 ed
 ed
 ed
-hm
-hm
-hm
-hm
 ed
 ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 hm
 hm
 hm
@@ -75138,6 +77369,38 @@ ed
 ed
 ed
 ed
+Xr
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 ed
 ed
 ed
@@ -75178,10 +77441,42 @@ ed
 ed
 ed
 ed
+FS
+lT
+kS
+FS
+FS
+FS
+FS
+FS
+BB
+mx
+mx
+mx
+mx
+mx
+MX
+mx
+gA
+mx
+Ts
+tR
 jk
 "}
 (248,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75217,34 +77512,22 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75260,63 +77543,17 @@ yP
 ed
 ed
 ed
+Xr
+Xr
+Xr
+FS
 ed
 ed
+FS
+FS
+FS
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+FS
 ed
 ed
 ed
@@ -75324,56 +77561,49 @@ ed
 hm
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+xo
+ub
+fA
+sP
+fq
+xo
+xo
+xo
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+DG
+ed
+Pe
+vC
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 ed
 ed
@@ -75396,6 +77626,38 @@ ed
 ed
 ed
 ed
+Xr
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 ed
 ed
 ed
@@ -75432,13 +77694,46 @@ ed
 ed
 ed
 ed
+Xr
 ed
 ed
 ed
+ed
+oB
+aH
+FS
+CP
+aH
+FS
+FS
+BB
+mx
+ns
+mx
+mx
+bd
+qp
+mx
+mx
+mx
+sZ
+ST
 jk
 "}
 (249,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75474,34 +77769,22 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75517,19 +77800,48 @@ yP
 ed
 ed
 ed
+Xr
 ed
+Xr
+er
+zY
 ed
+FS
+FS
 ed
 ed
+FS
+Qj
 ed
 ed
 ed
 ed
 ed
 ed
+xo
+mK
+pd
+Xx
+HU
+kQ
+Xx
+xo
+KG
+EH
+GR
+xo
+xo
 ed
+FS
+FS
+EB
+FS
+FS
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -75537,7 +77849,10 @@ ed
 ed
 ed
 ed
+Xr
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -75564,51 +77879,19 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -75639,6 +77922,8 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -75660,42 +77945,52 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
+Xr
+ed
+Xr
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+Tb
+YH
+gO
+FS
+oB
+fr
+FS
+FS
+ST
+tR
+tR
+qU
+tR
+tR
+ST
+ST
+tR
+tR
+ST
+ST
 jk
 "}
 (250,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75731,34 +78026,22 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75771,20 +78054,49 @@ yP
 yP
 yP
 yP
+FS
+oS
 ed
 ed
 ed
 ed
+oS
+FS
 ed
+FS
 ed
 ed
+FS
+FS
+FS
+FS
 ed
 ed
 ed
 ed
 ed
+Fn
+Fn
+xo
+xo
+xo
+xo
+Xx
+Xx
+Xx
+Xx
+Xx
+Dy
+xo
 ed
+FS
+FS
+nc
+FS
+FS
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -75796,6 +78108,10 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -75818,6 +78134,10 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -75828,6 +78148,7 @@ ed
 ed
 ed
 ed
+Xr
 ed
 ed
 ed
@@ -75859,12 +78180,19 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -75876,83 +78204,50 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+Xr
+fz
+bF
+nc
+vD
+FS
+zY
+FS
+kS
+FS
+tR
+Qz
+mx
+mx
+mx
+dd
+ST
+jk
+jk
+jk
+jk
+jk
 jk
 "}
 (251,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+ed
+ed
+ed
 hm
 hm
 hm
@@ -75988,35 +78283,23 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 hm
 hm
 hm
@@ -76028,14 +78311,48 @@ yP
 yP
 yP
 yP
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+FS
+FS
 ed
 ed
+FS
+oS
+er
+FS
+FS
+FS
 ed
 ed
 ed
+NF
 ed
 ed
 ed
+Xr
+xo
+Xx
+Xx
+sP
+Xx
+Xx
+Xx
+FS
+CO
+FS
+IQ
+Tb
+oW
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76050,6 +78367,12 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76067,6 +78390,10 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76079,6 +78406,8 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -76097,6 +78426,9 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76107,8 +78439,16 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76123,85 +78463,28 @@ ed
 ed
 ed
 ed
+Xr
 ed
 ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+FS
+te
+FS
+kr
+Uk
+FS
+EN
+FX
+tR
+Cm
+mx
+mx
+mx
+Mu
+tR
+jk
 tM
 tM
 tM
@@ -76210,6 +78493,18 @@ tM
 "}
 (252,1,1) = {"
 jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+Xr
+Xr
+ed
 hm
 hm
 hm
@@ -76245,38 +78540,26 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+ed
+ed
+ed
+ed
+ed
+ed
+Xr
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
 yP
 yP
 yP
@@ -76288,18 +78571,42 @@ yP
 ed
 ed
 ed
+oS
+FS
+Qj
+FS
 ed
 ed
 ed
 ed
+zY
+FS
+Xr
 ed
 ed
 ed
+FS
+FS
 ed
+FS
+FS
 ed
 ed
 ed
 ed
+xo
+cg
+Hm
+NJ
+Xx
+Xx
+do
+xo
+FS
+FS
+FS
+vK
+Id
 ed
 ed
 ed
@@ -76318,6 +78625,9 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76336,6 +78646,9 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76363,6 +78676,13 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76383,6 +78703,8 @@ ed
 ed
 ed
 ed
+Xr
+Xr
 ed
 ed
 ed
@@ -76405,60 +78727,21 @@ ed
 ed
 ed
 ed
+FS
+oW
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
+FS
+Yf
+ST
+XQ
+mx
+mx
+eB
+VB
+tR
+jk
 tM
 bo
 bo
@@ -76467,129 +78750,6 @@ tM
 "}
 (253,1,1) = {"
 jk
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
 ed
 ed
 ed
@@ -76607,122 +78767,21 @@ ed
 ed
 ed
 ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-ed
-tM
-bo
-Fj
-bo
-tM
-"}
-(254,1,1) = {"
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
+hm
 jk
 hm
 hm
@@ -76731,73 +78790,6 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
 ed
 ed
 ed
@@ -76851,12 +78843,26 @@ ed
 ed
 ed
 ed
+FS
+FS
+FS
 ed
 ed
 ed
 ed
 ed
+xo
+wr
+zU
+GX
+Xx
+Xx
+Ky
+Fu
 ed
+xO
+sl
+Sv
 ed
 ed
 ed
@@ -76906,6 +78912,10 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76926,6 +78936,10 @@ ed
 ed
 ed
 ed
+Xr
+Xr
+Xr
+Xr
 ed
 ed
 ed
@@ -76973,6 +78987,275 @@ ed
 ed
 ed
 ed
+ed
+ed
+ed
+ed
+ST
+ST
+cZ
+mx
+EQ
+NZ
+ST
+jk
+tM
+bo
+Fj
+bo
+tM
+"}
+(254,1,1) = {"
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+jk
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+xo
+xo
+xo
+xo
+xo
+xo
+xo
+xo
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ST
+ST
+tR
+tR
+ST
+ST
+jk
 tM
 bo
 bo

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -4088,7 +4088,7 @@
 /area/f13/wasteland)
 "caJ" = (
 /obj/machinery/door/poddoor/gate/preopen{
-	id = DenGate
+	id = "DenGate"
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/building)
@@ -7997,7 +7997,7 @@
 /obj/machinery/button/door{
 	pixel_x = -32;
 	name = "Pharmacy Window";
-	id = DenPharma
+	id = "DenPharma"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17502,7 +17502,7 @@
 "iNh" = (
 /obj/machinery/button/door{
 	pixel_x = -32;
-	id = DenGate;
+	id = "DenGate";
 	name = "Den Gate"
 	},
 /obj/effect/decal/cleanable/dirt/dust{
@@ -26351,7 +26351,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/barswindow,
 /obj/machinery/door/poddoor/shutters{
-	id = DenPharma
+	id = "DenPharma"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -33959,7 +33959,7 @@
 "rfh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	id = DenPharma
+	id = "DenPharma"
 	},
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -38552,7 +38552,7 @@
 "tzz" = (
 /obj/machinery/button/door{
 	pixel_x = -32;
-	id = DenGate;
+	id = "DenGate";
 	name = "Den Gate"
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -43368,7 +43368,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
 /obj/machinery/door/poddoor/shutters{
-	id = DenPharma
+	id = "DenPharma"
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -563,6 +563,7 @@
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/snacks/donut/jelly/trumpet,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -2573,6 +2574,7 @@
 /area/f13/building)
 "bpz" = (
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/donut/jelly/caramel,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -17323,6 +17325,7 @@
 "iJk" = (
 /obj/structure/table/booth,
 /obj/machinery/light/floor,
+/obj/item/reagent_containers/food/snacks/donut/choco,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -21301,6 +21304,8 @@
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor,
+/obj/item/reagent_containers/food/snacks/donut/caramel,
+/obj/item/reagent_containers/food/snacks/donut/meat,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -22116,6 +22121,7 @@
 "lbc" = (
 /obj/effect/decal/cleanable/flour,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/donut/matcha,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -146,10 +146,9 @@
 	},
 /area/f13/building/massfusion)
 "acG" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "acK" = (
 /obj/machinery/smoke_machine{
@@ -357,11 +356,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "agm" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/rollingpin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluerustychess"
+/obj/machinery/microwave/stove,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "agA" = (
@@ -378,11 +375,14 @@
 	},
 /area/f13/caves)
 "aht" = (
-/obj/structure/bonfire/prelit,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/chair/f13chair2{
+	dir = 4
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "aif" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -409,13 +409,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/hospital/clinic/nash)
 "ajn" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "aju" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -445,10 +446,8 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "akk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/plasteel/f13,
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "aks" = (
 /obj/structure/table/wood,
@@ -531,10 +530,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/nash)
 "alP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "amk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -560,11 +560,12 @@
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned)
 "amX" = (
-/obj/structure/simple_door/room/dirty,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "amZ" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -692,10 +693,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "aqg" = (
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/caves)
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plating/dirt,
+/area/f13/building)
 "aqu" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -750,8 +750,15 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "arj" = (
-/obj/structure/legion_extractor,
-/turf/open/floor/plating/dirt/dark,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/deployable_barricade/wooden,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "arl" = (
 /obj/structure/flora/grass/coyote/four,
@@ -1129,14 +1136,12 @@
 	},
 /area/f13/building)
 "aBT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_y = 0
 	},
-/turf/open/indestructible/cobble{
-	color = "#777777";
-	light_color = null
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "aBX" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -1233,7 +1238,7 @@
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
 "aEO" = (
-/obj/machinery/door/unpowered/securedoor,
+/obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aEP" = (
@@ -1255,8 +1260,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "aFC" = (
-/obj/effect/decal/cleanable/blood,
-/turf/closed/wall/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fermenting_barrel,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "aFD" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -1308,12 +1316,12 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "aFK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "aFS" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building/mall)
@@ -1676,11 +1684,9 @@
 	},
 /area/f13/building/massfusion)
 "aOb" = (
-/obj/structure/chair/bench{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/bed/dogbed,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "aOf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1710,12 +1716,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "aOw" = (
-/obj/structure/sink/well{
-	pixel_x = 12;
-	pixel_y = -8
+/obj/structure/chair/left{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "aOy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/carpet/black,
@@ -1796,15 +1804,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "aRh" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
+/obj/structure/flora/tree/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aRy" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag,
@@ -1935,14 +1937,24 @@
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "aVZ" = (
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowleft"
+	},
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "aWq" = (
-/obj/structure/fermenting_barrel,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "aWu" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -2131,8 +2143,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bbR" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/machinery/vending/medical,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -2184,20 +2195,10 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "bew" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
-	},
+/obj/machinery/vending/cola/red,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "beC" = (
@@ -2210,12 +2211,11 @@
 	},
 /area/f13/building/massfusion)
 "beR" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/obj/structure/flora/wasteplant/wild_broc,
-/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "beW" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2354,11 +2354,15 @@
 	},
 /area/f13/bar/heaven)
 "bhE" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster66{
+	pixel_x = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "bhF" = (
@@ -2446,10 +2450,8 @@
 	},
 /area/f13/building/abandoned)
 "bkG" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/obj/structure/stairs/west,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "bkN" = (
 /obj/machinery/light/broken,
@@ -2570,12 +2572,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bpz" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/obj/structure/closet/crate/wicker,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "bpP" = (
 /obj/structure/fence/wooden,
 /turf/open/floor/f13/wood,
@@ -2933,7 +2934,8 @@
 /turf/open/floor/carpet/blue,
 /area/f13/building)
 "bwk" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -3126,9 +3128,38 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "bCe" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/item/defibrillator/primitive,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -3250,10 +3281,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "bEe" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/chair/right,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "bEr" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -3366,11 +3399,11 @@
 	},
 /area/f13/building/massfusion)
 "bGu" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "bGK" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3432,11 +3465,8 @@
 	},
 /area/f13/wasteland/nash)
 "bHQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bIj" = (
 /turf/open/floor/wood_common{
@@ -3509,15 +3539,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "bLP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/flora/wasteplant/wild_fungus{
-	pixel_y = 16
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/deployable_barricade/wooden,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "bLU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -3591,9 +3621,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "bNL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowright"
+	},
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "bNT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -3710,11 +3744,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "bQk" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
+	},
+/area/f13/caves)
 "bQn" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -4053,14 +4087,10 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "caJ" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
+/obj/machinery/door/poddoor/gate/preopen{
+	id = DenGate
 	},
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "cbg" = (
 /turf/open/floor/wood_wide{
@@ -4068,11 +4098,8 @@
 	},
 /area/f13/wasteland)
 "cbq" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/obj/structure/stairs/east,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "cbD" = (
 /obj/effect/decal/cleanable/dirt{
@@ -4109,12 +4136,13 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "ccE" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/chair/bench{
-	dir = 8
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_x = 32
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "ccJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/tree/oak_five,
@@ -4132,9 +4160,12 @@
 	},
 /area/f13/building)
 "ccP" = (
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/landmark/start/f13/wastelander/den,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "ccR" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -4298,14 +4329,10 @@
 /area/f13/wasteland)
 "chl" = (
 /obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+	color = "#a98c5d"
 	},
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "chn" = (
 /obj/structure/junk/jukebox,
 /turf/open/floor/wood_common,
@@ -4361,8 +4388,13 @@
 	},
 /area/f13/building)
 "cjA" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "cjG" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -4508,11 +4540,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "cnz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/railing{
+	color = "#A47449"
 	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/deployable_barricade/wooden,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "cnA" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -4531,9 +4569,9 @@
 	},
 /area/f13/building/hospital)
 "cnH" = (
-/obj/structure/pondlily_small,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/simple_door/brokenglass,
+/turf/open/floor/wood_common,
+/area/f13/building)
 "cop" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4599,11 +4637,9 @@
 	},
 /area/f13/building/hospital)
 "cqv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13/wood,
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/fortress_brick,
 /area/f13/building)
 "cqK" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -5142,8 +5178,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "cFh" = (
-/obj/structure/flora/wasteplant/wild_xander,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
 /area/f13/building)
 "cFp" = (
 /obj/item/mine/shrapnel,
@@ -5334,15 +5374,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "cLD" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
-	},
-/turf/closed/wall/f13/store,
 /area/f13/building)
 "cLK" = (
 /obj/structure/flora/tree/oak_five,
@@ -5473,10 +5508,10 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building/abandoned)
 "cQl" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "cQJ" = (
@@ -5680,9 +5715,11 @@
 	},
 /area/f13/wasteland/nash)
 "cUY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/store,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "cVc" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace,
@@ -6076,14 +6113,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "dfD" = (
-/obj/structure/flora/tree/jungle{
-	color = "#999999";
-	pixel_y = -9
+/obj/structure/chair/stool/retro,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "dfN" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -6160,12 +6194,15 @@
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
 "dik" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#A47449"
 	},
 /turf/open/floor/plating/dirt/dark,
-/area/f13/building)
+/area/f13/wasteland)
 "din" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6264,18 +6301,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "dlV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/structure/flora/wild_plant/flower/pink,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dmb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/right{
@@ -6544,10 +6572,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "dse" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/storage/bag/plants,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "dsG" = (
 /obj/machinery/button/door{
 	id = "knowledgeking";
@@ -6610,16 +6637,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "dum" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "duA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6631,10 +6651,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "duL" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "dvF" = (
 /obj/effect/decal/cleanable/dirt{
@@ -6750,11 +6774,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "dxi" = (
-/obj/structure/simple_door/room/dirty,
-/obj/item/lock_bolt{
-	dir = 8
+/obj/structure/sink/greyscale{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/overlay/junk/mirror{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "dxw" = (
 /obj/machinery/dna_scannernew,
@@ -6806,10 +6835,10 @@
 /area/f13/ruins)
 "dze" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/dirt,
 /area/f13/building)
 "dzz" = (
 /obj/machinery/vending/cola/red,
@@ -6874,21 +6903,8 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "dAX" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/anvil/obtainable/basic,
-/obj/item/twohanded/sledgehammer/simple,
-/obj/item/clothing/gloves/f13/blacksmith,
-/turf/open/indestructible/cobble{
-	color = "#777777";
-	light_color = null
-	},
-/area/f13/building)
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "dBd" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -6906,19 +6922,20 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "dBv" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/junglebush/large,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "dBU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/deployable_barricade/wooden,
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "dBV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -6964,12 +6981,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building/mall)
 "dCf" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 0
+/obj/structure/simple_door/room/dirty,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "dCn" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7082,16 +7099,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "dDO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/machinery/shower{
+	pixel_y = 18
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
+/obj/structure/curtain,
+/obj/machinery/pool/drain,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/turf/closed/wall/f13/wood,
 /area/f13/building)
 "dEd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7208,10 +7223,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building/mall)
 "dIW" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/spacevine,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
 	},
-/turf/closed/wall/f13/wood,
 /area/f13/building)
 "dIX" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -7338,13 +7354,9 @@
 	},
 /area/f13/building/mall)
 "dMq" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -7390,18 +7402,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "dMW" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "dNl" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/interior{
@@ -7438,19 +7441,11 @@
 	},
 /area/f13/building)
 "dNO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/simple_door/metal/fence/wooden{
+	dir = 2
 	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "dOu" = (
 /obj/structure/chair/booth{
 	icon_state = "booth_west_south"
@@ -7831,9 +7826,11 @@
 	},
 /area/f13/building/mall)
 "dZt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "dZy" = (
 /obj/structure/barricade/bars,
 /obj/item/shard,
@@ -7997,12 +7994,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "edZ" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/button/door{
+	pixel_x = -32;
+	name = "Pharmacy Window";
+	id = DenPharma
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "eed" = (
-/obj/structure/simple_door/room/dirty,
-/turf/open/floor/f13/wood,
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "efh" = (
 /obj/structure/chair/wood{
@@ -8040,10 +8048,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "egb" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/mineral/wasteland_trader,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "egq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
@@ -8115,9 +8123,14 @@
 	},
 /area/f13/wasteland)
 "ehZ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluerustychess"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/greyscale{
+	dir = 4;
+	pixel_y = 10;
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "eiz" = (
@@ -8282,10 +8295,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "emQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/glass/bucket/wood,
+/obj/structure/fence/wooden,
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/area/f13/caves)
 "enl" = (
 /obj/structure/filingcabinet{
 	pixel_x = -8
@@ -8473,15 +8485,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bar/heaven)
 "etA" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "etE" = (
-/obj/machinery/light{
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -32
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/f13{
@@ -8549,11 +8560,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "evy" = (
-/obj/structure/flora/wasteplant/wild_fungus{
-	pixel_x = -16
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "evC" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/poddoor/shutters{
@@ -8568,10 +8579,17 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "evM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "evN" = (
 /obj/structure/decoration/rag,
 /obj/structure/simple_door/repaired,
@@ -8712,8 +8730,8 @@
 	},
 /area/f13/building)
 "eAC" = (
-/obj/structure/bed/dogbed,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/legion_extractor,
+/turf/open/floor/plating/dirt,
 /area/f13/caves)
 "eAD" = (
 /obj/effect/gibspawner/human,
@@ -9444,14 +9462,10 @@
 	},
 /area/f13/building/mall)
 "eQv" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/tree/jungle/small{
-	color = "#999999";
-	pixel_y = 12
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "eRm" = (
 /obj/structure/closet,
@@ -9462,18 +9476,9 @@
 	},
 /area/f13/building/massfusion)
 "eRx" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/furnace,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "eRT" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /obj/effect/decal/cleanable/dirt,
@@ -9753,9 +9758,8 @@
 	},
 /area/f13/building)
 "eZA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "eZQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9991,9 +9995,16 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/ruins)
 "fgm" = (
-/obj/structure/simple_door/wood,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fgV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -10082,9 +10093,13 @@
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
 "fie" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13/wood,
+/obj/structure/sign/departments/medbay{
+	name = "\improper PHARMACY"
+	},
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
 /area/f13/building)
 "fim" = (
 /obj/structure/flora/tallgrass5,
@@ -10337,9 +10352,15 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "fpm" = (
-/obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/wood/bar,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "fpy" = (
@@ -10357,12 +10378,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "fpX" = (
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/autolathe,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "fqm" = (
 /obj/structure/barricade/bars,
@@ -10383,16 +10400,16 @@
 	},
 /area/f13/building/abandoned)
 "fqF" = (
-/obj/structure/flora/tallgrass5,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
+/obj/structure/stairs/south,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "frq" = (
-/obj/structure/fence/door{
-	dir = 4
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "frs" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10604,12 +10621,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "fwF" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "fwH" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10632,12 +10646,16 @@
 	},
 /area/f13/building/mall)
 "fwT" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/item/storage/fancy/donut_box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "fwX" = (
 /obj/effect/spawner/lootdrop/f13/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -10786,13 +10804,8 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/nash)
 "fBs" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/spawner/lootdrop/f13/medical/surgical,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/bonfire/dense/prelit/grill,
+/turf/open/floor/plating/dirt/dark,
 /area/f13/building)
 "fBK" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -10888,11 +10901,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "fCZ" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "fDn" = (
@@ -11093,24 +11108,14 @@
 	},
 /area/f13/building/massfusion)
 "fHZ" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/landmark/start/f13/wastelander/den,
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "fIs" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench_center"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "fIt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11503,16 +11508,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fVT" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt{
+	color = "#6D6D6D"
 	},
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/area/f13/caves)
 "fWe" = (
 /obj/structure/spacevine{
 	color = "#225522"
@@ -11808,17 +11809,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "gej" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_y = 0
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "gen" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken1"
@@ -11988,17 +11984,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/mall)
 "ghN" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
+/obj/structure/flora/big_bush{
+	icon_state = "burnedbush10"
 	},
-/obj/structure/mirror{
-	pixel_y = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ghW" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -12022,11 +12012,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "gig" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
+/mob/living/simple_animal/chicken,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "gis" = (
 /obj/effect/validball_spawner,
 /turf/open/floor/carpet/black,
@@ -12048,10 +12036,12 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "giJ" = (
-/obj/structure/table,
-/obj/structure/barricade/barswindow,
+/obj/effect/decal/cleanable/flour,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "giL" = (
@@ -12095,11 +12085,8 @@
 	},
 /area/f13/building/mall)
 "gjl" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/turf/closed/wall/f13/coyote/fortress_brick,
+/area/f13/caves)
 "gjF" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -12341,12 +12328,13 @@
 	},
 /area/f13/caves)
 "gpq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/window/fulltile/store{
+	icon_state = "storewindowvertical"
 	},
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "gpC" = (
 /obj/structure/table/wood/bar,
 /obj/item/lock_construct,
@@ -13165,14 +13153,18 @@
 	},
 /area/f13/building/massfusion)
 "gGq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_wood,
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gHd" = (
-/obj/machinery/hydroponics/soil,
+/obj/structure/fence/wooden{
+	dir = 8;
+	icon_state = "post_wood"
+	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
+"gHd" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "gHi" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -13185,11 +13177,10 @@
 	},
 /area/f13/wasteland)
 "gHo" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "gHv" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -13977,16 +13968,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "haD" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "haW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing{
@@ -13998,8 +13982,10 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "haY" = (
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
+/obj/structure/window/fulltile/ruins,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "hbn" = (
 /obj/structure/barricade/bars,
@@ -14031,10 +14017,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hbz" = (
-/obj/structure/table,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/table/wood/bar,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hbL" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14124,11 +14109,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "heq" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/chair/left,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "hew" = (
 /obj/effect/turf_decal/trimline/neutral{
 	dir = 8;
@@ -14150,11 +14136,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hfs" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "hfy" = (
 /obj/structure/chair/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -14211,9 +14199,11 @@
 	},
 /area/f13/building/hospital)
 "hhi" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "hhu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14230,21 +14220,12 @@
 	},
 /area/f13/wasteland)
 "hhy" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 9
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hhC" = (
 /obj/machinery/light{
 	dir = 8
@@ -14553,15 +14534,16 @@
 	},
 /area/f13/building)
 "hnm" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
+/obj/structure/toilet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1;
+	light_color = "red"
 	},
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/plating/dirt/dark,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "hnn" = (
 /obj/structure/window/fulltile/wood,
@@ -14607,13 +14589,22 @@
 	},
 /area/f13/bar/nash)
 "hnO" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/closet/fridge,
+/obj/effect/decal/cleanable/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/caves)
+/area/f13/building)
 "hnP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -14649,8 +14640,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building/hospital/clinic/nash)
 "hpE" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "hpS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14696,13 +14691,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hqF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/tree/jungle{
-	color = "#999999"
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_y = -32
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hqL" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14762,13 +14754,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "hrR" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hsd" = (
 /turf/closed/wall/f13/supermart,
@@ -14856,9 +14843,10 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "hto" = (
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "htF" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt,
@@ -15014,7 +15002,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
 "hya" = (
-/obj/structure/table,
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -15031,19 +15020,15 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "hyu" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "hyz" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "hyM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -15304,11 +15289,33 @@
 /area/f13/caves)
 "hFG" = (
 /obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -3
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "hGb" = (
 /obj/structure/bed/old,
 /obj/item/blanket/blanketalt,
@@ -15677,9 +15684,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hQS" = (
-/obj/effect/landmark/start/f13/wastelander/den,
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/fortress_brick,
+/area/f13/building)
 "hRp" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -15785,13 +15792,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "hUt" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "hVx" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -15835,13 +15838,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "hWr" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 6
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/wood_common,
+/area/f13/building)
 "hWC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16097,11 +16098,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "icJ" = (
-/obj/structure/simple_door,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "idc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/donut_corp{
@@ -16194,9 +16196,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
 "ifb" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "ifg" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/f13/wood/house,
@@ -16448,10 +16453,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/hospital)
 "inU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_mutfruit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "iok" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -16556,13 +16560,8 @@
 	},
 /area/f13/building/mall)
 "ipE" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#9c9c9c"
-	},
-/area/f13/caves)
+/turf/open/floor/plating/dirt,
+/area/f13/building)
 "ipJ" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -16576,12 +16575,8 @@
 /area/f13/wasteland/nash)
 "ipP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "ipR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -16614,12 +16609,16 @@
 	},
 /area/f13/building/mall)
 "iqt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 4;
+	pixel_y = 0
 	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "iqu" = (
@@ -17016,13 +17015,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "iBt" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tallgrass2,
-/obj/structure/flora/tallgrass2,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/chair/bench,
+/turf/open/floor/plating/dirt,
+/area/f13/building)
 "iBz" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
@@ -17036,11 +17031,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "iCH" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iCV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17125,12 +17117,10 @@
 	},
 /area/f13/building/mall)
 "iEY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine{
-	name = "vines";
-	pixel_y = 2
-	},
-/turf/closed/wall/f13/store,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "iFg" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17331,12 +17321,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "iJk" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/structure/table/booth,
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "iJF" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -17450,14 +17439,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "iMa" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#845f58";
-	open = 0
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "iMn" = (
 /obj/structure/fence/end/wooden{
@@ -17475,14 +17462,9 @@
 	},
 /area/f13/building)
 "iMG" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "iMK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/tallgrass5,
@@ -17518,14 +17500,15 @@
 	},
 /area/f13/building/mall)
 "iNh" = (
-/obj/structure/window/fulltile/store,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/machinery/button/door{
+	pixel_x = -32;
+	id = DenGate;
+	name = "Den Gate"
 	},
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "iNp" = (
 /obj/machinery/light{
@@ -17879,14 +17862,12 @@
 	},
 /area/f13/building)
 "iWF" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/fence/wooden{
+	dir = 8;
+	icon_state = "post_wood"
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "iWL" = (
 /obj/structure/flora/tree/oak_five,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -17908,11 +17889,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "iXk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/machinery/shower{
+	pixel_y = 18
 	},
-/area/f13/wasteland)
+/obj/structure/curtain,
+/obj/machinery/pool/drain,
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "iXm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -18049,10 +18036,9 @@
 	},
 /area/f13/wasteland)
 "jaq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jaz" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -18257,11 +18243,11 @@
 	},
 /area/f13/building/mall)
 "jgn" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/table/booth,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "jgF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor2-old"
@@ -18283,22 +18269,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "jhc" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/tree/pink_tree{
-	pixel_x = -35;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/stairs/west,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "jhe" = (
-/obj/structure/closet/fridge,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
+/obj/structure/table/optable,
 /turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "jhg" = (
@@ -18750,10 +18727,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "jsq" = (
-/obj/machinery/vending/nukacolavend,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/mineral/wasteland_trader,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "jsI" = (
 /obj/structure/sink{
@@ -18895,13 +18870,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "jvR" = (
-/obj/item/clothing/gloves/botanic_leather,
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
+/obj/item/storage/trash_stack{
+	layer = 2
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "jvX" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-02"
@@ -18988,11 +18961,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "jyL" = (
+/obj/structure/closet,
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "jyW" = (
 /obj/structure/fluff/railing{
@@ -19001,10 +18972,8 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "jzb" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "jze" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -19238,11 +19207,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building/tribal)
 "jGi" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/machinery/vending/medical/becomingnook,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "jGs" = (
@@ -19781,15 +19749,16 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/massfusion)
 "jUW" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "jVf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/smoke_machine{
@@ -19839,15 +19808,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "jXs" = (
-/obj/structure/table,
-/obj/machinery/computer/pod/old{
-	icon_state = "terminal";
-	name = "terminal"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
+/obj/structure/flora/junglebush,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jXI" = (
 /obj/structure/flora/rock/pile/largejungle{
 	icon_state = "bush3"
@@ -19886,12 +19849,9 @@
 	},
 /area/f13/building)
 "jYx" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jYV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/validball_spawner,
@@ -19985,25 +19945,12 @@
 	},
 /area/f13/building/mall)
 "kaD" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -12
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "kaR" = (
 /obj/effect/decal/waste{
@@ -20411,11 +20358,15 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "kmf" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 4;
+	pixel_y = 0
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "kms" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20704,11 +20655,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ktc" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tree/oak_five,
-/turf/open/indestructible/ground/outside/roof,
+/obj/structure/chair/stool/retro/black,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "ktl" = (
 /obj/structure/rack/shelf_metal,
@@ -20748,7 +20696,8 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "kuD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -21240,12 +21189,12 @@
 	},
 /area/f13/building)
 "kDo" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/machinery/recycler,
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "kDu" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -21280,16 +21229,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "kDC" = (
-/obj/machinery/button/door{
-	id = "ogden";
-	name = "gate button";
-	pixel_x = 25;
-	pixel_y = -23
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/dirt,
 /area/f13/building)
 "kDD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -21352,13 +21298,9 @@
 	},
 /area/f13/building/mall)
 "kES" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/item/storage/fancy/donut_box,
-/obj/item/storage/fancy/donut_box,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -21395,10 +21337,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "kFo" = (
-/obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/f13/wood,
+/obj/structure/janitorialcart,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
 /area/f13/building)
 "kFD" = (
 /obj/machinery/door/airlock/hatch,
@@ -21550,9 +21493,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "kJq" = (
-/obj/effect/landmark/start/f13/wastelander/den,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "kKc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/two_barrels,
@@ -21782,11 +21728,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "kRq" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/stairs/west,
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kRD" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
@@ -21874,10 +21821,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "kSG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "kTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/tree/oak_five,
@@ -22010,10 +21960,14 @@
 /turf/open/floor/wood_common,
 /area/f13/caves)
 "kVE" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/stock_parts/chem_cartridge/pristine,
+/obj/item/stock_parts/chem_cartridge/pristine,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "kWr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rug/big/rug_yellow{
@@ -22152,16 +22106,19 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/nash)
 "laA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house/broken,
+/obj/structure/table/wood/bar,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "lbc" = (
-/obj/structure/flora/wasteplant/wild_fungus,
-/obj/structure/flora/wasteplant/wild_fungus{
-	pixel_x = -4;
-	pixel_y = 5
+/obj/effect/decal/cleanable/flour,
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "lbg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22314,8 +22271,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
 "leP" = (
-/obj/structure/flora/wasteplant/wild_feracactus,
-/turf/open/floor/plating/dirt/dark,
+/obj/structure/stairs/north{
+	color = "#A47449"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "lfe" = (
 /obj/structure/table/wood,
@@ -22371,11 +22333,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "lgs" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "lgu" = (
 /obj/item/kirbyplants,
@@ -22444,11 +22404,8 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/nash)
 "lja" = (
-/obj/structure/table/optable,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/machinery/mineral/ore_redemption,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "ljF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22478,21 +22435,15 @@
 	},
 /area/f13/building)
 "lkm" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants{
+	icon_state = "plant-12"
 	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/deployable_barricade/wooden{
-	pixel_y = 3
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "lkn" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -22574,16 +22525,10 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "lnp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 10
+/obj/structure/window/fulltile/ruins,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "lnw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22592,8 +22537,15 @@
 	},
 /area/f13/building)
 "lnA" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "lnM" = (
 /obj/structure/lattice/catwalk,
@@ -22609,9 +22561,9 @@
 	},
 /area/f13/building/abandoned)
 "lnR" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/wild_plant/flower/pink_three,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lom" = (
 /obj/item/clothing/under/f13/police/officer,
 /obj/item/clothing/shoes/combat,
@@ -22727,12 +22679,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "lqv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "lqF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -22884,16 +22833,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "lvv" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/turf/closed/indestructible/rock,
+/area/f13/wasteland)
 "lvD" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "lvE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -22983,9 +22934,14 @@
 /turf/closed/wall/mineral/brick,
 /area/f13/building)
 "lxD" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/chair/stool/retro/tan,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "lxO" = (
@@ -23019,10 +22975,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "lyA" = (
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "lyP" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -23032,18 +22990,14 @@
 	},
 /area/f13/building/mall)
 "lyR" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
-	},
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "lyV" = (
 /obj/structure/flora/grass/coyote/twentyone,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23231,13 +23185,10 @@
 	},
 /area/f13/wasteland)
 "lDc" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
+/obj/structure/stairs/east{
+	color = "#A47449"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "lDd" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -23678,14 +23629,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lPD" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/structure/simple_door/metal/fence/wooden{
+	dir = 2
 	},
-/turf/open/indestructible/cobble{
-	color = "#777777";
-	light_color = null
-	},
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "lPI" = (
 /obj/structure/rug/carpet,
 /obj/structure/nightstand/small{
@@ -23698,13 +23646,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lPT" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "lQz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23823,12 +23771,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "lTF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/fortress_brick,
+/area/f13/building)
 "lTP" = (
 /obj/machinery/light{
 	dir = 8
@@ -23891,18 +23836,30 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "lWj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
 	},
-/obj/structure/furnace{
-	light_range = 3;
-	pixel_x = -5
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
 	},
-/turf/open/indestructible/cobble{
-	color = "#777777";
-	light_color = null
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3
 	},
-/area/f13/building)
+/obj/structure/barricade/wooden/planks{
+	density = 0
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "lWG" = (
 /obj/structure/stairs/west{
 	color = "#A47449"
@@ -23920,17 +23877,12 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/nash)
 "lXb" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
 	},
-/obj/machinery/computer/terminal{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "lXd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13{
@@ -23966,11 +23918,17 @@
 	},
 /area/f13/building/massfusion)
 "lXs" = (
-/obj/machinery/chem_master,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "lXH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24291,10 +24249,14 @@
 	},
 /area/f13/building/mall)
 "mdU" = (
+/obj/structure/chair/booth{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "mdW" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -24479,17 +24441,9 @@
 	},
 /area/f13/wasteland)
 "mjT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/obj/structure/flora/tree/jungle/small,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mkp" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24509,11 +24463,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "mky" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mkF" = (
 /obj/structure/flora/twig2,
@@ -24544,11 +24495,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "mlA" = (
-/obj/structure/flora/tallgrass5,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "mmg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/tallgrass5,
@@ -24602,8 +24555,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
 "mnU" = (
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mob" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken,
@@ -24890,12 +24845,14 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/heaven)
 "mvO" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/area/f13/building)
 "mvR" = (
 /obj/structure/table/glass,
 /turf/open/floor/wood_common,
@@ -25078,17 +25035,8 @@
 	},
 /area/f13/building/massfusion)
 "mzZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#999999"
-	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mAb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25146,10 +25094,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "mBe" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/closed/indestructible/rock,
-/area/f13/caves)
+/turf/closed/indestructible/f13/matrix,
+/area/f13/building/tunnel)
 "mBg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25367,14 +25313,9 @@
 	},
 /area/f13/building)
 "mHc" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mHk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/small/table,
@@ -25395,9 +25336,16 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
 "mHN" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "mIa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -25529,11 +25477,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "mJY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mKa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25943,12 +25888,8 @@
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
 "mSQ" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mTt" = (
@@ -26381,9 +26322,12 @@
 	},
 /area/f13/building)
 "neM" = (
-/obj/structure/simple_door/repaired,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "neQ" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/lit,
@@ -26404,17 +26348,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/mall)
 "nfv" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/table/reinforced,
+/obj/structure/barricade/barswindow,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
 	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "nfz" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
@@ -26471,9 +26413,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ngb" = (
+/obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "ngm" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -26592,6 +26536,14 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"njR" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
+/area/f13/building)
 "nkd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
@@ -26604,9 +26556,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "nkJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2"
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster71{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "nle" = (
@@ -26659,13 +26615,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "nlQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
+/obj/structure/tires/five,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "nlY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27121,12 +27072,12 @@
 	},
 /area/f13/wasteland/nash)
 "nxF" = (
-/obj/structure/bonfire/prelit,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "nxG" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -27450,9 +27401,11 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "nEF" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "nEG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -27519,9 +27472,8 @@
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "nHf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/hacked,
-/turf/open/floor/f13/wood,
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "nHh" = (
 /obj/structure/curtain{
@@ -28077,8 +28029,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nRP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/black,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nRT" = (
@@ -28138,14 +28095,13 @@
 	},
 /area/f13/building/mall)
 "nUs" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/table/wood/bar,
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Public"
 	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nVC" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28181,17 +28137,10 @@
 /turf/open/floor/carpet/blue,
 /area/f13/bar/nash)
 "nWw" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "nWS" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28325,14 +28274,12 @@
 	},
 /area/f13/building)
 "nZK" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/terminal,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
 /area/f13/building)
 "oab" = (
 /obj/effect/decal/cleanable/dirt{
@@ -28559,11 +28506,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oga" = (
-/obj/structure/sign/poster/contraband/donut_corp,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "ogk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/broken{
@@ -28600,9 +28545,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "ogS" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/donut,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -28669,15 +28613,9 @@
 /turf/closed/wall/mineral/brick,
 /area/f13/bar/nash)
 "oig" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/billboard/den{
-	desc = "A sprayed metal sheet that says \"The Den \".ssssssssdddddddddddddddddddddddddddddddddddddddddddd";
-	pixel_y = 17
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "oip" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood3-broken"
@@ -28829,11 +28767,8 @@
 	},
 /area/f13/building)
 "omN" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/closed/wall/f13/tunnel,
+/area/f13/building/tunnel)
 "omQ" = (
 /obj/structure/dresser{
 	pixel_y = 10
@@ -28928,11 +28863,12 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/caves)
 "orb" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/caves)
+/area/f13/building)
 "org" = (
 /obj/structure/fluff/hedge,
 /obj/effect/decal/cleanable/dirt,
@@ -29035,17 +28971,14 @@
 	},
 /area/f13/building)
 "otq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/tallgrass5,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "otu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "otX" = (
 /obj/structure/window/fulltile/store{
@@ -29127,11 +29060,19 @@
 	},
 /area/f13/building/abandoned)
 "owA" = (
-/obj/structure/flora/tallgrass5,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/area/f13/wasteland)
+/area/f13/building)
+"owB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "owR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -29458,12 +29399,11 @@
 /turf/open/floor/carpet,
 /area/f13/building/abandoned)
 "oDY" = (
-/obj/structure/simple_door/house{
-	icon_state = "dirtystore"
+/obj/structure/chair/sofa/left{
+	dir = 4
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "oEe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29484,9 +29424,14 @@
 /turf/open/floor/carpet/cyan,
 /area/f13/building)
 "oFf" = (
-/obj/machinery/gear_painter,
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "oGd" = (
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -29669,12 +29614,14 @@
 /turf/closed/wall,
 /area/f13/building)
 "oLF" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "oLL" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -29782,11 +29729,13 @@
 	},
 /area/f13/building)
 "oOB" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/structure/table/wood,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants,
+/obj/item/fishingrod,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "oOE" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -29849,10 +29798,17 @@
 	},
 /area/f13/building/massfusion)
 "oQZ" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/structure/billboard/den{
+	desc = "A sprayed metal sheet that says \"The Den \".ssssssssdddddddddddddddddddddddddddddddddddddddddddd";
+	pixel_y = 17
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "oRk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29923,23 +29879,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "oSB" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "oSF" = (
-/obj/structure/flora/tree/jungle{
-	color = "#999999"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "oSM" = (
-/turf/closed/wall/f13/wood,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "oSN" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
@@ -30300,14 +30257,9 @@
 	},
 /area/f13/building/tribal)
 "pdm" = (
-/obj/structure/chair/stool{
-	dir = 2;
-	icon_state = "bench"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_datura,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pdX" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood_common{
@@ -30408,11 +30360,10 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
 "pgE" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "pgN" = (
@@ -30547,12 +30498,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "plz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "plV" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -30588,10 +30539,13 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "poL" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster62{
+	pixel_x = -32
 	},
-/turf/closed/wall/f13/wood/house/broken,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "ppD" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -30614,9 +30568,11 @@
 	},
 /area/f13/wasteland)
 "ppP" = (
-/obj/structure/flora/wasteplant/wild_broc,
+/obj/structure/sink/well{
+	pixel_x = 13
+	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/area/f13/wasteland)
 "ppS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/concrete,
@@ -30703,10 +30659,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
 "psI" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "psK" = (
@@ -30720,12 +30677,11 @@
 	},
 /area/f13/building)
 "pte" = (
-/obj/structure/sink/deep_water{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/area/f13/building)
 "ptv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/secure/safe{
@@ -30819,9 +30775,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "puH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "puJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -30849,15 +30807,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "pwl" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/turf/closed/indestructible/rock,
+/obj/structure/flora/tree/jungle,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "pws" = (
 /obj/structure/table,
@@ -30912,9 +30863,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "pxo" = (
+/obj/machinery/processor,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "pxA" = (
 /obj/structure/simple_door/dirtyglass,
@@ -31221,10 +31174,16 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building)
 "pEx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pEE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -31404,12 +31363,19 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "pIp" = (
+/obj/structure/toilet,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
 "pIs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -31441,13 +31407,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "pIV" = (
-/obj/structure/flora/tree/jungle{
-	color = "#999999"
+/obj/structure/sign/painting/library{
+	pixel_x = 32
 	},
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = 16
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pJe" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -31455,12 +31424,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "pKF" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/structure/sink/deep_water,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "pKI" = (
 /obj/structure/window,
 /turf/open/floor/f13{
@@ -31534,13 +31500,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "pLU" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/obj/structure/fence/wooden,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "pMd" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -31793,9 +31755,15 @@
 	},
 /area/f13/building/massfusion)
 "pUj" = (
-/obj/structure/closet,
+/obj/structure/sink/greyscale{
+	dir = 1
+	},
+/obj/structure/mirror{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "pUq" = (
@@ -31807,12 +31775,11 @@
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic/nash)
 "pUK" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "pVh" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -31858,15 +31825,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "pWq" = (
+/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/wasteland)
+/area/f13/building)
 "pWr" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -32273,18 +32237,18 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "qgG" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/table/wood/bar,
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/area/f13/building)
 "qgK" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 1
@@ -32303,13 +32267,9 @@
 	},
 /area/f13/building/mall)
 "qgO" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/item/instrument/harmonica,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "qhe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -32404,11 +32364,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "qiY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "qiZ" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/light{
@@ -32461,15 +32422,12 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland)
 "qls" = (
-/obj/structure/flora/tree/jungle{
-	color = "#999999";
-	pixel_y = -5
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "qlH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
@@ -32572,15 +32530,11 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland/nash)
 "qnO" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "qnQ" = (
 /obj/structure/railing/corner{
@@ -32620,12 +32574,16 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "qqe" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/machinery/computer/terminal{
+	dir = 4;
+	termtag = "Public"
+	},
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "qqh" = (
@@ -32657,11 +32615,13 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "qqD" = (
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/structure/sink/greyscale{
+	pixel_y = 20
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "qqQ" = (
 /obj/structure/spacevine,
@@ -32814,8 +32774,13 @@
 	},
 /area/f13/building/massfusion)
 "qtg" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/caves)
+/obj/structure/stairs/north{
+	color = "#A47449"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "qtx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -32846,18 +32811,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "qtT" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/structure/sink/deep_water{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/building)
 "qtY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33119,11 +33077,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "qAP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/f13/wood,
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "qBy" = (
 /turf/closed/wall/f13/wood/interior{
@@ -33144,10 +33099,12 @@
 	},
 /area/f13/wasteland)
 "qCz" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/right{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "qDg" = (
@@ -33182,8 +33139,9 @@
 	},
 /area/f13/building/mall)
 "qDJ" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/machinery/vending/cola/starkist,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -33378,13 +33336,24 @@
 	},
 /area/f13/building/massfusion)
 "qLq" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/closet/fridge,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/grains,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
 /area/f13/building)
 "qLD" = (
 /turf/open/floor/carpet/black,
@@ -33447,11 +33416,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "qNW" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "qNX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -33480,13 +33451,7 @@
 	},
 /area/f13/building)
 "qOx" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "qOL" = (
 /obj/structure/simple_door/metal/store,
@@ -33535,14 +33500,9 @@
 	},
 /area/f13/wasteland/nash)
 "qOZ" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qPu" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
@@ -33641,10 +33601,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
 "qSg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/structure/simple_door/repaired,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
 /area/f13/building)
 "qSl" = (
 /obj/structure/fence/wooden{
@@ -33667,11 +33627,12 @@
 	},
 /area/f13/building/mall)
 "qSt" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qTn" = (
 /obj/structure/railing,
 /obj/machinery/light{
@@ -33699,18 +33660,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "qUc" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/donut/jelly,
-/obj/item/reagent_containers/food/snacks/donut/jelly,
-/obj/item/reagent_containers/food/snacks/donut/jelly,
-/obj/item/reagent_containers/food/snacks/donut/jelly,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "qUo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -33769,10 +33721,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qYc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/smartfridge/bottlerack/seedbin/primitive,
-/turf/open/floor/plating/dirt/dark,
-/area/f13/building)
+/obj/structure/nest/frog,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "qYp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33888,11 +33839,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "qZD" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "ray" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33952,9 +33900,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rek" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house/broken,
+/obj/structure/table/wood/bar,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "rey" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34004,12 +33957,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "rfh" = (
-/obj/structure/closet/crate{
-	icon_state = "medicalcrate"
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
 	},
-/obj/item/stock_parts/chem_cartridge/crafted,
-/obj/item/stock_parts/chem_cartridge/crafted,
-/obj/item/stock_parts/chem_cartridge/crafted,
+/obj/structure/barricade/bars,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -34128,15 +34080,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rhW" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 5
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
-	},
-/turf/open/floor/plating/dirt/dark,
 /area/f13/building)
 "rhY" = (
 /obj/machinery/light{
@@ -34327,8 +34275,10 @@
 	},
 /area/f13/building/mall)
 "rkM" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/uncommon,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rkP" = (
@@ -34435,10 +34385,10 @@
 /turf/open/floor/carpet/blue,
 /area/f13/building/hospital/clinic/nash)
 "rmt" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluerustychess"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
 /area/f13/building)
 "rmv" = (
@@ -34501,10 +34451,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rpe" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/floor/plating/dirt,
+/obj/structure/stairs/south,
+/turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rpk" = (
 /obj/effect/decal/cleanable/dirt{
@@ -34831,10 +34782,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/mall)
 "rwS" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "rxb" = (
 /obj/item/paper_bin,
@@ -34865,10 +34814,14 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "ryv" = (
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/structure/chair/right{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "ryx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/double,
@@ -35428,13 +35381,12 @@
 /turf/open/floor/carpet/arcade,
 /area/f13/building/mall)
 "rMp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "rMQ" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -35472,12 +35424,14 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/abandoned)
 "rOb" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "rOK" = (
 /obj/structure/barricade/wooden,
@@ -35606,12 +35560,11 @@
 	},
 /area/f13/building/massfusion)
 "rSL" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 10
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "rSX" = (
 /obj/structure/window{
 	dir = 4;
@@ -35649,16 +35602,10 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "rTw" = (
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/junglebush/c,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rTy" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -35854,8 +35801,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "sbk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/coffee,
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -36080,13 +36027,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "sgY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/structure/flora/wasteplant/wild_xander,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "shp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -36352,23 +36295,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "sqL" = (
-/obj/structure/chair/stool{
-	dir = 1;
-	icon_state = "bench"
-	},
-/obj/effect/decal/remains{
-	icon_state = "remains"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"sqM" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt,
+/obj/structure/flora/grass/jungle,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"sqM" = (
+/obj/structure/anvil/obtainable/basic,
+/obj/item/clothing/gloves/f13/blacksmith,
+/obj/item/twohanded/sledgehammer/simple,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/building)
 "sqS" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -36723,14 +36658,8 @@
 	},
 /area/f13/building/mall)
 "sDd" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "sDl" = (
 /obj/effect/decal/waste{
@@ -36982,9 +36911,19 @@
 	},
 /area/f13/building/tribal)
 "sJb" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/machinery/smartfridge/bottlerack,
+/obj/item/export/bottle/applejack,
+/obj/item/export/bottle/absinthe,
+/obj/item/export/bottle/grenadine,
+/obj/item/export/bottle/patron,
+/obj/item/export/bottle/rum,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "sJX" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -36995,15 +36934,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
 "sKE" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "sKM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing{
@@ -37059,15 +36994,11 @@
 /turf/open/transparent/openspace,
 /area/f13/bar/nash)
 "sMB" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "sNs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37402,25 +37333,22 @@
 	},
 /area/f13/wasteland)
 "sWH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/tallgrass5,
-/obj/structure/flora/ausbushes/ywflowers{
-	light_color = "#EBAF4C";
-	light_power = 3;
-	light_range = 2
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
-"sWI" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 2
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
+"sWI" = (
+/obj/structure/closet/crate/footchest,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "sWJ" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/blood/drip,
@@ -37465,10 +37393,12 @@
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
 "sXS" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -37592,13 +37522,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland/massfusion)
 "taH" = (
-/obj/structure/ladder/unbreakable{
-	height = 1;
-	id = "bunnyden";
-	level = 1
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "tbw" = (
@@ -37673,13 +37601,13 @@
 /turf/closed/wall/f13/store,
 /area/f13/building/hospital)
 "tcN" = (
-/obj/structure/flora/tree/jungle/small{
-	color = "#999999"
+/mob/living/simple_animal/hostile/retaliate/frog,
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = -31;
+	pixel_x = -31
 	},
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "tcP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -37974,14 +37902,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "tke" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile,
-/obj/structure/curtain{
-	color = "#845f58";
-	open = 0
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tkk" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/roof,
@@ -38015,15 +37938,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "tkV" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/structure/flora/tree/oak_five,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/area/f13/building)
 "tkW" = (
 /obj/structure/decoration/rag,
 /obj/structure/fence/wooden{
@@ -38115,11 +38034,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tmG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
 	},
-/turf/closed/wall/f13/store,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "tmK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38241,24 +38159,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "toT" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "tpg" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "ogden";
-	name = "outpost gate2"
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/building)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/wasteland)
 "tpu" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -38376,8 +38287,16 @@
 /area/f13/building/mall)
 "trg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/cultivator/rake,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/item/mop,
+/obj/item/soap,
+/obj/item/storage/bag/trash,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
+	},
 /area/f13/building)
 "tsD" = (
 /obj/machinery/smoke_machine{
@@ -38576,9 +38495,18 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "txV" = (
-/obj/structure/pondlily_small,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9;
+	density = 0
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	pixel_y = 14;
+	pixel_x = 18
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/building)
 "tyb" = (
 /obj/item/storage/box/cups,
 /obj/structure/table/wood,
@@ -38608,10 +38536,9 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
 "tyE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
+/obj/structure/flora/tree/jungle/small,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "tzj" = (
 /obj/structure/dresser,
 /obj/item/clothing/shoes/f13/cowboy{
@@ -38623,8 +38550,12 @@
 	},
 /area/f13/building)
 "tzz" = (
-/obj/item/shovel/spade,
-/turf/open/indestructible/ground/outside/dirt/harsh,
+/obj/machinery/button/door{
+	pixel_x = -32;
+	id = DenGate;
+	name = "Den Gate"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "tzG" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
@@ -38669,26 +38600,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/mall)
 "tAR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tBo" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood1-broken"
 	},
 /area/f13/wasteland/nash)
 "tBF" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
+/obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tBX" = (
@@ -38930,12 +38852,9 @@
 	},
 /area/f13/building)
 "tHt" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "tHJ" = (
 /obj/item/clothing/under/f13/petrochico,
 /obj/effect/decal/cleanable/dirt{
@@ -38953,8 +38872,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "tIx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair,
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "whiteyellowdirtychess2"
 	},
@@ -39340,13 +39259,14 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "tQp" = (
-/obj/structure/flora/tallgrass5,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass{
-	color = "#225522"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "tQG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -39566,11 +39486,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "tWa" = (
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/obj/structure/flora/wild_plant/flower/purple_two,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "tWj" = (
 /obj/machinery/teleport/station{
 	name = "power unit"
@@ -39683,16 +39601,14 @@
 	},
 /area/f13/building/mall)
 "tZo" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/caves)
+/area/f13/building)
 "tZQ" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -39776,13 +39692,13 @@
 	},
 /area/f13/building)
 "udw" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/closed/indestructible/rock,
-/area/f13/caves)
+/area/f13/building)
 "udH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -39956,9 +39872,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "uiy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
+/obj/item/kirbyplants{
+	icon_state = "plant-12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "uiG" = (
 /obj/structure/bed/wooden,
@@ -39986,12 +39904,16 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "ujb" = (
-/obj/effect/decal/cleanable/flour,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/area/f13/building)
+/obj/structure/deployable_barricade/wooden,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "ujC" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -40347,12 +40269,9 @@
 	},
 /area/f13/building/abandoned)
 "urX" = (
-/obj/structure/window/fulltile/wood_window,
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/rack/shelf_metal,
+/obj/item/reagent_containers/glass/beaker,
+/turf/open/floor/plating/dirt,
 /area/f13/building)
 "usf" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -40588,11 +40507,9 @@
 /turf/open/floor/wood_fancy,
 /area/f13/building)
 "uwq" = (
-/obj/structure/sink/deep_water{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/water,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "uwG" = (
 /obj/structure/toilet{
@@ -40756,12 +40673,17 @@
 	},
 /area/f13/building/mall)
 "uBg" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 9;
+	density = 0
 	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/dirt/dark,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_x = -18;
+	pixel_y = 14
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "uBj" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -40981,11 +40903,8 @@
 /turf/open/floor/wood_wide,
 /area/f13/building)
 "uJY" = (
-/obj/structure/simple_door/metal/store,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uJZ" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -41035,13 +40954,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "uLi" = (
-/obj/structure/simple_door/repaired,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/cobble{
-	color = "#777777";
-	light_color = null
-	},
-/area/f13/building)
+/obj/structure/flora/wasteplant/fever_blossom,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "uLN" = (
 /obj/structure/simple_door/room,
 /obj/structure/spacevine{
@@ -41101,12 +41016,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "uNR" = (
-/obj/structure/flora/tallgrass5,
+/obj/structure/simple_door/room/dirty,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/grass{
-	color = "#225522"
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
 	},
-/area/f13/wasteland)
+/area/f13/building)
 "uOi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair{
@@ -41124,12 +41039,9 @@
 	},
 /area/f13/building)
 "uOV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/f13/store,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "uOY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_fancy,
@@ -41287,12 +41199,9 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "uSN" = (
-/obj/machinery/vending/nukacolavend,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
+/obj/structure/fence/wooden,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "uSO" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -41821,14 +41730,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vfT" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 10
 	},
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vgh" = (
 /obj/structure/table,
 /obj/effect/validball_spawner,
@@ -41941,10 +41848,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "vjd" = (
-/obj/structure/bed,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "vje" = (
 /turf/closed/mineral/random/low_chance,
@@ -41991,12 +41901,15 @@
 	},
 /area/f13/building/tribal)
 "vkf" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/obj/structure/decoration/clock{
-	pixel_y = 30
+/obj/structure/reagent_dispensers/barrel/explosive{
+	pixel_x = -9;
+	pixel_y = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/structure/reagent_dispensers/barrel/explosive{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "vkh" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42324,9 +42237,8 @@
 	},
 /area/f13/building)
 "vsz" = (
-/obj/structure/chair,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "vsN" = (
@@ -42368,11 +42280,9 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland/nash)
 "vui" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "vuv" = (
 /obj/structure/flora/tallgrass5,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -42501,14 +42411,15 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "vzN" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet{
-	anchored = 1
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "vAd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42826,12 +42737,12 @@
 	},
 /area/f13/building)
 "vFD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/dirt/harsh,
-/area/f13/building)
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vFL" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -42871,20 +42782,9 @@
 	},
 /area/f13/caves)
 "vGB" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -7
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "vGC" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43069,18 +42969,11 @@
 	},
 /area/f13/wasteland)
 "vNA" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/beret,
+/obj/machinery/workbench,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vNT" = (
 /obj/structure/table/reinforced,
@@ -43308,8 +43201,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/building/mall)
 "vUp" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
+/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "vUr" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -43355,28 +43251,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "vVm" = (
-/obj/structure/flora/tallgrass5,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vVt" = (
-/obj/structure/reagent_dispensers/barrel/explosive{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/obj/structure/reagent_dispensers/barrel/explosive{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/obj/structure/reagent_dispensers/barrel/old{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/structure/reagent_dispensers/barrel/old{
-	pixel_x = -3;
-	pixel_y = 1
+/obj/structure/table/wood/bar,
+/obj/item/storage/box/cups,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -43480,15 +43365,13 @@
 	},
 /area/f13/building)
 "vYY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/structure/barricade/barswindow,
-/obj/item/paper_bin,
-/obj/item/paper/natural,
-/obj/item/paper/natural,
-/obj/item/paper/natural,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "vZr" = (
@@ -43609,13 +43492,13 @@
 	},
 /area/f13/building)
 "wcm" = (
-/obj/structure/closet{
-	anchored = 1
-	},
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/wood/bar,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/knife/butcher,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
 /area/f13/building)
 "wcK" = (
@@ -43637,9 +43520,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "wdc" = (
-/obj/machinery/recycler,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/obj/structure/chair/right,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "wdn" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -43771,11 +43656,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
 "whl" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "whm" = (
 /obj/structure/table/wood,
@@ -44082,15 +43967,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wql" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wqo" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -44202,10 +44083,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wsr" = (
-/obj/structure/flora/wasteplant/wild_feracactus,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/structure/chair/bench{
+	dir = 1
 	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "wss" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -44343,12 +44224,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/bar/heaven)
 "wvK" = (
-/obj/machinery/hydroponics/soil{
-	color = "#9c9c9c";
-	pixel_y = 7
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/building)
 "wvT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44493,9 +44375,9 @@
 /turf/closed/wall/f13/coyote/darkwoodwall,
 /area/f13/building/hospital/clinic/nash)
 "wAl" = (
-/obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "wAt" = (
 /obj/machinery/light{
 	dir = 4
@@ -44537,9 +44419,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wBC" = (
-/obj/structure/fence,
+/obj/structure/curtain,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "wBE" = (
@@ -44626,8 +44510,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/mall)
 "wCn" = (
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/item/binoculars,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "wCE" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44635,8 +44523,14 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "wCK" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13/wood,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/dropper,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
 /area/f13/building)
 "wCN" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -44645,11 +44539,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building/hospital)
 "wCP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
+/turf/open/floor/plating/dirt/dark,
 /area/f13/wasteland)
 "wCS" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -45020,11 +44910,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wQi" = (
-/obj/structure/simple_door/house{
-	icon_state = "roomopening"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "wQj" = (
@@ -45199,17 +45088,19 @@
 /area/f13/building)
 "wUY" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/grass{
-	color = "#225522"
-	},
-/area/f13/wasteland)
-"wVc" = (
-/obj/structure/chair{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"wVc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
 "wVo" = (
@@ -45344,9 +45235,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wYG" = (
-/obj/structure/rack/shelf_wood,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/indestructible/ground/outside/roof,
+/area/f13/wasteland)
 "wYH" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18";
@@ -45371,12 +45268,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "wZa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "wZh" = (
 /obj/structure/window/fulltile/ruins,
 /obj/structure/barricade/bars,
@@ -45390,15 +45287,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "wZx" = (
-/obj/item/clothing/under/f13/police,
-/obj/item/clothing/head/f13/police,
-/obj/item/clothing/shoes/combat,
-/obj/structure/closet,
-/obj/item/clothing/head/beret,
-/obj/effect/spawner/lootdrop/f13/uncommon,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "wZy" = (
 /obj/structure/table,
@@ -45526,10 +45416,18 @@
 	},
 /area/f13/building)
 "xdp" = (
-/obj/structure/simple_door/metal/fence/wooden{
-	dir = 2
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/storage/box/rxglasses,
+/obj/item/storage/box/rxglasses,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "xdJ" = (
 /obj/structure/simple_door/room,
@@ -45542,10 +45440,18 @@
 	},
 /area/f13/building/hospital)
 "xed" = (
-/obj/effect/temp_visual/steam,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/obj/structure/chair/left,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "xel" = (
 /obj/structure/spacevine,
 /turf/open/floor/wood_wide{
@@ -45593,11 +45499,11 @@
 	},
 /area/f13/wasteland)
 "xhv" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
 "xhL" = (
@@ -45706,10 +45612,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "xku" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/turf/open/floor/plating/dirt,
 /area/f13/building)
 "xkz" = (
 /obj/structure/dresser,
@@ -45767,17 +45673,8 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "xma" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#999999"
-	},
+/obj/structure/flora/wild_plant/flower/red_two,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xmT" = (
 /turf/open/indestructible/ground/outside/ruins,
@@ -45805,10 +45702,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "xnJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "xnQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -45910,12 +45809,13 @@
 	},
 /area/f13/building/mall)
 "xsB" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
+/obj/effect/landmark/start/f13/wastelander/den,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/turf/open/floor/plating/dirt,
+/area/f13/building/tunnel)
 "xsC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -46103,18 +46003,13 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "xwN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/deployable_barricade/wooden{
-	pixel_y = 3
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/black,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2;
-	layer = 4;
-	pixel_y = -2
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xxc" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -46207,11 +46102,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "xzv" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whiteyellowdirtychess2"
-	},
-/area/f13/building)
+/obj/item/reagent_containers/glass/bucket/wood,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/caves)
 "xzz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46605,13 +46498,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "xJi" = (
-/obj/structure/flora/tree/jungle/small{
-	color = "#999999"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/area/f13/wasteland)
+/obj/structure/flora/wasteplant/wild_punga,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "xJu" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -46653,11 +46550,7 @@
 	},
 /area/f13/building)
 "xLx" = (
-/obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -46957,11 +46850,9 @@
 	},
 /area/f13/wasteland)
 "xTA" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/floor/plating/dirt/dark,
+/area/f13/caves)
 "xTG" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -46988,13 +46879,9 @@
 	},
 /area/f13/building/massfusion)
 "xUt" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt{
-	color = "#6D6D6D"
-	},
-/area/f13/wasteland)
+/obj/machinery/gear_painter,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "xUv" = (
 /obj/machinery/smoke_machine{
 	name = "HVAC Machine"
@@ -47559,23 +47446,10 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
 "yiT" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/rock/jungle{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/structure/flora/rock/jungle{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/building)
 "ykd" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -47980,9 +47854,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -48234,17 +48108,17 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -48486,6 +48360,12 @@ vje
 vje
 vje
 vje
+vtF
+vje
+vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -48496,13 +48376,7 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -48743,6 +48617,7 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
@@ -48763,8 +48638,7 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 aKa
@@ -48998,8 +48872,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -49254,8 +49128,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -49510,8 +49384,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -49766,8 +49640,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -56957,7 +56831,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -57214,7 +57088,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -57471,7 +57345,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -57728,7 +57602,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -57985,7 +57859,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -58241,7 +58115,7 @@ iRb
 iRb
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -72128,8 +72002,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -72382,12 +72256,12 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -72639,7 +72513,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -72895,7 +72769,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -73152,7 +73026,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -73409,7 +73283,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -73666,7 +73540,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -73919,11 +73793,11 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -74175,14 +74049,14 @@ iRb
 iRb
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -74432,15 +74306,15 @@ iRb
 iRb
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -74676,7 +74550,7 @@ oez
 oez
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -74690,14 +74564,14 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
+vtF
 vje
+vtF
 vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -74933,7 +74807,7 @@ mbu
 mbu
 mbu
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -74947,15 +74821,15 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -75190,7 +75064,7 @@ mbu
 mbu
 mbu
 mbu
-vje
+vtF
 vje
 vje
 vje
@@ -75204,15 +75078,15 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -75447,7 +75321,7 @@ mbu
 mbu
 mbu
 mbu
-vje
+vtF
 vje
 vje
 vje
@@ -75465,10 +75339,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -75704,8 +75578,8 @@ mbu
 mbu
 mbu
 mbu
-vje
-vje
+vtF
+vtF
 vje
 iRb
 iRb
@@ -75723,9 +75597,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -75962,7 +75836,7 @@ mbu
 mbu
 mbu
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -76219,7 +76093,7 @@ mbu
 mbu
 mbu
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -76241,7 +76115,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 enE
@@ -76479,7 +76353,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -76498,7 +76372,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 nSB
@@ -76736,7 +76610,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -76754,8 +76628,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 nSB
@@ -76994,7 +76868,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -77010,8 +76884,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -77251,7 +77125,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -77259,8 +77133,8 @@ iRb
 iRb
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -77508,7 +77382,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -77517,7 +77391,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -77764,8 +77638,8 @@ oez
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 iRb
 "}
@@ -77774,7 +77648,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -77815,9 +77689,9 @@ oez
 oez
 oez
 oez
-vje
-vje
-vje
+iRb
+iRb
+iRb
 oez
 oez
 oez
@@ -78021,7 +77895,7 @@ oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -78036,9 +77910,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -78072,9 +77946,9 @@ oez
 oez
 oez
 oez
+iRb
 vje
-vje
-vje
+iRb
 oez
 oez
 oez
@@ -78278,7 +78152,7 @@ oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -78288,15 +78162,15 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -78327,9 +78201,9 @@ oez
 oez
 oez
 oez
-vje
-vje
-vje
+iRb
+iRb
+iRb
 vje
 vje
 vje
@@ -78534,8 +78408,8 @@ oez
 oez
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 iRb
@@ -78545,15 +78419,15 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -78582,9 +78456,9 @@ nSY
 eLR
 oez
 oez
-vje
-vje
-vje
+iRb
+iRb
+iRb
 vje
 vje
 vje
@@ -78790,8 +78664,8 @@ oez
 oez
 oez
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -78802,15 +78676,15 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -78838,13 +78712,13 @@ dAp
 nSY
 oLE
 iRb
+iRb
+kHz
+spb
 vje
-vje
-vje
-vje
-vje
-vje
-vje
+spb
+spb
+spb
 vje
 vje
 oez
@@ -79059,14 +78933,14 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
+vtF
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -79096,12 +78970,12 @@ nSY
 enE
 iRb
 vje
-spb
-spb
 vje
-spb
-spb
-spb
+bQk
+usw
+gpe
+qXb
+fKM
 vje
 vje
 vje
@@ -79306,8 +79180,8 @@ oez
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 iRb
 "}
@@ -79315,16 +79189,16 @@ iRb
 iRb
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -79353,12 +79227,12 @@ nSY
 enE
 iRb
 vje
-vje
+spb
 gpe
-usw
 gpe
-qXb
-fKM
+aNr
+vGw
+gpe
 vje
 vje
 vje
@@ -79561,16 +79435,18 @@ oez
 oez
 oez
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
 vje
 iRb
 "}
 (125,1,1) = {"
 iRb
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -79579,9 +79455,7 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -79610,13 +79484,13 @@ cys
 enE
 iRb
 vje
-spb
-gpe
-gpe
-aNr
-vGw
-gpe
 vje
+fKM
+hdE
+qvv
+ahb
+gpe
+spb
 vje
 vje
 vje
@@ -79818,7 +79692,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -79838,7 +79712,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -79868,12 +79742,12 @@ enE
 iRb
 vje
 vje
-fKM
-hdE
-qvv
-ahb
+qXb
 gpe
-spb
+wYg
+gpe
+usw
+vje
 vje
 vje
 vje
@@ -80095,7 +79969,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -80124,18 +79998,18 @@ enE
 iRb
 iRb
 vje
-vje
-qXb
-gpe
-wYg
-gpe
+spb
 usw
+fKM
+gpe
+gpe
+fVT
 vje
 vje
 vje
 vje
 vje
-oez
+ueB
 oez
 oez
 oez
@@ -80352,7 +80226,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -80382,18 +80256,18 @@ iRb
 vje
 vje
 spb
-usw
-fKM
-gpe
-gpe
-qXb
 vje
+spb
 vje
+gDs
+spb
+spb
 vje
-vje
-vje
-oez
-oez
+icJ
+aFK
+evM
+ueB
+ueB
 oez
 oez
 oez
@@ -80598,6 +80472,7 @@ iRb
 "}
 (129,1,1) = {"
 iRb
+iRb
 vje
 vje
 vje
@@ -80608,8 +80483,7 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -80638,18 +80512,18 @@ iRb
 iRb
 vje
 vje
-spb
+tyE
+uLi
+hUt
+rpp
+rpp
+rpp
+pwl
+icJ
+qYc
+qls
 vje
-spb
-vje
-gDs
-spb
-spb
-vje
-vje
-vje
-vje
-oez
+ueB
 oez
 wss
 wss
@@ -80856,6 +80730,7 @@ iRb
 (130,1,1) = {"
 iRb
 iRb
+iRb
 vje
 vje
 vje
@@ -80864,8 +80739,7 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -80885,33 +80759,33 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-gpe
-vje
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rpp
+pwl
+rpp
+rpp
 xJi
-fSd
-fSd
-hMq
-hMq
-hMq
-fSd
-fSd
-hMq
-fSd
-dIW
+tcN
+qls
+vje
+vje
+oez
+oez
+aKa
+aKa
+aKa
+aKa
 tcm
 tcm
 tcm
@@ -81114,7 +80988,7 @@ iRb
 iRb
 iRb
 iRb
-vje
+iRb
 vje
 vje
 vje
@@ -81140,35 +81014,35 @@ oLE
 iRb
 vje
 vje
-hMq
-eEx
+vje
+vje
+rRJ
+rhW
 laA
-laA
-laA
-eEx
-hMq
-eEx
-eEx
-eEx
-hMq
-iEJ
-hMq
-poL
-poL
-hMq
-gpe
-gpe
-lyA
-jgn
-hMq
-vfT
-qqe
-lXs
-hMq
-rfh
-xAb
-vjd
-dIW
+qgG
+pxo
+rRJ
+uZl
+uZl
+lxD
+lvD
+uZl
+rRJ
+rpp
+dAX
+dAX
+ogV
+rpp
+lnA
+vje
+vje
+vje
+oez
+oez
+aKa
+aKa
+aKa
+aKa
 fSF
 tcm
 flC
@@ -81397,35 +81271,35 @@ enE
 iRb
 vje
 vje
-laA
-gej
-vCZ
+vje
+vje
+rRJ
 qqD
-wCK
-hMq
-qnO
-vCZ
-pUK
-wCK
-eEx
-qnO
+uZl
+kJq
+uZl
+ngb
+uZl
+hyu
+udw
+owA
 hyu
 cqv
-rkM
-hMq
-vje
+rpp
+dAX
+rpp
 oSF
-jgn
-iXk
+pKF
+rpp
 tyE
-gig
-etA
-xAb
-hMq
-qOx
-xAb
-bbR
-fSd
+vje
+vje
+oez
+oez
+aKa
+aKa
+aKa
+aKa
 fSF
 tcm
 dHl
@@ -81654,35 +81528,35 @@ enE
 iRb
 iRb
 vje
-hMq
-wtK
-eed
-cdN
-cdN
-akj
-tWa
-aEO
-cdN
-cdN
-hMq
-wtK
-aEO
-cdN
-cdN
-eEx
 vje
-lyA
-jgn
-hMq
-akj
-akj
-hMq
-wQi
-hMq
-xWl
-xAb
-vjd
-hMq
+vje
+rRJ
+qLq
+kJq
+kJq
+uZl
+rRJ
+uZl
+uZl
+hyu
+hyu
+uZl
+lTF
+rpp
+dAX
+hhG
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+tcm
 fSF
 tcm
 dHl
@@ -81888,7 +81762,7 @@ vje
 vje
 vje
 iRb
-vje
+iRb
 iRb
 iRb
 vje
@@ -81911,35 +81785,35 @@ nSB
 enE
 iRb
 vje
-hMq
-ghN
-vCZ
-vUp
-oxM
-hMq
-ghN
-vCZ
-sJb
-oxM
-hMq
-ghN
-vCZ
-vUp
-oxM
-eEx
 vje
-lyA
-xJi
+vje
+rRJ
+vUp
+mlA
+wcm
+owA
+rRJ
+sJb
+aFC
+uZl
+uZl
+uZl
+rRJ
+pKF
+dAX
+rpp
+ixY
+plz
 sXS
 xLx
 etE
-xAb
-xAb
-wQi
-xAb
-xAb
-bbR
-hMq
+qiY
+ixY
+xWl
+xku
+sWc
+dIW
+tcm
 tcm
 dGy
 qQC
@@ -82146,7 +82020,7 @@ vje
 vje
 iRb
 iRb
-vje
+iRb
 iRb
 iRb
 vje
@@ -82168,36 +82042,36 @@ pve
 enE
 iRb
 vje
-hMq
-iWF
-vCZ
-fie
-ngb
-hMq
-nUs
-vCZ
-hUt
-jaq
-eEx
-iWF
-vCZ
-vkf
-oxM
-hMq
 vje
-jgn
+vje
+rRJ
+rRJ
+ngb
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+rRJ
+gIL
+rRJ
+rRJ
+vGl
+dAX
+inU
+ixY
 qNW
-jUW
+xku
+xLx
 kuD
-kuD
-xAb
-xAb
-fSd
-fSd
-fSd
-fSd
-fSd
-tcm
+jhe
+ixY
+xhv
+dze
+qtT
+dIW
+xVO
+xVO
 tcm
 lXN
 eiT
@@ -82404,7 +82278,7 @@ vje
 vje
 iRb
 iRb
-vje
+iRb
 iRb
 vje
 vje
@@ -82425,36 +82299,36 @@ rfA
 oLE
 iRb
 vje
-hMq
-hMq
-eEx
-hMq
-dxi
-hMq
-eEx
-rek
-hMq
-dxi
-laA
-hMq
-poL
-iEJ
-dxi
-hMq
 vje
-fFE
-wtB
-oDY
-xAb
+vje
+rRJ
+nEF
+kJq
+kmf
+fpm
+rek
+haY
+uZl
+uZl
+uZl
+poL
+rRJ
+gjl
+dAX
+gjl
+ixY
+wBC
+xLx
+xLx
 hya
-jXs
-xAb
-fSd
-fCZ
+xLx
+ixY
+wUY
+xku
 bCe
-sWc
-hMq
-tcm
+ixY
+xVO
+xVO
 gud
 riL
 tcm
@@ -82662,9 +82536,9 @@ vje
 vje
 vje
 iRb
-vje
 iRb
-vje
+iRb
+iRb
 vje
 vje
 vje
@@ -82682,35 +82556,35 @@ iTI
 oLE
 iRb
 vje
-cjA
-cjA
-cjA
+vje
+vje
+rRJ
 oFf
-fFE
-fFE
-wtB
-wtB
-wtB
-fFE
-fFE
-fFE
-wtB
-fFE
-wtB
-wtB
+kJq
+kJq
+kJq
+kJq
+kJq
+kJq
+kJq
+uZl
+mdU
+rRJ
 gjl
-fFE
-hfs
-nWw
-xAb
-bbR
-xAb
-xAb
-wQi
+dAX
+gjl
+ixY
+wUY
 xAb
 xAb
-xAb
-dIW
+xku
+xku
+ixY
+xku
+dze
+kVE
+ixY
+tcm
 tcm
 pZu
 gpE
@@ -82921,8 +82795,8 @@ vje
 iRb
 vje
 iRb
-vje
-vje
+iRb
+iRb
 vje
 vje
 vje
@@ -82939,37 +82813,37 @@ jNi
 gCp
 iRb
 vje
-cjA
-qtg
+vje
+vje
+rRJ
+tZo
 kJq
-lFv
-wtB
-ryv
-ryv
-xJi
-lyA
-qgG
-lyA
-lyA
+kJq
+hfs
+kJq
+wvK
+hyu
+kJq
+uZl
+hpE
+rRJ
 bkG
-lyA
-mlA
-xJi
+dik
 bkG
-fFE
-jgn
+ixY
+kaD
 dMq
-vsz
-toT
-wVc
-bwk
-fSd
-iMG
+xku
 xAb
-lja
-dIW
-xTA
-gpq
+xku
+bwk
+xku
+dze
+xdp
+ixY
+tcm
+tcm
+gud
 aqu
 dHl
 kgS
@@ -83163,7 +83037,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 iRb
 "}
 (139,1,1) = {"
@@ -83178,9 +83052,9 @@ vje
 vje
 vje
 iRb
-vje
 iRb
-vje
+iRb
+iRb
 vje
 vje
 vje
@@ -83196,36 +83070,36 @@ pIe
 oLE
 iRb
 vje
-cjA
-qtg
-kJq
-hZf
-wtB
-lyA
+vje
+vje
+rRJ
+nkJ
+owA
+owA
 lyR
 owA
-bkG
-lyA
+tkV
+hyu
 mlA
-xJi
+uZl
 ajn
-lyA
-owA
-lyA
-wZa
-fFE
-jgn
-iEJ
-iEJ
-hMq
-hMq
-akj
-fSd
-fBs
-xAb
-xAb
+lTF
+iCH
+wCP
+iCH
 dIW
-aKa
+ixY
+ixY
+bwk
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+ixY
+tcm
+tcm
 tcm
 csq
 dGy
@@ -83420,7 +83294,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 iRb
 "}
 (140,1,1) = {"
@@ -83438,7 +83312,7 @@ iRb
 iRb
 vje
 iRb
-vje
+iRb
 vje
 vje
 enE
@@ -83453,36 +83327,36 @@ vpM
 enE
 iRb
 vje
-cjA
-qtg
+rRJ
+rRJ
 hQS
-hZf
-wtB
+hyu
+hyu
 hfs
-lyA
-owA
-qNW
-jgn
-mlA
-sWH
-ryv
+hfs
+hyu
+hyu
+uZl
+kJq
+kJq
+uZl
 lTF
-tQp
-jgn
-pIp
-wtB
-lyA
+iCH
+wCP
+iCH
+dIW
 aht
-lyA
-aVZ
-tpK
-bpz
-fSd
-hMq
-fSd
-hMq
-fSd
+aht
+dze
+dze
+xku
+ixY
+jGi
+dze
+edZ
+vYY
 tcm
+xVO
 epN
 wss
 iyF
@@ -83677,7 +83551,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 iRb
 "}
 (141,1,1) = {"
@@ -83696,7 +83570,7 @@ vje
 vje
 vje
 iRb
-vje
+iRb
 iRb
 enE
 nSB
@@ -83710,36 +83584,36 @@ enE
 enE
 iRb
 vje
-cjA
+rRJ
 qtg
 kJq
-lFv
+kJq
+kJq
+kJq
+kJq
+uZl
+uZl
+uZl
+uZl
+kJq
+kJq
+gIL
 wtB
-ryv
-mlA
-jgn
-ryv
-fFE
-fFE
-owA
-jgn
-mlA
-wCP
-wCP
-otu
+wtB
+wtB
 puH
-kmf
-cUY
-mvO
+xku
+xku
 dze
-tpg
+dze
+xku
+bwk
+dze
+dze
+orb
+nfv
 tcm
-tcm
-wss
-nfv
-nfv
-nfv
-nfv
+wYG
 aUQ
 oez
 oez
@@ -83934,7 +83808,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 iRb
 "}
 (142,1,1) = {"
@@ -83954,7 +83828,7 @@ vje
 vje
 iRb
 iRb
-oez
+lvv
 iRb
 iRb
 iRb
@@ -83967,36 +83841,36 @@ iRb
 iRb
 iRb
 vje
-cjA
-qtg
-hQS
-lFv
-wtB
-jgn
-fwT
-lyA
-fFE
-ccE
-rpe
-rpe
-wtB
-lyA
-eQv
+rRJ
+leP
+uZl
+kJq
+uZl
+uZl
+kJq
+kJq
+uZl
+uZl
+uZl
+uZl
+uZl
+rRJ
+iCH
 wCP
-pIp
-wtB
-puH
-bHQ
+iCH
+ixY
+wUY
+dze
 pWq
 nZK
-qLq
+xku
+ixY
+rOb
+xku
+xku
+rfh
 tcm
-aKa
-xwN
-oez
-oez
-oez
-oez
+ujb
 oez
 oez
 oez
@@ -84190,8 +84064,8 @@ oez
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 iRb
 "}
 (143,1,1) = {"
@@ -84200,7 +84074,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -84224,35 +84098,35 @@ vje
 vje
 iRb
 vje
-cjA
-cjA
-cjA
+rRJ
+rRJ
+rRJ
 cjA
 wdc
 jgn
-lyA
-lyA
-vld
-fFE
 aOw
-wtB
-wtB
-lyA
-lyA
-lyA
-otu
-mvO
+uZl
+bEe
+hhi
+aOw
+bhE
+rRJ
+rRJ
 eZA
-eZA
+wtB
+iCH
+lnp
+dze
+iMa
 mvO
 kDC
 xku
-tcm
-dGy
-lkm
-oez
-oez
-oez
+ixY
+pgE
+kDC
+sWH
+ixY
+oLF
 oez
 oez
 oez
@@ -84447,7 +84321,7 @@ oez
 vje
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -84456,8 +84330,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -84483,33 +84357,33 @@ iRb
 vje
 vje
 vje
-vje
-vje
-vje
-lyA
+rRJ
+rRJ
+xed
+hhi
 ryv
-lyR
-vld
-fFE
-fFE
-nEF
+mNn
+heq
+hhi
+qCz
+rRJ
+rRJ
+mJY
+sDd
 wtB
-wtB
-wtB
-wtB
-wtB
-wtB
-hqF
-xUt
-vVm
+iCH
+lnp
+xku
+xku
+pWq
 cQl
-tpK
-oig
-tcm
-eRx
-oez
-oez
-oez
+bbR
+ixY
+eed
+xku
+wCK
+dIW
+bLP
 oez
 wss
 utE
@@ -84713,7 +84587,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -84741,32 +84615,32 @@ vje
 vje
 vje
 vje
-vje
-vje
-lyA
-ryv
-pIV
-vld
-evM
+lTF
 kSG
+kSG
+kSG
+kSG
+kSG
+kSG
+kSG
+lTF
+iCH
+iCH
 wtB
 wtB
-rMp
-heq
-ryv
-lyA
-wtB
-lyA
-jgn
-lyA
+mjT
+fie
 taH
-tpK
-tcm
-tcm
-lkm
-oez
-oez
-oez
+taH
+taH
+taH
+ixY
+ixY
+dIW
+ixY
+ixY
+ixY
+bLP
 oez
 wss
 flC
@@ -84969,7 +84843,7 @@ iRb
 iRb
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -84998,32 +84872,32 @@ vje
 vje
 vje
 jhc
-jzb
-uwq
+kRq
+mJY
 lgs
 mzZ
-ryv
+rTw
+acG
+haD
+mJY
+iCH
+iCH
 wtB
-mJY
-mJY
-aOb
-fFE
-aFK
-wZa
-lyA
-heq
+wtB
+iCH
+iCH
 bHQ
-lyA
-tpK
-qSt
-dZt
-tpK
-tpK
+iCH
+iCH
+jaq
+iCH
+qOx
+tzz
 caJ
 iNh
 tmG
-oOB
-oez
+lPT
+dBU
 oez
 wss
 fSF
@@ -85226,7 +85100,7 @@ iRb
 iRb
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -85250,36 +85124,36 @@ oez
 oez
 vje
 vje
-iRb
-gJP
-gJP
+omN
+omN
+omN
 omN
 jzb
-mnU
-txV
-acG
-xma
-lyA
-tcN
-nEF
-hto
-bEe
-qiY
-tcN
-wZa
-lyA
-wUY
-mdU
-lyA
-tpK
-kcn
-alP
-alP
-xDk
-xDk
-xDk
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+ipE
+ipE
+ipE
+tmG
 lPT
-tpK
+cnz
 oez
 oez
 wss
@@ -85483,13 +85357,13 @@ iRb
 iRb
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
-vje
 mbu
 mbu
 mbu
@@ -85507,37 +85381,37 @@ oez
 oez
 oez
 oez
-iRb
-lvD
+mBe
+jzb
 xsB
-hWr
-mnU
-mnU
-txV
-acG
-mzZ
+jzb
+jzb
+wtB
+iCH
+iCH
+iCH
 hrR
-qiY
-otq
-qiY
-otq
-qiY
-qiY
-otu
-lyA
-otu
-puH
-lyA
-qSt
-qDJ
-jhe
-dum
-jTa
-bGu
-xDk
-qZD
-tpK
-vje
+iCH
+wtB
+iCH
+sDd
+iCH
+wtB
+wtB
+egb
+wql
+iCH
+iCH
+iCH
+iCH
+iCH
+ipE
+uJY
+ipE
+lPT
+lPT
+arj
+oez
 oez
 wss
 fSF
@@ -85742,11 +85616,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
-vje
 mbu
 mbu
 mbu
@@ -85764,38 +85638,38 @@ oez
 oez
 oez
 oez
-iRb
-gJP
+mBe
+jzb
 fHZ
-wCn
-pte
-cnH
-wCn
-pKF
-mzZ
-chl
-mlA
-cbq
-lyA
-lyA
-lyA
-otu
-ipP
-lyA
-hqF
+jzb
+jzb
+iCH
+iCH
+iCH
+iCH
+mjT
+sgY
 wtB
-lyA
-qSt
-tpK
-tpK
-tpK
-tpK
-tpK
+iCH
+iCH
+iCH
+mHc
+wtB
+wtB
+hqF
+ixY
+nof
+gpq
+otX
+ixY
+men
+ixY
+ixY
 oQZ
-tpK
-tpK
-vje
-vje
+vjd
+oez
+oez
+oez
 wss
 tcm
 tcm
@@ -85989,7 +85863,7 @@ oez
 oez
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -85999,11 +85873,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
-vje
 mbu
 mbu
 mbu
@@ -86021,38 +85895,38 @@ oez
 oez
 oez
 oez
-iRb
-gJP
-lnA
-fSd
-dIW
-haD
+mBe
+jzb
+fHZ
+jzb
+jzb
+iCH
 aRh
-dIW
+iCH
 haD
-fSd
-frq
-edZ
-tpK
-lyA
-lyA
-qls
-eZA
-puH
-cUY
-cUY
+lnR
+iCH
+wtB
+iCH
+iCH
+tWa
+bHQ
+iCH
+wtB
+iCH
+aVZ
 lyA
 cLD
 sbk
-alP
-ujb
-xDk
-xDk
-xDk
-xDk
-tpK
-vje
-vje
+cLD
+cLD
+bew
+ixY
+duL
+vzN
+oez
+oez
+oez
 wss
 wss
 pHx
@@ -86246,7 +86120,7 @@ oez
 oez
 vje
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -86256,11 +86130,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
-vje
 mbu
 mbu
 mbu
@@ -86278,42 +86152,42 @@ oez
 oez
 oez
 oez
-udw
-lvD
-gJP
-fSd
-lbc
-bLP
-qtT
-rhW
-uBg
-dik
-gHd
-lvv
-oLF
-lyA
-lyA
-tAR
-eZA
-wCP
-nxF
+mBe
+jzb
+fHZ
+jzb
+jzb
+iCH
+iCH
+otu
+iCH
+iCH
+iCH
 wtB
-lyA
-tpK
+iCH
+iCH
+aRh
+iCH
+eZA
+wtB
+sqL
+cUY
+iJk
+rmt
 kES
-qUc
-dlV
+cLD
+rmt
 qDJ
-lXb
-ogS
-xzv
-tpK
-vje
-vje
-vje
-vje
-vje
-vje
+ixY
+oez
+oez
+oez
+oez
+oez
+tcm
+tcm
+tcm
+tcm
 wss
 aFJ
 fpN
@@ -86503,7 +86377,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -86513,7 +86387,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -86536,42 +86410,42 @@ oez
 oez
 oez
 mBe
-gJP
+jzb
 ccP
-xdp
+jzb
 evy
 sgY
-hFG
-rSL
-beR
-jXS
-leP
-tzz
-oLF
-lyA
-hfs
-lyA
-puH
-otu
-otu
-eZA
+iCH
+iCH
+iCH
+uwq
+iCH
+wtB
+iCH
+iCH
+haD
+iCH
+iCH
+wtB
+iCH
+cUY
 dfD
-tpK
-vui
+rmt
+sbk
 xDk
-xDk
-xDk
-xDk
-alP
-xDk
-tpK
-tpK
-tpK
-tpK
-fSd
-wAl
-wAl
-vje
+rmt
+njR
+ixY
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+oez
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -86760,7 +86634,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -86770,6 +86644,7 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
@@ -86777,7 +86652,6 @@ vje
 vje
 vje
 vje
-vje
 oez
 oez
 oez
@@ -86792,43 +86666,43 @@ oez
 oez
 oez
 oez
-kHz
-lnA
-gJP
-fSd
+omN
+omN
+omN
+omN
 kDo
-qSg
-lnp
-wql
+hrR
+iCH
+iCH
 mjT
 dse
 jvR
-inU
-oLF
-qNW
-qNW
-otu
-eZA
-lyA
-wCP
-cUY
 wtB
-men
+wtB
+dse
+iCH
+iCH
+iCH
+wtB
+iCH
+cUY
 xDk
+cLD
+cLD
 xDk
-xDk
-xDk
-xDk
-xDk
-xDk
-men
-hnO
-oOB
-pUj
-pUj
-pUj
-fSd
-vje
+cLD
+cLD
+ixY
+akk
+nHf
+hyz
+ipE
+gDZ
+oez
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -87017,7 +86891,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -87027,13 +86901,13 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
-vje
 oez
 oez
 oez
@@ -87049,44 +86923,44 @@ oez
 oez
 oez
 oez
-pwl
-lvD
-gJP
-wAl
-dYn
-emQ
-vFD
-kaD
-rOb
-trg
-cFh
+iRb
+iRb
+jUW
+iRb
+iRb
+iCH
+iCH
+iCH
+iCH
+vld
+fFE
 ppP
-oLF
-jgn
-ryv
-otu
-mdU
-ryv
-qls
+fFE
+wsr
+iCH
+iCH
+aRh
+wtB
+iCH
 bNL
-lyA
-dZt
-qgO
-lqv
-dNO
+cLD
+cLD
+cLD
+xDk
+xDk
 tIx
-lqv
+ixY
 nlQ
-alP
-tpK
+hyz
+txV
 ipE
-oOB
-jxp
-jxp
-jxp
-wAl
-vje
-oez
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
 oez
 oez
 oez
@@ -87274,7 +87148,7 @@ oez
 oez
 oez
 vje
-vje
+vtF
 vje
 iRb
 "}
@@ -87284,7 +87158,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -87307,49 +87181,49 @@ mbu
 mbu
 iRb
 iRb
-ccP
-gJP
-fSd
-plz
+iRb
+lXb
+oSB
+iRb
 lvv
-vFD
-yiT
-hnm
-arj
-qYc
-hpE
-fSd
+aRh
+iCH
+iCH
+vld
+fFE
+fFE
+fFE
 wsr
-ryv
-wUY
-mdU
-wZa
-lyA
-kVE
+iCH
+iCH
+iCH
+wtB
+iCH
+dIW
 fwT
-qSt
-nof
-otX
-dZt
-nof
-otX
-tpK
-dZt
-oga
-ipE
-tpK
+iqt
+bpz
+qqe
+xDk
+ixY
+ixY
+lja
+hyz
+hyz
+hyz
+aEO
 hbz
-jxp
-tpK
-tpK
-tpK
-qSt
-qSt
-qSt
-uOV
+cdN
 iEY
+mnU
+etA
+gDZ
 qSt
-qSt
+vfT
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -87532,7 +87406,7 @@ oez
 oez
 vje
 vje
-vje
+vtF
 iRb
 "}
 (156,1,1) = {"
@@ -87540,9 +87414,9 @@ iRb
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -87564,49 +87438,49 @@ mbu
 mbu
 iRb
 eAC
-gJP
-ccP
-fSd
-fSd
-iMa
-kFo
-fSd
-vFs
-vFs
-tke
-vFs
-lKt
-lyA
-lyA
-ryv
-mdU
-pLU
+hZf
+wZa
+chl
+iRb
+iRb
+iCH
+iCH
+mHc
+vld
+fFE
+fFE
+fFE
+wsr
+ghN
+iCH
+iCH
+wtB
 fqF
-cUY
+ixY
 mHN
-mHN
-hZf
-hZf
-lFv
-lFv
-hyz
-gpe
-hnO
-hnO
-hnO
-tpK
-fpX
-jxp
-tpK
+cLD
 psI
-uSN
-tpK
-oSB
+xDk
+rmt
+trg
+ixY
+hyz
+jXS
+jXS
+hyz
+aEO
+fpX
+cdN
+cdN
+cdN
+cdN
+gDZ
+sDd
 sKE
-tpK
-rTw
-fVT
-tpK
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -87799,7 +87673,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -87820,50 +87694,50 @@ mbu
 mbu
 mbu
 iRb
-eAC
-gJP
-vje
-fSd
-cdN
-oxM
-oxM
-aFC
-tBF
-haY
-cdN
-hhi
-fSd
-hfs
-jgn
-nxF
-puH
-mky
-sqM
-xnJ
-fSd
-qAP
-fSd
-qAP
-dIW
+vui
+lFv
+xzv
+lXs
 hZf
-hZf
-hnO
+gGq
+wtB
+wtB
+wtB
+dse
+wtB
+wtB
+wtB
+dse
+qOZ
+iCH
+sDd
+wtB
+fqF
+ixY
+ogS
+ccE
+rmt
+cLD
+cLD
+kFo
+ixY
+vkf
 hyz
-hyz
-hnO
-tpK
+jXS
+jXS
+aEO
 wZx
-jxp
-rwS
-jxp
-ejB
-dZt
+cdN
+cdN
+cdN
+gKO
+gDZ
 dBv
-jxp
-dZt
-dBv
-jxp
-qSt
+sKE
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -88056,7 +87930,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -88078,49 +87952,49 @@ mbu
 mbu
 iRb
 iRb
-vje
-vje
-fSd
+uOV
+lFv
+lWj
 dAX
 lPD
-rVk
-uLi
-cdN
-kff
-cdN
-cdN
-tke
-jgn
-qNW
-wCP
-eZA
-bkG
-cUY
-amX
-iok
-iok
-icJ
-jGi
-fSd
-hnO
-kRq
-hZf
-hnO
-hnO
-hnO
-tpK
+wtB
+iCH
+iCH
+iCH
+iCH
+wtB
+iCH
+aRh
+iCH
+iCH
+iCH
+wtB
+iCH
+ixY
+ixY
+ixY
+ixY
+ixY
+men
+ixY
+ixY
+sqM
+hyz
+hyz
+hyz
+gDZ
 vNA
-jxp
-tpK
-ejB
+cdN
+cdN
+cdN
 jyL
-tpK
-wBC
-pgE
-dZt
-mHc
-wBC
-uOV
+gDZ
+iCH
+sKE
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -88313,7 +88187,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -88334,50 +88208,50 @@ mbu
 mbu
 mbu
 iRb
-spb
-spb
-oSM
-fSd
-lWj
-aBT
-kff
-fSd
-egb
-oxM
-cdN
-cdN
-lnR
-wtB
-cUY
-mdU
-puH
-wZa
-lyA
-fSd
-gHo
-lxD
-vFs
-fSd
-fSd
-hnO
-hyz
+oOB
 lFv
-orb
-hyz
+oSM
+oSM
+oSM
+aBT
+iCH
+iCH
+iCH
+aRh
+iCH
+wtB
+iCH
+xma
+iCH
+iCH
+mjT
+wtB
+iCH
+sgY
+iCH
+ixY
+lbc
+rmt
+cLD
 hnO
-tpK
-wZx
-jxp
-tpK
-jxp
-nHV
-dZt
-ejB
-jxp
-jxp
-ejB
-jxp
-uOV
+ixY
+eRx
+jXS
+hyz
+hyz
+hyz
+cdN
+cdN
+vsz
+cdN
+tAR
+gDZ
+iCH
+sKE
+oez
+oez
+oez
+oez
 oez
 oez
 oez
@@ -88570,7 +88444,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -88591,50 +88465,50 @@ oez
 vje
 vje
 iRb
-spb
-vVt
-cdN
-fSd
-fSd
+xTA
+lFv
+hFG
+pEx
+aWq
 gGq
-oxM
-lKt
-nHf
-oxM
-oxM
-aju
+iCH
+haD
+iCH
+iCH
+iCH
+wtB
 tke
-jgn
-otu
-ryv
-jgn
-tQp
-lyA
-urX
-bhE
-nkJ
+eZA
+iCH
+iCH
+iCH
+wtB
+wtB
+wtB
+iCH
+ixY
 agm
 rmt
-fSd
+cLD
+amX
+ixY
+urX
+ipE
+ipE
 hyz
-hnO
-hnO
-hZf
-hyz
-hnO
-tpK
-tpK
-tpK
-tpK
-dZt
-uJY
-uiy
-ejB
-iqt
-jxp
-wcm
-vzN
-tpK
+gKO
+cdN
+cdN
+cdN
+xUt
+gDZ
+gDZ
+iCH
+iCH
+vfT
+oez
+oez
+oez
 oez
 oez
 oez
@@ -88848,50 +88722,50 @@ oez
 oez
 oez
 iRb
-spb
-cdN
-cdN
-cdN
-neM
-cdN
-bQk
-fSd
-pxo
-omG
-oxM
-cdN
-fSd
-otu
-jgn
-qNW
-owA
-uNR
-lyA
-fwF
-jYx
-nkJ
-akk
-ehZ
-fSd
-hyz
-tZo
-aqg
+qUc
 hZf
-hnO
-hnO
-tpK
-pdm
-fIs
-lDc
+ifb
+ifb
+neM
+aBT
+iCH
+tke
+iCH
+iCH
+dlV
+wtB
+iCH
+otu
+iCH
+iCH
+iCH
+iCH
+iCH
+wtB
+jYx
+ixY
+jTa
+ehZ
+giJ
+kcn
+ixY
+aqg
+ipE
+uBg
+hyz
+hyz
+oBS
+cdN
+cdN
 jsq
-jxp
-tpK
+gDZ
+sDd
 qOZ
-dZt
-dZt
-tpK
-tpK
-qSt
+iCH
+sKE
+oez
+oez
+oez
 oez
 oez
 oez
@@ -89084,7 +88958,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -89105,49 +88979,49 @@ oez
 oez
 oez
 iRb
-oSM
-aWq
-cdN
-pEx
-vFs
-wYG
-dBU
-fSd
-nRP
-cdN
-oxM
-mSQ
-fSd
-lyA
-ryv
-lyA
-oSF
-lyA
-oSF
-fSd
-vFs
-fSd
-fSd
-dDO
-dIW
-hnO
-tZo
-hyz
+iRb
 hZf
-lFv
-kRq
+lWj
+pEx
+aWq
+aBT
+iCH
+iCH
+gDZ
+hyz
+hyz
+hyz
+gDZ
+hyz
+hyz
+hyz
+gDZ
+iCH
+haD
+wtB
+gDZ
+ixY
+ixY
+dIW
+dIW
+ixY
+ixY
+gDZ
+hyz
+hyz
+hyz
 rwS
-jxp
-jxp
-jxp
-nHV
-ejB
-rwS
-jxp
+hyz
+hyz
+hyz
+gDZ
+gDZ
+iCH
+fFE
 dZt
-fYR
-xVO
-xVO
+vFD
+oez
+oez
 oez
 oez
 oez
@@ -89340,14 +89214,14 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
-vje
-vje
 oez
 oez
 oez
@@ -89362,49 +89236,49 @@ oez
 oez
 oez
 oez
-spb
-spb
-oSM
-oSM
-fSd
-fSd
-fSd
-fSd
-dDO
-dDO
-dDO
-dDO
+iRb
+lFv
+neM
+neM
+neM
+gGq
+lFv
+lFv
 qAP
-lyA
-lyA
-lyA
-ryv
-ryv
-lyA
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-hnO
-gpe
-gpe
-tpK
-fpm
-ejB
-jxp
-jxp
-jxp
-dZt
-psI
-tpK
-fYR
-xVO
-ktc
+hyz
+jXS
+hyz
+qAP
+hyz
+ipE
+ipE
+qAP
+fFE
+iCH
+wtB
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+iCH
+fFE
+fFE
+fFE
+iCH
+iCH
+fFE
+fFE
+fFE
+wCn
+oez
+oez
 oez
 oez
 oez
@@ -89559,7 +89433,7 @@ hBR
 kQo
 rQP
 pIT
-oez
+vje
 oez
 oez
 oez
@@ -89597,12 +89471,13 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
+oez
 oez
 oez
 oez
@@ -89618,50 +89493,49 @@ oez
 oez
 oez
 oez
+iRb
+hZf
+lWj
+pEx
+aWq
+aBT
+hZf
+lFv
+qAP
+ipE
+fBs
+jXS
+qAP
+jXS
+fBs
+ipE
+iBt
+fFE
+iCH
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+wtB
+sqL
+iCH
+fFE
+fFE
+iCH
+aRh
+fFE
+fFE
+fFE
+rSL
 oez
 oez
-oez
-oez
-oez
-vje
-vje
-vje
-dMW
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-oez
-sDd
-tcm
-tcm
-tpK
-fpm
-jxp
-jxp
-sMB
-jxp
-tpK
-tpK
-uOV
-fYR
-xVO
-tcm
 oez
 oez
 oez
@@ -89816,6 +89690,8 @@ guk
 hET
 cYV
 pIT
+vje
+vje
 oez
 oez
 oez
@@ -89836,10 +89712,8 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
+vje
+vje
 vje
 vje
 vje
@@ -89854,71 +89728,71 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-xed
-ueB
-oez
-ueB
-oez
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
 vje
 oez
 oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+iRb
+iRb
+dAX
+oSM
+ifb
+ifb
+aBT
+hZf
+dAX
+iBt
+ipE
+ipE
+jXS
+iBt
+jXS
+ipE
+ipE
+iBt
+fFE
+iCH
+sqL
+pdm
+iCH
+iCH
+iCH
+wtB
+iCH
+iCH
+iCH
 sDd
-tcm
-tcm
-dZt
-tpK
-giJ
-vYY
-dZt
-rwS
-tpK
-csq
-tcm
-tcm
-tkV
-tcm
+iCH
+wtB
+iCH
+jXs
+iCH
+fFE
+fFE
+fFE
+fFE
+qgO
+ktc
+rSL
+oez
+oez
 oez
 oez
 oez
@@ -90073,6 +89947,10 @@ aKq
 aKq
 rQP
 iDX
+vje
+vje
+vtF
+vje
 oez
 oez
 oez
@@ -90091,12 +89969,8 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
 vje
 vje
 vje
@@ -90111,71 +89985,71 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-ueB
-oez
-ueB
-oez
-oez
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 oez
 oez
 oez
-sDd
-aKa
-tcm
-dZt
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+iRb
+iRb
+emQ
+uSN
+emQ
+emQ
+gGq
+hZf
+pLU
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+rwS
+rwS
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+hWr
+hWr
+gDZ
+cnH
+gDZ
+hWr
+hWr
+gDZ
 iCH
-xhv
-cnz
-dZt
-ejB
-dCf
-tcm
-flC
-tcm
-anD
-flC
+wtB
+iCH
+iCH
+sDd
+iCH
+fFE
+fFE
+fFE
+ktc
+tHt
+frq
+oez
+oez
 oez
 oez
 oez
@@ -90330,6 +90204,10 @@ aKq
 sFC
 qNX
 pIT
+vje
+vje
+vtF
+vje
 oez
 oez
 oez
@@ -90347,13 +90225,9 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
 vje
 vje
 vje
@@ -90368,45 +90242,7 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-ueB
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-vje
-vje
+vtF
 vje
 vje
 oez
@@ -90418,21 +90254,59 @@ oez
 oez
 oez
 oez
-ifb
-ifb
-fgm
-tpK
-tpK
-sWX
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+iRb
+iRb
+sWI
+hZf
+oga
+dAX
+aBT
+lFv
+dAX
 rwS
-tpK
-jxp
-iJk
-tcm
+fwF
+tQp
+tBF
+gDZ
+cVV
+cFh
+tBF
+gDZ
+fwF
+vVm
+tBF
+gDZ
+oDY
+gHd
+uiy
+kff
+uiy
+oDY
+gHd
+gDZ
+iCH
+wtB
+sDd
+iCH
+iCH
+iCH
+haD
+fFE
+fFE
+fFE
 ktc
-qrE
-tcm
-fYR
+rSL
+oez
+oez
 oez
 oez
 oez
@@ -90587,17 +90461,12 @@ mFU
 dDM
 rQP
 pIT
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vtF
+vtF
+vtF
+vtF
 oez
 oez
 oez
@@ -90615,6 +90484,11 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vje
+vje
+vtF
 vje
 vje
 iRb
@@ -90625,9 +90499,9 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
 oez
 oez
 oez
@@ -90647,49 +90521,49 @@ oez
 oez
 oez
 oez
+iRb
+lFv
+oig
+lFv
+dAX
+dNO
+dAX
+iMG
+gDZ
+nRP
+kff
+nxF
+gDZ
+xwN
+oxM
+nxF
+ipP
+nRP
+owB
+oxM
+gDZ
+yiT
+oxM
+oxM
+wVc
+oxM
+oxM
+oxM
+rwS
+iCH
+wtB
+jYx
+iCH
+eZA
+haD
+iCH
+fFE
+fFE
+fFE
+fFE
+rSL
 oez
 oez
-oez
-wvK
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-tcm
-aKa
-tcm
-tpK
-tHt
-sKE
-jxp
-qCz
-jxp
-sWI
-tcm
-tcm
-tcm
-dGy
-fYR
 oez
 oez
 oez
@@ -90844,27 +90718,14 @@ pIT
 pIT
 pIT
 pIT
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
 oez
 oez
 oez
@@ -90872,6 +90733,19 @@ vje
 vje
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
+vje
+vje
+vje
+vtF
 vje
 vje
 iRb
@@ -90882,12 +90756,12 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
 oez
 oez
 oez
@@ -90904,49 +90778,49 @@ oez
 oez
 oez
 oez
+iRb
+lqv
+oga
+lFv
+wAl
+aBT
+lFv
+gDZ
+gDZ
+gDZ
+gDZ
+nWw
+gDZ
+gDZ
+gDZ
+nWw
+ipP
+ipP
+gDZ
+toT
+ipP
+alP
+kff
+beR
+oxM
+kff
+oxM
+rMp
+rwS
+haD
+wtB
+eQv
+iCH
+iCH
+iCH
+iCH
+jYx
+dMW
+fFE
+fFE
+rSL
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-aKa
-tcm
-aKa
-tpK
-whl
-jxp
-jxp
-jxp
-ePI
-tpK
-fYR
-fYR
-dGy
-tcm
-fYR
 oez
 oez
 oez
@@ -91104,31 +90978,31 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
+vtF
+vtF
+vje
+vje
+vje
+vje
+vtF
 vje
 vje
 iRb
@@ -91139,12 +91013,12 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
 oez
 oez
 oez
@@ -91161,49 +91035,49 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-tcm
-tcm
-vGB
-tpK
-hbz
-pdm
+iRb
+gHo
+dAX
+lFv
+dAX
+aBT
+lFv
+rwS
+cdN
+cdN
+oxM
+kff
+oxM
+oxM
+oxM
+kff
+kff
+kff
+cdN
+oxM
+pte
+oxM
+kff
+oxM
+oxM
+kff
+oxM
+oxM
+rwS
+iCH
+wtB
+iCH
+mky
+iCH
 sqL
-duL
-psI
-tpK
-tcm
-dGy
-ksX
-iBt
-fYR
+mjT
+iCH
+iCH
+fFE
+fFE
+sKE
+oez
+oez
 oez
 oez
 oez
@@ -91363,29 +91237,29 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
 vje
 vje
 iRb
@@ -91396,12 +91270,12 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
 oez
 oez
 oez
@@ -91418,49 +91292,49 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-avp
-tpK
-tpK
-bew
+iRb
+dum
+dAX
+hZf
+dAX
+gej
+hZf
+rwS
+cdN
+oxM
+oxM
+kff
+bGu
+oxM
+oxM
+kff
+lkm
+whl
+fgm
+rkM
+gDZ
+vVt
+hto
+qZD
+kff
+kff
+omG
+oxM
+gDZ
+iCH
+wtB
+iCH
 hhy
-tpK
-tpK
-qSt
-tcm
-tcm
-tcm
-tcm
-tcm
+hhy
+hhy
+hhy
+hhy
+hhy
+hhy
+hhy
+xnJ
+oez
+oez
 oez
 oez
 oez
@@ -91621,18 +91495,10 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
+vje
 oez
 oez
 oez
@@ -91643,6 +91509,14 @@ vje
 vje
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
 vje
 vje
 iRb
@@ -91653,7 +91527,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -91675,38 +91549,38 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-vje
-vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-avp
-oez
+iRb
+iRb
+vGB
+gig
+dAX
+iWF
+iRb
+gDZ
+cdN
+cdN
+cdN
+gDZ
+gDZ
+gDZ
+otq
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+yiT
+qnO
+nUs
+hto
+gDZ
+tpg
+fIs
+tpg
 oez
 oez
 oez
@@ -91888,18 +91762,18 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
 vje
+vje
+vje
+oez
+oez
+vje
+vtF
+vtF
+vtF
 vje
 vje
 iRb
@@ -91933,34 +91807,34 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+iRb
+iRb
+aOb
+aOb
+iRb
+iRb
+gDZ
+gDZ
+lDc
+lDc
+gDZ
+hnm
+dCf
+wQi
+dxi
+gDZ
+iRb
+iRb
+iRb
+iRb
+iRb
+iRb
+gDZ
+oxM
+cdN
+sMB
+mSQ
+gDZ
 oez
 avp
 iDX
@@ -92156,7 +92030,7 @@ oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -92167,7 +92041,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -92191,33 +92065,33 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
+iRb
+iRb
+iRb
+iRb
+iRb
+iRb
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+vGK
+pUK
+gDZ
+iRb
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
+iRb
+gDZ
+cdN
+oxM
+pIV
+pte
+gDZ
 oez
 iDX
 qNX
@@ -92413,7 +92287,7 @@ oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -92424,7 +92298,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -92453,28 +92327,28 @@ oez
 oez
 oez
 vje
+iRb
+iRb
+iRb
+iRb
+gDZ
+pIp
+uNR
+wtK
+pUj
+gDZ
+iRb
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-aKa
-hsd
-hsd
-hsd
-hsd
-aKa
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
+iRb
+gDZ
+rwS
+rwS
+gDZ
+gDZ
+gDZ
 oez
 iDX
 qNX
@@ -92664,13 +92538,13 @@ oez
 pIT
 pIT
 pIT
+vje
 oez
 oez
-oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -92681,7 +92555,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -92713,19 +92587,19 @@ vje
 vje
 vje
 vje
+iRb
+gDZ
+gDZ
+gDZ
+qSg
+gDZ
+gDZ
+iRb
 vje
 vje
 vje
 vje
-vje
-aKa
-hsd
-wqF
-wqF
-hsd
-aKa
-vje
-vje
+iRb
 oez
 oez
 oez
@@ -92921,13 +92795,13 @@ pIT
 nCK
 coA
 plV
+vje
+vje
 oez
-oez
-oez
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -92940,7 +92814,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -92970,17 +92844,17 @@ vje
 vje
 gpQ
 vje
+iRb
+gDZ
+dDO
+vGK
+vGK
+gDZ
+iRb
+iRb
 vje
 vje
 vje
-vje
-vje
-aKa
-hsd
-wqF
-wqF
-hsd
-aKa
 vje
 vje
 oez
@@ -93178,12 +93052,12 @@ oez
 pIT
 nCK
 pIT
-oez
-oez
-oez
 vje
 vje
 vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -93197,7 +93071,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -93227,18 +93101,18 @@ vje
 vje
 vje
 vje
+iRb
+gDZ
+fCZ
+wQi
+wQi
+gDZ
+iRb
 vje
 vje
+vtF
 vje
 vje
-vje
-aKa
-hsd
-wqF
-wqF
-hsd
-aKa
-aKa
 vje
 oez
 oez
@@ -93435,12 +93309,12 @@ pIT
 pIT
 dEn
 pIT
-oez
-oez
-oez
 vje
 vje
 vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -93454,8 +93328,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 mbu
@@ -93484,18 +93358,18 @@ vje
 vje
 vje
 vje
+iRb
+gDZ
+iXk
+vGK
+vGK
+gDZ
+iRb
 vje
 vje
+vtF
 vje
 vje
-vje
-aKa
-hsd
-wqF
-wqF
-hsd
-hsd
-aKa
 vje
 oez
 oez
@@ -93692,9 +93566,9 @@ eyX
 doQ
 ydm
 pIT
-oez
-oez
-oez
+vje
+vje
+vje
 vje
 vje
 vje
@@ -93712,7 +93586,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 mbu
@@ -93741,18 +93615,18 @@ vje
 vje
 vje
 vje
+iRb
+gDZ
+gDZ
+gDZ
+gDZ
+gDZ
+iRb
 vje
 vje
+vtF
 vje
 vje
-vje
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
 vje
 vje
 vje
@@ -93949,9 +93823,9 @@ cxi
 fEd
 khU
 pIT
-oez
-oez
-oez
+vje
+vje
+vje
 vje
 vje
 vje
@@ -93998,18 +93872,18 @@ vje
 vje
 vje
 vje
+iRb
+iRb
+iRb
+iRb
+iRb
+iRb
+iRb
+vje
+vtF
 vje
 vje
 vje
-vje
-vje
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
 vje
 vje
 vje
@@ -94206,9 +94080,9 @@ eyX
 guk
 iWL
 pIT
-oez
-oez
-oez
+vje
+vje
+vje
 vje
 vje
 vje
@@ -94260,13 +94134,13 @@ vje
 vje
 vje
 vje
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
+vje
+vje
+vtF
+vje
+vje
+vje
+vje
 vje
 vje
 vje
@@ -94463,9 +94337,9 @@ pIT
 pIT
 pIT
 pIT
-oez
-oez
-oez
+vje
+vje
+vje
 vje
 vje
 vje
@@ -94517,14 +94391,14 @@ vje
 vje
 vje
 vje
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
 vje
+vje
+vtF
+vje
+vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -94716,13 +94590,13 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
+vje
+vje
+vje
+vje
 vje
 vje
 vje
@@ -94774,13 +94648,13 @@ vje
 vje
 vje
 vje
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
+vje
+vje
+vje
+vtF
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -94969,21 +94843,21 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
+vtF
 vje
 vje
 iRb
@@ -94996,7 +94870,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -95031,13 +94905,13 @@ oez
 oez
 oez
 oez
-aKa
-hsd
-wqF
-wqF
-wqF
-hsd
-aKa
+vje
+vje
+vje
+vje
+vje
+vtF
+vje
 vje
 vje
 vje
@@ -95222,22 +95096,22 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
+vtF
+vtF
+vtF
+vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -95253,8 +95127,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -95288,13 +95162,13 @@ oez
 oez
 oez
 oez
-aKa
-hsd
-hsd
-hsd
-hsd
-hsd
-aKa
+vje
+vje
+vje
+vje
+vtF
+vtF
+vje
 vje
 vje
 vje
@@ -95479,22 +95353,22 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
+vje
+vje
+vje
+vje
+vtF
+vtF
+vje
+vje
+vje
+vje
+vtF
+vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -95511,7 +95385,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -95545,13 +95419,13 @@ oez
 oez
 oez
 oez
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
-aKa
+vje
+vje
+vje
+vje
+vje
+vtF
+vje
 vje
 vje
 vje
@@ -95736,23 +95610,23 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
+vtF
 vje
 vje
 vje
@@ -95769,7 +95643,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 oDo
@@ -95987,29 +95861,29 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
+vje
+vje
+vje
+rit
+rit
+rit
+rit
+rit
+rit
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vtF
 vje
 vje
 vje
@@ -96023,10 +95897,10 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 oDo
@@ -96243,32 +96117,32 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
 vje
+vje
+vje
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+vje
+vje
+vtF
+vtF
 vje
 vje
 iRb
@@ -96279,8 +96153,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -96500,32 +96374,32 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
 vje
 vje
+vtF
 vje
+vje
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+vje
+vje
+vje
+vtF
 vje
 vje
 iRb
@@ -96535,8 +96409,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -96757,32 +96631,32 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vtF
+vtF
+vje
+vje
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+rit
+vje
+rit
+rit
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 iRb
@@ -96792,7 +96666,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -97014,28 +96888,28 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vtF
+vtF
+vje
+vje
+rit
+rit
+rit
+rit
+rit
+rit
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+rit
 vje
 vje
 vje
@@ -97049,8 +96923,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -97271,26 +97145,26 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
 vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
+vje
+vje
+rit
+rit
+rit
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
 vje
 vje
 vje
@@ -97528,17 +97402,17 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
+vje
 pIT
 pIT
 ozM
@@ -97565,7 +97439,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -97785,6 +97659,7 @@ oez
 oez
 oez
 oez
+vje
 oez
 oez
 oez
@@ -97793,9 +97668,8 @@ oez
 oez
 oez
 oez
-oez
-oez
-oez
+vje
+vje
 pIT
 rQP
 nCK
@@ -97821,8 +97695,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -98042,7 +97916,7 @@ oez
 oez
 oez
 oez
-oez
+vje
 oez
 oez
 oez
@@ -98078,7 +97952,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -98299,7 +98173,7 @@ oez
 oez
 oez
 oez
-oez
+vje
 oez
 oez
 oez
@@ -98335,7 +98209,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -98556,7 +98430,7 @@ oez
 oez
 oez
 oez
-oez
+vje
 oez
 oez
 oez
@@ -98592,7 +98466,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -98848,8 +98722,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -99105,8 +98979,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -100908,7 +100782,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -101164,8 +101038,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -101419,9 +101293,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -101675,10 +101549,10 @@ iRb
 vje
 vje
 vje
+vtF
+vtF
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -101932,7 +101806,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -102189,10 +102063,10 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -102446,7 +102320,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -102706,7 +102580,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -102761,7 +102635,7 @@ lLt
 lLt
 lLt
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -102960,10 +102834,10 @@ iRb
 vje
 vje
 vje
+vtF
 vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -102993,8 +102867,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -103018,7 +102892,7 @@ lLt
 vje
 vje
 vje
-vje
+vtF
 vje
 oez
 oez
@@ -103216,10 +103090,10 @@ iRb
 iRb
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -103250,9 +103124,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -103275,7 +103149,7 @@ lLt
 vje
 vje
 vje
-vje
+vtF
 vje
 oez
 oez
@@ -103473,43 +103347,43 @@ iRb
 iRb
 vje
 vje
+vtF
+vje
+vje
+vtF
+vje
+vje
+vje
+vje
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 vje
 vje
 vje
 vje
 vje
 vje
-vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -103531,8 +103405,8 @@ nYt
 lLt
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 oez
 oez
@@ -103730,6 +103604,36 @@ iRb
 iRb
 vje
 vje
+vtF
+vje
+vje
+vtF
+vtF
+vje
+vje
+vje
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
+oez
 vje
 vje
 vje
@@ -103737,37 +103641,7 @@ vje
 vje
 vje
 vje
-vje
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-oez
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -103788,7 +103662,7 @@ lLt
 lLt
 vje
 vje
-vje
+vtF
 vje
 vje
 oez
@@ -103987,11 +103861,11 @@ iRb
 iRb
 vje
 vje
+vtF
+vtF
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -104025,6 +103899,12 @@ vje
 vje
 vje
 vje
+vtF
+vje
+vje
+vje
+vtF
+vtF
 vje
 vje
 vje
@@ -104038,13 +103918,7 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -104245,10 +104119,10 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -104282,6 +104156,13 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vje
+vtF
+vje
+vtF
+vtF
 vje
 vje
 vje
@@ -104292,16 +104173,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -104502,9 +104376,9 @@ iRb
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -104540,23 +104414,23 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -106047,7 +105921,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -106304,8 +106178,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -106560,9 +106434,9 @@ vje
 vje
 vje
 vje
+vtF
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -106816,10 +106690,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -107073,10 +106947,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -107329,10 +107203,10 @@ iRb
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -107586,7 +107460,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -107843,7 +107717,7 @@ iRb
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -108100,8 +107974,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -108358,8 +108232,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -108616,7 +108490,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -108873,7 +108747,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -109129,8 +109003,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -109385,8 +109259,8 @@ iRb
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -109641,8 +109515,8 @@ iRb
 iRb
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -109898,8 +109772,8 @@ iRb
 iRb
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -110157,8 +110031,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -110376,7 +110250,7 @@ nCK
 dri
 dri
 rQP
-rQP
+rpe
 vje
 oez
 oez
@@ -110415,8 +110289,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -110477,7 +110351,7 @@ oez
 aKa
 aKa
 kjh
-aKa
+cbq
 aKa
 aKa
 aKa
@@ -110673,11 +110547,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 oez
@@ -110931,10 +110805,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 oez
 oez
@@ -111037,7 +110911,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -111188,10 +111062,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 oez
 oez
@@ -111239,7 +111113,7 @@ vje
 vje
 vje
 vje
-vje
+vtF
 vje
 vje
 vje
@@ -111293,9 +111167,9 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -111341,6 +111215,8 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111348,10 +111224,8 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111445,10 +111319,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 oez
 oez
@@ -111487,6 +111361,7 @@ aKa
 cRp
 vje
 vje
+vtF
 vje
 vje
 vje
@@ -111495,8 +111370,7 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -111521,6 +111395,7 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
@@ -111549,7 +111424,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111569,6 +111447,9 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -111588,26 +111469,19 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111638,8 +111512,8 @@ vje
 vje
 vje
 vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111702,10 +111576,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 oez
 oez
@@ -111744,6 +111618,8 @@ cRp
 cRp
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111751,9 +111627,7 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -111778,12 +111652,16 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111791,6 +111669,8 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111801,8 +111681,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111810,19 +111693,30 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -111830,15 +111724,20 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -111869,40 +111768,15 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 rQP
 qNX
@@ -111959,10 +111833,10 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
-vje
-vje
+vtF
 vje
 oez
 oez
@@ -112002,14 +111876,14 @@ aKa
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -112037,13 +111911,21 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
+vtF
+vtF
 vje
+vtF
+vtF
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112052,6 +111934,7 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
@@ -112060,8 +111943,14 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112076,9 +111965,13 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112096,8 +111989,11 @@ vje
 vje
 vje
 vje
+vtF
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112128,36 +112024,14 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112261,12 +112135,12 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
-vje
-vje
-vje
+vtF
 vje
 vje
 vje
@@ -112295,10 +112169,18 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
+vtF
+vtF
 vje
+vtF
 vje
 vje
 vje
@@ -112307,6 +112189,9 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112316,6 +112201,10 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112335,6 +112224,9 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112354,6 +112246,10 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112367,6 +112263,10 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112380,34 +112280,8 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112519,6 +112393,10 @@ vje
 vje
 vje
 vje
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje
@@ -112557,6 +112435,8 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112565,6 +112445,8 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112641,29 +112523,21 @@ vje
 vje
 vje
 vje
+vtF
+vtF
 vje
 vje
 vje
 vje
 vje
 vje
+vtF
 vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
 vje
 vje
 vje
@@ -112907,13 +112781,13 @@ vje
 vje
 vje
 vje
-vje
-vje
-vje
-vje
-vje
-vje
-vje
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
+vtF
 vje
 vje
 vje

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
@@ -29642,7 +29642,9 @@
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowdestroyed"
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "doO" = (
@@ -31470,7 +31472,9 @@
 	icon_state = "housewindow"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building/abandoned)
 "dJa" = (
@@ -36789,7 +36793,9 @@
 	icon_state = "housewindowbroken"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building/abandoned)
 "eVs" = (
@@ -43417,7 +43423,9 @@
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "guH" = (
@@ -51335,7 +51343,9 @@
 	icon_state = "housewindowbrokenvertical"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building/abandoned)
 "iiZ" = (
@@ -76652,7 +76662,9 @@
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbroken"
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "nLU" = (
@@ -78250,7 +78262,9 @@
 /area/f13/building/coyote/nash/firestation)
 "odx" = (
 /obj/structure/simple_door/metal/dirtystore,
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "odA" = (
@@ -98793,7 +98807,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "sLJ" = (
@@ -108976,7 +108992,9 @@
 	pixel_x = -12;
 	pixel_y = -8
 	},
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = DenPharma
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "uYT" = (

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
@@ -29642,9 +29642,7 @@
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowdestroyed"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "doO" = (
@@ -31472,9 +31470,7 @@
 	icon_state = "housewindow"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building/abandoned)
 "dJa" = (
@@ -36793,9 +36789,7 @@
 	icon_state = "housewindowbroken"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/building/abandoned)
 "eVs" = (
@@ -43423,9 +43417,7 @@
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "guH" = (
@@ -51343,9 +51335,7 @@
 	icon_state = "housewindowbrokenvertical"
 	},
 /obj/structure/barricade/bars,
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building/abandoned)
 "iiZ" = (
@@ -76662,9 +76652,7 @@
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowbroken"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "nLU" = (
@@ -78262,9 +78250,7 @@
 /area/f13/building/coyote/nash/firestation)
 "odx" = (
 /obj/structure/simple_door/metal/dirtystore,
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "odA" = (
@@ -98807,9 +98793,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "sLJ" = (
@@ -108992,9 +108976,7 @@
 	pixel_x = -12;
 	pixel_y = -8
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = DenPharma
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "uYT" = (


### PR DESCRIPTION
## About The Pull Request
Completely and utterly changes every part of the Den, adds 2 new ruins and a bunch of mineable rock to the uppermost Nash z-level, with barrier walls between dungeons obviously left intact.

New Den Z-2: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/17a1d985-4baa-4493-866e-909781ec79bc)

New Den Z-3: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/8942c6ed-ad50-43a2-97e4-7f947e69943a)

New Ruin 1, Raider Cabin:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/1693e00e-0eb3-403d-ab76-8708f3212e86)

New Ruin 2, Machine Shop:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/e9696973-052b-4b9f-9c6f-f2086f83a07b)

Post Machine-Shop Reward, isolated mountain house, figured a livable area instead of a ton of loot might be cool as a prize:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/86585db5-f4eb-4579-bf1a-a81f39b2037c)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Two new ruins, mineable rock added to upper Tex-Arkana.
del: Removed Old Den
tweak: Entirely New Den
balance: rebalanced something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
