### PR TITLE
Overhauling Medical Vendors (DRAFT, DO NOT MERGE)

### DIFF
--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -819,7 +819,6 @@
 /obj/effect/spawner/lootdrop/f13/common_medicine
 	name = "common medicines"
 	loot = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/epipak = 10,
 		/obj/item/stack/medical/gauze = 10,
 		/obj/item/stack/medical/suture/five = 4,
@@ -834,7 +833,7 @@
 /obj/effect/spawner/lootdrop/f13/uncommon_medicine
 	name = "uncommon medicines"
 	loot = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,
+		/obj/item/reagent_containers/pill/bitterdrink = 10,
 		/obj/item/stack/medical/gauze = 10,
 		/obj/item/stack/medical/suture/five = 10,
 		/obj/item/reagent_containers/blood/radaway = 10,
@@ -852,8 +851,8 @@
 /obj/effect/spawner/lootdrop/f13/rare_medicine
 	name = "rare medicines"
 	loot = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 10,
-		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 10,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 4,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 1,
 		/obj/item/stack/medical/gauze/adv = 10,
 		/obj/item/stack/medical/suture/medicated/five = 4,
 		/obj/item/stack/medical/mesh/advanced/five = 4,

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -536,11 +536,12 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Syringe",						/obj/item/reagent_containers/syringe,								5),
 		new /datum/data/wasteland_equipment("Rad-X Bottle",					/obj/item/storage/pill_bottle/chem_tin/radx,						25),
 		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							40),
+		new /datum/data/wasteland_equipment("Basic Bandages",				/obj/item/stack/medical/gauze/improvised,							30),
+		new /datum/data/wasteland_equipment("Basic Stitches",				/obj/item/stack/medical/suture/emergency/fifteen,					30),
 		new /datum/data/wasteland_equipment("Healing Powder",				/obj/item/reagent_containers/pill/healingpowder,					30),
-		new /datum/data/wasteland_equipment("Survival Medipen",				/obj/item/reagent_containers/hypospray/medipen/survival,			60),
-		new /datum/data/wasteland_equipment("Stimpak",						/obj/item/reagent_containers/hypospray/medipen/stimpak,				100),
-		new /datum/data/wasteland_equipment("Standard Medkit",				/obj/item/storage/firstaid/regular,									60),
-		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							150),
+		new /datum/data/wasteland_equipment("Survival Medipen",				/obj/item/reagent_containers/hypospray/medipen/survival,			120),
+		new /datum/data/wasteland_equipment("Improvised Defibrillator",		/obj/item/defibrillator/primitive,									150),
+		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							300),
 		new /datum/data/wasteland_equipment("D.C. Journal of Internal Medicine",		/obj/item/book/granter/trait/midsurgery,				750),
 		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								1500)
 		)
@@ -548,13 +549,46 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Syringe",						/obj/item/reagent_containers/syringe,								5),
 		new /datum/data/wasteland_equipment("Rad-X Bottle",					/obj/item/storage/pill_bottle/chem_tin/radx,						25),
 		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							40),
+		new /datum/data/wasteland_equipment("Basic Bandages",				/obj/item/stack/medical/gauze/improvised,							30),
+		new /datum/data/wasteland_equipment("Basic Stitches",				/obj/item/stack/medical/suture/emergency/fifteen,					30),
 		new /datum/data/wasteland_equipment("Healing Powder",				/obj/item/reagent_containers/pill/healingpowder,					30),
-		new /datum/data/wasteland_equipment("Survival Medipen",				/obj/item/reagent_containers/hypospray/medipen/survival,			60),
-		new /datum/data/wasteland_equipment("Stimpak",						/obj/item/reagent_containers/hypospray/medipen/stimpak,				100),
-		new /datum/data/wasteland_equipment("Standard Medkit",				/obj/item/storage/firstaid/regular,									60),
-		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							150),
+		new /datum/data/wasteland_equipment("Survival Medipen",				/obj/item/reagent_containers/hypospray/medipen/survival,			120),
+		new /datum/data/wasteland_equipment("Improvised Defibrillator",		/obj/item/defibrillator/primitive,									150),
+		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							300),
 		new /datum/data/wasteland_equipment("D.C. Journal of Internal Medicine",		/obj/item/book/granter/trait/midsurgery,				750),
 		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								1500)
