### PR TITLE
F-list hyperlink as flavour text option [ready to merge]

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -7,6 +7,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	var/list/texts_by_atom = list()
 	var/addendum = ""
 	var/always_show = FALSE
+	var/attach_internet_link = FALSE
 	var/max_len = MAX_FLAVOR_LEN
 	var/can_edit = TRUE
 	/// For preference/DNA saving/loading. Null to prevent. Prefs are only loaded from obviously if it exists in preferences.features.
@@ -14,7 +15,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	/// Do not attempt to render a preview on examine. If this is on, it will display as \[flavor_name\]
 	var/examine_no_preview = FALSE
 
-/datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE)
+/datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE, _attach_internet_link = FALSE)
 	. = ..()
 
 	if(. == ELEMENT_INCOMPATIBLE || !isatom(target)) //no reason why this shouldn't work on atoms too.
@@ -27,6 +28,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		flavor_name = _name
 	if(!isnull(addendum))
 		addendum = _addendum
+	if(_attach_internet_link)
+		attach_internet_link = _attach_internet_link
 	always_show = _always_show
 	can_edit = _edit
 	save_key = _save_key
@@ -82,6 +85,16 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return
 	if(href_list["show_flavor"])
 		var/atom/target = locate(href_list["show_flavor"])
+
+		if(attach_internet_link)
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				if(alert("This will open the following link '[H.dna.features["flist"]]' in your browser. Are you sure?","Open external link","Yes","No") =="Yes")
+					usr << link(H.dna.features["flist"])
+					return TRUE
+				else
+					return
+
 		var/mob/living/L = target
 		var/text = texts_by_atom[target]
 		if(text)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -231,6 +231,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		"flavor_text" = "",
 		"silicon_flavor_text" = "",
 		"ooc_notes" = "",
+		"flist" = "",
 		"meat_type" = "Mammalian",
 		"taste" = "something",
 		"body_model" = MALE,
@@ -602,6 +603,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "[features["ooc_notes"]]"
 			else
 				dat += "[TextPreview(features["ooc_notes"])]...<br>"
+
+			//outside link stuff
+			dat += "<h3>Outer hyper-links settings</h3>"
+			dat += "<a href='?_src_=prefs;preference=flist;task=input'><b>Set F-list link</b></a><br>"
+			var/flist_len = length(features["flist"])
+			if(flist_len <= 40)
+				if(!flist_len)
+					dat += "\[...\]"
+				else
+					dat += "[features["flist"]]"
+			else
+				dat += "[TextPreview(features["flist"])]...<br>"
+
 			//Start Creature Character
 			dat += "<h2>Simple Creature Character</h2>"
 			dat += "<b>Creature Species</b><a style='display:block;width:100px' href='?_src_=prefs;preference=creature_species;task=input'>[creature_species ? creature_species : "Eevee"]</a><BR>"
@@ -2632,6 +2646,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/msg = stripped_multiline_input(usr, "Set always-visible OOC notes related to content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", html_decode(features["ooc_notes"]), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
 						features["ooc_notes"] = msg
+
+				if("flist")
+					var/link = input(usr, "Set always-visible F-list. Just copy and paste the link you want to use from the browser. Leave it blank to remove the previous link.", "F-list")
+					if(!length(link))
+						features["flist"] = ""
+						to_chat(usr, span_alert("Removed the previous F-list link."))
+					else if(findtext(link, "https://www.f-list.net"))  //we want to avoid malicious links, so let's check if it's actually a valid link first
+						features["flist"] = link
+					else
+						features["flist"] = ""
+						to_chat(usr, span_alert("This is not a correct F-list link!"))
 
 				if("hide_ckey")
 					hide_ckey = !hide_ckey

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -833,10 +833,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		S["feature_flavor_text"]		>> features["flavor_text"]
 
 
-	S["silicon_feature_flavor_text"]		>> features["silicon_flavor_text"]
-
+	S["silicon_feature_flavor_text"]	>> features["silicon_flavor_text"]
 	S["feature_ooc_notes"]				>> features["ooc_notes"]
-	S["silicon_flavor_text"] >> features["silicon_flavor_text"]
+	S["feature_flist"]					>> features["flist"]
+	S["silicon_flavor_text"]			>> features["silicon_flavor_text"]
 
 	//gear loadout
 	if(S["loadout"])
@@ -1354,6 +1354,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["feature_has_womb"], features["has_womb"])
 
 	WRITE_FILE(S["feature_ooc_notes"], features["ooc_notes"])
