### PR TITLE
The Gun cargo-ening part 1

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -920,7 +920,7 @@
 /datum/supply_pack/security/weaponname
 	name = ""
 	desc = ""
-	cost = weapon dps 2x
+	cost = weapon dps 2x, add a zero at the end
 	num_contained = 1
 	contains = list(/obj/item/clothing/glasses/night/prescription)
 	crate_name = "select weapon crate"
@@ -1014,7 +1014,7 @@
 	contains = list(/obj/item/gun/ballistic/revolver/shotpistol)
 	crate_name = "select weapon crate"
 
-/datum/supply_pack/security/10mmsmg
+/datum/supply_pack/security/tenmmsmg
 	name = "10mm Submissive Machine Gun"
 	desc = "A big chunky monkey fucking typewriter of an SMG. Good for bashing people to death when you inevitably run out of ammo because it was too heavy for you to carry."
 	cost = 6300
@@ -1062,7 +1062,6 @@
 	contains = list(/obj/item/gun/ballistic/automatic/m1919)
 	crate_name = "select weapon crate"
 
-
 /datum/supply_pack/security/pancorjackhammer
 	name = "Pancor Jackhammer"
 	desc = "You're not making Ian proud right now."
@@ -1079,7 +1078,7 @@
 	contains = list(/obj/item/gun/ballistic/automatic/smg/p90)
 	crate_name = "select weapon crate"
 
-/datum/supply_pack/security/14mmsmg
+/datum/supply_pack/security/fourteenmilsmg
 	name = "14mm SMG"
 	desc = "Listen, we know why you're here but you don't have to hate your wrists in character as much as out of character."
 	cost = 6300

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -912,3 +912,249 @@
 					)
 	crate_name = "gun grab-bag crate"
 */
+
+//Fenny goes absolutely batshit insane and adds a bunch of weapons to the shop
+//Gun cargo?  More like gun.  Gun.  I guess.  Fuck off.
+
+/*
+/datum/supply_pack/security/weaponname
+	name = ""
+	desc = ""
+	cost = weapon dps 2x
+	num_contained = 1
+	contains = list(/obj/item/clothing/glasses/night/prescription)
+	crate_name = "select weapon crate"
+	*/
+
+/datum/supply_pack/security/fatman
+	name = "Fatman"
+	desc = "Its a fatman.  It blows shit way the fuck up."
+	cost = 140000
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/fatman)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/nightops
+	name = "M22 Night Ops SMG"
+	desc = "An SMG of all time."
+	cost = 8600
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/m22)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/bozar
+	name = "Bozar"
+	desc = "It's a sniper rifle. It's a machine gun. It's overpowered."
+	cost = 7400
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/bozar)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/greasegun
+	name = "M3A1 Greasegun"
+	desc = "Smearing people off sidewalks since 1942."
+	cost = 7200
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/greasegun)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/asval
+	name = "AS-VAL Supressed Rifle"
+	desc = "No, Artyom.  You are the zone."
+	cost = 6800
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/vss)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/autorevolver
+	name = "Auto-Revolver"
+	desc = "It's like a single action army if the single action army was an ma deuce."
+	cost = 6600
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/colt357/auto)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/webley
+	name = "Webley Revolver"
+	desc = "These reproduction Webley revolvers are of the highest quality.  Buy 4.  Trust me."
+	cost = 6600
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/police/webley)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/carlgustaf
+	name = "10mm Carl Gustaf"
+	desc = "Did Carl ever come in other calibers?  Where are the Swedes these days?"
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/cg45)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/widowmaker
+	name = "Winchester Widowmaker"
+	desc = "It has widowmaker in the name.  It doesn't come edgier than this, hombre."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/widowmaker)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/shotpistol
+	name = "Hand Shotgun"
+	desc = "Versus a butt shotgun.  Where else are you supposed to hold this damn thing?"
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/shotpistol)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/shotpistol
+	name = "Hand Shotgun"
+	desc = "Versus a butt shotgun.  Where else are you supposed to hold this damn thing?"
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/shotpistol)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/10mmsmg
+	name = "10mm Submissive Machine Gun"
+	desc = "A big chunky monkey fucking typewriter of an SMG. Good for bashing people to death when you inevitably run out of ammo because it was too heavy for you to carry."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/smg10mm)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/r91
+	name = "R91 Assault Rifle"
+	desc = "A devisive weapon of war. Purists will say it shouldn't exist because Dr. House didn't want Sneezer to lose in Old Vegas.  Or something.  I don't know."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/assault_rifle)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/maria
+	name = "9mm Maria"
+	desc = "A blessed pistol, forged in the fires of Gondor or something."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/ninemil/maria)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/mp5sd
+	name = "MP-5 SD"
+	desc = "An MP-5 of curious ancestry."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/mp5sd)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/bren
+	name = "Bren Gun"
+	desc = "We're going to Brazil, get in."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/bren)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/m1919
+	name = "M1919 Machine Gun"
+	desc = "You know you will never look as cool as the guys in Soldier of Fortune, no matter how much you try."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/m1919)
+	crate_name = "select weapon crate"
+
+
+/datum/supply_pack/security/pancorjackhammer
+	name = "Pancor Jackhammer"
+	desc = "You're not making Ian proud right now."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/shotgun/pancor)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/p90
+	name = "FN P90c"
+	desc = "We can never go back to 2002, but Counter Strike will live in our hearts forever."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/p90)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/14mmsmg
+	name = "14mm SMG"
+	desc = "Listen, we know why you're here but you don't have to hate your wrists in character as much as out of character."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/smg14)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/ppsh41
+	name = "PPSH-41"
+	desc = "FPS Russia moment."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/ppsh)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/ppsh41
+	name = "PPSH-41"
+	desc = "FPS Russia moment."
+	cost = 6300
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/ppsh)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/r84lmg
+	name = "R84 Light Machine Gun"
+	desc = "Yep.  It's a gun."
+	cost = 5800
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/r84)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/lsw
+	name = "Light Support Weapon"
+	desc = "A tool of war that is neither light, nor supportive.  It is a weapon though.  Thank god."
+	cost = 5800
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/lsw)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/ch47assrifle
+	name = "4.7mm Chinese Assault Rifle"
+	desc = "Well above average in caliber, we assure you."
+	cost = 5800
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/rifle47mm/china)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/tommygun
+	name = "Thomspon SMG"
+	desc = "You're either gangster or a paratrooper.  Which is it?"
+	cost = 5800
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/tommygun)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/amr
+	name = "Anti-Material Rifle"
+	desc = "As opposed to Pro-material rifles?"
+	cost = 5000
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/rifle/mag/antimaterial)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/mac10
+	name = "Ingram Model 10"
+	desc = "Okay, maybe you are an operator."
+	cost = 4400
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/automatic/smg/mini_uzi/mac10)
+	crate_name = "select weapon crate"
+
+/datum/supply_pack/security/heavyneedlerifle
+	name = "OT-64 Heavy Needler Rifle"
+	desc = "The bane of anyone not wearing light armor or the simple minded."
+	cost = 4400
+	num_contained = 1
+	contains = list(/obj/item/gun/ballistic/revolver/needlerrifle)
+	crate_name = "select weapon crate"


### PR DESCRIPTION
Adds the first pass of weapons into the shop to be bought without randomization.  Using cactus's gun proc it only includes some of the guns from the first 100.

We have 500 guns+ to add to this list, and we shouldn't add all of them.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
