### PR TITLE
second wind and toe tapping fixes

### DIFF
--- a/code/controllers/subsystem/second_wind.dm
+++ b/code/controllers/subsystem/second_wind.dm
@@ -163,12 +163,12 @@ SUBSYSTEM_DEF(secondwind)
 		if(!corpse || currenter != corpse)
 			corpse = currenter
 			ownermob = WEAKREF(corpse)
-			initialize_lives()
+			//initialize_lives()      <--- any feature that makes you switch mobs will make this happen so. i made it not
 	else if(isliving(current))
 		if(!corpse || current != corpse)
 			corpse = current
 			ownermob = WEAKREF(corpse)
-			initialize_lives()
+			//initialize_lives()      <--- same as above
 	if(!corpse)
 		return
 		//CRASH("get_revivable_body for [ownerkey] called with no corpse and no currently played mob! wtf") // turns out disconnected players count, I guess?

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -2110,7 +2110,7 @@
 	if(LAZYLEN(hurt_parts))
 		hurts += "wound"
 	if(!LAZYLEN(hurts))
-		tap_toes(M, songpower, FALSE)
+		//tap_toes(M, songpower, FALSE)
 		return
 	var/winner = pick(hurts)
 	switch(winner)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
-stop re-init'ing second wind lives when a new mob is found
-no more `nods along to` when at full health


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
