### PR TITLE
Generic chest/arm patches are made free, plus GWTB afterthought (why)

### DIFF
--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -658,10 +658,12 @@
 /datum/gear/backpack/chestpatch
 	name = "generic patch (chest)"
 	path = /obj/item/clothing/accessory/patch
+	cost = 0
 
 /datum/gear/backpack/armpatch
 	name = "generic patch (arm)"
 	path = /obj/item/clothing/accessory/patch/arm
+	cost = 0
 
 /datum/gear/backpack/headphones
 	name = "Headphones"

--- a/modular_sunset/code/modules/clothing/head/f13head.dm
+++ b/modular_sunset/code/modules/clothing/head/f13head.dm
@@ -10,7 +10,7 @@ Just leaving this here for quick copy-pasting, for future contributors.
 
 /obj/item/clothing/head/helmet/f13/goner
 	name = "dev-marked generic helmet"
-	desc = "A non-existent cheap-looking helmet."
+	desc = "A non-existent cheap-looking helmet.<br><b>If you see it, then it means universe broke <u>even more</u>.</b>"
 	icon = 'modular_sunset/icons/obj/clothing/hats.dmi'
 	mob_overlay_icon = 'modular_sunset/icons/mob/clothing/head.dmi'
 	icon_state = "goner_helmet"
@@ -24,46 +24,46 @@ Just leaving this here for quick copy-pasting, for future contributors.
 
 /obj/item/clothing/head/helmet/f13/goner/red
 	name = "red-marked generic helmet"
-	desc = "A cheap-looking helmet with red paint applied from front to back."
+	desc = "A cheap-looking helmet with red paint applied from front to back.<br>Perfect-shaped for small moths to sit on."
 	icon_state = "goner_helmet_r"
 
 /obj/item/clothing/head/helmet/f13/goner/green
 	name = "green-marked generic helmet"
-	desc = "A cheap-looking helmet with green paint applied from front to back."
+	desc = "A cheap-looking helmet with green paint applied from front to back.<br>Will not protect you much from the bombs, and especially not while in cardboard box."
 	icon_state = "goner_helmet_g"
 
 /obj/item/clothing/head/helmet/f13/goner/blue
 	name = "blue-marked generic helmet"
-	desc = "A cheap-looking helmet with blue paint applied from front to back."
+	desc = "A cheap-looking helmet with blue paint applied from front to back.<br>Seems to be a perfect fit for the wasted people."
 	icon_state = "goner_helmet_b"
 
 /obj/item/clothing/head/helmet/f13/goner/yellow
 	name = "yellow-marked generic helmet"
-	desc = "A cheap-looking helmet with yellow paint applied from front to back."
+	desc = "A cheap-looking helmet with yellow paint applied from front to back.<br>Doesn't seem superior than other helmets."
 	icon_state = "goner_helmet_y"
 
 /obj/item/clothing/head/helmet/f13/goner/officer
 	name = "peaked dev cap"
-	desc = "A non-existent militaristic cap."
+	desc = "A non-existent militaristic cap.<br><i>Zee Captain would be not pleased...</i>"
 	icon_state = "goner_offcap"
 	flags_inv = NONE
 
 /obj/item/clothing/head/helmet/f13/goner/officer/red
 	name = "peaked red cap"
-	desc = "A militaristic cap with red pin on the front."
+	desc = "A militaristic cap with red pin on the front.<br>Best headwear to give out promotions based on ones kill count."
 	icon_state = "goner_offcap_r"
 
 /obj/item/clothing/head/helmet/f13/goner/officer/green
 	name = "peaked green cap"
-	desc = "A militaristic cap with green pin on the front."
+	desc = "A militaristic cap with green pin on the front.<br>Ideal for a commander of the extinct army."
 	icon_state = "goner_offcap_g"
 
 /obj/item/clothing/head/helmet/f13/goner/officer/blue
 	name = "peaked blue cap"
-	desc = "A militaristic cap with blue pin on the front."
+	desc = "A militaristic cap with blue pin on the front.<br>You probably want to keep your head low with this on."
 	icon_state = "goner_offcap_b"
 
 /obj/item/clothing/head/helmet/f13/goner/officer/yellow
 	name = "peaked yellow cap"
-	desc = "A militaristic cap with yellow pin on the front."
+	desc = "A militaristic cap with yellow pin on the front.<br>Might be not the best thing to wear if you are lost in the enemy territory..."
 	icon_state = "goner_offcap_y"

--- a/modular_sunset/code/modules/clothing/under/accessories.dm
+++ b/modular_sunset/code/modules/clothing/under/accessories.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/accessory/patch
 	name = "chest patch"
-	desc = "A generic chest patch with sleek, six-pointed star on it."
+	desc = "A generic chest patch with sleek, eight-pointed star on it."
 	icon = 'modular_sunset/icons/obj/clothing/accessories.dmi'
 	icon_state = "chestpatch"
 	mob_overlay_icon = 'modular_sunset/icons/mob/clothing/accessories.dmi'
@@ -9,5 +9,5 @@
 
 /obj/item/clothing/accessory/patch/arm
 	name = "arm patch"
-	desc = "A generic yet sleek six-pointed star patch."
+	desc = "A generic yet sleek eight-pointed star patch."
 	icon_state = "armpatch"


### PR DESCRIPTION
## About The Pull Request
Adds flavored text descriptions for the GWTB helmets and caps.
But honestly I just wanted to make chest and arm patches free in loadout, I don't know why I did that too.
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl: Anonymous
tweak: Additional (poor) flavor descriptors for Blastwave helmets and peaked caps.
tweak: Generic chest and arm patches in loadout are now available for free.
spellcheck: Generic chest and arm patches default description: "six-pointed" -> "eight-pointed" (it is more close to the sprite look).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
