### PR TITLE
Reskinnable Kelpmagic Staves [ready to merge]

### DIFF
--- a/code/datums/components/reskin.dm
+++ b/code/datums/components/reskin.dm
@@ -155,6 +155,9 @@ GLOBAL_LIST_EMPTY(reskin_list)
 	/// the type of thing this thing expects
 	var/expected_type = /obj/item
 
+	var/lefthand_file
+	var/righthand_file
+
 /datum/reskin/New(obj/item/template)
 	if(!isitem(template))
 		return
@@ -173,6 +176,8 @@ GLOBAL_LIST_EMPTY(reskin_list)
 	icon = template.icon
 	icon_state = template.icon_state
 	item_state = template.item_state
+	lefthand_file = template.lefthand_file
+	righthand_file = template.righthand_file
 	mob_overlay_icon = template.mob_overlay_icon
 	mutantrace_variation = template.mutantrace_variation
 
@@ -190,6 +195,10 @@ GLOBAL_LIST_EMPTY(reskin_list)
 		target.icon_state = icon_state
 	if(!isnull(item_state))
 		target.item_state = item_state
+	if(!isnull(lefthand_file))
+		target.lefthand_file = lefthand_file
+	if(!isnull(righthand_file))
+		target.righthand_file = righthand_file
 	if(!isnull(mob_overlay_icon))
 		target.mob_overlay_icon = mob_overlay_icon
 	if(!isnull(mutantrace_variation))
@@ -2299,21 +2308,14 @@ GLOBAL_LIST_EMPTY(reskin_list)
 		"Shaman Staff",
 	)
 
-/datum/reskin/gun/staff_kelpmagic
-	skin = "Magic Staff"
-	name = "magic staff"
-	desc = "An intricate staff, carried for centuries by the shaman class of the tribe."
-	icon = 'icons/obj/guns/magic.dmi'
-	icon_state = "staffofnothing"
-	item_state = "staff"
-	expected_type = /obj/item/gun
-
 /datum/reskin/gun/staff_kelpmagic/shaman
 	skin = "Shaman Staff"
 	name = "shaman staff"
 	desc = "An intricate staff, carried for centuries by the shaman class of the tribe."
 	icon = 'icons/fallout/objects/melee/twohanded.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
+	lefthand_file = 'icons/fallout/onmob/weapons/melee2h_lefthand.dmi'
+	righthand_file = 'icons/fallout/onmob/weapons/melee2h_righthand.dmi'
 	icon_state = "staff-shaman"
 	item_state = "staff-shaman"
 	expected_type = /obj/item/gun

--- a/code/datums/components/reskin.dm
+++ b/code/datums/components/reskin.dm
@@ -2290,6 +2290,28 @@ GLOBAL_LIST_EMPTY(reskin_list)
 	unloaded_empty_icon = 'icons/fallout/objects/guns/ballistic.dmi'
 	unloaded_empty_state = "scarl-e"
 
+
+////////////////////////////
+///   KELPMAGIC STAVES   ///
+/datum/component/reskinnable/staff_kelpmagic
+	skins = list(
+		"Shaman Staff",
+	)
+/datum/reskin/gun/staff_kelpmagic/shaman
+	skin = "Shaman Staff"
+	name = "shaman staff"
+	desc = "An intricate staff, carried for centuries by the shaman class of the tribe."
+	icon = 'icons/fallout/objects/melee/twohanded.dmi'
+	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
+	icon_state = "staff-shaman"
+	expected_type = /obj/item/gun
+
+
+
+
+
+
+
 ////////////////////////////
 /// DEBUG SERVICE RIFLE ///
 /datum/component/reskinnable/service_rifle/debug

--- a/code/datums/components/reskin.dm
+++ b/code/datums/components/reskin.dm
@@ -2295,8 +2295,19 @@ GLOBAL_LIST_EMPTY(reskin_list)
 ///   KELPMAGIC STAVES   ///
 /datum/component/reskinnable/staff_kelpmagic
 	skins = list(
+		"Magic Staff",
 		"Shaman Staff",
 	)
+
+/datum/reskin/gun/staff_kelpmagic
+	skin = "Magic Staff"
+	name = "magic staff"
+	desc = "An intricate staff, carried for centuries by the shaman class of the tribe."
+	icon = 'icons/obj/guns/magic.dmi'
+	icon_state = "staffofnothing"
+	item_state = "staff"
+	expected_type = /obj/item/gun
+
 /datum/reskin/gun/staff_kelpmagic/shaman
 	skin = "Shaman Staff"
 	name = "shaman staff"
@@ -2304,6 +2315,7 @@ GLOBAL_LIST_EMPTY(reskin_list)
 	icon = 'icons/fallout/objects/melee/twohanded.dmi'
 	mob_overlay_icon = 'icons/fallout/onmob/backslot_weapon.dmi'
 	icon_state = "staff-shaman"
+	item_state = "staff-shaman"
 	expected_type = /obj/item/gun
 
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -158,6 +158,7 @@
 	init_firemodes = list(
 		/datum/firemode/semi_auto
 	)
+	reskinnable_component = /datum/component/reskinnable/staff_kelpmagic
 	// NOTE: max_charges is the number of shots, recharge_rate is time to recharge a single charge.
 
 /* This segment is commented out because the original template is over in wand.dm; this is here just for ease of reference

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,7 +13,7 @@ Format:
 	disabled (disables the map)
 endmap
 
-map pahrump-everything
+map pahrump-unit-test
 	default
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,7 +13,7 @@ Format:
 	disabled (disables the map)
 endmap
 
-map pahrump-unit-test
+map pahrump-everything
 	default
 endmap
 


### PR DESCRIPTION
## About The Pull Request
Adding the component we already have to make kelpmagic staves reskinnable.
Staves can be reskinned in "shaman staves" now.
I also modified the reskinnable component to fetch the lefthand and righthand files, this way it's possible to give unique sprites to weapon that require it!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds reskinnable component to staves.
tweak: Modified the reskinnable component to accept lefthand and righthand files as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
