### PR TITLE
Den Vendorification

### DIFF
--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -59,6 +59,12 @@
 /obj/structure/railing,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ao" = (
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aq" = (
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 7
@@ -314,6 +320,10 @@
 /obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"bf" = (
+/obj/structure/chair/bench,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "bg" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -505,6 +515,16 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"bR" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/cloth/thirty{
+	pixel_y = 13;
+	pixel_x = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bS" = (
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -551,6 +571,13 @@
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#999999"
 	},
+/area/f13/wasteland)
+"bY" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "bZ" = (
 /obj/structure/rack/shelf_metal,
@@ -792,6 +819,9 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"cO" = (
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "cP" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/fence/end/wooden{
@@ -1066,6 +1096,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"dS" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbroken"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "dT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -1301,6 +1338,16 @@
 "eM" = (
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"eP" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/easel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eQ" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -1410,6 +1457,19 @@
 /obj/structure/butter_churn,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"fj" = (
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/obj/structure/chair/wood{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fk" = (
 /obj/item/clothing/gloves/color/red/insulated,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -2396,6 +2456,15 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iP" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iT" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -2574,6 +2643,18 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/building)
+"js" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/easel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood1-broken"
+	},
+/area/f13/building)
 "ju" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/tree/cherryblossom4{
@@ -2581,6 +2662,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jv" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jw" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -2961,6 +3050,21 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"la" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/table/wood,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "le" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3129,6 +3233,10 @@
 	color = "#779999"
 	},
 /area/f13/bar/heaven)
+"lK" = (
+/obj/structure/chair/bench,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "lL" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3168,6 +3276,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
+"lP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "lR" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -3200,6 +3312,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lX" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lY" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowvertical"
@@ -3745,6 +3863,20 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ob" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
+"od" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "og" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack/shelf_metal,
@@ -3909,6 +4041,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"oO" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oR" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4311,6 +4452,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"qo" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "qp" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "TexGarageSouth";
@@ -4520,6 +4665,17 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ra" = (
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rb" = (
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior2"
@@ -4569,6 +4725,18 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"rk" = (
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "rm" = (
 /turf/open/floor/wood_common{
 	color = "#888888"
@@ -4600,6 +4768,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
 /area/f13/building)
+"rs" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "rt" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -4867,6 +5042,15 @@
 /obj/structure/nest/protectron,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"sw" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sx" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -5212,6 +5396,16 @@
 /obj/structure/sink/deep_water,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"tJ" = (
+/obj/structure/table/wood,
+/obj/item/wirecutters,
+/obj/item/wirecutters{
+	pixel_y = 12;
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tK" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5974,6 +6168,17 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"wA" = (
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "wB" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken3"
@@ -7377,6 +7582,13 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"Bp" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Bq" = (
 /obj/structure/bonfire/prelit,
 /obj/effect/decal/cleanable/blood,
@@ -7790,10 +8002,35 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"De" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Df" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"Dh" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/obj/structure/rug/big/rug_red{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "Dk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8019,6 +8256,18 @@
 /obj/structure/pondlily_small,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"Ee" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Ef" = (
 /obj/item/stock_parts/cell/super/empty,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -9122,6 +9371,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"HZ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Ia" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass{
@@ -9385,6 +9644,15 @@
 /obj/structure/tires/half,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"IR" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "IU" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10041,6 +10309,14 @@
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"Lo" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "Lr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10062,6 +10338,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/purple,
 /area/f13/building)
+"Ly" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/slaggy{
+	pixel_x = 7
+	},
+/obj/item/binoculars{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "Lz" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 2;
@@ -10102,6 +10388,16 @@
 /obj/structure/fluff/beach_umbrella,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"LE" = (
+/obj/structure/table/wood,
+/obj/item/toy/beach_ball{
+	pixel_x = 17
+	},
+/obj/structure/fluff/beach_umbrella{
+	pixel_y = 0
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland)
 "LF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass{
@@ -10139,6 +10435,18 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"LK" = (
+/obj/structure/rug/big/rug_fancy{
+	dir = 4;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
+/area/f13/building)
 "LL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -10308,6 +10616,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"Mt" = (
+/obj/structure/window/fulltile/ruins,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Mu" = (
@@ -11262,6 +11574,9 @@
 /turf/open/floor/f13/wood{
 	color = "#999999"
 	},
+/area/f13/wasteland)
+"PG" = (
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "PH" = (
 /obj/structure/spacevine{
@@ -12590,6 +12905,17 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"TB" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "TC" = (
 /obj/item/flag/locust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12898,6 +13224,11 @@
 /obj/effect/validball_spawner,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/roof,
+/area/f13/building)
+"UO" = (
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "UQ" = (
 /obj/structure/sign/poster/prewar/poster93{
@@ -13597,6 +13928,28 @@
 "Xy" = (
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"XA" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/table/wood,
+/obj/item/chisel,
+/obj/item/chisel{
+	pixel_x = 7
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "XB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/fortress_brick,
@@ -58533,22 +58886,22 @@ jk
 jk
 jk
 jk
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+qo
+cO
+lK
+LE
+bf
+PG
+Ea
+eP
+la
+XA
+js
+HZ
+Ea
+De
+Dh
+Ea
 hm
 hm
 hm
@@ -58790,22 +59143,22 @@ hm
 hm
 hm
 jk
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+cO
+PG
+lK
+Ly
+lK
+cO
+Lo
+dW
+od
+LK
+Du
+Du
+Ee
+dW
+yr
+wA
 hm
 hm
 hm
@@ -59047,22 +59400,22 @@ hm
 hm
 hm
 jk
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+PG
+PG
+PG
+cO
+cO
+PG
+dW
+dW
+Du
+Du
+dW
+dW
+dW
+dW
+dW
+fj
 hm
 hm
 hm
@@ -59304,22 +59657,22 @@ hm
 hm
 hm
 jk
-yP
-yP
-yP
-yP
-yP
-yP
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+rs
+bY
+bY
+bY
+bY
+bY
+yr
+dW
+dW
+dW
+dW
+dW
+dW
+ob
+dW
+ra
 hm
 hm
 hm
@@ -59567,16 +59920,16 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+TB
+bR
+tJ
+ao
+UO
+yr
+dW
+sw
+yr
+rk
 hm
 hm
 hm
@@ -59824,16 +60177,16 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
-hm
+Ea
+Bp
+lX
+oO
+lX
+lX
+lP
+WH
+IR
+Ea
 hm
 hm
 hm
@@ -60087,10 +60440,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
+Mt
+WH
+iP
+Mt
 hm
 hm
 hm
@@ -60344,10 +60697,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
+Mt
+rH
+dW
+dS
 hm
 hm
 hm
@@ -60601,10 +60954,10 @@ hm
 hm
 hm
 hm
-hm
-hm
-hm
-hm
+Ea
+lX
+jv
+Ea
 hm
 hm
 hm

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -427,7 +427,10 @@
 	dir = 8;
 	pixel_y = 0
 	},
-/obj/machinery/trading_machine,
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "akf" = (
@@ -1427,6 +1430,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"aJg" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "aJk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3395,6 +3405,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bGw" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bGK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -4044,15 +4062,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building/mall)
-"bZd" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "bZh" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -6183,11 +6192,6 @@
 /obj/effect/spawner/lootdrop/f13/trash,
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/hospital/clinic/nash)
-"dhH" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "dhW" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -8162,6 +8166,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"ejb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "ejq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8655,13 +8666,6 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
-"ewi" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ewZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8804,6 +8808,18 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"eBi" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "eBE" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -11128,7 +11144,9 @@
 /obj/structure/railing{
 	color = "#A47449"
 	},
-/obj/machinery/trading_machine/weapon,
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fIt" = (
@@ -14216,14 +14234,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/blue,
 /area/f13/building)
-"hhs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rug/mat{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hhu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -16116,6 +16126,15 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"icv" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/machinery/trading_machine,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "icJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16245,11 +16264,12 @@
 /turf/closed/wall,
 /area/f13/building)
 "igv" = (
-/obj/structure/railing{
-	color = "#A47449"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "whiteyellowdirtychess2"
 	},
-/obj/machinery/trading_machine/ammo,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "igw" = (
 /obj/structure/window/fulltile/house,
@@ -16844,11 +16864,10 @@
 	},
 /area/f13/building)
 "iwM" = (
-/obj/structure/stairs/east{
-	color = "#A47449"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
 /area/f13/building)
 "ixg" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -17033,6 +17052,15 @@
 "iBt" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plating/dirt,
+/area/f13/building)
+"iBy" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "iBz" = (
 /obj/structure/lattice/catwalk,
@@ -17995,15 +18023,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"iYQ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/destructible/tribal_torch/wall/lit,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "iZd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -18847,6 +18866,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"jux" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "juI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19047,12 +19075,6 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"jAf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
-	},
-/area/f13/building)
 "jAq" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -19062,20 +19084,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"jAt" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_x = -7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/building)
 "jAx" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -19259,7 +19267,10 @@
 	color = "#A47449";
 	dir = 4
 	},
-/obj/machinery/vending/cigarette,
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -19773,15 +19784,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"jTQ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "jUp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -20783,15 +20785,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"kvd" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "kvm" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -22154,6 +22147,12 @@
 /obj/item/storage/fancy/cigarettes/cigpack_greytort,
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
+"kYw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_yellow,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kYM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13/vault_floor/blue/corner{
@@ -23040,14 +23039,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
-"lxU" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lxY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -23709,17 +23700,6 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"lOL" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/chair/bench{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lOV" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
@@ -24051,6 +24031,17 @@
 /obj/structure/flora/tree/oak_five,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"lXM" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lXN" = (
 /obj/structure/flora/tallgrass5,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -25567,15 +25558,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mJO" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/machinery/mineral/wasteland_vendor/crafting{
-	icon_state = "parts_idle"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "mJX" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -25986,6 +25968,13 @@
 	icon_state = "common-broken2"
 	},
 /area/f13/wasteland)
+"mSx" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mSB" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -26003,13 +25992,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
-"mSH" = (
-/obj/machinery/smartfridge/chemistry,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
-	},
-/area/f13/building)
 "mSQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29878,18 +29860,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"oPu" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/chair/bench{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "oPH" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30112,6 +30082,15 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"oUX" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oVn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
@@ -32412,6 +32391,13 @@
 /obj/item/instrument/harmonica,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
+"qgU" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/trading_machine/weapon,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qhe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -33199,6 +33185,13 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/building)
+"qAE" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/trading_machine/ammo,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "qAI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33421,9 +33414,10 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "qJP" = (
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rug/big/rug_yellow,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qJQ" = (
@@ -34024,10 +34018,6 @@
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"reb" = (
-/obj/machinery/mineral/wasteland_vendor/mining,
-/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "rek" = (
 /obj/structure/table/wood/bar,
@@ -36324,15 +36314,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
-"slM" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "slU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -36392,14 +36373,13 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "spB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/obj/machinery/vending/medical/becomingnook,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "spG" = (
 /obj/structure/simple_door/house{
@@ -37073,6 +37053,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
+"sKv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/mat{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "sKE" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -38556,13 +38544,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"tvJ" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/machinery/trading_machine/armor,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "tvU" = (
 /obj/structure/simple_door/metal/barred{
@@ -40566,6 +40547,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland/nash)
+"uvY" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/mineral/wasteland_vendor/attachments{
+	icon_state = "weapon_idle"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uwi" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/swimsuit/green{
@@ -41124,6 +41114,16 @@
 /obj/structure/flora/jungle2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"uMl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "uMo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt,
@@ -41401,13 +41401,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
 	},
-/area/f13/building)
-"uTl" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "uTs" = (
 /obj/structure/spacevine,
@@ -42138,6 +42131,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"vmu" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vmF" = (
 /obj/machinery/light{
 	dir = 4
@@ -42221,6 +42223,20 @@
 /obj/structure/rack,
 /turf/open/floor/carpet/black,
 /area/f13/building/mall)
+"vom" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/chair/wood{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "vot" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/wiki/research_and_development,
@@ -42394,14 +42410,9 @@
 /area/f13/building)
 "vsz" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	color = "#A47449"
 	},
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/trading_machine/armor,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vsN" = (
@@ -42460,15 +42471,6 @@
 	},
 /turf/open/floor/carpet/arcade,
 /area/f13/bar/nash)
-"vvc" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/machinery/mineral/wasteland_vendor/attachments{
-	icon_state = "weapon_idle"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "vvS" = (
 /obj/machinery/hydroponics/soil/pot,
 /turf/open/floor/wood_common{
@@ -43268,6 +43270,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/f13/building/massfusion)
+"vRL" = (
+/obj/machinery/mineral/wasteland_vendor/mining,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "vSe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -43442,18 +43448,6 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
-/area/f13/building)
-"vVI" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_y = 8
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "vVN" = (
 /obj/structure/sink/greyscale{
@@ -43735,6 +43729,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/mall)
+"wef" = (
+/obj/machinery/smartfridge/chemistry,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "wek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
@@ -44085,6 +44086,11 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/building/abandoned)
+"wnU" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "wnW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -46455,6 +46461,15 @@
 /turf/open/floor/f13{
 	icon_state = "neutralrustyfull"
 	},
+/area/f13/building)
+"xDe" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "xDk" = (
 /turf/open/floor/f13{
@@ -82502,7 +82517,7 @@ xLx
 hya
 xLx
 ixY
-spB
+uMl
 xku
 bCe
 ixY
@@ -82759,7 +82774,7 @@ xAb
 xku
 xku
 ixY
-xku
+ejb
 dze
 kVE
 ixY
@@ -83529,7 +83544,7 @@ aht
 dze
 dze
 xku
-mSH
+wef
 xku
 dze
 edZ
@@ -86612,7 +86627,7 @@ dfD
 rmt
 sbk
 xDk
-rmt
+igv
 njR
 ixY
 gDZ
@@ -87643,7 +87658,7 @@ xDk
 rmt
 trg
 ixY
-reb
+vRL
 jXS
 jXS
 hyz
@@ -92017,12 +92032,12 @@ gDZ
 fSd
 avp
 fSd
-vVI
-vsz
-vsz
-lKt
+eBi
 ajQ
-bZd
+ajQ
+lKt
+icv
+iBy
 fSd
 oez
 oez
@@ -92272,15 +92287,15 @@ pIV
 lAR
 gDZ
 fSd
-hhs
+sKv
 oxM
 oxM
 kff
 owB
-ewi
+mSx
 oxM
-qJP
-vvc
+kYw
+uvY
 oez
 oez
 oez
@@ -92537,7 +92552,7 @@ chh
 kff
 oxM
 kff
-mJO
+spB
 oez
 oez
 oez
@@ -92794,7 +92809,7 @@ kff
 kff
 kff
 oxM
-fIs
+qgU
 oez
 oez
 oez
@@ -93043,15 +93058,15 @@ oez
 oez
 oez
 fSd
-lxU
+bGw
 omG
 kff
 kff
 kff
 kff
 oxM
-jAf
-slM
+iwM
+fIs
 oez
 oez
 oez
@@ -93299,16 +93314,16 @@ oez
 oez
 oez
 oez
-dhH
+wnU
 qAd
-dhH
+wnU
+xDe
 jGi
-oPu
-lOL
+lXM
 fSd
-uTl
+aJg
 kff
-kvd
+jux
 oez
 oez
 oez
@@ -93563,9 +93578,9 @@ oez
 oez
 oez
 fSd
-iwM
+qJP
 gIf
-tvJ
+vsz
 oez
 oez
 oez
@@ -93820,9 +93835,9 @@ oez
 oez
 oez
 fSd
-jTQ
+vmu
 kff
-igv
+qAE
 oez
 oez
 oez
@@ -94077,8 +94092,8 @@ oez
 oez
 oez
 fSd
-jAt
-iYQ
+vom
+oUX
 fSd
 oez
 oez

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -422,14 +422,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ajQ" = (
-/obj/structure/flora/tallgrass5,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/trading_machine,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "akf" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -864,20 +864,12 @@
 	},
 /area/f13/building)
 "avp" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -7
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "avO" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -4052,6 +4044,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building/mall)
+"bZd" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "bZh" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -4316,15 +4317,11 @@
 	},
 /area/f13/building/massfusion)
 "chh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_red,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "chl" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -6186,6 +6183,11 @@
 /obj/effect/spawner/lootdrop/f13/trash,
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/hospital/clinic/nash)
+"dhH" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/building)
 "dhW" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -8653,6 +8655,13 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building/mall)
+"ewi" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ewZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10382,6 +10391,7 @@
 /area/f13/wasteland)
 "fpX" = (
 /obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fqm" = (
@@ -11115,12 +11125,12 @@
 /turf/open/floor/plating/dirt,
 /area/f13/building/tunnel)
 "fIs" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 8
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland)
+/obj/machinery/trading_machine/weapon,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "fIt" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13213,13 +13223,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ruins)
 "gIf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/flora/tree/oak_five,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "gIh" = (
 /obj/item/locked_box/weapon/melee/tier2,
 /obj/structure/rack/shelf_wood{
@@ -14022,6 +14033,7 @@
 "hbz" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hbL" = (
@@ -14203,6 +14215,14 @@
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/blue,
+/area/f13/building)
+"hhs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/mat{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "hhu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16225,13 +16245,12 @@
 /turf/closed/wall,
 /area/f13/building)
 "igv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/trading_machine/ammo,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "igw" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/window/fulltile/house,
