### PR TITLE
Map Fix: New Booston + Redwater 'faction' doors removed

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -651,10 +651,8 @@
 	},
 /area/f13/building)
 "gf" = (
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "131"
-	},
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "gg" = (

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -7539,7 +7539,7 @@
 /obj/structure/simple_door/room{
 	req_access_txt = "123"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "gHl" = (
 /turf/closed/indestructible/f13/matrix,
@@ -18120,7 +18120,7 @@
 	},
 /area/f13/wasteland)
 "pAf" = (
-/obj/machinery/door/unpowered/securedoor/legion,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pAi" = (
@@ -20688,7 +20688,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "rPv" = (
-/obj/machinery/door/unpowered/securedoor/legion,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "rPR" = (
@@ -21394,7 +21394,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "sqV" = (
-/obj/machinery/door/unpowered/securedoor/legion,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "srh" = (
@@ -21502,7 +21502,10 @@
 	},
 /area/f13/trainstation)
 "swo" = (
-/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/poddoor/shutters{
+	id = "ncr_garage";
+	name = "Ranger Garage"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkrustysolid"
 	},
@@ -28019,10 +28022,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "xXv" = (
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "125"
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/door/unpowered/securedoor,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "xXE" = (
 /turf/open/indestructible,
@@ -83251,7 +83252,7 @@ gcG
 gcG
 gcG
 mBr
-mBr
+tQk
 mBr
 mBr
 hRl
@@ -86451,7 +86452,7 @@ jZU
 tPQ
 tPQ
 tPQ
-aiB
+lhn
 wAc
 xpl
 mwI
@@ -87716,7 +87717,7 @@ kwB
 qQj
 dGj
 sAR
-aiB
+lhn
 kwB
 kwB
 kwB
@@ -89797,7 +89798,7 @@ gcG
 tPQ
 tPQ
 tPQ
-aiB
+lhn
 kwB
 tWp
 kwB
@@ -90540,7 +90541,7 @@ cQY
 gUO
 kwB
 kwB
-aiB
+lhn
 kwB
 kwB
 gUO
@@ -91306,7 +91307,7 @@ qQj
 cAF
 eCy
 dGj
-aiB
+lhn
 kwB
 gUO
 kwB
@@ -91822,7 +91823,7 @@ cQY
 qQj
 qQj
 qQj
-aiB
+lhn
 qQj
 qQj
 qQj

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -4844,9 +4844,7 @@
 	},
 /area/f13/building)
 "eux" = (
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "131"
-	},
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "euE" = (
@@ -27289,10 +27287,8 @@
 	},
 /area/f13/building)
 "xqI" = (
-/obj/machinery/door/unpowered/securedoor{
-	req_access_txt = "131"
-	},
 /obj/structure/decoration/rag,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "xqN" = (

--- a/_maps/map_files/coyote_bayou/Redwater.dmm
+++ b/_maps/map_files/coyote_bayou/Redwater.dmm
@@ -37236,13 +37236,7 @@
 	},
 /area/f13/building)
 "nfr" = (
-/obj/machinery/door/unpowered/securedoor{
-	autoclose = 1;
-	damage_deflection = 28;
-	max_integrity = 400;
-	obj_integrity = 400;
-	req_access_txt = "123"
-	},
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nft" = (


### PR DESCRIPTION
## About The Pull Request
This should be removing most of the Ave and Doogmen doors that were access locked and also fixes the Rangerdangers garage up a tad bit including the garage door finally opens.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
remove: faction doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
