### PR TITLE
Shields Adjusted & Expanded

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -27,6 +27,10 @@
 	var/shieldbash_stagger_duration = 5 SECONDS
 	/// Shield bashing push distance
 	var/shieldbash_push_distance = 1
+	weapon_special_component = /datum/component/weapon_special/single_turf
+	force = 12
+	force_wielded = 20
+	force_unwielded = 12
 
 /datum/block_parry_data/shield
 	block_damage_multiplier = 0.25
@@ -561,7 +565,10 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	desc = "Yep, that's a shield. Good for not getting whacked."
 	icon_state = "shield_stop"
 	item_state = "shield_stop"
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 0, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 0, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+	force = 12
+	force_wielded = 20
+	force_unwielded = 12
 	max_integrity = -1
 	resistance_flags = null
 
@@ -576,7 +583,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "red_buckler"
 	item_state = "red_buckler"
-	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+
 	max_integrity = -1
 	resistance_flags = null
 
@@ -592,7 +599,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "blue_buckler"
 	item_state = "blue_buckler"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 30, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+
 	max_integrity = -1
 	resistance_flags = null
 
@@ -607,7 +614,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "steel_shield"
 	item_state = "steel_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+
 	max_integrity = -1
 	resistance_flags = null
 
@@ -623,7 +630,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "iron_shield"
 	item_state = "iron_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -639,7 +646,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "bronze_shield"
 	item_state = "bronze_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -654,7 +661,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "ironshield2"
 	item_state = "semioval_shield_blue"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -669,7 +676,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "ironshield3"
 	item_state = "semioval_shield_blue"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -684,7 +691,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "ironshield4"
 	item_state = "semioval_shield_blue"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -699,7 +706,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "roman_buckler"
 	item_state = "roman_buckler"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -714,7 +721,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "semioval_shield_blue"
 	item_state = "semioval_shield_blue"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -729,7 +736,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "egyptian_shield"
 	item_state = "egyptian_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -744,7 +751,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "buckler2"
 	item_state = "buckler2"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -759,7 +766,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "imperial_kite"
 	item_state = "imperial_kite"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -774,7 +781,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "pegasus_shield"
 	item_state = "pegasus_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -789,7 +796,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "owl_shield"
 	item_state = "owl_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -803,7 +810,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "chimalli"
 	item_state = "chimalli"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -818,7 +825,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "scutum"
 	item_state = "scutum"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -832,7 +839,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "orc_shield"
 	item_state = "orc_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -847,7 +854,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "nguni_shield"
 	item_state = "nguni_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -861,7 +868,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "chitin_shield"
 	item_state = "chitin_shield"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -876,7 +883,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
 	icon_state = "chitin_buckler"
 	item_state = "chitin_buckler"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -892,7 +899,7 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	desc = "A heavily weathered riot shield that has seen much use, it seems to have been modified to be foldable for storage, at the cost of some protection."
 	icon_state = "shield_riot"
 	item_state = "shield_riot"
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 0, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null
 
@@ -908,6 +915,6 @@ The telescopic shields are legacy and don't fit, but the code might be of intere
 	mob_overlay_icon = 'modular_coyote/icons/objects/back.dmi'
 	icon_state = "semioval_shield_templar2"
 	item_state = "semioval_shield_templar2"
-	armor = list("melee" = 35, "bullet" = 15, "laser" = 25, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 40)
+	
 	max_integrity = -1
 	resistance_flags = null


### PR DESCRIPTION
So, this doesn't touch the loot shields for the most part (at least, not their armor amount)

What this does do is lower them all to be 20-15-15-0.  Then it adds a force of 12, wielded 20.  Then it lets you also use them as melee weapons directly.

This means you can dual wield with your shield, using it with a single handed melee weapon.  It also adds directional melee attacks to them.

It also means you can't round start scoop up to 90 fucking melee armor, lmao

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