+		)
+
+/obj/machinery/mineral/wasteland_vendor/supermedical
+	name = "Clinic Vending Machine - Medical"
+	icon_state = "numed_idle"
+	prize_list = list(
+		new /datum/data/wasteland_equipment("Syringe",						/obj/item/reagent_containers/syringe,								5),
+		new /datum/data/wasteland_equipment("Rad-X Bottle",					/obj/item/storage/pill_bottle/chem_tin/radx,						5),
+		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							15),
+		new /datum/data/wasteland_equipment("Standard Bandages",			/obj/item/stack/medical/gauze,										15),
+		new /datum/data/wasteland_equipment("Standard Stitches",			/obj/item/stack/medical/suture,										15),
+		new /datum/data/wasteland_equipment("Healing Powder Pack",			/obj/item/storage/box/medicine/powder5,								15),
+		new /datum/data/wasteland_equipment("Bitter Drink Pack",			/obj/item/storage/box/medicine/bitterdrink5,						20),
+		new /datum/data/wasteland_equipment("Stimpak Pack",					/obj/item/storage/box/medicine/stimpaks/stimpaks5,					30),
+		new /datum/data/wasteland_equipment("Improvised Defibrillator",		/obj/item/defibrillator,											75),
+		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							150),
+		new /datum/data/wasteland_equipment("D.C. Journal of Internal Medicine",		/obj/item/book/granter/trait/midsurgery,				500),
+		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								1000)
+		)
+	highpop_list = list(
+		new /datum/data/wasteland_equipment("Syringe",						/obj/item/reagent_containers/syringe,								5),
+		new /datum/data/wasteland_equipment("Rad-X Bottle",					/obj/item/storage/pill_bottle/chem_tin/radx,						5),
+		new /datum/data/wasteland_equipment("RadAway",						/obj/item/reagent_containers/blood/radaway,							15),
+		new /datum/data/wasteland_equipment("Standard Bandages",			/obj/item/stack/medical/gauze,										15),
+		new /datum/data/wasteland_equipment("Standard Stitches",			/obj/item/stack/medical/suture,										15),
+		new /datum/data/wasteland_equipment("Healing Powder Pack",			/obj/item/storage/box/medicine/powder5,								15),
+		new /datum/data/wasteland_equipment("Bitter Drink Pack",			/obj/item/storage/box/medicine/bitterdrink5,						20),
+		new /datum/data/wasteland_equipment("Stimpak Pack",					/obj/item/storage/box/medicine/stimpaks/stimpaks5,					30),
+		new /datum/data/wasteland_equipment("Improvised Defibrillator",		/obj/item/defibrillator,											75),
+		new /datum/data/wasteland_equipment("Surgery for Wastelanders",		/obj/item/book/granter/trait/lowsurgery,							150),
+		new /datum/data/wasteland_equipment("D.C. Journal of Internal Medicine",		/obj/item/book/granter/trait/midsurgery,				500),
+		new /datum/data/wasteland_equipment("Chemistry for Wastelanders",	/obj/item/book/granter/trait/chemistry,								1000)
 		)
 
 /obj/machinery/mineral/wasteland_vendor/khanchem


### PR DESCRIPTION
## About The Pull Request
Tweaks the medical WVM to only sell low-quality supplies at a high price, adds a machine for the clinic interior to promote them actually selling stuff, and largely axes stimpaks from loot.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Standard medical WVM lost the medkit, replaced standard bandages/sutures with improvised versions, and generally increased prices.
- New clinic-specific WVM for medical supplies that sells bulk meds, standard bandages/sutures, and is generally cheaper.
- Removed Stimpaks from the Common medicine loot pool.
- Replaced Stimpaks with Bitter Drinks (Bitters are like ~40%? better than Poultice, while Stims are almost flatly 100% better) in the Uncommon medicine loot pool.
- Lowered Stimpaks to '4' weight in the Rare medicine loot pool and Super Stims to '1' in the same tier.

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
