### PR TITLE
Old Bokken no longer applies stamina damage on click regardless of click cooldown

### DIFF
--- a/code/game/objects/items/melee/coyotemelee.dm
+++ b/code/game/objects/items/melee/coyotemelee.dm
@@ -557,6 +557,11 @@
 	attack_speed = CLICK_CD_MELEE * 0.7
 	block_chance = 15
 
+/obj/item/melee/classic_baton/coyote/oldquarterstaff/oldbokken/attack(mob/living/M, mob/living/user)
+	. = ..()
+	if(!istype(M) || !CheckAttackCooldown(user, M))
+		return
+	M.apply_damage(30, STAMINA, "chest", M.run_armor_check("chest", "brute"))
 
 /obj/item/melee/coyote/olddervish
 	name = "Old Dervish Blade"


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/ARF-SS13/coyote-bayou/assets/53862927/57f53fc6-c4c5-4605-b4ec-0185f9e5d78e)
We hear you.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Old Bokken can no longer be abused to insta stamcrit people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
