### PR TITLE
Autotriage [ready to merge]

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1587,3 +1587,22 @@
 	if(HAS_TRAIT(src, TRAIT_HEAL_TOUCH) || HAS_TRAIT(src, TRAIT_HEAL_TONGUE) || HAS_TRAIT(src, TRAIT_HEAL_TEND))
 		. += ""
 		. += "Healing Charges: [FLOOR(heal_reservoir, 1)]"
+
+
+//-->alt+click on mob for autotriage
+/mob/living/carbon/AltClickOn(atom/A, params)
+	. = ..()
+	if(iscarbon(A))
+		if(view(1).Find(A))
+			if(src.a_intent == INTENT_HELP)
+				if(isnull(src.get_active_held_item()))
+					if(HAS_TRAIT(src, TRAIT_HEAL_TONGUE))
+						src.emote("lick")
+					else if(HAS_TRAIT(src, TRAIT_HEAL_TOUCH))
+						src.emote("touch")
+					else if(HAS_TRAIT(src, TRAIT_HEAL_TEND))
+						src.emote("tend")
+					
+					var/obj/item/I = get_active_held_item()
+					I.melee_attack_chain(src, A, params)
+//<--


### PR DESCRIPTION
## About The Pull Request
ALT+Clicking with HELP intent on a carbon retrieves one of the 3 healing emotes (lick, touch, tend with this order) and autoheals them without the need for a keybind for the "triages".

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds Autotriage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
