### PR TITLE
Makes craftable shelf drop metal instead of wood

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -877,6 +877,9 @@
 	chance_initial_contents = list(
 
 )
+/obj/machinery/smartfridge/bottlerack/lootshelf/craftable/on_deconstruction()
+	new /obj/item/stack/sheet/metal(drop_location(), 15)
+	..()
 
 /obj/machinery/smartfridge/bottlerack/lootshelf/craftable/accept_check(obj/item/O)
 	if(istype(O, /obj/item/clothing/head/mob_holder))


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Should fix the issue of it dropping wood instead of metal, its construction material
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
