### PR TITLE
Halfs the needler lmg rof

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -3667,7 +3667,7 @@
 	init_recoil = HMG_RECOIL (1.4 , 4.2)
 	init_firemodes = list(
 		/datum/firemode/semi_auto/fast ,
-		/datum/firemode/automatic/rpm400
+		/datum/firemode/automatic/rpm200
 	)
 	can_suppress = FALSE
 	can_bayonet = FALSE


### PR DESCRIPTION
Because 800 rounds a minute with an average of +25% from a single mod (1000 rpm) and then maybe, say 33% boost from gold paint is 1330 rpm on a weapon that has high wounding (while most folks wear light armor) and insane bane.

This ACTUALLY brings it down to NORMAL LMG rate of fires.  I'm biting Tox on the b-tooty

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