+
+	WRITE_FILE(S["feature_flist"], features["flist"])
 
 	WRITE_FILE(S["feature_taste"], features["taste"])
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,6 +58,8 @@ GLOBAL_VAR_INIT(crotch_call_cooldown, 0)
 	AddElement(/datum/element/flavor_text/carbon, _name = "Flavor Text", _save_key = "flavor_text")
 	AddElement(/datum/element/flavor_text, "", "Set Pose/Leave OOC Message", "This should be used only for things pertaining to the current round!")
 	AddElement(/datum/element/flavor_text, _name = "OOC Notes", _addendum = "Put information on ERP/lewd-related preferences here. THIS SHOULD NOT CONTAIN REGULAR FLAVORTEXT!!", _always_show = TRUE, _save_key = "ooc_notes", _examine_no_preview = TRUE)
+	//if(length(dna.features["flist"]))  //we are showing this only if the player has attached a link at all
+	AddElement(/datum/element/flavor_text, _name = "F-list link", _always_show = FALSE, _save_key = "flist", _examine_no_preview = TRUE, _attach_internet_link = TRUE)
 	RegisterSignal(src, COMSIG_HUMAN_UPDATE_GENITALS, .proc/signal_update_genitals)
 
 /mob/living/carbon/human/Destroy()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,7 +58,6 @@ GLOBAL_VAR_INIT(crotch_call_cooldown, 0)
 	AddElement(/datum/element/flavor_text/carbon, _name = "Flavor Text", _save_key = "flavor_text")
 	AddElement(/datum/element/flavor_text, "", "Set Pose/Leave OOC Message", "This should be used only for things pertaining to the current round!")
 	AddElement(/datum/element/flavor_text, _name = "OOC Notes", _addendum = "Put information on ERP/lewd-related preferences here. THIS SHOULD NOT CONTAIN REGULAR FLAVORTEXT!!", _always_show = TRUE, _save_key = "ooc_notes", _examine_no_preview = TRUE)
-	//if(length(dna.features["flist"]))  //we are showing this only if the player has attached a link at all
 	AddElement(/datum/element/flavor_text, _name = "F-list link", _always_show = FALSE, _save_key = "flist", _examine_no_preview = TRUE, _attach_internet_link = TRUE)
 	RegisterSignal(src, COMSIG_HUMAN_UPDATE_GENITALS, .proc/signal_update_genitals)
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -36,7 +36,7 @@
 	set desc = "Visit Github"
 	set hidden = 1
 	SEND_SOUND(usr, sound('sound/machines/button4.ogg', repeat = 0, wait = 0, volume = 100, channel = 512))
-	var/githuburl = CONFIG_GET(string/githuburl)
+	var/githuburl = CONFIG_GET(string/githuburl) 
 	if(githuburl)
 		if(alert("This will open the Github repository in your browser. Are you sure?",,"Yes","No")!="Yes")
 			return


### PR DESCRIPTION
## About The Pull Request
Adds a box inside the character editor where people can copy-paste their F-list.
The system asks people if they want to open up said link on the browser before actually doing so and as an addendum it also shows what link is about to open in the alert box.
This little logic is also capable of recognizing if the link placed in doesn't belong to "https://www.f-list.net", in case people put other (maybe malicious) links in.
If people don't put any link in this box, it won't even show the [F-list link] option in their examine text.

![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/d7d70f67-0c8c-4aef-8d27-e2184e8ecbce)
![immagine](https://github.com/ARF-SS13/coyote-bayou/assets/64517916/02ffaf82-6f67-4420-bd61-5ca58e7c8af6)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Adds F-list link
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
