### PR TITLE
Negative Trait: Weak of Muscles second attempt [do NOT merge]

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -1427,7 +1427,7 @@ Edit: TK~  This is the dumbest fucking shit I've ever seen in my life.  This isn
 /datum/quirk/weak_of_muscles
 	name = "Weak of Muscles"
 	desc = "For a reason or another, you're unable to lift objects bigger than normal size "
-	value = -45
+	value = -50  //it's really a big drawback
 	category = "Functional Quirks"
 	mechanics = "You're only capable of lifting up objects that have weight class equal or smaller than normal. Anything heavier will be impossible for you to lift up, \
 				with some core item exceptions. (This is a WIP quirk, feel free to ping us if we forgot to whitelist any core item)."

--- a/code/modules/mob/living/carbon/weak_of_muscles.dm
+++ b/code/modules/mob/living/carbon/weak_of_muscles.dm
@@ -3,8 +3,10 @@
 //<--
 
 /obj/item/equipped(mob/living/user)
-	. = ..()
-	if(w_class > WEIGHT_CLASS_NORMAL)
-		if(!istype(src, /obj/item/defibrillator))  //this is a core item, we cannot remove the ability for players to reanimate others
-			user.dropItemToGround(src, TRUE)
-			to_chat(user, span_alert("The [src] is too heavy for you!"))
+	..()
+	if(HAS_TRAIT(user, TRAIT_WEAK_OF_MUSCLES))  //we obviously need to check if the user HAS the trait.... DUH! (thank you a lot Blue and Dan)
+		if(w_class > WEIGHT_CLASS_NORMAL)
+			if( !istype(src, /obj/item/defibrillator/) || \
+				!istype(src, /obj/item/storage/))
+				user.dropItemToGround(src, TRUE)
+				to_chat(user, span_alert("The [src] is too heavy for you!"))


### PR DESCRIPTION
## About The Pull Request
Negative trait where the player is unable to pick up items with weight class greater than normal.
This time should ignore equipped backpacks.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new trait: Weak of Muscles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
