### PR TITLE
Fixes the loadout again

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -769,13 +769,13 @@
 	new /obj/item/gun/ballistic/rifle/mag/bifrost(src)
 
 /datum/gear/donator/kits/palpapus
-	name = "Darth Plapapus Customs"
+	name = "Darth Plapappus Customs"
 	path = /obj/item/storage/box/large/custom_kit/palpapus
 	ckeywhitelist = list("lordpapalus", "Lord_Papalus")
 
 /obj/item/storage/box/large/custom_kit/palpapus/PopulateContents()
 	new /obj/item/clothing/head/helmet/f13/brahmincowboyhat(src)
-	new /obj/item/clothing/suit/armor/harpercoat(src)
+	new /obj/item/clothing/suit/armor/medium/raider/combatduster(src)
 	new /obj/item/clothing/under/f13/eighties(src)
 	new /obj/item/clothing/shoes/f13/rag/pawb(src)
 	new /obj/item/gun/ballistic/rifle/repeater/cowboy/tribal(src)


### PR DESCRIPTION
## About The Pull Request
Kilmented gave my loadout the wrong coat. Fixing it myself to make it faster, look at my ticket if you need context.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Changes the light-armour duster to the medium-armour variant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