@@ -16825,14 +16844,12 @@
 	},
 /area/f13/building)
 "iwM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
+/obj/structure/stairs/east{
+	color = "#A47449"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "ixg" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -17978,6 +17995,15 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"iYQ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "iZd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -18964,6 +18990,7 @@
 "jyL" = (
 /obj/structure/closet,
 /obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jyW" = (
@@ -19020,6 +19047,12 @@
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
+"jAf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/building)
 "jAq" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -19029,6 +19062,20 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"jAt" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/chair/wood{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/building)
 "jAx" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -19208,11 +19255,13 @@
 /turf/closed/wall/f13/wood,
 /area/f13/building/tribal)
 "jGi" = (
-/obj/machinery/vending/medical/becomingnook,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
+/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "jGs" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -19724,6 +19773,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"jTQ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "jUp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -20725,6 +20783,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"kvd" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kvm" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -22973,6 +23040,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
+"lxU" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lxY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -23634,6 +23709,17 @@
 /obj/structure/flora/tallgrass2,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"lOL" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lOV" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/roof,
@@ -24577,6 +24663,7 @@
 "mnU" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/ore/blackpowder/fifty,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mob" = (
@@ -25480,6 +25567,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mJO" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mJX" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#111111"
@@ -25907,6 +26003,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
+"mSH" = (
+/obj/machinery/smartfridge/chemistry,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "mSQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29775,6 +29878,18 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"oPu" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "oPH" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33078,24 +33193,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
 "qAd" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -7
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 9
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/turf/open/floor/plating/dirt,
+/area/f13/building)
 "qAI" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33318,13 +33421,11 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "qJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_yellow,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/building)
 "qJQ" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -33923,6 +34024,10 @@
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"reb" = (
+/obj/machinery/mineral/wasteland_vendor/mining,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building)
 "rek" = (
 /obj/structure/table/wood/bar,
@@ -36219,6 +36324,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
+"slM" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "slU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -36278,10 +36392,15 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "spB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
 "spG" = (
 /obj/structure/simple_door/house{
 	name = "New Age Gardening"
@@ -38187,9 +38306,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tpg" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks,
-/turf/closed/wall/f13/wood,
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tpu" = (
 /obj/structure/closet/cabinet,
@@ -38435,6 +38557,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"tvJ" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/trading_machine/armor,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "tvU" = (
 /obj/structure/simple_door/metal/barred{
 	name = "Slave Keep"
@@ -38622,6 +38751,7 @@
 /area/f13/building/mall)
 "tAR" = (
 /obj/structure/closet,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tBo" = (
@@ -41272,6 +41402,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"uTl" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "uTs" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/blood/drip,
@@ -42256,9 +42393,16 @@
 	},
 /area/f13/building)
 "vsz" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
 	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vsN" = (
 /obj/structure/chair/f13chair2{
@@ -42316,6 +42460,15 @@
 	},
 /turf/open/floor/carpet/arcade,
 /area/f13/bar/nash)
+"vvc" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/machinery/mineral/wasteland_vendor/attachments{
+	icon_state = "weapon_idle"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "vvS" = (
 /obj/machinery/hydroponics/soil/pot,
 /turf/open/floor/wood_common{
@@ -43289,6 +43442,18 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
+/area/f13/building)
+"vVI" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_y = 8
+	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "vVN" = (
 /obj/structure/sink/greyscale{
@@ -45303,6 +45468,7 @@
 /area/f13/building)
 "wZx" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wZy" = (
@@ -82336,7 +82502,7 @@ xLx
 hya
 xLx
 ixY
-wUY
+spB
 xku
 bCe
 ixY
@@ -83363,8 +83529,8 @@ aht
 dze
 dze
 xku
-ixY
-jGi
+mSH
+xku
 dze
 edZ
 vYY
@@ -87226,7 +87392,7 @@ hyz
 hyz
 aEO
 hbz
-cdN
+oxM
 iEY
 mnU
 etA
@@ -87477,16 +87643,16 @@ xDk
 rmt
 trg
 ixY
-hyz
+reb
 jXS
 jXS
 hyz
 aEO
 fpX
-cdN
-cdN
-cdN
-cdN
+kff
+kff
+kff
+oxM
 gDZ
 sDd
 sKE
@@ -87740,10 +87906,10 @@ jXS
 jXS
 aEO
 wZx
-cdN
-cdN
-cdN
-gKO
+kff
+kff
+kff
+omG
 gDZ
 dBv
 sKE
@@ -87997,9 +88163,9 @@ hyz
 hyz
 gDZ
 vNA
-cdN
-cdN
-cdN
+kff
+kff
+oxM
 jyL
 gDZ
 iCH
@@ -88253,10 +88419,10 @@ jXS
 hyz
 hyz
 hyz
-cdN
-cdN
-vsz
-cdN
+oxM
+oxM
+nxF
+oxM
 tAR
 gDZ
 iCH
@@ -88509,10 +88675,10 @@ urX
 ipE
 ipE
 hyz
-gKO
-cdN
-cdN
-cdN
+beR
+oxM
+kff
+kff
 xUt
 gDZ
 gDZ
@@ -88767,9 +88933,9 @@ ipE
 uBg
 hyz
 hyz
-oBS
-cdN
-cdN
+yiT
+kff
+kff
 jsq
 gDZ
 sDd
@@ -91591,8 +91757,8 @@ qnO
 nUs
 esy
 gDZ
-tpg
-fIs
+iCH
+wtB
 tpg
 oez
 oez
@@ -91848,16 +92014,16 @@ jts
 sMB
 mSQ
 gDZ
-oez
+fSd
 avp
-iDX
-iDX
-iDX
-iDX
-iDX
-iDX
-iDX
-iDX
+fSd
+vVI
+vsz
+vsz
+lKt
+ajQ
+bZd
+fSd
 oez
 oez
 oez
@@ -92105,16 +92271,16 @@ lAR
 pIV
 lAR
 gDZ
-oez
-iDX
-qNX
-qNX
-qNX
-spB
-qNX
-qNX
+fSd
+hhs
+oxM
+oxM
+kff
+owB
+ewi
+oxM
 qJP
-iDX
+vvc
 oez
 oez
 oez
@@ -92362,16 +92528,16 @@ rwS
 gDZ
 gDZ
 gDZ
-oez
-iDX
-qNX
-gIf
-igv
+fSd
+oxM
+kff
+kff
+kff
 chh
-ajQ
-qNX
-gIf
-iDX
+kff
+oxM
+kff
+mJO
 oez
 oez
 oez
@@ -92619,16 +92785,16 @@ oez
 oez
 oez
 oez
-oez
-iDX
-qNX
-qJP
-iwM
-jsi
-nXo
-qNX
-qNX
-iDX
+fSd
+oxM
+kff
+kff
+kff
+kff
+kff
+kff
+oxM
+fIs
 oez
 oez
 oez
@@ -92876,16 +93042,16 @@ oez
 oez
 oez
 oez
-oez
-iDX
-qNX
-qNX
-igv
-guk
-rQP
-qNX
-qNX
-iDX
+fSd
+lxU
+omG
+kff
+kff
+kff
+kff
+oxM
+jAf
+slM
 oez
 oez
 oez
@@ -93133,16 +93299,16 @@ oez
 oez
 oez
 oez
-oez
+dhH
 qAd
-iDX
-iDX
-iDX
-iDX
-iDX
-qNX
-qNX
-iDX
+dhH
+jGi
+oPu
+lOL
+fSd
+uTl
+kff
+kvd
 oez
 oez
 oez
@@ -93396,10 +93562,10 @@ oez
 oez
 oez
 oez
-xkq
-qJP
+fSd
+iwM
 gIf
-iDX
+tvJ
 oez
 oez
 oez
@@ -93653,10 +93819,10 @@ oez
 oez
 oez
 oez
-iDX
-qNX
-qNX
-iDX
+fSd
+jTQ
+kff
+igv
 oez
 oez
 oez
@@ -93910,10 +94076,10 @@ oez
 oez
 oez
 oez
-iDX
-iDX
-iDX
-iDX
+fSd
+jAt
+iYQ
+fSd
 oez
 oez
 oez


### PR DESCRIPTION
## About The Pull Request
Adds the Garland vendors to the Den as per request from Fenny. The guns, ammo, armor, and trading machines are in a new building out the East exit, with a mining vendor next to the ORM and a smart-fridge now placed in the chemistry lab.

Also adds an art room and lounge above the new vendor room, because why not?

Vendor room:
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/6a7ed5e8-e345-485d-998a-c16b577884b3)

Mining vendor: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/da6f3bc0-d184-4191-90af-be04f555f9d8)

Smartfridge (Becoming Nook and other vendor now added to storage closet):
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/5aa637cf-62b5-4b60-b174-63685cbf82a1)

Art room/Lounge: 
![image](https://github.com/ARF-SS13/coyote-bayou/assets/12074028/c5525160-9ba4-4185-a49f-053084ee3f61)


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Den vendors, art room, smart-fridge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
