### PR TITLE
Paint, and Propaint accessories

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -1,7 +1,7 @@
 // Different Paint!
 
 /datum/crafting_recipe/paint/redreroll
-	name = "Red Paint"
+	name = "Re-roll Red Paint"
 	result = /obj/item/tool_upgrade/paint/red
 	reqs = list(/obj/item/tool_upgrade/paint/red = 2)
 	time = 5
@@ -9,7 +9,7 @@
 	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/paint/bluereroll
-	name = "Blue Paint"
+	name = "Re-roll Blue Paint"
 	result = /obj/item/tool_upgrade/paint/blue
 	reqs = list(/obj/item/tool_upgrade/paint/blue = 2)
 	time = 5
@@ -17,9 +17,33 @@
 	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/paint/yellowreroll
-	name = "Yellow Paint"
+	name = "Re-roll Yellow Paint"
 	result = /obj/item/tool_upgrade/paint/yellow
 	reqs = list(/obj/item/tool_upgrade/paint/yellow = 2)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_PARTS
+
+/datum/crafting_recipe/paint/orangereroll
+	name = "Re-roll Orange Paint"
+	result = /obj/item/tool_upgrade/paint/orange
+	reqs = list(/obj/item/tool_upgrade/paint/orange = 2)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_PARTS
+
+/datum/crafting_recipe/paint/purplereroll
+	name = "Re-roll Purple Paint"
+	result = /obj/item/tool_upgrade/paint/purple
+	reqs = list(/obj/item/tool_upgrade/paint/purple = 2)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_PARTS
+
+/datum/crafting_recipe/paint/greenreroll
+	name = "Re-roll Green Paint"
+	result = /obj/item/tool_upgrade/paint/green
+	reqs = list(/obj/item/tool_upgrade/paint/green = 2)
 	time = 5
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS
@@ -54,9 +78,9 @@
 /datum/crafting_recipe/paint/black
 	name = "Black Paint"
 	result = /obj/item/tool_upgrade/paint/black
-	reqs = list(/obj/item/tool_upgrade/paint/red = 1,
-				/obj/item/tool_upgrade/paint/blue = 1,
-				/obj/item/tool_upgrade/paint/yellow = 1)
+	reqs = list(/obj/item/tool_upgrade/paint/orange = 1,
+				/obj/item/tool_upgrade/paint/purple = 1,
+				/obj/item/tool_upgrade/paint/green = 1)
 	time = 10
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS

--- a/modular_coyote/eris/code/mods/mod_types.dm
+++ b/modular_coyote/eris/code/mods/mod_types.dm
@@ -345,7 +345,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-50,25) * 0.01,
+		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-70,-50) * 0.01,
 		GUN_UPGRADE_RECOIL_1H=1 + rand(-40,25) * 0.01,
 		GUN_UPGRADE_DAMAGE_MULT=1 + rand(-25,40) * 0.01,
 		UPGRADE_COLOR = "#FFFF00"
@@ -362,7 +362,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-65,10) * 0.01,
+		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-85,-65) * 0.01,
 		GUN_UPGRADE_RECOIL_1H=1 + rand(-50,10) * 0.01,
 		GUN_UPGRADE_DAMAGE_MULT=1 + rand(-10,50) * 0.01,
 		GUN_UPGRADE_FIRE_DELAY_MULT=1 + rand(-50,10) * 0.01,
@@ -400,7 +400,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-60,15) * 0.01,
+		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-80,-60) * 0.01,
 		GUN_UPGRADE_RECOIL_1H=1 + rand(-50,15) * 0.01,
 		GUN_UPGRADE_DAMAGE_MULT=1 + rand(-15,50) * 0.01,
 		GUN_UPGRADE_RECOIL_2H=1 + rand(-50,15) * 0.01,
@@ -425,7 +425,7 @@
 		GUN_UPGRADE_RECOIL_2H=1 + rand(-65,5) * 0.01,
 		GUN_UPGRADE_CHARGECOST=1 + rand(-65,5) * 0.01,
 		GUN_UPGRADE_RICO_MULT=1 + rand(-65,5) * 0.01,
-		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-70,5) * 0.01,
+		GUN_UPGRADE_MOVE_DELAY_MULT=1 + rand(-90,-70) * 0.01,
 		GUN_UPGRADE_RECOIL_1H=1 + rand(-65,5) * 0.01,
 		GUN_UPGRADE_DAMAGE_MULT=1 + rand(-5,65) * 0.01,
 		UPGRADE_COLOR = "#000000"


### PR DESCRIPTION
Adds crafting recipes to reroll orange, purple, and green paint.

Fixes the black paint to require orange, purple, and green paint.

Adjusts the move delay for the paint to always be positive and quite high. It only seems to affect guns that slow you down like antimaterial rifles anywho.