### PR TITLE
Makes craftable shop shelves not drop wood

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -569,7 +569,6 @@
 
 /obj/machinery/smartfridge/bottlerack/on_deconstruction()
 	new /obj/item/stack/sheet/mineral/wood(drop_location(), 10)
-	..()
 
 //god, don't just put the procs, at least put a return there!
 /obj/machinery/smartfridge/bottlerack/RefreshParts()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -873,9 +873,8 @@
 	max_n_of_items = 20
 
 /obj/machinery/smartfridge/bottlerack/lootshelf/craftable
-	chance_initial_contents = list(
+	chance_initial_contents = list()
 
-)
 /obj/machinery/smartfridge/bottlerack/lootshelf/craftable/on_deconstruction()
 	new /obj/item/stack/sheet/metal(drop_location(), 15)
 


### PR DESCRIPTION
for real this time

## About The Pull Request
<!-- Write here -->
(For real this time), should remove the thing that makes all the child objects call the parent object, and therefor, make them drop wood. Stupid wood. I should have just made the recipe 10 wood
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
