### PR TITLE
Uniform Addition: Keyhole Sweater to loadout menu

### DIFF
--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -786,21 +786,30 @@
 	name = "cream sweater"
 	path = /obj/item/clothing/under/sweater
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_SWEATERS
+
 /datum/gear/uniform/sweater/black
 	name = "black sweater"
 	path = /obj/item/clothing/under/sweater/black
+
 /datum/gear/uniform/sweater/blue
 	name = "blue sweater"
 	path = /obj/item/clothing/under/sweater/blue
+
 /datum/gear/uniform/sweater/purple
 	name = "purple sweater"
 	path = /obj/item/clothing/under/sweater/purple
+
 /datum/gear/uniform/sweater/green
 	name = "green sweater"
 	path = /obj/item/clothing/under/sweater/green
+
 /datum/gear/uniform/sweater/red
 	name = "red sweater"
 	path = /obj/item/clothing/under/sweater/red
+
+/datum/gear/uniform/sweater/keyhole
+	name =  "Keyhole Sweater"
+	path = /obj/item/clothing/under/misc/keyholesweater
 
 /datum/gear/uniform/skirt/blueschool
 	name = "blue schoolgirl uniform"


### PR DESCRIPTION
## About The Pull Request
This PR adds the keyhole sweater to the loadout menu instead of actually finding it in game only you can find it in THE LOADOUT menu
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: loadout keyhole sweater
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
