### PR TITLE
Autotriage III [ready to merge but evaluate yourself first]

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -125,7 +125,10 @@
 
 /datum/emote/living/carbon/lick/run_emote(mob/user)
 	. = ..()
-	if(user.get_active_held_item())
+	var/obj/item/I = user.get_active_held_item()
+	if(istype(I, /obj/item/hand_item/healable/))
+		I.melee_attack_chain(user, user)
+	else if(I)
 		to_chat(user, span_warning("Your active hand is full, and therefore you can't lick anything! Don't ask why!"))
 		return
 	var/obj/item/hand_item/healable/licker/licky = new(user)
@@ -141,7 +144,10 @@
 
 /datum/emote/living/carbon/touch/run_emote(mob/user)
 	. = ..()
-	if(user.get_active_held_item())
+	var/obj/item/I = user.get_active_held_item()
+	if(istype(I, /obj/item/hand_item/healable/))
+		I.melee_attack_chain(user, user)
+	else if(I)
 		to_chat(user, span_warning("Your active hand is full, and therefore you can't touch anything!"))
 		return
 	var/obj/item/hand_item/healable/toucher/touchy = new(user)
@@ -157,7 +163,10 @@
 
 /datum/emote/living/carbon/tend/run_emote(mob/user)
 	. = ..()
-	if(user.get_active_held_item())
+	var/obj/item/I = user.get_active_held_item()
+	if(istype(I, /obj/item/hand_item/healable/))
+		I.melee_attack_chain(user, user)
+	else if(I)
 		to_chat(user, span_warning("Your active hand is full, and therefore you can't tend anything!"))
 		return
 	var/obj/item/hand_item/healable/tender/tendy = new(user)


### PR DESCRIPTION
## About The Pull Request
Basically, Fenny asked me to make the double click function of the autotriage button bound to a shortcut on the keyboard.
To which I thought.... what if simply calling the triage emote twice using the same key on the keyboard, would also start healing yourself?
I played with this little logic a little bit and it honestly feels quite good

tl;dr: doublepressing the key that calls one of the triage emotes initiates healing automatically.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaked autotriage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
