### PR TITLE
Makes Genetics Less Tedious

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -5,9 +5,9 @@
 /// Timeout for DNA Scramble in DNA Consoles
 #define SCRAMBLE_TIMEOUT 600
 /// Timeout for using the Joker feature to solve a gene in DNA Console
-#define JOKER_TIMEOUT 12000
+#define JOKER_TIMEOUT 6000
 /// How much time DNA Scanner upgrade tiers remove from JOKER_TIMEOUT
-#define JOKER_UPGRADE 3000
+#define JOKER_UPGRADE 1500
 
 /// Maximum value for radiaton strength when pulsing enzymes
 #define RADIATION_STRENGTH_MAX 15


### PR DESCRIPTION
Since research is already boring, might as well make genetics less slow so it can be finished early, just like the rest of the time-gates research stuff. Basically just cuts joker timer in half, which allows for faster goofing off with genetics. Doesnt make the powers any more useless than they already are tho. |D