### PR TITLE
Allows people to move only when using the tend emotes [ready to merge]

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -147,7 +147,7 @@
 	//var/is_skilled = 1
 	if(start_sound)
 		playsound(get_turf(user), start_sound, 50, 1, SOUND_DISTANCE(4))
-	if(istype(src, /obj/item/stack/medical/bruise_pack/lick/))s
+	if(istype(src, /obj/item/stack/medical/bruise_pack/lick/))
 		if(!do_after(user, get_delay_time(user, C, 1), TRUE, C, required_mobility_flags = NONE, allow_movement = TRUE,))
 			to_chat(user, span_warning("You were interrupted!"))
 			is_healing = FALSE

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -147,7 +147,12 @@
 	//var/is_skilled = 1
 	if(start_sound)
 		playsound(get_turf(user), start_sound, 50, 1, SOUND_DISTANCE(4))
-	if(!do_mob(user, C, get_delay_time(user, C, 1), progress = TRUE, allow_lying = TRUE))
+	if(istype(src, /obj/item/stack/medical/bruise_pack/lick/))s
+		if(!do_after(user, get_delay_time(user, C, 1), TRUE, C, required_mobility_flags = NONE, allow_movement = TRUE,))
+			to_chat(user, span_warning("You were interrupted!"))
+			is_healing = FALSE
+			return FALSE
+	else if(!do_mob(user, C, get_delay_time(user, C, 1), progress = TRUE, allow_lying = TRUE))
 		to_chat(user, span_warning("You were interrupted!"))
 		is_healing = FALSE
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Allows people to move while healing using one of the 3 healing emotes, but everything else still requires to stand still.
For example, the player can't use sutures while moving, but can lick their own butt on the go.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tweaks how licking butts works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
