### PR TITLE
New Boston Update - The Guildening & Heavens Night Overhaul

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -9,6 +9,29 @@
 /obj/structure/rug/carpet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ac" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "ad" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/wasteland/city/newboston/house/cabin_three)
@@ -141,13 +164,17 @@
 	},
 /area/f13/building)
 "as" = (
-/obj/effect/spawner/lootdrop/f13/trash,
-/obj/structure/chair/bench{
-	icon_state = "bench";
-	dir = 8
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 8;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 5;
+	pixel_x = -6
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "at" = (
 /obj/structure/railing/corner,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
@@ -218,15 +245,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aC" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4;
-	color = "pink"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
+"aD" = (
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/rug/big/rug_red,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aE" = (
 /obj/machinery/vending/nukacolavendfull,
@@ -285,6 +318,13 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"aK" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "pink"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "aL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glitter/blue{
@@ -564,6 +604,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
+"bt" = (
+/obj/structure/table/plasmaglass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/tavern_wall{
@@ -700,14 +753,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bM" = (
-/obj/structure/railing{
-	color = "#A47449";
+/obj/structure/chair/sofa/corp/left{
 	dir = 4;
-	pixel_x = 2
+	color = "pink"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "bN" = (
 /obj/structure/bookshelf{
@@ -813,13 +863,10 @@
 /turf/open/water,
 /area/f13/building/tribal)
 "cf" = (
-/obj/machinery/light/small{
-	color = "#FFC0CB";
-	light_color = "#FFC0CB";
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "cg" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -829,12 +876,12 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "ch" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "ci" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -1011,6 +1058,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building)
+"cr" = (
+/obj/machinery/light/small{
+	color = "#FFC0CB";
+	light_color = "#FFC0CB";
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "cs" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1204,15 +1260,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/city)
 "cP" = (
-/obj/item/lock_bolt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/simple_door/wood,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building/hospital/clinic/nash)
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "cQ" = (
 /obj/item/stack/sheet/cloth/ten,
 /obj/item/stack/sheet/leather/ten,
@@ -1329,9 +1385,13 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
 "de" = (
-/obj/structure/railing,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/room{
+	name = "Clinic"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "df" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -1367,6 +1427,15 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
+"dl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "dm" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -1376,17 +1445,17 @@
 	},
 /area/f13/building)
 "dn" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
-	density = 0
+/obj/structure/campfire/stove{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 11
 	},
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/storage/box/matches,
 /turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/bar/heaven)
 "do" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1;
@@ -1427,12 +1496,12 @@
 /turf/open/indestructible,
 /area/f13/tcoms)
 "dt" = (
-/obj/machinery/light,
-/obj/structure/sign/departments/examroom{
-	pixel_y = -32
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "du" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/machinery/light{
@@ -1516,11 +1585,11 @@
 	},
 /area/f13/tribe)
 "dG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "dH" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -1871,12 +1940,10 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
 "et" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/obj/structure/table/plasmaglass,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "eu" = (
 /obj/structure/simple_door/interior,
 /obj/item/lock_bolt{
@@ -1952,12 +2019,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/wasteland/city/newboston/house/cabin_one)
 "eF" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_x = 10
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/area/f13/caves)
 "eG" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1997,12 +2062,9 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland/city/newboston/house)
 "eK" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain/directional/west{
-	color = "#1e549c"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "eM" = (
 /obj/structure/chair/sofa/left{
 	dir = 8;
@@ -2111,10 +2173,22 @@
 	},
 /area/f13/ncr)
 "fa" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"fb" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/sign/painting/library{
+	pixel_x = 28
+	},
+/obj/item/toy/plush/whitecat,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/hospital/clinic/nash)
 "fc" = (
 /obj/structure/rack/shelf_metal/modern,
@@ -2128,6 +2202,15 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"fd" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland/city/newboston/outdoors)
 "fe" = (
 /obj/structure/window/fulltile/wood_window{
 	icon_state = "storewindowvertical";
@@ -2197,10 +2280,8 @@
 	},
 /area/f13/ncr)
 "fk" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/toy/plush/whitecat,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/transparent/openspace,
+/area/f13/city)
 "fl" = (
 /obj/structure/campfire/wallfire{
 	pixel_y = 29;
@@ -2222,15 +2303,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 2;
-	pixel_x = -12
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "fo" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -2732,6 +2812,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
+"gl" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "gm" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 4
@@ -2758,6 +2844,11 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
+"go" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "gp" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -2819,7 +2910,12 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
 /area/f13/wasteland)
 "gy" = (
 /obj/effect/turf_decal/siding/brown,
@@ -3067,21 +3163,19 @@
 	},
 /area/f13/building/tribal)
 "hc" = (
-/obj/machinery/button/door{
-	id = "xenobio44";
-	name = "Containment Blast Doors";
-	pixel_y = 36;
-	req_access_txt = null;
-	pixel_x = 5;
-	req_one_access_txt = null
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 8;
-	network = list("ss13","rd")
+/obj/machinery/light/floor{
+	light_color = "#883388"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
+/obj/machinery/light/small{
+	light_color = "#884444";
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "hd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3433,10 +3527,11 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "hU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "hV" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -3471,12 +3566,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ic" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	color = "pink"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "id" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3561,6 +3655,18 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
+"ip" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	req_one_access_txt = "136"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "iq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -3621,6 +3727,9 @@
 	name = "dirty floor"
 	},
 /area/f13/caves)
+"iw" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/building/hospital/clinic/nash)
 "ix" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -3640,16 +3749,8 @@
 	},
 /area/f13/tribe)
 "iz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench{
-	icon_state = "bench";
-	dir = 8;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "iA" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3679,6 +3780,27 @@
 	},
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/building)
+"iD" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "iF" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -3752,6 +3874,22 @@
 "iM" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_five)
+"iN" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/step_trigger/player_choice_log{
+	title = "Welcome to Heavens Night.";
+	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bar/heaven)
 "iQ" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
@@ -3983,6 +4121,14 @@
 "jp" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/wasteland/city/newboston/house)
+"jq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "js" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -4369,6 +4515,13 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"kj" = (
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	pixel_x = -15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "kk" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13{
@@ -4771,12 +4924,12 @@
 	},
 /area/f13/wasteland)
 "le" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner{
-	color = "#A47449"
+/obj/structure/chair/sofa/corner{
+	color = "#475340";
+	dir = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral{
@@ -4838,6 +4991,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bank)
+"lo" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "lp" = (
 /obj/structure/rack/shelf_wood/modern,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -4993,6 +5153,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/wasteland)
+"lH" = (
+/obj/structure/chair/sofa/corp/right{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "lI" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -5014,7 +5182,13 @@
 	},
 /area/f13/building)
 "lL" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/sofa/corp/left{
+	dir = 2;
+	color = "pink"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "lM" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -5068,6 +5242,18 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
+"lQ" = (
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_y = 8;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "lS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -5091,6 +5277,18 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"lV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	light_color = "#884444"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "lW" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -5338,11 +5536,12 @@
 	},
 /area/f13/building)
 "mx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/sustenance,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
+	},
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/caves)
 "my" = (
 /obj/structure/simple_door/room,
 /obj/item/lock_bolt{
@@ -5351,12 +5550,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mz" = (
-/obj/effect/spawner/lootdrop/f13/trash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "mA" = (
 /obj/structure/rack/shelf_metal/modern,
 /obj/item/stack/sheet/sandblock/five,
@@ -5634,15 +5837,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nc" = (
-/obj/machinery/light/small{
-	dir = 4;
-	color = "#FFC0CB";
-	light_color = "#FFC0CB";
-	pixel_y = 5;
-	pixel_x = 6
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/area/f13/wasteland)
 "nd" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -5687,9 +5887,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
 "ni" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/ladder/unbreakable{
+	id = "hn2";
+	height = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "nj" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/dirt,
@@ -5797,8 +6000,26 @@
 	},
 /area/f13/building/tribal)
 "nu" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
+"nv" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1;
+	color = "brown"
+	},
+/obj/structure/rug/big/rug_red{
+	pixel_x = -16
+	},
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "nw" = (
 /obj/machinery/workbench{
 	pixel_y = 18;
@@ -5894,6 +6115,10 @@
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nF" = (
+/obj/structure/railing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "nG" = (
 /obj/structure/railing{
 	dir = 4
@@ -6054,12 +6279,17 @@
 /turf/open/floor/carpet,
 /area/f13/wasteland/city/newboston/house)
 "nZ" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain/directional/south{
-	color = "#1e549c"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/dancing_pole{
+	pixel_x = -5;
+	pixel_y = -8
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing/dancing_pole{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "oa" = (
 /obj/item/flashlight/oldlamp{
 	light_on = 1;
@@ -6380,8 +6610,25 @@
 	},
 /area/f13/building/tribal)
 "oN" = (
-/turf/open/floor/carpet/royalblack,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 1;
+	pixel_x = -14
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 1;
+	pixel_x = 14
+	},
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/f13/bar/heaven)
 "oO" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -6656,13 +6903,8 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "py" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pz" = (
 /obj/structure/railing{
 	dir = 10
@@ -6740,10 +6982,13 @@
 	},
 /area/f13/building/tribal)
 "pI" = (
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/f13/bar/heaven)
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital/clinic/nash)
 "pJ" = (
 /obj/structure/table/glass,
 /obj/item/stack/tile/blackmarble/thirty{
@@ -6764,12 +7009,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "pM" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "pO" = (
 /obj/structure/stone_tile/block{
 	dir = 8;
@@ -6887,6 +7129,12 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
+"qc" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "qd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -6956,16 +7204,8 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ql" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	req_one_access_txt = "136"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/caves)
 "qm" = (
 /obj/structure/table,
 /turf/open/floor/wood_common,
@@ -7198,11 +7438,11 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
 "qS" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "qT" = (
 /turf/open/indestructible/ground/outside/civ/grass3{
 	color = "#777777";
@@ -7346,6 +7586,11 @@
 /obj/structure/chair/metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
+"rm" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "rn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookshelf{
@@ -7369,13 +7614,12 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "rs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "ru" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/food,
@@ -7435,13 +7679,8 @@
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
 "rC" = (
-/obj/item/storage/secure/safe{
-	name = "safety deposit box";
-	pixel_x = 5;
-	pixel_y = -30
-	},
-/turf/closed/wall/r_wall/rust,
-/area/f13/wasteland/city/newboston/bank)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "rD" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
@@ -7449,17 +7688,16 @@
 	},
 /area/f13/building)
 "rE" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/ladder/unbreakable{
-	id = "hn";
-	height = 1
+/obj/structure/railing/corner{
+	dir = 1;
+	pixel_y = -31;
+	pixel_x = -1
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "rF" = (
 /obj/structure/railing{
 	dir = 6
@@ -7601,10 +7839,30 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/outdoors)
 "rW" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/thinplating/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/bed/wooden,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/railing/wood/post{
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/obj/structure/railing/wood/post{
+	pixel_x = -13;
+	pixel_y = 1
+	},
+/obj/structure/curtain{
+	color = "#5c131b";
+	layer = 5;
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/structure/rug/mat{
+	color = "#CC4444";
+	layer = 6;
+	pixel_x = 2;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "rX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/oldlamp{
@@ -7957,17 +8215,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "sM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/machinery/light/small{
-	light_color = "#884444";
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland/city/newboston/bank)
 "sN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -8100,12 +8353,25 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"ta" = (
-/obj/structure/chair/office{
-	dir = 8
+"sZ" = (
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"ta" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8;
+	color = "pink"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "tb" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -8280,10 +8546,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "tr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/f13/building)
+/area/f13/caves)
 "ts" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirtcorner,
@@ -8646,14 +8915,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "un" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
 	},
-/obj/machinery/mineral/wasteland_vendor/specialplus,
-/turf/open/floor/f13{
-	icon_state = "darkredfull"
-	},
-/area/f13/wasteland/city/newboston/bank)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/caves)
 "uo" = (
 /obj/structure/rack,
 /obj/item/pickaxe/drill,
@@ -8982,6 +9249,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
+"vb" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
+/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "vc" = (
 /obj/structure/railing{
 	dir = 8
@@ -9087,15 +9365,19 @@
 	},
 /area/f13/building/tribal)
 "vp" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = -30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/item/kirbyplants/random{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "vq" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9248,10 +9530,23 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building)
+"vM" = (
+/obj/structure/sign/poster/contraband/pinup_vixen{
+	icon_state = "poster52";
+	pixel_x = -28
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "vN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing/corner{
+	color = "#A47449"
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 10
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "vO" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -9373,10 +9668,10 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "wg" = (
 /obj/structure/table/wood,
@@ -9574,10 +9869,12 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wD" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "wE" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -10074,14 +10371,18 @@
 	},
 /area/f13/building/tribal)
 "xP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/secure/safe{
-	name = "safety deposit box";
-	pixel_x = 5;
-	pixel_y = -30
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/bank)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5;
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/open/transparent/openspace,
+/area/f13/building/hospital/clinic/nash)
 "xQ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10154,6 +10455,12 @@
 /obj/item/ammo_box/magazine/garand3006,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
+"yg" = (
+/obj/structure/chair/sofa/left{
+	color = "#475340"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "yh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -10409,11 +10716,17 @@
 	},
 /area/f13/building)
 "yN" = (
-/obj/effect/turf_decal/trimline/neutral{
-	icon_state = "trimline_fill"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/wood_wide,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10500,10 +10813,10 @@
 /area/f13/tribe)
 "zb" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "zc" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/glass,
@@ -10584,10 +10897,17 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "zp" = (
-/obj/effect/spawner/lootdrop/trash,
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa/left{
+	color = "#475340";
+	dir = 4;
+	icon_state = "sofacorner"
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 20;
+	pixel_x = -9
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "zq" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -10661,13 +10981,12 @@
 	},
 /area/f13/tribe)
 "zz" = (
-/obj/item/storage/secure/safe{
-	name = "safety deposit box";
-	pixel_x = 5;
-	pixel_y = -30
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/bank)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/bar/heaven)
 "zB" = (
 /obj/machinery/light{
 	dir = 8
@@ -10699,23 +11018,13 @@
 	},
 /area/f13/building)
 "zF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/obj/machinery/button/door{
-	id = "xenobio55";
-	name = "Containment Blast Doors";
-	pixel_y = -6;
-	req_access_txt = null;
-	pixel_x = 26;
-	req_one_access_txt = null
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/area/f13/wasteland)
 "zG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -11085,17 +11394,11 @@
 	},
 /area/f13/tribe)
 "At" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
+/obj/structure/railing{
+	pixel_y = -3
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_one_access_txt = "136"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/caves)
 "Au" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13
@@ -11119,6 +11422,23 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
+"Av" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 4;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Aw" = (
 /turf/open/floor/carpet,
 /area/f13/wasteland)
@@ -11548,7 +11868,10 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar/heaven)
 "Bx" = (
-/obj/machinery/light/small,
+/obj/structure/chair/sofa/right{
+	pixel_x = 8;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "Bz" = (
@@ -11611,14 +11934,10 @@
 /area/f13/building/tribal/cave)
 "BH" = (
 /obj/structure/railing,
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "BJ" = (
 /obj/structure/railing{
 	dir = 6
@@ -11857,6 +12176,13 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"Cn" = (
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Co" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -12022,14 +12348,15 @@
 	},
 /area/f13/building/tribal)
 "CF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449";
+	pixel_y = -3
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "CG" = (
 /obj/structure/table/greyscale,
 /obj/item/pda/bar{
@@ -12144,7 +12471,7 @@
 	plane = -14
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "CU" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -12233,6 +12560,9 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"Db" = (
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "Dc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8;
@@ -12390,6 +12720,12 @@
 	name = "spring water"
 	},
 /area/f13/building/tribal)
+"Du" = (
+/obj/structure/chair/sofa{
+	color = "#475340"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Dv" = (
 /obj/effect/turf_decal/big{
 	dir = 1
@@ -12407,14 +12743,12 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "Dx" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1;
-	color = "brown"
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/f13Cash/random/banker,
+/obj/item/stack/f13Cash/random/banker,
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
 	},
-/obj/structure/rug/big/rug_red{
-	pixel_x = -16
-	},
-/turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bank)
 "Dy" = (
 /obj/structure/railing{
@@ -12483,12 +12817,10 @@
 	},
 /area/f13/building/tribal)
 "DF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/purple/side{
+	dir = 1
+	},
+/area/f13/caves)
 "DG" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
@@ -12570,16 +12902,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "DS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/obj/structure/simple_door/room{
-	name = "Clinic"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "DT" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -12623,7 +12947,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "DV" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/f13{
@@ -12671,6 +12995,13 @@
 	name = "spring water"
 	},
 /area/f13/building/tribal)
+"Eb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "Ec" = (
 /obj/structure/railing/wood{
 	pixel_y = 31;
@@ -12742,8 +13073,13 @@
 "Ei" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa/left{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Ej" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12777,9 +13113,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "Eo" = (
-/obj/structure/table/plasmaglass,
-/obj/item/storage/box/dice,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/curtain{
+	color = "#c40e0e";
+	alpha = 255
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "Ep" = (
 /turf/open/indestructible/ground/outside/desert{
@@ -12845,11 +13185,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "Ev" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Ew" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -13049,9 +13390,6 @@
 	color = "#A47449";
 	dir = 4
 	},
-/obj/structure/railing{
-	color = "#A47449"
-	},
 /turf/open/transparent/openspace,
 /area/f13/caves)
 "ET" = (
@@ -13130,8 +13468,11 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "Fd" = (
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
+/area/f13/caves)
 "Fe" = (
 /obj/structure/mirror{
 	dir = 8;
@@ -13297,13 +13638,8 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "FA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "FB" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
@@ -13330,13 +13666,12 @@
 	},
 /area/f13/tribe)
 "FE" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_y = 25
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/structure/dresser,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "FF" = (
 /obj/structure/flora/tree/jungle/small{
@@ -13370,6 +13705,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
+"FI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/slime_extract/grey,
+/turf/open/floor/engine,
+/area/f13/caves)
 "FJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13479,14 +13823,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "FY" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/area/f13/bar/heaven)
+/area/f13/wasteland)
 "FZ" = (
 /obj/structure/fermenting_barrel{
 	anchored = 1
@@ -13554,6 +13897,14 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/building)
+"Gk" = (
+/obj/structure/railing/corner{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "Gl" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -13723,6 +14074,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
+"GF" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/f13/caves)
 "GG" = (
 /obj/item/storage/box/dice{
 	pixel_y = 7
@@ -13968,6 +14326,14 @@
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Hg" = (
+/obj/machinery/light/small{
+	light_color = "#884444"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "Hh" = (
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -14169,9 +14535,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "HK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "HL" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -14349,6 +14721,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"Ic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "Id" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirt,
@@ -14789,7 +15166,17 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "IY" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/royalblack,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
+"IZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/f13/building/hospital/clinic/nash)
 "Ja" = (
 /obj/structure/sign/warning/securearea,
@@ -15086,19 +15473,17 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
 "JG" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats,
-/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
-/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
-/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 4;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 5;
+	pixel_x = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "JH" = (
 /obj/structure/rack/shelf_wood/modern,
 /obj/item/book/granter/crafting_recipe/blueprint/smg10mm,
@@ -15197,6 +15582,11 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
+"JW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "JX" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -15239,16 +15629,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "Ke" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
+/obj/item/watertank/janitor{
+	pixel_y = 24
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "Kf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera,
@@ -15924,6 +16309,16 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
+"LJ" = (
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "LK" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -15942,6 +16337,13 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"LM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/f13/caves)
 "LN" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -16010,6 +16412,24 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
+"LV" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "LW" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -16086,13 +16506,8 @@
 	},
 /area/f13/building/tribal)
 "Mb" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/ketchup{
-	pixel_y = 14;
-	pixel_x = 16;
-	layer = 3.2
-	},
-/turf/open/floor/carpet/blue,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital/clinic/nash)
 "Mc" = (
 /obj/structure/chair/left{
@@ -16304,9 +16719,6 @@
 	color = "#A47449";
 	dir = 8
 	},
-/obj/structure/railing{
-	color = "#A47449"
-	},
 /turf/open/transparent/openspace,
 /area/f13/caves)
 "MF" = (
@@ -16427,24 +16839,20 @@
 /turf/open/floor/carpet/arcade,
 /area/f13/building)
 "MS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 6
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "MT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench{
-	icon_state = "bench";
-	dir = 4
+/obj/structure/chair/sofa/corner{
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "MU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -16470,6 +16878,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building)
+"MX" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "MY" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16871,17 +17283,16 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "NL" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
 	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	req_one_access_txt = "136"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "NM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -16973,10 +17384,13 @@
 	},
 /area/f13/building)
 "NU" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/obj/structure/chair/sofa/corp/right{
+	dir = 1;
+	pixel_y = 0;
+	color = "brown"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "NV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor{
@@ -17000,6 +17414,13 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"NZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "Oa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/photocopier,
@@ -17214,12 +17635,10 @@
 	},
 /area/f13/tribe)
 "OC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "OD" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -17245,7 +17664,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
 "OH" = (
-/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
 /turf/open/transparent/openspace,
 /area/f13/wasteland/city/newboston/outdoors)
 "OI" = (
@@ -17259,6 +17681,10 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
+"OK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "OL" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -17342,7 +17768,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "OR" = (
 /obj/structure/railing{
 	dir = 1
@@ -17546,6 +17972,14 @@
 	color = "#779999"
 	},
 /area/f13/wasteland)
+"Pq" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Pr" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -17715,15 +18149,10 @@
 "PE" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4
+	pixel_y = -3
 	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 1;
-	pixel_y = 0;
-	color = "brown"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "PF" = (
 /obj/structure/table/glass,
 /obj/item/stack/tile/whitemarble/thirty{
@@ -17747,10 +18176,8 @@
 	},
 /area/f13/building)
 "PI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/closed/mineral/random/low_chance,
+/area/f13/building)
 "PJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -18021,6 +18448,11 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"Qr" = (
+/obj/structure/table/plasmaglass,
+/obj/item/storage/box/dice,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Qs" = (
 /mob/living/simple_animal/hostile/bs/knight,
 /turf/open/floor/carpet/royalblack,
@@ -18055,6 +18487,14 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
+"Qy" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Qz" = (
 /obj/effect/landmark/start/f13/hunter,
 /turf/open/indestructible/ground/inside/mountain{
@@ -18082,7 +18522,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "QB" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -18133,6 +18573,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/city)
+"QL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "xenobio55";
+	name = "Containment Blast Doors";
+	pixel_y = -6;
+	req_access_txt = null;
+	pixel_x = 26;
+	req_one_access_txt = null
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "QN" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -18233,6 +18691,14 @@
 	},
 /turf/open/water,
 /area/f13/building/tribal/cave)
+"Rb" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Rd" = (
 /obj/item/storage/box/gloves,
 /obj/structure/table/reinforced,
@@ -18429,17 +18895,24 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"Ry" = (
+/obj/structure/chair/sofa/right{
+	color = "#475340";
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Rz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "RA" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-02"
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/wood_common{
 	icon_state = "common-broken3"
@@ -18513,9 +18986,11 @@
 	},
 /area/f13/tribe)
 "RL" = (
-/obj/structure/table/plasmaglass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "RM" = (
 /obj/structure/closet/cabinet/anchored,
@@ -18557,15 +19032,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "RP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
-"RR" = (
-/obj/structure/spacevine{
-	opacity = 1
+/obj/structure/chair/sofa{
+	color = "#475340"
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"RR" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "RS" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -18734,6 +19219,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Si" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "Sj" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "120"
@@ -18830,11 +19325,12 @@
 	},
 /area/f13/building)
 "Su" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/curtain{
+	color = "#c40e0e"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Sv" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
@@ -18938,19 +19434,14 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "SI" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 8;
-	pixel_x = 2
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "SJ" = (
 /obj/structure/anvil/obtainable/basic,
 /obj/item/melee/smith/hammer/premade,
@@ -18980,18 +19471,18 @@
 	},
 /area/f13/tribe)
 "SO" = (
-/obj/machinery/light{
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
+	},
+/obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench{
-	icon_state = "bench";
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "SQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -19239,6 +19730,15 @@
 /obj/machinery/light,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_four)
+"Ty" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Tz" = (
 /obj/structure/legion_extractor{
 	pixel_y = 6
@@ -19268,8 +19768,9 @@
 	},
 /area/f13/building/tribal)
 "TC" = (
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/table/plasmaglass,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "TD" = (
 /obj/structure/table,
 /turf/open/floor/wood_common{
@@ -19330,30 +19831,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "TM" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/chair/wood/wings{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "TN" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -19582,6 +20067,22 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Up" = (
+/obj/machinery/button/door{
+	id = "xenobio44";
+	name = "Containment Blast Doors";
+	pixel_y = 36;
+	req_access_txt = null;
+	pixel_x = 5;
+	req_one_access_txt = null
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "Uq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -19623,8 +20124,13 @@
 /area/f13/building)
 "Uv" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Uw" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -19711,14 +20217,12 @@
 	},
 /area/f13/building/tribal)
 "UI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library{
-	pixel_y = 35
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
 	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/bar/heaven)
 "UK" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
@@ -20107,9 +20611,8 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "VC" = (
-/obj/machinery/light,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "VD" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = -4;
@@ -20140,16 +20643,11 @@
 	},
 /obj/machinery/grill,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "VG" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
-	},
-/obj/machinery/light/floor{
-	light_color = "#883388"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "VH" = (
 /obj/structure/table/wood/fancy/blackred{
 	density = 0;
@@ -20309,6 +20807,22 @@
 /obj/item/reagent_containers/food/snacks/pizzaslice/sassysage,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
+"Wb" = (
+/obj/structure/table/plasmaglass,
+/obj/structure/railing/dancing_pole{
+	pixel_y = 31
+	},
+/obj/structure/railing/dancing_pole{
+	pixel_y = 10
+	},
+/obj/structure/fence/pole_b{
+	pixel_y = 7
+	},
+/obj/structure/fence/pole_t{
+	pixel_y = 36
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Wc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -20571,16 +21085,15 @@
 	},
 /area/f13/bar/heaven)
 "WF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
-"WG" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/f13/building)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"WG" = (
+/obj/machinery/door/unpowered/securedoor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bar/heaven)
 "WI" = (
 /obj/structure/fence/wooden{
 	dir = 8;
@@ -20608,14 +21121,12 @@
 	},
 /area/f13/building)
 "WK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/slime_extract/grey,
-/turf/open/floor/engine,
-/area/f13/building)
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "pink"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "WL" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20702,11 +21213,12 @@
 /area/f13/tribe)
 "WW" = (
 /obj/structure/chair/sofa/corp/right{
-	dir = 8;
+	dir = 2;
 	color = "pink"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "WX" = (
 /obj/structure/railing/dancing_pole{
@@ -20725,16 +21237,27 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar/heaven)
 "WY" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/structure/curtain{
+	color = "#c40e0e";
+	alpha = 255
 	},
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bar/heaven)
 "WZ" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Xa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444";
+	pixel_x = -16;
+	pixel_y = -8
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "Xc" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -20891,6 +21414,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Xx" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "Xy" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -20992,19 +21521,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "XL" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_y = 2;
-	pixel_x = 12
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/mustard{
-	pixel_x = 16;
-	pixel_y = -4;
-	layer = 3.1
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "XM" = (
 /obj/structure/table/wood/settler,
 /obj/structure/railing{
@@ -21076,10 +21598,23 @@
 	},
 /area/f13/bar/heaven)
 "XT" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin/color,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	color = "#444499";
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = -13
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "XU" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -21391,14 +21926,12 @@
 	},
 /area/f13/building)
 "YD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "YE" = (
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
@@ -21752,10 +22285,16 @@
 	},
 /area/f13/building)
 "Zx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Zy" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -21763,13 +22302,12 @@
 	},
 /area/f13/building)
 "Zz" = (
-/obj/structure/window/fulltile/house,
 /obj/structure/curtain{
-	color = "#1e549c";
+	color = "#c40e0e";
 	alpha = 255
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "ZB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -21805,20 +22343,26 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "ZJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building/hospital/clinic/nash)
-"ZK" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4;
-	color = "pink"
+/obj/machinery/light/small{
+	color = "#444499";
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = -13
 	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"ZK" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8
+	dir = 5;
+	pixel_y = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/bank)
 "ZL" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -21858,7 +22402,11 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/binoculars,
+/obj/structure/table,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
 /area/f13/wasteland)
 "ZP" = (
 /obj/effect/turf_decal/trimline/neutral{
@@ -43318,19 +43866,19 @@ tN
 tN
 tN
 tN
+Ws
+Ws
+Ws
+Ws
 tN
+Ws
+Ws
+Ws
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Ws
+Ws
+Ws
+Ws
 tN
 tN
 tN
@@ -43566,29 +44114,29 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-TC
-WY
-Rn
-Rn
-TC
+bh
+bh
+bh
+tj
+tj
+tj
+tj
+tj
+tj
 WY
 WY
 WY
 WY
-TC
-tN
-tN
+tj
+WY
+WY
+WY
+tj
+WY
+WY
+WY
+WY
+tj
 tN
 tN
 tN
@@ -43822,30 +44370,30 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-TC
-xU
-vN
-So
-bg
-Tb
+tj
+RM
+ol
+ej
+ej
+VI
+kn
+TQ
+cJ
+tj
+rW
+YE
+RL
+aD
+tj
+iz
+iz
+iz
+tj
 zp
-zp
-kF
-TC
-tN
-tN
+sZ
+Ev
+le
+tj
 tN
 tN
 tN
@@ -44080,29 +44628,29 @@ tN
 tN
 tN
 tj
-bh
-bh
-bh
+hg
+ys
+iz
+dt
+Uv
+Pq
+lQ
+iz
 tj
-tj
-tj
-tj
-tj
-tj
-tN
-tN
+yN
+Op
 nZ
-kP
-mz
-df
-wp
-lA
-HK
+kj
+tj
+bM
+aK
+MS
+tj
 RP
-zW
 TC
-tN
-tN
+TC
+XT
+tj
 tN
 tN
 tN
@@ -44332,34 +44880,34 @@ Yj
 Yj
 GU
 qF
-GU
+tN
 tN
 tN
 tN
 tj
-RM
-ol
-ej
-ej
-VI
-kn
-TQ
-cJ
+mE
+ys
+aa
+yx
+Zm
+kC
+ob
+iz
 tj
-tN
-GU
+FE
+Op
+YE
+YE
+tj
+bt
+Qr
+iz
+tj
+Du
 TC
-EI
-Ei
-wp
-wp
-EV
-dX
-dX
-dX
-TC
-tN
-tN
+Wb
+YD
+tj
 tN
 tN
 tN
@@ -44589,34 +45137,34 @@ Yj
 Yj
 GU
 qF
-En
-ZK
-aC
-pM
+tN
+Ws
+Ws
+Ws
 tj
-hg
-ys
-OY
-FE
-Ke
-bM
-SI
-Bx
 tj
-tN
-GU
-TC
-wp
-wp
-PC
-dh
-EV
-dX
-dX
-dX
-TC
-tN
-tN
+gD
+tj
+tj
+YG
+tj
+tj
+tj
+tj
+Eb
+Op
+Op
+YE
+tj
+ta
+WK
+iz
+tj
+yg
+Zm
+et
+Ry
+tj
 tN
 OW
 db
@@ -44846,36 +45394,36 @@ Yj
 Yj
 GU
 qF
-En
-RL
-Eo
-lL
 tj
-mE
-ys
-aa
-yx
-Zm
-kC
-ob
+Eo
+Eo
+Eo
+tj
+rs
+Ux
+tj
+Sq
+pc
+Bv
+tj
 wf
 tj
-GU
-TC
-TC
-pa
-TC
+dn
+YE
+Op
+YE
+tj
+iz
+iz
+iz
+tj
 Zx
+MS
+iz
 ZJ
-TC
-ZJ
-Zx
-ZJ
-TC
-ZJ
-Rn
-TC
-TC
+tj
+Ws
+CF
 eV
 NR
 aN
@@ -44883,12 +45431,12 @@ uu
 aN
 kY
 eV
-yN
+Cd
+mz
 gw
+mz
 gw
-gw
-gw
-gw
+FY
 ZO
 tN
 tN
@@ -45103,36 +45651,36 @@ Yj
 Yj
 GU
 qF
-En
+tj
 WW
-ic
-lL
+OY
+Xx
+tj
+Ux
+Ux
+RW
+Va
+CV
+hm
+qN
+OY
 tj
 tj
-gD
 tj
-tj
-YG
-tj
-tj
-tj
-tj
-GU
-TC
-ks
+Su
 oN
-FA
-Wm
-MT
+tj
+Su
+tj
 XL
-Mb
-SO
-XT
-TC
-dn
-ga
-fa
-TC
+tj
+XL
+Su
+tj
+tj
+tj
+py
+PE
 eV
 NR
 gP
@@ -45140,13 +45688,13 @@ nT
 In
 gP
 az
-yN
-cc
-cc
-cc
-cc
-OT
-ma
+Cd
+Qy
+nu
+Qy
+nu
+OC
+BH
 tN
 tN
 tN
@@ -45360,36 +45908,36 @@ Yj
 Yj
 GU
 qF
-qF
-lL
-lL
-lL
 tj
-Ux
-Ux
+lL
+Xa
+OY
+AA
+OY
+aL
+tW
+Uy
+WX
+Hy
+eG
+Uc
 tj
-Sq
-pc
-Bv
-pI
-rE
-tj
-GU
-TC
-xM
-oN
-IY
-Ev
 as
-fn
-hU
+vM
 iz
-dt
-TC
-ga
-ga
-bw
-TC
+iz
+iz
+iz
+as
+iz
+iz
+iz
+iz
+tj
+py
+py
+py
+PE
 eV
 Dv
 uu
@@ -45402,8 +45950,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+zF
+Cn
 tN
 tN
 tN
@@ -45617,36 +46165,36 @@ Yj
 Yj
 GU
 qF
-qF
-lL
-nc
-lL
-VZ
-Ux
-Ux
-RW
-Va
-CV
-hm
-qN
-OY
 tj
-GU
-TC
-GI
-oN
-ch
-Wm
-Wm
-Wm
-Wm
-PI
-Wm
-pa
-ga
-ga
-xs
-TC
+tj
+tj
+tj
+tj
+OY
+vD
+kL
+Uy
+CV
+Hy
+Kk
+ot
+Zz
+iz
+iz
+iz
+iz
+WF
+iz
+iz
+iz
+iz
+JG
+iz
+tj
+py
+py
+py
+PE
 eV
 NR
 zK
@@ -45659,8 +46207,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+Ty
+nc
 tN
 tN
 tN
@@ -45875,35 +46423,35 @@ Yj
 GU
 qF
 qF
-jo
-tj
-tj
-tj
+xx
+Yy
+rU
+AA
 OY
-aL
-tW
-Uy
-WX
-Hy
-eG
-Uc
-tF
-GU
-TC
-TC
-DS
-TC
+OY
+UD
+qz
+AW
+cs
+cB
+HA
+Zz
+iz
+iz
+JG
+iz
+iz
 JG
 WF
-PI
-WF
-WF
+iz
+iz
+tj
 ni
-TC
-ZJ
-TC
-TC
-TC
+tj
+py
+py
+py
+PE
 eV
 UL
 Ho
@@ -45916,8 +46464,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+zF
+Cn
 tN
 tN
 tN
@@ -46133,34 +46681,34 @@ GU
 qF
 qF
 xx
-rU
-lL
+xx
+Ro
 AA
 OY
-vD
-kL
-Uy
-CV
-Hy
-Kk
 ot
+HA
+ot
+OY
+ot
+ot
+Hg
 tj
-GU
-TC
-bD
+iz
+iz
+tj
 Su
-Zx
-IC
-Wm
-mx
-Wm
-wD
-Wm
-pa
+ch
+tj
+ch
+tj
+Su
+tj
+tj
+tj
 py
-ga
-fk
-TC
+py
+py
+PE
 eV
 eV
 eV
@@ -46173,8 +46721,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+Rb
+nc
 tN
 tN
 tN
@@ -46390,34 +46938,34 @@ GU
 GU
 xx
 xx
-Ro
-lL
-AA
-OY
-OY
-UD
-qz
-AW
-cs
-cB
-HA
+jo
+tF
+VZ
 tj
-GU
-TC
-Fe
-mt
-dG
-mG
-Wm
+hc
+Hw
+uT
+uT
+Sd
+nf
+Hg
+tj
+iz
+iz
+tj
+vp
+WF
+tj
+MS
 dG
 cP
-Zz
-TC
-TC
-ga
-ga
-bw
-TC
+tj
+py
+py
+py
+py
+py
+py
 hE
 Tr
 lf
@@ -46430,8 +46978,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+zF
+Cn
 tN
 tN
 tN
@@ -46646,35 +47194,35 @@ Yj
 GU
 GU
 xx
-jo
-tF
+xx
+xx
+Yy
+xx
 tj
-VZ
-tj
-sM
-HA
-ot
+yj
+MG
+lZ
+ud
+MG
+RB
 OY
-ot
-ot
-OY
-tj
-GU
-TC
-pC
-Qn
-TC
-UI
+Zz
 MS
-dG
-dK
-dK
-dK
-TC
-gv
-ga
-ta
-TC
+iz
+tj
+Bx
+iz
+tj
+MS
+iz
+WF
+UI
+LJ
+py
+py
+py
+py
+py
 hE
 Zj
 ZY
@@ -46687,8 +47235,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+Rb
+BH
 tN
 tN
 tN
@@ -46904,34 +47452,34 @@ GU
 GU
 xx
 xx
-Yy
+xx
 Ab
 xx
 tj
-VG
-Hw
-uT
-uT
-Sd
-nf
-FY
+YF
+Op
+YE
+kM
+LZ
+NA
+ot
+Zz
+iz
+iz
 tj
-GU
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-dK
-dK
-dK
-TC
-TC
-eK
-TC
-TC
+MT
+Ei
+tj
+Av
+lH
+dl
+zz
+py
+py
+py
+py
+py
+py
 hE
 EX
 ZY
@@ -46944,8 +47492,8 @@ tN
 tN
 tN
 tN
-Ts
-ma
+zF
+qc
 tN
 tN
 tN
@@ -47165,30 +47713,30 @@ xx
 xx
 xx
 tj
-yj
-MG
-lZ
-ud
-MG
-RB
-OY
+YE
+Op
+Op
+Op
+YE
+YE
+lV
 tj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-dK
-dK
-dK
+WG
+WG
+tj
+tj
+tj
+tj
+tj
+tj
+tj
+tj
+eK
 qS
-dK
-dK
-dK
-dK
+qS
+qS
+qS
+Gk
 hE
 cL
 nr
@@ -47422,29 +47970,29 @@ xx
 xx
 xx
 tj
-YF
-Op
-YE
-kM
-LZ
-NA
-ot
+zw
+IL
+Io
+ef
+qt
+ws
+OY
+VZ
+iN
+iN
 tj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-dK
-dK
-dK
-dK
-dK
-dK
-dK
+xx
+xx
+xx
+xx
+xx
+xx
+xx
+RR
+Ap
+Ap
+Ap
+At
 dK
 gL
 YV
@@ -47673,35 +48221,35 @@ Yj
 Yj
 GU
 GU
-us
 GU
-xx
+mx
+SO
 xx
 xx
 tj
-YE
-Op
-Op
-Op
-YE
-YE
-vD
 tj
-GU
-GU
-GU
-GU
-GU
-RR
-Qj
+tj
+tj
+tj
+tj
+tj
+zD
+VZ
+cr
+xx
+Yy
+xx
 qF
-dK
-dK
-dK
-dK
-dK
-dK
-dK
+qF
+xx
+xx
+xx
+xx
+hU
+gl
+gl
+gl
+rE
 dK
 hE
 vd
@@ -47930,30 +48478,30 @@ Yj
 Yj
 GU
 GU
-us
 GU
-xx
+un
+EY
 xx
 xx
 tj
-zw
-IL
-Io
-ef
-qt
-ws
-OY
-tj
-GU
-GU
-GU
+ka
+dS
+dS
+dS
+jI
+dS
+jI
+UI
+fa
+xx
+xx
 qF
 qF
-Qj
+qF
 Qk
 Qk
 Qk
-sb
+Qk
 Qk
 Qk
 Qk
@@ -48193,20 +48741,20 @@ xx
 xx
 xx
 tj
-tj
-tj
-tj
-tj
-tj
-tj
-zD
-tj
-GU
-GU
+TJ
+WD
+tk
+Kg
+XS
+CC
+BR
+zz
+xx
+xx
+xx
 qF
-qF
-GU
-GU
+Qk
+Qk
 Qk
 sD
 hh
@@ -48447,23 +48995,23 @@ GU
 GU
 Xt
 ME
-EY
-vp
+xx
+xx
 tj
-ka
-dS
-dS
-dS
-jI
-dS
-jI
 tj
-GU
-qF
-qF
-GU
+tj
+tj
+tj
+tj
+tj
+tj
+tj
+cr
+xx
+xx
 Qk
 Qk
+PR
 Qk
 zI
 eD
@@ -48704,22 +49252,22 @@ GU
 GU
 Xt
 ES
-EY
-cf
-tj
-TJ
-WD
-tk
-Kg
-XS
-CC
-BR
-tj
-GU
+xx
+xx
+qF
+xx
+xx
+xx
 qF
 qF
-GU
+xx
+xx
+xx
+xx
+xx
+qF
 Qk
+iD
 PR
 Qk
 Qk
@@ -48962,24 +49510,24 @@ GU
 GU
 GU
 qF
-Yj
-tj
-tj
-tj
-tj
-tj
-tj
-tj
-tj
-tj
-GU
+xx
+xx
+xx
+qF
+xx
+xx
+xx
+qF
+qF
+qF
+xx
 qF
 um
-GU
 Qk
+ac
 cR
 cR
-TM
+cR
 fg
 cR
 Yu
@@ -49234,11 +49782,11 @@ wi
 Ap
 Ap
 Ap
-Fd
-Fd
-Fd
-Fd
-Fd
+Ap
+Ap
+Ap
+Ap
+Ap
 Qk
 JE
 HG
@@ -49491,11 +50039,11 @@ wi
 Ap
 Ap
 Ap
-Fd
-Fd
-Fd
-Fd
-Fd
+Ap
+Ap
+Ap
+Ap
+Ap
 jB
 Mq
 Vr
@@ -49746,20 +50294,20 @@ hq
 eP
 qF
 eP
-GU
 Sf
 QA
+QA
 DU
-Fd
-Fd
-Fd
+Ap
+Ap
+Ap
 Qk
 Qk
 Qk
 Qk
 Qk
 Dd
-NL
+Cv
 Cv
 jp
 mI
@@ -50000,11 +50548,11 @@ Ap
 Ap
 Ap
 Ap
-GU
 qF
 qF
-GU
+qF
 Sf
+LV
 VF
 CT
 OQ
@@ -50016,8 +50564,8 @@ aZ
 xb
 Sf
 dK
-OH
-Iu
+HK
+dK
 QO
 eJ
 wl
@@ -50253,14 +50801,14 @@ GU
 GU
 GU
 qF
-GU
-Ap
-Ap
-Ap
-GU
-GU
 qF
-GU
+Ap
+Ap
+Ap
+qF
+qF
+qF
+Sf
 Sf
 Sf
 pT
@@ -50274,7 +50822,7 @@ TF
 rN
 dK
 OH
-Iu
+dK
 jp
 jp
 jp
@@ -50510,11 +51058,11 @@ GU
 GU
 GU
 qF
-GU
-GU
-GU
-GU
-GU
+qF
+qF
+qF
+qF
+qF
 qF
 qF
 GU
@@ -50530,7 +51078,7 @@ NM
 AX
 rN
 dK
-Cv
+OH
 dK
 dK
 dK
@@ -50787,7 +51335,7 @@ YS
 ID
 lI
 dK
-dK
+OH
 ci
 eW
 FP
@@ -51019,20 +51567,20 @@ GU
 GU
 GU
 us
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-qF
-GU
+DO
+DO
+DO
+DO
+sM
+DO
+DO
+DO
+rC
+Rn
+Rn
+rC
+rC
+rC
 Sf
 Sf
 Sf
@@ -51044,7 +51592,7 @@ SY
 Pu
 rN
 dK
-dK
+OH
 dK
 Xq
 GW
@@ -51276,22 +51824,22 @@ GU
 GU
 GU
 us
-GU
-GU
-GU
-us
 DO
+Gu
+lE
+ln
+uK
+fY
+OE
 DO
-DO
-DO
-DO
-DO
-DO
-DO
-qF
-qF
-GU
-GU
+xU
+wp
+So
+bg
+Tb
+kF
+dX
+Sf
 Sf
 Td
 KH
@@ -51301,7 +51849,7 @@ lW
 ff
 Sf
 dK
-dK
+OH
 dK
 eW
 eW
@@ -51533,21 +52081,21 @@ us
 GU
 GU
 GU
-GU
-GU
-us
-us
 DO
-Gu
-lE
-ln
-uK
-fY
-OE
+aq
+lS
+mT
+iU
 DO
-GU
-qF
-GU
+Kr
+DO
+kP
+wp
+df
+wp
+lA
+dX
+zW
 Sf
 Sf
 Sf
@@ -51558,7 +52106,7 @@ Sf
 Sf
 Sf
 dK
-dK
+Si
 dK
 eW
 zT
@@ -51790,21 +52338,21 @@ us
 GU
 GU
 GU
-us
-us
-us
-GU
 DO
-aq
-lS
+gr
+yY
 mT
-iU
+Ur
 DO
-Kr
 DO
-GU
-qF
-GU
+DO
+EI
+wp
+wp
+wp
+EV
+dX
+dX
 hC
 RN
 nI
@@ -51815,7 +52363,7 @@ Rv
 JF
 hC
 Ej
-xm
+dK
 dK
 eW
 CH
@@ -52047,21 +52595,21 @@ GU
 us
 GU
 GU
-GU
-GU
-GU
-GU
 DO
-gr
-yY
+RS
+LE
 mT
-Ur
+cu
 DO
 DO
 DO
-DO
-qF
-qF
+PC
+wp
+wp
+dh
+pI
+Mb
+dX
 hC
 ad
 LY
@@ -52072,8 +52620,8 @@ HC
 HC
 Cq
 dK
-OH
-Iu
+pB
+dK
 eW
 QU
 wI
@@ -52304,21 +52852,21 @@ GU
 us
 us
 GU
-GU
-GU
-GU
-us
 DO
-RS
-LE
+lT
 mT
-cu
-rC
-MP
-Vh
+mT
+jL
 DO
-GU
-qF
+DO
+DO
+iw
+rC
+pa
+pM
+rC
+IY
+pM
 hC
 hC
 Mk
@@ -52329,8 +52877,8 @@ yz
 rk
 hC
 dK
-OH
-Iu
+Mg
+dK
 eW
 eW
 Nf
@@ -52561,21 +53109,21 @@ GU
 GU
 us
 us
-GU
-GU
-GU
-us
-DO
-lT
+Ny
+UM
 mT
-uK
-VC
+mT
+nv
 DO
-MP
 Vh
+MP
 DO
+ks
+Wm
+lo
+rC
 GU
-qF
+GU
 hC
 Wa
 HC
@@ -52586,7 +53134,7 @@ HC
 HC
 Cq
 dK
-Cv
+Mg
 dK
 LI
 eW
@@ -52818,21 +53366,21 @@ GU
 GU
 GU
 GU
-GU
-GU
-us
-GU
-Ny
+DO
 zj
+uK
 mT
-jL
-mT
+NU
 DO
-un
-xP
+Vh
+Dx
 DO
-GU
-qF
+xM
+Wm
+Wm
+rC
+rC
+rC
 hC
 es
 xg
@@ -52843,7 +53391,7 @@ OJ
 OJ
 tI
 dK
-dK
+fd
 dK
 dK
 rl
@@ -53075,21 +53623,21 @@ GU
 GU
 GU
 GU
-GU
-GU
-us
-GU
 DO
-UM
+ja
+uK
 mT
+ZD
+yZ
+Vh
 Dx
-mT
 DO
-MP
-zz
-DO
-GU
-qF
+GI
+Wm
+Wm
+de
+Db
+bD
 hC
 TO
 Ao
@@ -53100,7 +53648,7 @@ SA
 qv
 Cq
 dK
-oW
+dK
 xm
 xm
 xm
@@ -53332,21 +53880,21 @@ Yj
 GU
 GU
 GU
-GU
-GU
-us
-GU
+Ny
+VS
+vN
+wD
+mT
 DO
-ja
-le
-PE
-ZD
-yZ
-Vh
-Vh
 DO
-GU
-qF
+DO
+DO
+go
+Wm
+vb
+rC
+Ke
+Db
 hC
 If
 bH
@@ -53589,21 +54137,21 @@ GU
 GU
 GU
 GU
-GU
-GU
-GU
-GU
 Ny
-VS
-et
+DO
+Ny
+ZK
+mT
+sM
+Wm
 zb
-eF
-DO
-DO
-DO
-DO
-GU
-qF
+Wm
+xP
+Wm
+IC
+rC
+Fe
+mt
 hC
 hC
 hC
@@ -53848,20 +54396,20 @@ GU
 GU
 GU
 GU
-GU
-GU
-Ny
-DO
-Ny
-Ny
-DO
-DO
-GU
-GU
-GU
-GU
-qF
-qF
+DS
+DS
+DS
+DS
+MX
+Wm
+Wm
+Wm
+Wm
+mG
+rC
+pC
+Qn
+rC
 Qj
 EP
 LK
@@ -53871,7 +54419,7 @@ Ap
 Ap
 sK
 Iu
-rW
+EC
 tN
 tN
 tN
@@ -54108,16 +54656,16 @@ GU
 GU
 GU
 GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-qF
+rC
+rC
+pM
+pa
+rC
+pa
+rC
+rC
+rC
+rC
 TI
 TI
 TI
@@ -54128,7 +54676,7 @@ TI
 ll
 TI
 vz
-pB
+EC
 tN
 tN
 tN
@@ -54366,15 +54914,15 @@ GU
 GU
 GU
 GU
+rC
+TM
+ga
+rC
+cf
+IZ
+rC
 GU
 GU
-GU
-GU
-GU
-qF
-qF
-qF
-qF
 TI
 wX
 DJ
@@ -54385,7 +54933,7 @@ sf
 wS
 DI
 dK
-Mg
+EC
 tN
 tN
 tN
@@ -54623,13 +55171,13 @@ GU
 GU
 GU
 GU
-GU
-qF
-qF
-qF
-qF
-qF
-GU
+rC
+bw
+ga
+rC
+ga
+bw
+rC
 GU
 GU
 TI
@@ -54642,7 +55190,7 @@ PZ
 Tx
 TI
 dK
-BH
+EC
 tN
 tN
 tN
@@ -54880,15 +55428,15 @@ GU
 GU
 GU
 GU
+rC
+fb
+gv
+rC
+gv
+xs
+rC
 GU
-qF
 GU
-GU
-GU
-GU
-GU
-Yj
-Yj
 TI
 TI
 TI
@@ -55135,16 +55683,16 @@ GU
 GU
 us
 us
-us
-us
-GU
-qF
 GU
 GU
+rC
+rC
+rC
+rC
+rC
+rC
+rC
 GU
-GU
-GU
-Yj
 mf
 mf
 mf
@@ -55395,10 +55943,10 @@ GU
 GU
 GU
 GU
+GU
+GU
+GU
 qF
-GU
-GU
-GU
 GU
 GU
 Yj
@@ -55655,7 +56203,7 @@ GU
 qF
 GU
 GU
-GU
+qF
 GU
 GU
 Yj
@@ -55912,7 +56460,7 @@ GU
 qF
 GU
 GU
-GU
+qF
 GU
 GU
 Yj
@@ -56169,7 +56717,7 @@ GU
 qF
 GU
 GU
-GU
+qF
 GU
 GU
 Yj
@@ -56178,11 +56726,11 @@ mf
 mf
 mf
 mf
-ji
-ji
-ji
-ji
-ji
+Yj
+Yj
+Yj
+Yj
+Yj
 tN
 tN
 tN
@@ -56425,22 +56973,22 @@ GU
 GU
 qF
 GU
-GU
-GU
-ji
-ji
-ji
-ji
-ji
-ji
-ji
-ji
-ji
 qF
 qF
-nu
-Zh
-Zh
+qF
+qF
+qF
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+tN
 tN
 tN
 tN
@@ -56681,23 +57229,23 @@ us
 GU
 GU
 qF
-GU
-GU
-GU
-ji
-cO
-up
-TG
-uo
-ji
 qF
 qF
 qF
 qF
 qF
-de
-Zh
-Zh
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+tN
 tN
 tN
 tN
@@ -56938,22 +57486,22 @@ GU
 GU
 GU
 qF
-GU
-GU
-GU
-ji
-gp
-QK
-TG
-yK
-ji
-Qw
-Al
-uF
-Bh
-Qw
-nu
-Zh
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
+qF
 Fo
 Fo
 Fo
@@ -57197,20 +57745,20 @@ qF
 qF
 qF
 qF
-GU
+qF
 ji
-gp
-TG
-QK
-Bp
-uo
-yD
-PS
-tB
-TU
-Dn
-oS
 ji
+ji
+ji
+ji
+ji
+qF
+qF
+qF
+qF
+qF
+VC
+fk
 Fo
 sh
 sh
@@ -57456,18 +58004,18 @@ qF
 qF
 GU
 ji
-HQ
-QS
-Oi
+cO
+up
 TG
-we
-Rp
-BZ
-PK
-jh
-ok
-oS
+uo
 ji
+qF
+qF
+qF
+qF
+qF
+nF
+fk
 Fo
 lD
 rJ
@@ -57710,21 +58258,21 @@ qF
 qF
 qF
 qF
-qF
+GU
 GU
 ji
-gU
-IP
-bm
-bm
 gp
-iv
-Cs
-Ql
-jW
-UW
-oS
-oS
+QK
+TG
+yK
+ji
+Qw
+Al
+uF
+Bh
+Qw
+VC
+fk
 Fo
 lb
 hx
@@ -57970,18 +58518,18 @@ qF
 qF
 GU
 ji
-ji
-ji
-ji
-ji
-ji
-qF
-qA
-xc
-UW
-qF
-GU
-GU
+gp
+TG
+QK
+Bp
+uo
+yD
+PS
+tB
+TU
+Dn
+ql
+eF
 Fo
 MF
 FV
@@ -58225,20 +58773,20 @@ qF
 qF
 qF
 qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
 GU
-GU
+ji
+HQ
+QS
+Oi
+TG
+we
+Rp
+BZ
+PK
+jh
+ok
+ql
+eF
 Fo
 fj
 hx
@@ -58482,20 +59030,20 @@ qF
 qF
 qF
 qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
 GU
-GU
-GU
+ji
+gU
+IP
+bm
+bm
+gp
+iv
+Cs
+Ql
+jW
+UW
+ql
+ql
 Fo
 ov
 hx
@@ -58739,18 +59287,18 @@ qF
 qF
 qF
 qF
-qF
-qF
-qF
-qF
-qF
-qF
-qF
-Qw
-qF
-qF
-qF
 GU
+ji
+ji
+ji
+ji
+ji
+ji
+qF
+qA
+xc
+UW
+qF
 GU
 GU
 Fo
@@ -58997,17 +59545,17 @@ qF
 qF
 qF
 qF
-GU
-GU
-GU
-GU
 qF
 qF
 qF
 qF
 qF
 qF
-GU
+qF
+qF
+qF
+qF
+qF
 GU
 GU
 Fo
@@ -59253,17 +59801,17 @@ qF
 qF
 qF
 qF
-GU
-GU
-GU
-GU
-GU
-IQ
-xF
-xF
-xF
-xF
-IQ
+qF
+qF
+qF
+qF
+qF
+FA
+FA
+FA
+FA
+FA
+FA
 GU
 GU
 GU
@@ -59510,17 +60058,17 @@ qF
 qF
 qF
 qF
-GU
-IQ
-IQ
-IQ
-IQ
-CR
-Ew
-IQ
-zE
-di
-IQ
+qF
+FA
+FA
+FA
+FA
+FA
+FA
+VG
+FA
+FA
+FA
 GU
 GU
 GU
@@ -59768,16 +60316,16 @@ qF
 qF
 qF
 qF
-IQ
-Wy
-pb
-Pk
-SZ
-Th
-IQ
-Nj
-di
-IQ
+PI
+PI
+PI
+PI
+FA
+FA
+FA
+FA
+FA
+FA
 GU
 GU
 GU
@@ -60024,20 +60572,20 @@ qF
 qF
 qF
 qF
-qF
+GU
+PI
+PI
+PI
+PI
+IQ
 xF
-Ds
-PW
-uG
-KN
-ku
-CR
-Gi
+xF
+xF
+xF
 IQ
-IQ
-IQ
-IQ
-IQ
+PI
+PI
+PI
 tN
 tN
 tN
@@ -60281,20 +60829,20 @@ qF
 qF
 qF
 qF
-qF
-xF
-OS
-pb
-Qe
-CS
-Ai
-Th
-zE
-Js
-jb
-VO
-jl
+GU
 IQ
+IQ
+IQ
+IQ
+CR
+Ew
+IQ
+zE
+di
+IQ
+PI
+PI
+PI
 us
 GU
 GU
@@ -60540,18 +61088,18 @@ qF
 qF
 qF
 IQ
-rO
-jA
-nN
-CS
-Xv
-Bo
-zE
-yQ
-vE
-bs
-ti
+Wy
+pb
+Pk
+SZ
+Th
 IQ
+Nj
+di
+IQ
+PI
+PI
+PI
 us
 GU
 GU
@@ -60795,19 +61343,19 @@ qF
 qF
 qF
 qF
-GU
-IQ
-PY
-DT
-WQ
+qF
+xF
+Ds
+PW
+uG
+KN
+ku
 CR
-Lf
-Th
-Br
-ir
-fs
-BQ
-uI
+Gi
+IQ
+IQ
+IQ
+IQ
 IQ
 GU
 us
@@ -61051,20 +61599,20 @@ qF
 qF
 qF
 qF
-GU
-GU
-IQ
-IQ
-IQ
-IQ
-IQ
-CR
-mi
+qF
+qF
+xF
+OS
+pb
+Qe
+CS
+Ai
+Th
 zE
-IQ
-IQ
-IQ
-CR
+Js
+jb
+VO
+jl
 IQ
 GU
 us
@@ -61308,20 +61856,20 @@ qF
 qF
 qF
 qF
-GU
-GU
-GU
-IQ
-SX
-jR
-MM
-wr
-in
+qF
+qF
+eF
+rO
+jA
+nN
+CS
+Xv
+Bo
 zE
-Js
-XY
-cA
-jl
+yQ
+vE
+bs
+ti
 IQ
 GU
 us
@@ -61565,20 +62113,20 @@ qF
 qF
 qF
 qF
+qF
 GU
-GU
-GU
-IQ
-Ij
-td
-iY
-Gy
-BW
-zE
-yQ
-xf
-bs
-Vd
+eF
+PY
+DT
+WQ
+CR
+Lf
+Th
+Br
+ir
+fs
+BQ
+uI
 IQ
 GU
 GU
@@ -61824,18 +62372,18 @@ GU
 GU
 GU
 GU
-GU
+eF
 IQ
-sF
-uI
-or
-CW
-BW
-Br
-Ah
-vs
-BQ
-BQ
+IQ
+IQ
+IQ
+CR
+mi
+zE
+IQ
+IQ
+IQ
+CR
 IQ
 GU
 GU
@@ -62083,16 +62631,16 @@ GU
 GU
 GU
 IQ
-qp
-yT
-gX
+SX
+jR
+MM
 wr
-Ai
-Br
-FJ
-Az
-BF
-jx
+in
+zE
+Js
+XY
+cA
+jl
 IQ
 GU
 GU
@@ -62341,15 +62889,15 @@ GU
 GU
 IQ
 Ij
-WK
-At
-OC
-Ai
+td
+iY
+Gy
+BW
 zE
 yQ
-ql
-CF
-NU
+xf
+bs
+Vd
 IQ
 GU
 GU
@@ -62597,16 +63145,16 @@ GU
 GU
 GU
 IQ
-Uv
-DF
-rs
-YD
-hc
-zE
-zF
-WG
-bs
-tr
+sF
+uI
+or
+CW
+BW
+Br
+Ah
+vs
+BQ
+BQ
 IQ
 us
 us
@@ -62854,16 +63402,16 @@ GU
 GU
 GU
 IQ
-IQ
-IQ
-IQ
-IQ
-CR
-IQ
-IQ
-IQ
-IQ
-IQ
+qp
+yT
+gX
+wr
+Ai
+Br
+FJ
+Az
+BF
+jx
 IQ
 us
 GU
@@ -63110,18 +63658,18 @@ GU
 GU
 GU
 GU
-GU
-GU
-GU
-jZ
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+eF
+tr
+FI
+ip
+NZ
+JW
+DF
+aC
+NL
+SI
+rm
+eF
 GU
 GU
 GU
@@ -63367,18 +63915,18 @@ GU
 GU
 GU
 GU
-GU
-GU
-GU
-jZ
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+eF
+OK
+LM
+jq
+fn
+Up
+DF
+QL
+GF
+ic
+Ic
+eF
 GU
 GU
 GU
@@ -63624,18 +64172,18 @@ GU
 GU
 GU
 GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-Yj
-Yj
+eF
+eF
+eF
+eF
+eF
+Fd
+eF
+eF
+eF
+eF
+eF
+eF
 Yj
 Yj
 Yj

--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -222,24 +222,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/campfire/stove{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/storage/box/matches,
-/turf/open/floor/carpet/red,
+/obj/structure/table/plasmaglass,
+/obj/item/storage/box/dice,
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "aC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/railing{
+	dir = 8
 	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "aE" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -712,13 +706,12 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bM" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1;
-	pixel_y = 0;
-	color = "brown"
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/bar/heaven)
 "bN" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -815,6 +808,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"cd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "ce" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4;
@@ -823,11 +823,9 @@
 /turf/open/water,
 /area/f13/building/tribal)
 "cf" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "cg" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -1335,31 +1333,18 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
-"dc" = (
+"dd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp/left{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "de" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/effect/step_trigger/player_choice_log{
-	title = "Welcome to Heavens Night.";
-	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/area/f13/caves)
 "df" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -1404,8 +1389,9 @@
 	},
 /area/f13/building)
 "dn" = (
+/obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+	color = "#883300"
 	},
 /area/f13/wasteland)
 "do" = (
@@ -1448,7 +1434,10 @@
 /turf/open/indestructible,
 /area/f13/tcoms)
 "dt" = (
-/turf/open/floor/carpet/black,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "du" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
@@ -1459,6 +1448,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"dv" = (
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "dx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
@@ -1616,13 +1619,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"dR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random{
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "dS" = (
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -1832,14 +1828,6 @@
 "ek" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
-"el" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "em" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1903,9 +1891,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
 "et" = (
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	pixel_x = -15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "eu" = (
 /obj/structure/simple_door/interior,
 /obj/item/lock_bolt{
@@ -1981,15 +1972,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/wasteland/city/newboston/house/cabin_one)
 "eF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444";
-	pixel_x = -16;
-	pixel_y = -8
+/obj/machinery/light/small{
+	color = "#444499";
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = -13
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "eG" = (
 /obj/structure/railing{
@@ -2031,20 +2021,12 @@
 /area/f13/wasteland/city/newboston/house)
 "eK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
-"eL" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital/clinic/nash)
 "eM" = (
 /obj/structure/chair/sofa/left{
 	dir = 8;
@@ -2153,7 +2135,14 @@
 	},
 /area/f13/ncr)
 "fa" = (
-/obj/structure/table/plasmaglass,
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
+	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "fc" = (
@@ -2237,12 +2226,8 @@
 	},
 /area/f13/ncr)
 "fk" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	color = "pink"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "fl" = (
 /obj/structure/campfire/wallfire{
 	pixel_y = 29;
@@ -2264,11 +2249,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/caves)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "fo" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -2700,14 +2684,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
-"gc" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
 "ge" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -2715,14 +2691,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"gf" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/structure/sign/painting/library{
-	pixel_x = 28
-	},
-/obj/item/toy/plush/whitecat,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
 "gg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -2812,6 +2780,16 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
+"go" = (
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "gp" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -2873,8 +2851,11 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+	color = "#888888"
 	},
 /area/f13/wasteland)
 "gy" = (
@@ -2918,10 +2899,6 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
-/area/f13/bar/heaven)
-"gE" = (
-/obj/machinery/door/unpowered/securedoor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "gF" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -3127,11 +3104,12 @@
 	},
 /area/f13/building/tribal)
 "hc" = (
-/obj/structure/railing{
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "hd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3483,11 +3461,10 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "hU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/caves)
 "hV" = (
 /obj/structure/railing{
@@ -3523,16 +3500,23 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ic" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/chair/bench{
-	dir = 8
+/obj/machinery/button/door{
+	id = "xenobio55";
+	name = "Containment Blast Doors";
+	pixel_y = -6;
+	req_access_txt = null;
+	pixel_x = 26;
+	req_one_access_txt = null
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "id" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3677,6 +3661,13 @@
 	name = "dirty floor"
 	},
 /area/f13/caves)
+"iw" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	color = "pink"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "ix" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -3696,22 +3687,8 @@
 	},
 /area/f13/tribe)
 "iz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "xenobio55";
-	name = "Containment Blast Doors";
-	pixel_y = -6;
-	req_access_txt = null;
-	pixel_x = 26;
-	req_one_access_txt = null
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/f13/caves)
 "iA" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -3823,6 +3800,13 @@
 	},
 /turf/open/floor/grass,
 /area/f13/wasteland)
+"iR" = (
+/obj/structure/chair/sofa/right{
+	color = "#475340";
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "iS" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/reagent_containers/glass/bucket/wood{
@@ -4046,24 +4030,9 @@
 "jp" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/wasteland/city/newboston/house)
-"jq" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+"jr" = (
+/turf/open/transparent/openspace,
+/area/f13/city)
 "js" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -4450,19 +4419,30 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"kj" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "kk" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"kl" = (
-/obj/effect/overlay/palmtree_l{
-	pixel_x = -14;
-	color = "#F833DE"
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/bar/heaven)
 "km" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -4767,6 +4747,11 @@
 	color = "#779999"
 	},
 /area/f13/ncr)
+"kX" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "kY" = (
 /obj/effect/turf_decal/trimline/neutral{
 	dir = 4;
@@ -4858,26 +4843,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/wasteland)
-"ld" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/room{
-	name = "Clinic"
+"le" = (
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
+	},
+/obj/structure/curtain/directional/east{
+	color = "#450159"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
-"le" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_one_access_txt = "136"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/area/f13/wasteland/city/newboston/bank)
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral{
@@ -4939,6 +4914,15 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bank)
+"lo" = (
+/obj/machinery/light/small{
+	color = "#FFC0CB";
+	light_color = "#FFC0CB";
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "lp" = (
 /obj/structure/rack/shelf_wood/modern,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -5175,21 +5159,12 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
-"lP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
 "lR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
 "lS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5314,6 +5289,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mh" = (
+/obj/item/watertank/janitor{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "mi" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
@@ -5461,10 +5442,12 @@
 	},
 /area/f13/building)
 "mx" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
+/obj/structure/chair/sofa/corner{
+	color = "#475340";
 	dir = 1
 	},
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "my" = (
 /obj/structure/simple_door/room,
 /obj/item/lock_bolt{
@@ -5473,26 +5456,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mz" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/area/f13/wasteland)
 "mA" = (
 /obj/structure/rack/shelf_metal/modern,
 /obj/item/stack/sheet/sandblock/five,
@@ -5770,9 +5739,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nc" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/structure/railing{
+	pixel_y = -3
 	},
+/turf/open/transparent/openspace,
 /area/f13/caves)
 "nd" = (
 /obj/structure/curtain{
@@ -5931,9 +5901,17 @@
 	},
 /area/f13/building/tribal)
 "nu" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_y = 8;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "nw" = (
 /obj/machinery/workbench{
 	pixel_y = 18;
@@ -6649,6 +6627,14 @@
 /obj/item/reagent_containers/rag/towel/random,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
+"pf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "pg" = (
 /obj/item/weapon/copperpot2,
 /obj/item/weapon/copperpot,
@@ -6813,11 +6799,14 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "py" = (
-/obj/item/watertank/janitor{
-	pixel_y = 24
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland/city/newboston/outdoors)
 "pz" = (
 /obj/structure/railing{
 	dir = 10
@@ -6895,8 +6884,12 @@
 	},
 /area/f13/building/tribal)
 "pI" = (
-/turf/open/transparent/openspace,
-/area/f13/city)
+/obj/structure/chair/sofa/right{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "pJ" = (
 /obj/structure/table/glass,
 /obj/item/stack/tile/blackmarble/thirty{
@@ -6917,16 +6910,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "pM" = (
-/obj/structure/chair/sofa/right{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
-"pN" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
+/obj/structure/curtain{
+	color = "#c40e0e";
+	alpha = 255
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -7007,6 +6993,14 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
+"pX" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "pY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -7047,13 +7041,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
-"qc" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
 "qd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7123,11 +7110,20 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ql" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	color = "#444499";
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = -13
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -7201,18 +7197,17 @@
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "qu" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 5;
-	pixel_y = 3;
-	pixel_x = 2
+/obj/machinery/light/small{
+	light_color = "#884444"
 	},
-/turf/open/transparent/openspace,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "qv" = (
 /obj/structure/chair/sofa/left{
 	color = "#353535";
@@ -7234,16 +7229,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building)
-"qy" = (
-/obj/structure/railing/corner{
-	color = "#A47449"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_x = 10
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
 "qz" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -7306,11 +7291,6 @@
 	color = "#779999"
 	},
 /area/f13/wasteland)
-"qJ" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "qK" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8
@@ -7539,10 +7519,6 @@
 /obj/structure/chair/metal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
-"rm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "rn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookshelf{
@@ -7566,13 +7542,15 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "rs" = (
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "ru" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/food,
@@ -7624,12 +7602,6 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal)
-"rA" = (
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
 "rB" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -7647,11 +7619,21 @@
 	},
 /area/f13/building)
 "rE" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340"
+/obj/machinery/button/door{
+	id = "xenobio44";
+	name = "Containment Blast Doors";
+	pixel_y = 36;
+	req_access_txt = null;
+	pixel_x = 5;
+	req_one_access_txt = null
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "rF" = (
 /obj/structure/railing{
 	dir = 6
@@ -7793,16 +7775,16 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/outdoors)
 "rW" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
 	},
-/obj/structure/chair/bench{
-	dir = 8
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	req_one_access_txt = "136"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "rX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/oldlamp{
@@ -8107,6 +8089,13 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"sH" = (
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "sJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -8155,18 +8144,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "sM" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
+/obj/structure/chair/sofa/corner{
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "sN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -8300,8 +8284,21 @@
 	},
 /area/f13/tribe)
 "ta" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/plasmaglass,
+/obj/structure/railing/dancing_pole{
+	pixel_y = 31
+	},
+/obj/structure/railing/dancing_pole{
+	pixel_y = 10
+	},
+/obj/structure/fence/pole_b{
+	pixel_y = 7
+	},
+/obj/structure/fence/pole_t{
+	pixel_y = 36
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "tb" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -8476,12 +8473,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "tr" = (
-/obj/structure/curtain{
-	color = "#c40e0e";
-	alpha = 255
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "ts" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirtcorner,
@@ -8735,15 +8731,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
-"tZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
 "ua" = (
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/structure/bed/wooden,
@@ -8853,12 +8840,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "un" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/railing,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "uo" = (
 /obj/structure/rack,
 /obj/item/pickaxe/drill,
@@ -9050,14 +9034,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
-"uJ" = (
-/obj/structure/chair/sofa/corner{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "uK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
@@ -9229,6 +9205,9 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"ve" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "vf" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -9264,6 +9243,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
+"vj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "vk" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/f13{
@@ -9300,9 +9288,9 @@
 	},
 /area/f13/building/tribal)
 "vp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side{
+	dir = 1
+	},
 /area/f13/caves)
 "vq" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -9457,18 +9445,21 @@
 /turf/open/transparent/openspace,
 /area/f13/building)
 "vN" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/caves)
+/obj/structure/railing{
+	color = "#A47449";
+	pixel_y = -3
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "vO" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_one)
-"vP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
 "vQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -9785,10 +9776,12 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland/city/newboston/bank)
 "wE" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -9893,6 +9886,10 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_three,
 /turf/open/floor/wood_common,
 /area/f13/building)
+"wR" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "wS" = (
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_four)
@@ -10146,6 +10143,18 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/campfire/stove{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/storage/box/matches,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "xv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -10175,12 +10184,28 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "xA" = (
-/obj/structure/railing,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
 	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "xC" = (
 /obj/effect/overlay/junk/toilet{
 	pixel_x = 9;
@@ -10292,15 +10317,12 @@
 	},
 /area/f13/building/tribal)
 "xP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/left{
-	dir = 8;
-	pixel_x = 8;
-	pixel_y = 12
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/area/f13/wasteland)
 "xQ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10349,6 +10371,14 @@
 /mob/living/simple_animal/hostile/bs/paladin,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"ya" = (
+/obj/structure/railing/corner{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "yb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
@@ -10362,6 +10392,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"ye" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "yf" = (
 /obj/structure/safe{
 	pixel_x = 3
@@ -10628,18 +10667,11 @@
 	},
 /area/f13/building)
 "yN" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random{
+	pixel_y = 20
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"yP" = (
-/obj/structure/table/plasmaglass,
-/obj/item/restraints/handcuffs/fake/kinky,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10895,8 +10927,15 @@
 	},
 /area/f13/tribe)
 "zz" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/railing/corner{
+	color = "#A47449"
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 10
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "zB" = (
 /obj/machinery/light{
 	dir = 8
@@ -10928,12 +10967,12 @@
 	},
 /area/f13/building)
 "zF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "zG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -11303,14 +11342,8 @@
 	},
 /area/f13/tribe)
 "At" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/slime_extract/grey,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "Au" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13
@@ -11441,19 +11474,24 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
 "AJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "AK" = (
 /turf/open/transparent/glass,
 /area/f13/wasteland)
 "AL" = (
-/obj/structure/chair/sofa{
-	color = "#475340"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "AM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11774,12 +11812,16 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar/heaven)
 "Bx" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444";
+	pixel_x = -16;
+	pixel_y = -8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "Bz" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -11839,9 +11881,19 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/building/tribal/cave)
 "BH" = (
-/obj/structure/railing,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"BI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "BJ" = (
 /obj/structure/railing{
 	dir = 6
@@ -12014,6 +12066,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"Cg" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/f13/caves)
 "Ch" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13{
@@ -12080,17 +12139,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"Cn" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = -31;
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "Co" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -12243,11 +12291,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bar/heaven)
-"CD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
 "CE" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -12261,16 +12304,13 @@
 	},
 /area/f13/building/tribal)
 "CF" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 5;
-	pixel_y = 4
+/obj/machinery/light/small{
+	light_color = "#884444"
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/bank)
+/area/f13/bar/heaven)
 "CG" = (
 /obj/structure/table/greyscale,
 /obj/item/pda/bar{
@@ -12698,6 +12738,10 @@
 "DA" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"DB" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "DD" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -12722,21 +12766,15 @@
 	},
 /area/f13/building/tribal)
 "DF" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing/dancing_pole{
-	pixel_y = 31
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/railing/dancing_pole{
-	pixel_y = 10
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/structure/fence/pole_b{
-	pixel_y = 7
-	},
-/obj/structure/fence/pole_t{
-	pixel_y = 36
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "DG" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
@@ -12818,14 +12856,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "DS" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 25;
-	density = 0
-	},
-/turf/open/floor/f13{
-	icon_state = "darkredfull"
-	},
-/area/f13/wasteland/city/newboston/bank)
+/obj/machinery/door/unpowered/securedoor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bar/heaven)
 "DT" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -12986,13 +13019,13 @@
 	},
 /area/f13/building)
 "Ei" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8;
-	color = "pink"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Ej" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13098,14 +13131,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "Ev" = (
-/obj/machinery/mineral/wasteland_vendor/specialplus{
-	pixel_y = 25;
-	density = 0
-	},
-/turf/open/floor/f13{
-	icon_state = "darkredfull"
-	},
-/area/f13/wasteland/city/newboston/bank)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "Ew" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -13383,9 +13414,13 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "Fd" = (
-/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
 "Fe" = (
 /obj/structure/mirror{
@@ -13552,8 +13587,13 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "FA" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_y = 25
+	},
+/obj/structure/dresser,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "FB" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13{
@@ -13580,16 +13620,17 @@
 	},
 /area/f13/tribe)
 "FE" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats,
-/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
-/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
-/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	req_one_access_txt = "136"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "FF" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#999999"
@@ -13667,13 +13708,6 @@
 "FN" = (
 /turf/open/floor/wood_common,
 /area/f13/building)
-"FO" = (
-/obj/structure/chair/sofa/corner{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "FP" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/wood_common/wood_common_dark,
@@ -13738,29 +13772,20 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "FY" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/railing/wood/post{
-	pixel_x = 16;
-	pixel_y = 2
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/railing/wood/post{
-	pixel_x = -13;
-	pixel_y = 1
+/obj/effect/step_trigger/player_choice_log{
+	title = "Welcome to Heavens Night.";
+	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
 	},
-/obj/structure/curtain{
-	color = "#5c131b";
-	layer = 5;
-	pixel_x = 2;
-	pixel_y = -3
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/obj/structure/rug/mat{
-	color = "#CC4444";
-	layer = 6;
-	pixel_x = 2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "FZ" = (
 /obj/structure/fermenting_barrel{
@@ -13768,6 +13793,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Ga" = (
+/obj/structure/sign/poster/contraband/pinup_vixen{
+	icon_state = "poster52";
+	pixel_x = -28
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Gb" = (
 /obj/structure/table,
 /obj/structure/fluff/paper/stack,
@@ -13782,17 +13814,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"Ge" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Gf" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -13826,6 +13847,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
+"Gh" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Gi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/science/glass{
@@ -13840,23 +13867,6 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/building)
-"Gk" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite{
-	pixel_y = 6;
-	pixel_x = 1
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 4;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 5;
-	pixel_x = 6
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Gl" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -13964,6 +13974,10 @@
 /obj/item/storage/box/cups,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bank)
+"Gv" = (
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital/clinic/nash)
 "Gw" = (
 /obj/structure/bed{
 	pixel_y = 10
@@ -14026,6 +14040,17 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
+"GE" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 1;
+	pixel_y = -31;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "GG" = (
 /obj/item/storage/box/dice{
 	pixel_y = 7
@@ -14272,18 +14297,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Hg" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/chair/sofa/left{
+	color = "#475340"
 	},
-/obj/machinery/light/floor{
-	light_color = "#883388"
-	},
-/obj/machinery/light/small{
-	light_color = "#884444";
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "Hh" = (
 /turf/open/floor/wood_common,
@@ -14313,29 +14330,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
-"Hl" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "Hm" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -14509,14 +14503,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "HK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/obj/machinery/light/floor{
+	light_color = "#883388"
+	},
+/obj/machinery/light/small{
+	light_color = "#884444";
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "HL" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -14844,6 +14843,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
+"Ir" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1;
+	pixel_y = 0;
+	color = "brown"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "Is" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -14862,6 +14869,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
+"Iv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/left{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Iw" = (
 /obj/structure/rack/shelf_metal/modern,
 /obj/item/wrench/medical,
@@ -15133,12 +15150,15 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
 "IY" = (
-/obj/structure/railing,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"IZ" = (
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
 	},
-/area/f13/wasteland)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/caves)
 "Ja" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall/rust,
@@ -15193,6 +15213,14 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Jg" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/sign/painting/library{
+	pixel_x = 28
+	},
+/obj/item/toy/plush/whitecat,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "Jh" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/table/wood/settler,
@@ -15246,12 +15274,14 @@
 	},
 /area/f13/tribe)
 "Jo" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/structure/rack/shelf_metal{
+	pixel_y = 25;
+	density = 0
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/wasteland/city/newboston/bank)
 "Jp" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/f13{
@@ -15313,19 +15343,6 @@
 /obj/item/shovel/serrated,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"Ju" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1;
-	color = "brown"
-	},
-/obj/structure/rug/big/rug_red{
-	pixel_x = -16
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
 "Jw" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt,
@@ -15333,6 +15350,15 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/slime_extract/grey,
+/turf/open/floor/engine,
+/area/f13/caves)
 "Jy" = (
 /obj/structure/stone_tile/block{
 	pixel_x = 17;
@@ -15436,6 +15462,13 @@
 	name = "spring water"
 	},
 /area/f13/tribe)
+"JD" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "JE" = (
 /obj/machinery/light_switch{
 	pixel_y = 26
@@ -15535,16 +15568,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"JT" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "JU" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8;
@@ -15573,10 +15596,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"JW" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "JX" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/prisoner,
@@ -15619,14 +15638,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "Ke" = (
-/obj/machinery/light/small{
-	color = "#FFC0CB";
-	light_color = "#FFC0CB";
-	dir = 1;
-	pixel_y = 10
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "Kf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera,
@@ -15919,6 +15937,17 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
+"KF" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
+/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "KG" = (
 /obj/effect/turf_decal/weather/springflowers,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -15932,24 +15961,6 @@
 /obj/structure/bed/wooden,
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"KI" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "KJ" = (
 /turf/open/indestructible/ground/outside/water/running{
@@ -16070,14 +16081,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"KY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror{
-	pixel_y = 25
-	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "KZ" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/structure/wreck/trash/machinepile,
@@ -16098,14 +16101,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"Lb" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
 "Lc" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -16140,6 +16135,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"Lh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/room{
+	name = "Clinic"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "Li" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4;
@@ -16181,6 +16184,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"Lo" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/building/hospital/clinic/nash)
 "Lp" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/decal/cleanable/dirt,
@@ -16422,19 +16428,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
-"LV" = (
-/obj/structure/table/plasmaglass,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "LW" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -16511,20 +16504,17 @@
 	},
 /area/f13/building/tribal)
 "Mb" = (
-/obj/machinery/button/door{
-	id = "xenobio44";
-	name = "Containment Blast Doors";
-	pixel_y = 36;
-	req_access_txt = null;
-	pixel_x = 5;
-	req_one_access_txt = null
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 8;
-	network = list("ss13","rd")
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "Mc" = (
 /obj/structure/chair/left{
@@ -16856,19 +16846,18 @@
 /turf/open/floor/carpet/arcade,
 /area/f13/building)
 "MS" = (
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "MT" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4;
-	color = "pink"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "MU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -17171,6 +17160,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Nu" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Nv" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -17235,6 +17231,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
+"NB" = (
+/obj/structure/table/plasmaglass,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "NC" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
@@ -17245,12 +17246,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/wasteland/city/newboston/house/cabin_four)
-"NE" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
 "NF" = (
 /obj/machinery/computer/arcade/battle{
 	icon_state = "oldcomp";
@@ -17301,15 +17296,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "NL" = (
-/obj/structure/railing{
-	color = "#A47449";
-	pixel_y = -3
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "NM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -17401,13 +17390,12 @@
 	},
 /area/f13/building)
 "NU" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "pink"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "NV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor{
@@ -17462,6 +17450,14 @@
 	color = "#775555"
 	},
 /area/f13/ncr)
+"Oe" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Of" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/mop{
@@ -17554,6 +17550,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
+"Oq" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5;
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/bank)
 "Or" = (
 /obj/structure/railing/wooden_fencing,
 /obj/structure/railing/wooden_fencing{
@@ -17645,12 +17652,18 @@
 	},
 /area/f13/tribe)
 "OC" = (
-/obj/structure/sign/poster/contraband/pinup_vixen{
-	icon_state = "poster52";
-	pixel_x = -28
+/obj/structure/chair/sofa/corp{
+	dir = 1;
+	color = "brown"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/rug/big/rug_red{
+	pixel_x = -16
+	},
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "OD" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -17666,11 +17679,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/wasteland/city/newboston/bank)
-"OF" = (
-/obj/structure/table/plasmaglass,
-/obj/item/storage/box/dice,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "OG" = (
 /obj/structure/railing{
 	dir = 5
@@ -18156,11 +18164,14 @@
 /area/f13/wasteland/city/newboston/house/cabin_four)
 "PE" = (
 /obj/machinery/light/small{
-	light_color = "#884444"
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "PF" = (
 /obj/structure/table/glass,
@@ -18185,19 +18196,18 @@
 	},
 /area/f13/building)
 "PI" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
-/obj/item/kirbyplants/random{
-	pixel_y = 20
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5;
+	pixel_y = 3;
+	pixel_x = 2
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/transparent/openspace,
+/area/f13/building/hospital/clinic/nash)
 "PJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -18407,14 +18417,6 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
-"Qh" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "Qi" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -18476,14 +18478,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Qr" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Qs" = (
 /mob/living/simple_animal/hostile/bs/knight,
 /turf/open/floor/carpet/royalblack,
@@ -18518,6 +18512,27 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
+"Qy" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "Qz" = (
 /obj/effect/landmark/start/f13/hunter,
 /turf/open/indestructible/ground/inside/mountain{
@@ -18553,13 +18568,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"QC" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4;
-	color = "pink"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "QD" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -18573,6 +18581,11 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
+"QF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "QH" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/curtain/directional/west{
@@ -18603,13 +18616,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/city)
-"QM" = (
-/obj/effect/overlay/palmtree_r{
-	pixel_x = 16;
-	color = "#F833DE"
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/bar/heaven)
 "QN" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -18644,6 +18650,15 @@
 /obj/item/clothing/shoes/laceup,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"QR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "QS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18928,13 +18943,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
-"RC" = (
-/obj/structure/chair/sofa/right{
-	dir = 1;
-	pixel_x = -15
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "RD" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Proctors";
@@ -18997,12 +19005,9 @@
 	},
 /area/f13/tribe)
 "RL" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/plasmaglass,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "RM" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/clothing/under/fancy_red_formaldress,
@@ -19060,11 +19065,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "RR" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 4
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	pixel_x = -6
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/rug/big/rug_red,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "RS" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -19234,14 +19240,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Si" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/structure/chair/sofa{
+	color = "#475340"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Sj" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "120"
@@ -19338,12 +19341,11 @@
 	},
 /area/f13/building)
 "Su" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1;
-	pixel_x = -6
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/curtain{
+	color = "#c40e0e"
 	},
-/obj/structure/rug/big/rug_red,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "Sv" = (
 /turf/closed/indestructible/rock,
@@ -19448,11 +19450,8 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "SI" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
+/turf/closed/mineral/random/low_chance,
+/area/f13/building)
 "SJ" = (
 /obj/structure/anvil/obtainable/basic,
 /obj/item/melee/smith/hammer/premade,
@@ -19482,12 +19481,10 @@
 	},
 /area/f13/tribe)
 "SO" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 8
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/area/f13/caves)
 "SQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -19567,13 +19564,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
-"Ta" = (
-/obj/effect/overlay/palmtree_r{
-	pixel_x = 16;
-	color = "#F833DE"
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/caves)
 "Tb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19837,11 +19827,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "TM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "TN" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -20048,6 +20035,14 @@
 	icon_state = "common-broken2"
 	},
 /area/f13/wasteland)
+"Uj" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "Uk" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
@@ -20110,17 +20105,14 @@
 	},
 /area/f13/building)
 "Uv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 25;
+	density = 0
 	},
-/obj/machinery/light/small{
-	light_color = "#884444"
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
+/area/f13/wasteland/city/newboston/bank)
 "Uw" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -20207,21 +20199,10 @@
 	},
 /area/f13/building/tribal)
 "UI" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
-"UJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "UK" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
@@ -20490,9 +20471,6 @@
 	color = "#779999"
 	},
 /area/f13/ncr)
-"Vn" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
 "Vo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1";
@@ -20518,24 +20496,30 @@
 	},
 /area/f13/building/tribal)
 "Vp" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
+/obj/structure/bed/wooden,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/railing/wood/post{
+	pixel_x = 16;
+	pixel_y = 2
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Vq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/railing/wood/post{
+	pixel_x = -13;
+	pixel_y = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/curtain{
+	color = "#5c131b";
+	layer = 5;
+	pixel_x = 2;
+	pixel_y = -3
 	},
-/area/f13/wasteland)
+/obj/structure/rug/mat{
+	color = "#CC4444";
+	layer = 6;
+	pixel_x = 2;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "Vr" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -20634,8 +20618,13 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "VC" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa/corp/right{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "VD" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = -4;
@@ -20668,11 +20657,16 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "VG" = (
-/obj/structure/railing/corner{
+/obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "VH" = (
 /obj/structure/table/wood/fancy/blackred{
 	density = 0;
@@ -20713,6 +20707,13 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
+"VL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "VM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -21093,17 +21094,38 @@
 	name = "dirty floor"
 	},
 /area/f13/bar/heaven)
-"WF" = (
-/obj/structure/chair/sofa/right{
-	color = "#475340";
-	dir = 1
+"WE" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "pink"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
-"WG" = (
+"WF" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8;
+	color = "pink"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"WG" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 4;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "WI" = (
 /obj/structure/fence/wooden{
 	dir = 8;
@@ -21131,16 +21153,11 @@
 	},
 /area/f13/building)
 "WK" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 8;
-	pixel_x = 2
-	},
-/turf/open/floor/carpet/black,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/bar/heaven)
 "WL" = (
 /obj/structure/table/wood,
@@ -21262,6 +21279,11 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"Xa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "Xc" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -21279,6 +21301,11 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"Xd" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "Xf" = (
 /obj/item/storage/fancy/heart_box{
 	desc = "A heart shaped chocolate box, in memory of Xena.  Fens cat who passed in 2015.  Her mob here has been rescued from ARFS Dallus 1 for 1 from the final version of its map."
@@ -21418,16 +21445,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"Xx" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
 "Xy" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -21528,18 +21545,13 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"XK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
 "XL" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "XM" = (
 /obj/structure/table/wood/settler,
 /obj/structure/railing{
@@ -21592,11 +21604,17 @@
 	},
 /area/f13/caves)
 "XQ" = (
-/obj/structure/chair/sofa/left{
-	dir = 4;
-	pixel_x = -6
+/obj/structure/table/plasmaglass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "XR" = (
 /obj/structure/barricade/bars,
@@ -21618,11 +21636,16 @@
 	},
 /area/f13/bar/heaven)
 "XT" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "XU" = (
 /obj/structure/railing/corner{
@@ -21935,16 +21958,12 @@
 	},
 /area/f13/building)
 "YD" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	req_one_access_txt = "136"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/structure/railing,
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "YE" = (
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
@@ -22298,13 +22317,9 @@
 	},
 /area/f13/building)
 "Zx" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -22315,12 +22330,14 @@
 	},
 /area/f13/building)
 "Zz" = (
-/obj/effect/overlay/palmtree_l{
-	pixel_x = -14;
-	color = "#F833DE"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/caves)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "ZB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -22340,8 +22357,8 @@
 	},
 /area/f13/building)
 "ZD" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital/clinic/nash)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/caves)
 "ZE" = (
 /mob/living/simple_animal/hostile/bs/knight,
 /turf/open/floor/carpet/red,
@@ -22354,27 +22371,20 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "ZJ" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/glitter/blue{
 	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
+	layer = 3
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "ZK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "ZL" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -44392,19 +44402,19 @@ kn
 TQ
 cJ
 tj
-FY
+Vp
 YE
-XQ
-Su
+sH
+RR
 tj
-dt
-dt
-dt
+IY
+IY
+IY
 tj
 zp
-Ge
-RR
-FO
+fa
+AJ
+mx
 tj
 tN
 tN
@@ -44642,26 +44652,26 @@ tN
 tj
 hg
 ys
-dt
-pN
-ql
-el
-WK
-dt
+IY
+Nu
+BH
+pX
+nu
+IY
 tj
-ZK
+XT
 Op
 nZ
-RC
+et
 tj
-MT
-QC
-MS
+iw
+NU
+ZJ
 tj
 RP
-fa
-fa
-jq
+RL
+RL
+ql
 tj
 tN
 tN
@@ -44904,21 +44914,21 @@ yx
 Zm
 kC
 ob
-dt
+IY
 tj
-KY
+FA
 Op
 YE
 YE
 tj
-LV
-OF
-dt
+XQ
+aB
+IY
 tj
-AL
-fa
-DF
-eL
+Si
+RL
+ta
+zF
 tj
 tN
 tN
@@ -45163,19 +45173,19 @@ tj
 tj
 tj
 tj
-dR
+yN
 Op
 Op
 YE
 tj
-Ei
-fk
-dt
-tj
-rE
-Zm
-yP
 WF
+WE
+IY
+tj
+Hg
+Zm
+NB
+iR
 tj
 tN
 OW
@@ -45411,7 +45421,7 @@ Eo
 Eo
 Eo
 tj
-aC
+VL
 Ux
 tj
 Sq
@@ -45420,22 +45430,22 @@ Bv
 tj
 wf
 tj
-aB
+xu
 YE
 Op
 YE
 tj
-dt
-dt
-dt
+IY
+IY
+IY
 tj
-Zx
-MS
-dt
+PE
 ZJ
+IY
+eF
 tj
 Ws
-NL
+vN
 eV
 NR
 aN
@@ -45444,11 +45454,11 @@ aN
 kY
 eV
 Cd
-rW
-ic
-rW
-ic
+VG
 gw
+VG
+gw
+aC
 ZO
 tN
 tN
@@ -45666,7 +45676,7 @@ qF
 tj
 WW
 OY
-cf
+dt
 tj
 Ux
 Ux
@@ -45679,19 +45689,19 @@ OY
 tj
 tj
 tj
-XT
+Su
 oN
 tj
-XT
+Su
 tj
-SO
+XL
 tj
-SO
-XT
+XL
+Su
 tj
 tj
 tj
-ta
+fk
 TC
 eV
 NR
@@ -45701,12 +45711,12 @@ In
 gP
 az
 Cd
-Lb
-gc
-Lb
-gc
+Oe
+Uj
+Oe
+Uj
+kX
 dn
-SI
 tN
 tN
 tN
@@ -45922,7 +45932,7 @@ GU
 qF
 tj
 lL
-eF
+Bx
 OY
 AA
 OY
@@ -45935,20 +45945,20 @@ eG
 Uc
 tj
 as
-OC
-dt
-dt
-dt
-dt
+Ga
+IY
+IY
+IY
+IY
 as
-dt
-dt
-dt
-dt
+IY
+IY
+IY
+IY
 tj
-ta
-ta
-ta
+fk
+fk
+fk
 TC
 eV
 Dv
@@ -45962,8 +45972,8 @@ tN
 tN
 tN
 tN
-UI
-IY
+Ke
+mz
 tN
 tN
 tN
@@ -46190,22 +46200,22 @@ CV
 Hy
 Kk
 ot
-tr
-dt
-dt
-dt
-dt
+pM
+IY
+IY
+IY
+IY
 ch
-dt
-dt
-dt
-dt
+IY
+IY
+IY
+IY
 JG
-dt
+IY
 tj
-ta
-ta
-ta
+fk
+fk
+fk
 TC
 eV
 NR
@@ -46219,8 +46229,8 @@ tN
 tN
 tN
 tN
-Vq
-xA
+MT
+xP
 tN
 tN
 tN
@@ -46447,22 +46457,22 @@ AW
 cs
 cB
 HA
-tr
-dt
-dt
+pM
+IY
+IY
 JG
-dt
-dt
+IY
+IY
 JG
 ch
-dt
-dt
+IY
+IY
 tj
 ni
 tj
-ta
-ta
-ta
+fk
+fk
+fk
 TC
 eV
 UL
@@ -46476,8 +46486,8 @@ tN
 tN
 tN
 tN
-UI
-IY
+Ke
+mz
 tN
 tN
 tN
@@ -46703,23 +46713,23 @@ ot
 OY
 ot
 ot
-PE
+CF
 tj
-dt
-dt
+IY
+IY
 tj
-XT
-Jo
+Su
+Zx
 tj
-Jo
+Zx
 tj
-XT
+Su
 tj
 tj
 tj
-ta
-ta
-ta
+fk
+fk
+fk
 TC
 eV
 eV
@@ -46733,8 +46743,8 @@ tN
 tN
 tN
 tN
-rs
-xA
+Ei
+xP
 tN
 tN
 tN
@@ -46954,30 +46964,30 @@ jo
 tF
 VZ
 tj
-Hg
+HK
 Hw
 uT
 uT
 Sd
 nf
-PE
+CF
 tj
-dt
-dt
+IY
+IY
 tj
-PI
+dv
 ch
 tj
-MS
+ZJ
 dG
 cP
 tj
-ta
-ta
-ta
-ta
-ta
-ta
+fk
+fk
+fk
+fk
+fk
+fk
 hE
 Tr
 lf
@@ -46990,8 +47000,8 @@ tN
 tN
 tN
 tN
-UI
-IY
+Ke
+mz
 tN
 tN
 tN
@@ -47218,23 +47228,23 @@ ud
 MG
 RB
 OY
-tr
-MS
-dt
-tj
 pM
-dt
+ZJ
+IY
 tj
-MS
-dt
+pI
+IY
+tj
+ZJ
+IY
 ch
-kl
-Vp
-ta
-ta
-ta
-ta
-ta
+WK
+rs
+fk
+fk
+fk
+fk
+fk
 hE
 Zj
 ZY
@@ -47247,8 +47257,8 @@ tN
 tN
 tN
 tN
-rs
-SI
+Ei
+dn
 tN
 tN
 tN
@@ -47475,23 +47485,23 @@ kM
 LZ
 NA
 ot
-tr
-dt
-dt
+pM
+IY
+IY
 tj
-uJ
-xP
+sM
+Iv
 tj
-Gk
-Qr
-dc
-QM
-ta
-ta
-ta
-ta
-ta
-ta
+WG
+VC
+QR
+bM
+fk
+fk
+fk
+fk
+fk
+fk
 hE
 EX
 ZY
@@ -47504,8 +47514,8 @@ tN
 tN
 tN
 tN
-UI
-NE
+Ke
+Gh
 tN
 tN
 tN
@@ -47731,24 +47741,24 @@ Op
 Op
 YE
 YE
-Uv
+qu
 tj
-gE
-gE
-tj
-tj
+DS
+DS
 tj
 tj
 tj
 tj
 tj
 tj
-JW
+tj
+tj
+DB
 qS
 qS
 qS
 qS
-Qh
+ya
 hE
 cL
 nr
@@ -47990,8 +48000,8 @@ qt
 ws
 OY
 VZ
-de
-de
+FY
+FY
 tj
 xx
 xx
@@ -48000,11 +48010,11 @@ xx
 xx
 xx
 xx
-nu
+wR
 Ap
 Ap
 Ap
-rA
+nc
 dK
 gL
 YV
@@ -48234,8 +48244,8 @@ Yj
 GU
 GU
 GU
-Zz
-sM
+lR
+Mb
 xx
 xx
 tj
@@ -48247,7 +48257,7 @@ tj
 tj
 zD
 VZ
-Ke
+lo
 xx
 Yy
 xx
@@ -48257,11 +48267,11 @@ xx
 xx
 xx
 xx
-VG
-hc
-hc
-hc
-Cn
+de
+tr
+tr
+tr
+GE
 dK
 hE
 vd
@@ -48491,7 +48501,7 @@ Yj
 GU
 GU
 GU
-Ta
+IZ
 EY
 xx
 xx
@@ -48503,8 +48513,8 @@ dS
 jI
 dS
 jI
-kl
-JT
+WK
+go
 xx
 xx
 qF
@@ -48760,7 +48770,7 @@ Kg
 XS
 CC
 BR
-QM
+bM
 xx
 xx
 xx
@@ -49018,7 +49028,7 @@ tj
 tj
 tj
 tj
-Ke
+lo
 xx
 xx
 Qk
@@ -49279,7 +49289,7 @@ xx
 xx
 qF
 Qk
-mz
+Qy
 PR
 Qk
 Qk
@@ -49536,7 +49546,7 @@ xx
 qF
 um
 Qk
-Hl
+xA
 cR
 cR
 cR
@@ -50564,7 +50574,7 @@ qF
 qF
 qF
 Sf
-KI
+kj
 VF
 CT
 OQ
@@ -50833,7 +50843,7 @@ JR
 TF
 rN
 dK
-RL
+YD
 dK
 jp
 jp
@@ -51090,7 +51100,7 @@ NM
 AX
 rN
 dK
-RL
+YD
 dK
 dK
 dK
@@ -51347,7 +51357,7 @@ YS
 ID
 lI
 dK
-RL
+YD
 ci
 eW
 FP
@@ -51583,7 +51593,7 @@ DO
 DO
 DO
 DO
-Bx
+le
 DO
 DO
 DO
@@ -51604,7 +51614,7 @@ SY
 Pu
 rN
 dK
-RL
+YD
 dK
 Xq
 GW
@@ -51861,7 +51871,7 @@ lW
 ff
 Sf
 dK
-RL
+YD
 dK
 eW
 eW
@@ -52118,7 +52128,7 @@ Sf
 Sf
 Sf
 dK
-Xx
+DF
 dK
 eW
 zT
@@ -52619,8 +52629,8 @@ PC
 wp
 wp
 dh
-XK
-et
+eK
+Gv
 dX
 hC
 ad
@@ -52872,13 +52882,13 @@ DO
 DO
 MP
 DO
-VC
+Lo
 rC
 pa
-WG
+MS
 rC
-CD
-WG
+UI
+MS
 hC
 hC
 Mk
@@ -53124,15 +53134,15 @@ us
 Ny
 UM
 mT
-Ju
+OC
 DO
-DS
+Jo
 Vh
 MP
 DO
 ks
 Wm
-un
+hc
 rC
 GU
 GU
@@ -53381,9 +53391,9 @@ GU
 DO
 zj
 mT
-bM
+Ir
 DO
-Ev
+Uv
 Vh
 Dx
 DO
@@ -53403,7 +53413,7 @@ OJ
 OJ
 tI
 dK
-yN
+py
 dK
 dK
 rl
@@ -53647,8 +53657,8 @@ DO
 GI
 Wm
 Wm
-ld
-ZD
+Lh
+At
 bD
 hC
 TO
@@ -53894,19 +53904,19 @@ GU
 GU
 Ny
 VS
-qy
+zz
 mT
 DO
 DO
 DO
 DO
 DO
-qJ
+fn
 Wm
-FE
+KF
 rC
-py
-ZD
+mh
+At
 hC
 If
 bH
@@ -54152,13 +54162,13 @@ GU
 Ny
 DO
 Ny
-qc
+JD
 mT
-Bx
+wD
 Wm
 zb
 Wm
-qu
+PI
 Wm
 IC
 rC
@@ -54409,10 +54419,10 @@ GU
 GU
 GU
 DO
-CF
+Oq
 mT
 DO
-XL
+NL
 Wm
 Wm
 Wm
@@ -54670,7 +54680,7 @@ DO
 DO
 rC
 rC
-WG
+MS
 pa
 rC
 pa
@@ -54927,11 +54937,11 @@ GU
 GU
 GU
 rC
-Si
+ye
 ga
 rC
-wD
-lP
+QF
+Zz
 rC
 GU
 GU
@@ -55441,7 +55451,7 @@ GU
 GU
 GU
 rC
-gf
+Jg
 gv
 rC
 gv
@@ -57769,8 +57779,8 @@ qF
 qF
 qF
 qF
-Vn
-pI
+ve
+jr
 Fo
 sh
 sh
@@ -58026,8 +58036,8 @@ qF
 qF
 qF
 qF
-BH
-pI
+un
+jr
 Fo
 lD
 rJ
@@ -58283,8 +58293,8 @@ Al
 uF
 Bh
 Qw
-Vn
-pI
+ve
+jr
 Fo
 lb
 hx
@@ -58540,8 +58550,8 @@ PS
 tB
 TU
 Dn
-vN
-nc
+ZD
+SO
 Fo
 MF
 FV
@@ -58797,8 +58807,8 @@ BZ
 PK
 jh
 ok
-vN
-nc
+ZD
+SO
 Fo
 fj
 hx
@@ -59054,8 +59064,8 @@ Cs
 Ql
 jW
 UW
-vN
-vN
+ZD
+ZD
 Fo
 ov
 hx
@@ -59818,12 +59828,12 @@ qF
 qF
 qF
 qF
-zz
-zz
-zz
-zz
-zz
-zz
+TM
+TM
+TM
+TM
+TM
+TM
 GU
 GU
 GU
@@ -60071,16 +60081,16 @@ qF
 qF
 qF
 qF
-zz
-zz
-zz
-zz
-zz
-zz
-rm
-zz
-zz
-zz
+TM
+TM
+TM
+TM
+TM
+TM
+cf
+TM
+TM
+TM
 GU
 GU
 GU
@@ -60328,16 +60338,16 @@ qF
 qF
 qF
 qF
-FA
-FA
-FA
-FA
-zz
-zz
-zz
-zz
-zz
-zz
+SI
+SI
+SI
+SI
+TM
+TM
+TM
+TM
+TM
+TM
 GU
 GU
 GU
@@ -60585,19 +60595,19 @@ qF
 qF
 qF
 GU
-FA
-FA
-FA
-FA
+SI
+SI
+SI
+SI
 IQ
 xF
 xF
 xF
 xF
 IQ
-FA
-FA
-FA
+SI
+SI
+SI
 tN
 tN
 tN
@@ -60852,9 +60862,9 @@ IQ
 zE
 di
 IQ
-FA
-FA
-FA
+SI
+SI
+SI
 us
 GU
 GU
@@ -61109,9 +61119,9 @@ IQ
 Nj
 di
 IQ
-FA
-FA
-FA
+SI
+SI
+SI
 us
 GU
 GU
@@ -61870,7 +61880,7 @@ qF
 qF
 qF
 qF
-nc
+SO
 rO
 jA
 nN
@@ -62127,7 +62137,7 @@ qF
 qF
 qF
 GU
-nc
+SO
 PY
 DT
 WQ
@@ -62384,7 +62394,7 @@ GU
 GU
 GU
 GU
-nc
+SO
 IQ
 IQ
 IQ
@@ -63670,18 +63680,18 @@ GU
 GU
 GU
 GU
-nc
-NU
-At
-le
-hU
+SO
+ZK
+Jx
+FE
+Ev
+Xa
 vp
-mx
-tZ
-YD
-eK
 Fd
-nc
+rW
+AL
+Xd
+SO
 GU
 GU
 GU
@@ -63927,18 +63937,18 @@ GU
 GU
 GU
 GU
-nc
-vP
-zF
-UJ
-HK
-Mb
-mx
+SO
 iz
-lR
-TM
-AJ
-nc
+cd
+pf
+vj
+rE
+vp
+ic
+Cg
+dd
+BI
+SO
 GU
 GU
 GU
@@ -64184,18 +64194,18 @@ GU
 GU
 GU
 GU
-nc
-nc
-nc
-nc
-nc
-fn
-nc
-nc
-nc
-nc
-nc
-nc
+SO
+SO
+SO
+SO
+SO
+hU
+SO
+SO
+SO
+SO
+SO
+SO
 Yj
 Yj
 Yj

--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -9,29 +9,6 @@
 /obj/structure/rug/carpet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ac" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "ad" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/wasteland/city/newboston/house/cabin_three)
@@ -244,22 +221,24 @@
 /obj/item/kirbyplants,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
+"aB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
-"aD" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1;
-	pixel_x = -6
+/obj/structure/campfire/stove{
+	density = 0;
+	pixel_x = 8;
+	pixel_y = 11
 	},
-/obj/structure/rug/big/rug_red,
+/obj/item/grown/log/tree,
+/obj/item/grown/log/tree,
+/obj/item/storage/box/matches,
 /turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
+"aC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "aE" = (
 /obj/machinery/vending/nukacolavendfull,
@@ -318,13 +297,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"aK" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4;
-	color = "pink"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "aL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glitter/blue{
@@ -604,19 +576,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
-"bt" = (
-/obj/structure/table/plasmaglass,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/tavern_wall{
@@ -753,12 +712,13 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bM" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4;
-	color = "pink"
+/obj/structure/chair/sofa/corp/right{
+	dir = 1;
+	pixel_y = 0;
+	color = "brown"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "bN" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -863,10 +823,11 @@
 /turf/open/water,
 /area/f13/building/tribal)
 "cf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "cg" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -876,9 +837,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "ch" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -1058,15 +1018,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building)
-"cr" = (
-/obj/machinery/light/small{
-	color = "#FFC0CB";
-	light_color = "#FFC0CB";
-	dir = 1;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "cs" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1384,14 +1335,31 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
-"de" = (
+"dc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/room{
-	name = "Clinic"
+/obj/structure/chair/sofa/corp/left{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"de" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/step_trigger/player_choice_log{
+	title = "Welcome to Heavens Night.";
+	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bar/heaven)
 "df" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -1427,15 +1395,6 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
-"dl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp/left{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "dm" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -1445,17 +1404,10 @@
 	},
 /area/f13/building)
 "dn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/campfire/stove{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 11
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
 	},
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/storage/box/matches,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/area/f13/wasteland)
 "do" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1;
@@ -1496,10 +1448,6 @@
 /turf/open/indestructible,
 /area/f13/tcoms)
 "dt" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
-	pixel_y = -1
-	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "du" = (
@@ -1668,6 +1616,13 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
+"dR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "dS" = (
 /turf/open/floor/f13{
 	color = "#ffe9de";
@@ -1877,6 +1832,14 @@
 "ek" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
+"el" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "em" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1940,10 +1903,9 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
 "et" = (
-/obj/structure/table/plasmaglass,
-/obj/item/restraints/handcuffs/fake/kinky,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital/clinic/nash)
 "eu" = (
 /obj/structure/simple_door/interior,
 /obj/item/lock_bolt{
@@ -2019,10 +1981,16 @@
 /turf/open/floor/carpet/black,
 /area/f13/wasteland/city/newboston/house/cabin_one)
 "eF" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444";
+	pixel_x = -16;
+	pixel_y = -8
 	},
-/area/f13/caves)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "eG" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -2062,9 +2030,21 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland/city/newboston/house)
 "eK" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/f13/caves)
+"eL" = (
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "eM" = (
 /obj/structure/chair/sofa/left{
 	dir = 8;
@@ -2173,23 +2153,9 @@
 	},
 /area/f13/ncr)
 "fa" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"fb" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/structure/sign/painting/library{
-	pixel_x = 28
-	},
-/obj/item/toy/plush/whitecat,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/table/plasmaglass,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "fc" = (
 /obj/structure/rack/shelf_metal/modern,
 /obj/item/storage/toolbox/mechanical{
@@ -2202,15 +2168,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"fd" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "fe" = (
 /obj/structure/window/fulltile/wood_window{
 	icon_state = "storewindowvertical";
@@ -2280,8 +2237,12 @@
 	},
 /area/f13/ncr)
 "fk" = (
-/turf/open/transparent/openspace,
-/area/f13/city)
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "pink"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "fl" = (
 /obj/structure/campfire/wallfire{
 	pixel_y = 29;
@@ -2303,13 +2264,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
+	},
 /area/f13/caves)
 "fo" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -2742,6 +2700,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
+"gc" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "ge" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -2749,6 +2715,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"gf" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/sign/painting/library{
+	pixel_x = 28
+	},
+/obj/item/toy/plush/whitecat,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "gg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -2812,12 +2786,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
-"gl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "gm" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 4
@@ -2844,11 +2812,6 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
-"go" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "gp" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -2910,11 +2873,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/chair/bench{
-	dir = 8
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+	color = "#883300"
 	},
 /area/f13/wasteland)
 "gy" = (
@@ -2958,6 +2918,10 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
+/area/f13/bar/heaven)
+"gE" = (
+/obj/machinery/door/unpowered/securedoor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "gF" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -3163,19 +3127,11 @@
 	},
 /area/f13/building/tribal)
 "hc" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/light/floor{
-	light_color = "#883388"
-	},
-/obj/machinery/light/small{
-	light_color = "#884444";
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "hd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3527,10 +3483,11 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "hU" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/caves)
 "hV" = (
 /obj/structure/railing{
@@ -3566,11 +3523,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ic" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "id" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3655,18 +3617,6 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
-"ip" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_one_access_txt = "136"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
 "iq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -3727,9 +3677,6 @@
 	name = "dirty floor"
 	},
 /area/f13/caves)
-"iw" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/building/hospital/clinic/nash)
 "ix" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -3749,8 +3696,23 @@
 	},
 /area/f13/tribe)
 "iz" = (
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "xenobio55";
+	name = "Containment Blast Doors";
+	pixel_y = -6;
+	req_access_txt = null;
+	pixel_x = 26;
+	req_one_access_txt = null
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "iA" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3780,27 +3742,6 @@
 	},
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/building)
-"iD" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "iF" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -3874,22 +3815,6 @@
 "iM" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_five)
-"iN" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/step_trigger/player_choice_log{
-	title = "Welcome to Heavens Night.";
-	question = "Welcome to Heavens Night, this club is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
 "iQ" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
@@ -4122,13 +4047,23 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/wasteland/city/newboston/house)
 "jq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio44"
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/machinery/light/small{
+	color = "#444499";
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = -13
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "js" = (
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -4515,19 +4450,19 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"kj" = (
-/obj/structure/chair/sofa/right{
-	dir = 1;
-	pixel_x = -15
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "kk" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"kl" = (
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
+	},
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/bar/heaven)
 "km" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -4923,13 +4858,26 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/wasteland)
-"le" = (
-/obj/structure/chair/sofa/corner{
-	color = "#475340";
-	dir = 1
+"ld" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/room{
+	name = "Clinic"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
+"le" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	req_one_access_txt = "136"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral{
@@ -4991,13 +4939,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bank)
-"lo" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "lp" = (
 /obj/structure/rack/shelf_wood/modern,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -5153,14 +5094,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/wasteland)
-"lH" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "lI" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -5242,18 +5175,22 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
-"lQ" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+"lP" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 8;
-	pixel_x = 2
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
+"lR" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/f13/caves)
 "lS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -5277,18 +5214,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"lV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	light_color = "#884444"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
 "lW" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -5536,11 +5461,9 @@
 	},
 /area/f13/building)
 "mx" = (
-/obj/effect/overlay/palmtree_l{
-	pixel_x = -14;
-	color = "#F833DE"
+/turf/open/floor/plasteel/f13/vault_floor/purple/side{
+	dir = 1
 	},
-/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
 "my" = (
 /obj/structure/simple_door/room,
@@ -5550,16 +5473,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mz" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
 	},
-/obj/structure/chair/bench{
-	dir = 8
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
 	},
-/area/f13/wasteland)
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "mA" = (
 /obj/structure/rack/shelf_metal/modern,
 /obj/item/stack/sheet/sandblock/five,
@@ -5837,12 +5770,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nc" = (
-/obj/structure/railing,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/area/f13/wasteland)
+/area/f13/caves)
 "nd" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -6000,26 +5931,9 @@
 	},
 /area/f13/building/tribal)
 "nu" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
-"nv" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1;
-	color = "brown"
-	},
-/obj/structure/rug/big/rug_red{
-	pixel_x = -16
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "nw" = (
 /obj/machinery/workbench{
 	pixel_y = 18;
@@ -6115,10 +6029,6 @@
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nF" = (
-/obj/structure/railing,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
 "nG" = (
 /obj/structure/railing{
 	dir = 4
@@ -6903,8 +6813,11 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "py" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/watertank/janitor{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "pz" = (
 /obj/structure/railing{
 	dir = 10
@@ -6982,13 +6895,8 @@
 	},
 /area/f13/building/tribal)
 "pI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/transparent/openspace,
+/area/f13/city)
 "pJ" = (
 /obj/structure/table/glass,
 /obj/item/stack/tile/blackmarble/thirty{
@@ -7009,9 +6917,19 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "pM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/chair/sofa/right{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
+"pN" = (
+/obj/structure/railing/corner{
+	color = "#A47449";
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "pO" = (
 /obj/structure/stone_tile/block{
 	dir = 8;
@@ -7130,11 +7048,12 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "qc" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/area/f13/wasteland)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "qd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7204,8 +7123,14 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ql" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "qm" = (
 /obj/structure/table,
 /turf/open/floor/wood_common,
@@ -7275,6 +7200,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
+"qu" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5;
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/open/transparent/openspace,
+/area/f13/building/hospital/clinic/nash)
 "qv" = (
 /obj/structure/chair/sofa/left{
 	color = "#353535";
@@ -7296,6 +7234,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building)
+"qy" = (
+/obj/structure/railing/corner{
+	color = "#A47449"
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 10
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "qz" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -7358,6 +7306,11 @@
 	color = "#779999"
 	},
 /area/f13/wasteland)
+"qJ" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "qK" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8
@@ -7587,10 +7540,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
 "rm" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "rn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookshelf{
@@ -7614,12 +7566,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "rs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/railing{
+	dir = 1
 	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "ru" = (
 /obj/structure/closet/locker/fridge,
 /obj/effect/spawner/lootdrop/food,
@@ -7671,6 +7624,12 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal)
+"rA" = (
+/obj/structure/railing{
+	pixel_y = -3
+	},
+/turf/open/transparent/openspace,
+/area/f13/caves)
 "rB" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -7688,16 +7647,11 @@
 	},
 /area/f13/building)
 "rE" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/chair/sofa/left{
+	color = "#475340"
 	},
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = -31;
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "rF" = (
 /obj/structure/railing{
 	dir = 6
@@ -7839,30 +7793,16 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/outdoors)
 "rW" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/railing/wood/post{
-	pixel_x = 16;
-	pixel_y = 2
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/railing/wood/post{
-	pixel_x = -13;
-	pixel_y = 1
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/obj/structure/curtain{
-	color = "#5c131b";
-	layer = 5;
-	pixel_x = 2;
-	pixel_y = -3
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/obj/structure/rug/mat{
-	color = "#CC4444";
-	layer = 6;
-	pixel_x = 2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/area/f13/wasteland)
 "rX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/oldlamp{
@@ -8215,12 +8155,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "sM" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/wasteland/city/newboston/bank)
+/obj/effect/turf_decal/arrows/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "sN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -8353,25 +8299,9 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"sZ" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "ta" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8;
-	color = "pink"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "tb" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -8546,13 +8476,12 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "tr" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/curtain{
+	color = "#c40e0e";
+	alpha = 255
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "ts" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirtcorner,
@@ -8806,6 +8735,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
+"tZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "ua" = (
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/structure/bed/wooden,
@@ -8915,12 +8853,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "un" = (
-/obj/effect/overlay/palmtree_r{
-	pixel_x = 16;
-	color = "#F833DE"
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "uo" = (
 /obj/structure/rack,
 /obj/item/pickaxe/drill,
@@ -9112,6 +9050,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
+"uJ" = (
+/obj/structure/chair/sofa/corner{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "uK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
@@ -9249,17 +9195,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
-"vb" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/chem_tin/mentats,
-/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
-/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
-/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "vc" = (
 /obj/structure/railing{
 	dir = 8
@@ -9365,19 +9300,10 @@
 	},
 /area/f13/building/tribal)
 "vp" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/obj/item/kirbyplants/random{
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "vq" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/dirt,
@@ -9530,29 +9456,19 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building)
-"vM" = (
-/obj/structure/sign/poster/contraband/pinup_vixen{
-	icon_state = "poster52";
-	pixel_x = -28
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "vN" = (
-/obj/structure/railing/corner{
-	color = "#A47449"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_x = 10
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/caves)
 "vO" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_one)
+"vP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "vQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -9869,12 +9785,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wD" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "wE" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -10260,6 +10174,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"xA" = (
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "xC" = (
 /obj/effect/overlay/junk/toilet{
 	pixel_x = 9;
@@ -10371,18 +10292,15 @@
 	},
 /area/f13/building/tribal)
 "xP" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/left{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 12
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 5;
-	pixel_y = 3;
-	pixel_x = 2
-	},
-/turf/open/transparent/openspace,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "xQ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10455,12 +10373,6 @@
 /obj/item/ammo_box/magazine/garand3006,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/building)
-"yg" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "yh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -10716,16 +10628,18 @@
 	},
 /area/f13/building)
 "yN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland/city/newboston/outdoors)
+"yP" = (
+/obj/structure/table/plasmaglass,
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "yQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10981,12 +10895,8 @@
 	},
 /area/f13/tribe)
 "zz" = (
-/obj/effect/overlay/palmtree_r{
-	pixel_x = 16;
-	color = "#F833DE"
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/building)
 "zB" = (
 /obj/machinery/light{
 	dir = 8
@@ -11018,13 +10928,12 @@
 	},
 /area/f13/building)
 "zF" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "zG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -11394,10 +11303,13 @@
 	},
 /area/f13/tribe)
 "At" = (
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/slime_extract/grey,
+/turf/open/floor/engine,
 /area/f13/caves)
 "Au" = (
 /obj/structure/fence/wooden{
@@ -11422,23 +11334,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"Av" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite{
-	pixel_y = 6;
-	pixel_x = 1
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 4;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 5;
-	pixel_x = 6
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Aw" = (
 /turf/open/floor/carpet,
 /area/f13/wasteland)
@@ -11545,9 +11440,20 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
+"AJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "AK" = (
 /turf/open/transparent/glass,
 /area/f13/wasteland)
+"AL" = (
+/obj/structure/chair/sofa{
+	color = "#475340"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "AM" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -11868,12 +11774,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar/heaven)
 "Bx" = (
-/obj/structure/chair/sofa/right{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/wasteland/city/newboston/bank)
 "Bz" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -11934,10 +11840,8 @@
 /area/f13/building/tribal/cave)
 "BH" = (
 /obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "BJ" = (
 /obj/structure/railing{
 	dir = 6
@@ -12177,12 +12081,16 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "Cn" = (
-/obj/structure/railing,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/railing{
+	dir = 8
 	},
-/area/f13/wasteland)
+/obj/structure/railing/corner{
+	dir = 1;
+	pixel_y = -31;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "Co" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -12335,6 +12243,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bar/heaven)
+"CD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "CE" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -12350,13 +12263,14 @@
 "CF" = (
 /obj/structure/railing{
 	color = "#A47449";
-	pixel_y = -3
+	dir = 5;
+	pixel_y = 4
 	},
-/obj/structure/railing{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/wasteland/city/newboston/bank)
 "CG" = (
 /obj/structure/table/greyscale,
 /obj/item/pda/bar{
@@ -12560,9 +12474,6 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"Db" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital/clinic/nash)
 "Dc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8;
@@ -12720,12 +12631,6 @@
 	name = "spring water"
 	},
 /area/f13/building/tribal)
-"Du" = (
-/obj/structure/chair/sofa{
-	color = "#475340"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Dv" = (
 /obj/effect/turf_decal/big{
 	dir = 1
@@ -12817,10 +12722,21 @@
 	},
 /area/f13/building/tribal)
 "DF" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 1
+/obj/structure/table/plasmaglass,
+/obj/structure/railing/dancing_pole{
+	pixel_y = 31
 	},
-/area/f13/caves)
+/obj/structure/railing/dancing_pole{
+	pixel_y = 10
+	},
+/obj/structure/fence/pole_b{
+	pixel_y = 7
+	},
+/obj/structure/fence/pole_t{
+	pixel_y = 36
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "DG" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
@@ -12902,8 +12818,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "DS" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal{
+	pixel_y = 25;
+	density = 0
+	},
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/wasteland/city/newboston/bank)
 "DT" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -12995,13 +12917,6 @@
 	name = "spring water"
 	},
 /area/f13/building/tribal)
-"Eb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random{
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "Ec" = (
 /obj/structure/railing/wood{
 	pixel_y = 31;
@@ -13071,13 +12986,11 @@
 	},
 /area/f13/building)
 "Ei" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/left{
+/obj/structure/chair/sofa/corp/right{
 	dir = 8;
-	pixel_x = 8;
-	pixel_y = 12
+	color = "pink"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "Ej" = (
@@ -13185,12 +13098,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "Ev" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 4
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 25;
+	density = 0
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/f13{
+	icon_state = "darkredfull"
+	},
+/area/f13/wasteland/city/newboston/bank)
 "Ew" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -13468,10 +13383,9 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "Fd" = (
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
+/turf/open/floor/engine,
 /area/f13/caves)
 "Fe" = (
 /obj/structure/mirror{
@@ -13638,7 +13552,7 @@
 /turf/open/floor/grass,
 /area/f13/wasteland)
 "FA" = (
-/turf/open/indestructible/ground/inside/mountain,
+/turf/closed/mineral/random/low_chance,
 /area/f13/building)
 "FB" = (
 /obj/structure/simple_door/metal/barred,
@@ -13666,13 +13580,16 @@
 	},
 /area/f13/tribe)
 "FE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror{
-	pixel_y = 25
-	},
-/obj/structure/dresser,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/chem_tin/mentats,
+/obj/item/storage/pill_bottle/chem_tin/mentats/berry,
+/obj/item/storage/pill_bottle/chem_tin/mentats/grape,
+/obj/item/storage/pill_bottle/chem_tin/mentats/orange,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "FF" = (
 /obj/structure/flora/tree/jungle/small{
 	color = "#999999"
@@ -13705,15 +13622,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
-"FI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/slime_extract/grey,
-/turf/open/floor/engine,
-/area/f13/caves)
 "FJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13759,6 +13667,13 @@
 "FN" = (
 /turf/open/floor/wood_common,
 /area/f13/building)
+"FO" = (
+/obj/structure/chair/sofa/corner{
+	color = "#475340";
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "FP" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/wood_common/wood_common_dark,
@@ -13823,13 +13738,30 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "FY" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/bed/wooden,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/railing/wood/post{
+	pixel_x = 16;
+	pixel_y = 2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/structure/railing/wood/post{
+	pixel_x = -13;
+	pixel_y = 1
 	},
-/area/f13/wasteland)
+/obj/structure/curtain{
+	color = "#5c131b";
+	layer = 5;
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/structure/rug/mat{
+	color = "#CC4444";
+	layer = 6;
+	pixel_x = 2;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "FZ" = (
 /obj/structure/fermenting_barrel{
 	anchored = 1
@@ -13850,6 +13782,17 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
+"Ge" = (
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	color = "#444499";
+	layer = 3
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Gf" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -13898,13 +13841,22 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/building)
 "Gk" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
+/obj/structure/table/wood,
+/obj/item/candle/infinite{
+	pixel_y = 6;
+	pixel_x = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 4;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Gl" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -14074,13 +14026,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"GF" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/engine,
-/area/f13/caves)
 "GG" = (
 /obj/item/storage/box/dice{
 	pixel_y = 7
@@ -14327,12 +14272,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Hg" = (
+/obj/structure/chair/stool/retro/backed{
+	dir = 4
+	},
+/obj/machinery/light/floor{
+	light_color = "#883388"
+	},
 /obj/machinery/light/small{
-	light_color = "#884444"
+	light_color = "#884444";
+	dir = 1;
+	pixel_y = 15
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "Hh" = (
 /turf/open/floor/wood_common,
@@ -14362,6 +14313,29 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
+"Hl" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_one)
 "Hm" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -14535,15 +14509,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "HK" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/structure/railing{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/caves)
 "HL" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -14721,11 +14694,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/f13/wasteland)
-"Ic" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
 "Id" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirt,
@@ -15165,19 +15133,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/city/newboston/outdoors)
 "IY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
-"IZ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/railing,
+/obj/structure/chair/bench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
 	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland)
 "Ja" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall/rust,
@@ -15284,6 +15245,13 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"Jo" = (
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "Jp" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/f13{
@@ -15345,6 +15313,19 @@
 /obj/item/shovel/serrated,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
+"Ju" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1;
+	color = "brown"
+	},
+/obj/structure/rug/big/rug_red{
+	pixel_x = -16
+	},
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bank)
 "Jw" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt,
@@ -15554,6 +15535,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"JT" = (
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "JU" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8;
@@ -15583,9 +15574,8 @@
 	},
 /area/f13/building/tribal)
 "JW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "JX" = (
 /obj/structure/closet,
@@ -15629,11 +15619,14 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "Ke" = (
-/obj/item/watertank/janitor{
-	pixel_y = 24
+/obj/machinery/light/small{
+	color = "#FFC0CB";
+	light_color = "#FFC0CB";
+	dir = 1;
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "Kf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera,
@@ -15940,6 +15933,24 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/carpet/royalblack,
 /area/f13/wasteland/city/newboston/house/cabin_two)
+"KI" = (
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -6;
+	plane = -14
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2;
+	plane = -14
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/wasteland/city/newboston/house/cabin_two)
 "KJ" = (
 /turf/open/indestructible/ground/outside/water/running{
 	name = "tribe river";
@@ -16059,6 +16070,14 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"KY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror{
+	pixel_y = 25
+	},
+/obj/structure/dresser,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "KZ" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/structure/wreck/trash/machinepile,
@@ -16079,6 +16098,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"Lb" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Lc" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -16309,16 +16336,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
-"LJ" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "LK" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -16337,13 +16354,6 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"LM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
 /area/f13/caves)
 "LN" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -16413,23 +16423,18 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland)
 "LV" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
+/obj/structure/table/plasmaglass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "LW" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -16506,9 +16511,21 @@
 	},
 /area/f13/building/tribal)
 "Mb" = (
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/button/door{
+	id = "xenobio44";
+	name = "Containment Blast Doors";
+	pixel_y = 36;
+	req_access_txt = null;
+	pixel_x = 5;
+	req_one_access_txt = null
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology South";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/caves)
 "Mc" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -16846,11 +16863,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "MT" = (
-/obj/structure/chair/sofa/corner{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	color = "pink"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "MU" = (
@@ -16878,10 +16894,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building)
-"MX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "MY" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -17233,6 +17245,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/wasteland/city/newboston/house/cabin_four)
+"NE" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "NF" = (
 /obj/machinery/computer/arcade/battle{
 	icon_state = "oldcomp";
@@ -17283,16 +17301,15 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "NL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio55"
+/obj/structure/railing{
+	color = "#A47449";
+	pixel_y = -3
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	req_one_access_txt = "136"
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "NM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -17384,13 +17401,13 @@
 	},
 /area/f13/building)
 "NU" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1;
-	pixel_y = 0;
-	color = "brown"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "NV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor{
@@ -17414,13 +17431,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"NZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
 "Oa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/photocopier,
@@ -17635,10 +17645,12 @@
 	},
 /area/f13/tribe)
 "OC" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/sign/poster/contraband/pinup_vixen{
+	icon_state = "poster52";
+	pixel_x = -28
 	},
-/area/f13/wasteland)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "OD" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -17654,6 +17666,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/wasteland/city/newboston/bank)
+"OF" = (
+/obj/structure/table/plasmaglass,
+/obj/item/storage/box/dice,
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "OG" = (
 /obj/structure/railing{
 	dir = 5
@@ -17668,6 +17685,9 @@
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/city/newboston/outdoors)
 "OI" = (
@@ -17681,10 +17701,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
-"OK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
 "OL" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -17972,14 +17988,6 @@
 	color = "#779999"
 	},
 /area/f13/wasteland)
-"Pq" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Pr" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -18147,12 +18155,13 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/wasteland/city/newboston/house/cabin_four)
 "PE" = (
-/obj/structure/railing{
-	color = "#A47449";
-	pixel_y = -3
+/obj/machinery/light/small{
+	light_color = "#884444"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/bar/heaven)
 "PF" = (
 /obj/structure/table/glass,
 /obj/item/stack/tile/whitemarble/thirty{
@@ -18176,8 +18185,19 @@
 	},
 /area/f13/building)
 "PI" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "PJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -18387,6 +18407,14 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
+"Qh" = (
+/obj/structure/railing/corner{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "Qi" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -18449,8 +18477,11 @@
 	},
 /area/f13/tribe)
 "Qr" = (
-/obj/structure/table/plasmaglass,
-/obj/item/storage/box/dice,
+/obj/structure/chair/sofa/corp/right{
+	color = "pink";
+	dir = 8;
+	pixel_x = 8
+	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "Qs" = (
@@ -18487,14 +18518,6 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
-"Qy" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
 "Qz" = (
 /obj/effect/landmark/start/f13/hunter,
 /turf/open/indestructible/ground/inside/mountain{
@@ -18530,6 +18553,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"QC" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "pink"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "QD" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -18573,24 +18603,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/city)
-"QL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"QM" = (
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
 	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "xenobio55";
-	name = "Containment Blast Doors";
-	pixel_y = -6;
-	req_access_txt = null;
-	pixel_x = 26;
-	req_one_access_txt = null
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/caves)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/bar/heaven)
 "QN" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -18691,14 +18710,6 @@
 	},
 /turf/open/water,
 /area/f13/building/tribal/cave)
-"Rb" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
 "Rd" = (
 /obj/item/storage/box/gloves,
 /obj/structure/table/reinforced,
@@ -18895,13 +18906,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Ry" = (
-/obj/structure/chair/sofa/right{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Rz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -18921,6 +18925,13 @@
 "RB" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
+"RC" = (
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	pixel_x = -15
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
@@ -18986,12 +18997,12 @@
 	},
 /area/f13/tribe)
 "RL" = (
-/obj/structure/chair/sofa/left{
-	dir = 4;
-	pixel_x = -6
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/obj/structure/railing,
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "RM" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/clothing/under/fancy_red_formaldress,
@@ -19049,9 +19060,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "RR" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/structure/chair/sofa{
+	color = "#475340";
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "RS" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 5
@@ -19220,15 +19234,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Si" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/f13/building/hospital/clinic/nash)
 "Sj" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "120"
@@ -19325,11 +19338,12 @@
 	},
 /area/f13/building)
 "Su" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	pixel_x = -6
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/rug/big/rug_red,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "Sv" = (
 /turf/closed/indestructible/rock,
@@ -19434,14 +19448,11 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "SI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/f13/caves)
+/obj/structure/railing,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
 "SJ" = (
 /obj/structure/anvil/obtainable/basic,
 /obj/item/melee/smith/hammer/premade,
@@ -19471,18 +19482,12 @@
 	},
 /area/f13/tribe)
 "SO" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
-	},
-/obj/effect/turf_decal/arrows/red{
+/obj/structure/simple_door/repaired,
+/obj/item/lock_bolt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/carpet/black,
+/area/f13/bar/heaven)
 "SQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -19562,6 +19567,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
+"Ta" = (
+/obj/effect/overlay/palmtree_r{
+	pixel_x = 16;
+	color = "#F833DE"
+	},
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/caves)
 "Tb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19730,15 +19742,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_four)
-"Ty" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland)
 "Tz" = (
 /obj/structure/legion_extractor{
 	pixel_y = 6
@@ -19768,9 +19771,12 @@
 	},
 /area/f13/building/tribal)
 "TC" = (
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/railing{
+	color = "#A47449";
+	pixel_y = -3
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "TD" = (
 /obj/structure/table,
 /turf/open/floor/wood_common{
@@ -19831,14 +19837,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "TM" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "TN" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -20067,22 +20070,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Up" = (
-/obj/machinery/button/door{
-	id = "xenobio44";
-	name = "Containment Blast Doors";
-	pixel_y = 36;
-	req_access_txt = null;
-	pixel_x = 5;
-	req_one_access_txt = null
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/caves)
 "Uq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -20124,12 +20111,15 @@
 /area/f13/building)
 "Uv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
+/obj/machinery/light/small{
+	light_color = "#884444"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/bar/heaven)
 "Uw" = (
 /obj/structure/janitorialcart,
@@ -20217,12 +20207,21 @@
 	},
 /area/f13/building/tribal)
 "UI" = (
-/obj/effect/overlay/palmtree_l{
-	pixel_x = -14;
-	color = "#F833DE"
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland)
+"UJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio44"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "UK" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
@@ -20443,7 +20442,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/bank)
 "Vi" = (
-/obj/item/binoculars,
+/obj/item/binoculars{
+	name = "cucknoculars"
+	},
 /obj/structure/table/wood/settler,
 /obj/structure/railing/wood{
 	dir = 4
@@ -20489,6 +20490,9 @@
 	color = "#779999"
 	},
 /area/f13/ncr)
+"Vn" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/city)
 "Vo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1";
@@ -20513,6 +20517,25 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
+"Vp" = (
+/obj/machinery/light/sign/heaven{
+	pixel_y = 30;
+	pixel_x = 1;
+	light_color = "#FF55FF";
+	light_range = 1;
+	light_power = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
+"Vq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Vr" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -20611,8 +20634,8 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "VC" = (
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/city)
+/turf/closed/wall/r_wall/rust,
+/area/f13/building/hospital/clinic/nash)
 "VD" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = -4;
@@ -20645,9 +20668,11 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "VG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "VH" = (
 /obj/structure/table/wood/fancy/blackred{
 	density = 0;
@@ -20807,22 +20832,6 @@
 /obj/item/reagent_containers/food/snacks/pizzaslice/sassysage,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
-"Wb" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing/dancing_pole{
-	pixel_y = 31
-	},
-/obj/structure/railing/dancing_pole{
-	pixel_y = 10
-	},
-/obj/structure/fence/pole_b{
-	pixel_y = 7
-	},
-/obj/structure/fence/pole_t{
-	pixel_y = 36
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "Wc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -21085,15 +21094,16 @@
 	},
 /area/f13/bar/heaven)
 "WF" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/structure/chair/sofa/right{
+	color = "#475340";
+	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "WG" = (
-/obj/machinery/door/unpowered/securedoor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "WI" = (
 /obj/structure/fence/wooden{
 	dir = 8;
@@ -21121,9 +21131,14 @@
 	},
 /area/f13/building)
 "WK" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	color = "pink"
+/obj/effect/decal/cleanable/glitter/white{
+	color = "#884444"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_y = 8;
+	pixel_x = 2
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -21247,17 +21262,6 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Xa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444";
-	pixel_x = -16;
-	pixel_y = -8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
 "Xc" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -21415,11 +21419,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "Xx" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
 	},
-/area/f13/bar/heaven)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland/city/newboston/outdoors)
 "Xy" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -21520,13 +21528,18 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"XL" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 8
+"XK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building/hospital/clinic/nash)
+"XL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "XM" = (
 /obj/structure/table/wood/settler,
 /obj/structure/railing{
@@ -21578,6 +21591,13 @@
 	color = "#A1BFFF"
 	},
 /area/f13/caves)
+"XQ" = (
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "XR" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13{
@@ -21598,20 +21618,9 @@
 	},
 /area/f13/bar/heaven)
 "XT" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/curtain{
+	color = "#c40e0e"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -21926,12 +21935,16 @@
 	},
 /area/f13/building)
 "YD" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio55"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	req_one_access_txt = "136"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/f13/caves)
 "YE" = (
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
@@ -22302,12 +22315,12 @@
 	},
 /area/f13/building)
 "Zz" = (
-/obj/structure/curtain{
-	color = "#c40e0e";
-	alpha = 255
+/obj/effect/overlay/palmtree_l{
+	pixel_x = -14;
+	color = "#F833DE"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/caves)
 "ZB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -22327,10 +22340,8 @@
 	},
 /area/f13/building)
 "ZD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/building/hospital/clinic/nash)
 "ZE" = (
 /mob/living/simple_animal/hostile/bs/knight,
 /turf/open/floor/carpet/red,
@@ -22353,16 +22364,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
 "ZK" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 5;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	color = "#444499";
+	dir = 1;
+	light_color = "#444499";
+	light_power = 2;
+	light_range = 2;
+	pixel_y = 13
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/bank)
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "ZL" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -44380,19 +44392,19 @@ kn
 TQ
 cJ
 tj
-rW
+FY
 YE
-RL
-aD
+XQ
+Su
 tj
-iz
-iz
-iz
+dt
+dt
+dt
 tj
 zp
-sZ
-Ev
-le
+Ge
+RR
+FO
 tj
 tN
 tN
@@ -44630,26 +44642,26 @@ tN
 tj
 hg
 ys
-iz
 dt
-Uv
-Pq
-lQ
-iz
+pN
+ql
+el
+WK
+dt
 tj
-yN
+ZK
 Op
 nZ
-kj
+RC
 tj
-bM
-aK
+MT
+QC
 MS
 tj
 RP
-TC
-TC
-XT
+fa
+fa
+jq
 tj
 tN
 tN
@@ -44892,21 +44904,21 @@ yx
 Zm
 kC
 ob
-iz
+dt
 tj
-FE
+KY
 Op
 YE
 YE
 tj
-bt
-Qr
-iz
+LV
+OF
+dt
 tj
-Du
-TC
-Wb
-YD
+AL
+fa
+DF
+eL
 tj
 tN
 tN
@@ -45151,19 +45163,19 @@ tj
 tj
 tj
 tj
-Eb
+dR
 Op
 Op
 YE
 tj
-ta
-WK
-iz
+Ei
+fk
+dt
 tj
-yg
+rE
 Zm
-et
-Ry
+yP
+WF
 tj
 tN
 OW
@@ -45399,7 +45411,7 @@ Eo
 Eo
 Eo
 tj
-rs
+aC
 Ux
 tj
 Sq
@@ -45408,22 +45420,22 @@ Bv
 tj
 wf
 tj
-dn
+aB
 YE
 Op
 YE
 tj
-iz
-iz
-iz
+dt
+dt
+dt
 tj
 Zx
 MS
-iz
+dt
 ZJ
 tj
 Ws
-CF
+NL
 eV
 NR
 aN
@@ -45432,11 +45444,11 @@ aN
 kY
 eV
 Cd
-mz
+rW
+ic
+rW
+ic
 gw
-mz
-gw
-FY
 ZO
 tN
 tN
@@ -45654,7 +45666,7 @@ qF
 tj
 WW
 OY
-Xx
+cf
 tj
 Ux
 Ux
@@ -45667,20 +45679,20 @@ OY
 tj
 tj
 tj
-Su
+XT
 oN
 tj
-Su
+XT
 tj
-XL
+SO
 tj
-XL
-Su
+SO
+XT
 tj
 tj
 tj
-py
-PE
+ta
+TC
 eV
 NR
 gP
@@ -45689,12 +45701,12 @@ In
 gP
 az
 Cd
-Qy
-nu
-Qy
-nu
-OC
-BH
+Lb
+gc
+Lb
+gc
+dn
+SI
 tN
 tN
 tN
@@ -45910,7 +45922,7 @@ GU
 qF
 tj
 lL
-Xa
+eF
 OY
 AA
 OY
@@ -45923,21 +45935,21 @@ eG
 Uc
 tj
 as
-vM
-iz
-iz
-iz
-iz
+OC
+dt
+dt
+dt
+dt
 as
-iz
-iz
-iz
-iz
+dt
+dt
+dt
+dt
 tj
-py
-py
-py
-PE
+ta
+ta
+ta
+TC
 eV
 Dv
 uu
@@ -45950,8 +45962,8 @@ tN
 tN
 tN
 tN
-zF
-Cn
+UI
+IY
 tN
 tN
 tN
@@ -46178,23 +46190,23 @@ CV
 Hy
 Kk
 ot
-Zz
-iz
-iz
-iz
-iz
-WF
-iz
-iz
-iz
-iz
+tr
+dt
+dt
+dt
+dt
+ch
+dt
+dt
+dt
+dt
 JG
-iz
+dt
 tj
-py
-py
-py
-PE
+ta
+ta
+ta
+TC
 eV
 NR
 zK
@@ -46207,8 +46219,8 @@ tN
 tN
 tN
 tN
-Ty
-nc
+Vq
+xA
 tN
 tN
 tN
@@ -46435,23 +46447,23 @@ AW
 cs
 cB
 HA
-Zz
-iz
-iz
+tr
+dt
+dt
 JG
-iz
-iz
+dt
+dt
 JG
-WF
-iz
-iz
+ch
+dt
+dt
 tj
 ni
 tj
-py
-py
-py
-PE
+ta
+ta
+ta
+TC
 eV
 UL
 Ho
@@ -46464,8 +46476,8 @@ tN
 tN
 tN
 tN
-zF
-Cn
+UI
+IY
 tN
 tN
 tN
@@ -46691,24 +46703,24 @@ ot
 OY
 ot
 ot
-Hg
-tj
-iz
-iz
-tj
-Su
-ch
-tj
-ch
-tj
-Su
-tj
-tj
-tj
-py
-py
-py
 PE
+tj
+dt
+dt
+tj
+XT
+Jo
+tj
+Jo
+tj
+XT
+tj
+tj
+tj
+ta
+ta
+ta
+TC
 eV
 eV
 eV
@@ -46721,8 +46733,8 @@ tN
 tN
 tN
 tN
-Rb
-nc
+rs
+xA
 tN
 tN
 tN
@@ -46942,30 +46954,30 @@ jo
 tF
 VZ
 tj
-hc
+Hg
 Hw
 uT
 uT
 Sd
 nf
-Hg
+PE
 tj
-iz
-iz
+dt
+dt
 tj
-vp
-WF
+PI
+ch
 tj
 MS
 dG
 cP
 tj
-py
-py
-py
-py
-py
-py
+ta
+ta
+ta
+ta
+ta
+ta
 hE
 Tr
 lf
@@ -46978,8 +46990,8 @@ tN
 tN
 tN
 tN
-zF
-Cn
+UI
+IY
 tN
 tN
 tN
@@ -47206,23 +47218,23 @@ ud
 MG
 RB
 OY
-Zz
+tr
 MS
-iz
+dt
 tj
-Bx
-iz
+pM
+dt
 tj
 MS
-iz
-WF
-UI
-LJ
-py
-py
-py
-py
-py
+dt
+ch
+kl
+Vp
+ta
+ta
+ta
+ta
+ta
 hE
 Zj
 ZY
@@ -47235,8 +47247,8 @@ tN
 tN
 tN
 tN
-Rb
-BH
+rs
+SI
 tN
 tN
 tN
@@ -47463,23 +47475,23 @@ kM
 LZ
 NA
 ot
-Zz
-iz
-iz
+tr
+dt
+dt
 tj
-MT
-Ei
+uJ
+xP
 tj
-Av
-lH
-dl
-zz
-py
-py
-py
-py
-py
-py
+Gk
+Qr
+dc
+QM
+ta
+ta
+ta
+ta
+ta
+ta
 hE
 EX
 ZY
@@ -47492,8 +47504,8 @@ tN
 tN
 tN
 tN
-zF
-qc
+UI
+NE
 tN
 tN
 tN
@@ -47719,24 +47731,24 @@ Op
 Op
 YE
 YE
-lV
+Uv
 tj
-WG
-WG
-tj
-tj
+gE
+gE
 tj
 tj
 tj
 tj
 tj
 tj
-eK
+tj
+tj
+JW
 qS
 qS
 qS
 qS
-Gk
+Qh
 hE
 cL
 nr
@@ -47978,8 +47990,8 @@ qt
 ws
 OY
 VZ
-iN
-iN
+de
+de
 tj
 xx
 xx
@@ -47988,11 +48000,11 @@ xx
 xx
 xx
 xx
-RR
+nu
 Ap
 Ap
 Ap
-At
+rA
 dK
 gL
 YV
@@ -48222,8 +48234,8 @@ Yj
 GU
 GU
 GU
-mx
-SO
+Zz
+sM
 xx
 xx
 tj
@@ -48235,7 +48247,7 @@ tj
 tj
 zD
 VZ
-cr
+Ke
 xx
 Yy
 xx
@@ -48245,11 +48257,11 @@ xx
 xx
 xx
 xx
-hU
-gl
-gl
-gl
-rE
+VG
+hc
+hc
+hc
+Cn
 dK
 hE
 vd
@@ -48479,7 +48491,7 @@ Yj
 GU
 GU
 GU
-un
+Ta
 EY
 xx
 xx
@@ -48491,8 +48503,8 @@ dS
 jI
 dS
 jI
-UI
-fa
+kl
+JT
 xx
 xx
 qF
@@ -48748,7 +48760,7 @@ Kg
 XS
 CC
 BR
-zz
+QM
 xx
 xx
 xx
@@ -49006,7 +49018,7 @@ tj
 tj
 tj
 tj
-cr
+Ke
 xx
 xx
 Qk
@@ -49267,7 +49279,7 @@ xx
 xx
 qF
 Qk
-iD
+mz
 PR
 Qk
 Qk
@@ -49524,7 +49536,7 @@ xx
 qF
 um
 Qk
-ac
+Hl
 cR
 cR
 cR
@@ -50552,7 +50564,7 @@ qF
 qF
 qF
 Sf
-LV
+KI
 VF
 CT
 OQ
@@ -50564,7 +50576,7 @@ aZ
 xb
 Sf
 dK
-HK
+OH
 dK
 QO
 eJ
@@ -50821,7 +50833,7 @@ JR
 TF
 rN
 dK
-OH
+RL
 dK
 jp
 jp
@@ -51078,7 +51090,7 @@ NM
 AX
 rN
 dK
-OH
+RL
 dK
 dK
 dK
@@ -51335,7 +51347,7 @@ YS
 ID
 lI
 dK
-OH
+RL
 ci
 eW
 FP
@@ -51571,7 +51583,7 @@ DO
 DO
 DO
 DO
-sM
+Bx
 DO
 DO
 DO
@@ -51592,7 +51604,7 @@ SY
 Pu
 rN
 dK
-OH
+RL
 dK
 Xq
 GW
@@ -51849,7 +51861,7 @@ lW
 ff
 Sf
 dK
-OH
+RL
 dK
 eW
 eW
@@ -52106,7 +52118,7 @@ Sf
 Sf
 Sf
 dK
-Si
+Xx
 dK
 eW
 zT
@@ -52607,8 +52619,8 @@ PC
 wp
 wp
 dh
-pI
-Mb
+XK
+et
 dX
 hC
 ad
@@ -52855,18 +52867,18 @@ GU
 DO
 lT
 mT
-mT
 jL
 DO
 DO
+MP
 DO
-iw
+VC
 rC
 pa
-pM
+WG
 rC
-IY
-pM
+CD
+WG
 hC
 hC
 Mk
@@ -53112,15 +53124,15 @@ us
 Ny
 UM
 mT
-mT
-nv
+Ju
 DO
+DS
 Vh
 MP
 DO
 ks
 Wm
-lo
+un
 rC
 GU
 GU
@@ -53368,10 +53380,10 @@ GU
 GU
 DO
 zj
-uK
 mT
-NU
+bM
 DO
+Ev
 Vh
 Dx
 DO
@@ -53391,7 +53403,7 @@ OJ
 OJ
 tI
 dK
-fd
+yN
 dK
 dK
 rl
@@ -53627,16 +53639,16 @@ DO
 ja
 uK
 mT
-ZD
 yZ
+Vh
 Vh
 Dx
 DO
 GI
 Wm
 Wm
-de
-Db
+ld
+ZD
 bD
 hC
 TO
@@ -53882,19 +53894,19 @@ GU
 GU
 Ny
 VS
-vN
-wD
+qy
 mT
 DO
 DO
 DO
 DO
-go
+DO
+qJ
 Wm
-vb
+FE
 rC
-Ke
-Db
+py
+ZD
 hC
 If
 bH
@@ -54140,13 +54152,13 @@ GU
 Ny
 DO
 Ny
-ZK
+qc
 mT
-sM
+Bx
 Wm
 zb
 Wm
-xP
+qu
 Wm
 IC
 rC
@@ -54396,11 +54408,11 @@ GU
 GU
 GU
 GU
-DS
-DS
-DS
-DS
-MX
+DO
+CF
+mT
+DO
+XL
 Wm
 Wm
 Wm
@@ -54653,12 +54665,12 @@ Yj
 Yj
 Yj
 GU
-GU
-GU
-GU
+DO
+DO
+DO
 rC
 rC
-pM
+WG
 pa
 rC
 pa
@@ -54915,11 +54927,11 @@ GU
 GU
 GU
 rC
-TM
+Si
 ga
 rC
-cf
-IZ
+wD
+lP
 rC
 GU
 GU
@@ -55429,7 +55441,7 @@ GU
 GU
 GU
 rC
-fb
+gf
 gv
 rC
 gv
@@ -57757,8 +57769,8 @@ qF
 qF
 qF
 qF
-VC
-fk
+Vn
+pI
 Fo
 sh
 sh
@@ -58014,8 +58026,8 @@ qF
 qF
 qF
 qF
-nF
-fk
+BH
+pI
 Fo
 lD
 rJ
@@ -58271,8 +58283,8 @@ Al
 uF
 Bh
 Qw
-VC
-fk
+Vn
+pI
 Fo
 lb
 hx
@@ -58528,8 +58540,8 @@ PS
 tB
 TU
 Dn
-ql
-eF
+vN
+nc
 Fo
 MF
 FV
@@ -58785,8 +58797,8 @@ BZ
 PK
 jh
 ok
-ql
-eF
+vN
+nc
 Fo
 fj
 hx
@@ -59042,8 +59054,8 @@ Cs
 Ql
 jW
 UW
-ql
-ql
+vN
+vN
 Fo
 ov
 hx
@@ -59806,12 +59818,12 @@ qF
 qF
 qF
 qF
-FA
-FA
-FA
-FA
-FA
-FA
+zz
+zz
+zz
+zz
+zz
+zz
 GU
 GU
 GU
@@ -60059,16 +60071,16 @@ qF
 qF
 qF
 qF
-FA
-FA
-FA
-FA
-FA
-FA
-VG
-FA
-FA
-FA
+zz
+zz
+zz
+zz
+zz
+zz
+rm
+zz
+zz
+zz
 GU
 GU
 GU
@@ -60316,16 +60328,16 @@ qF
 qF
 qF
 qF
-PI
-PI
-PI
-PI
 FA
 FA
 FA
 FA
-FA
-FA
+zz
+zz
+zz
+zz
+zz
+zz
 GU
 GU
 GU
@@ -60573,19 +60585,19 @@ qF
 qF
 qF
 GU
-PI
-PI
-PI
-PI
+FA
+FA
+FA
+FA
 IQ
 xF
 xF
 xF
 xF
 IQ
-PI
-PI
-PI
+FA
+FA
+FA
 tN
 tN
 tN
@@ -60840,9 +60852,9 @@ IQ
 zE
 di
 IQ
-PI
-PI
-PI
+FA
+FA
+FA
 us
 GU
 GU
@@ -61097,9 +61109,9 @@ IQ
 Nj
 di
 IQ
-PI
-PI
-PI
+FA
+FA
+FA
 us
 GU
 GU
@@ -61858,7 +61870,7 @@ qF
 qF
 qF
 qF
-eF
+nc
 rO
 jA
 nN
@@ -62115,7 +62127,7 @@ qF
 qF
 qF
 GU
-eF
+nc
 PY
 DT
 WQ
@@ -62372,7 +62384,7 @@ GU
 GU
 GU
 GU
-eF
+nc
 IQ
 IQ
 IQ
@@ -63658,18 +63670,18 @@ GU
 GU
 GU
 GU
-eF
-tr
-FI
-ip
-NZ
-JW
-DF
-aC
-NL
-SI
-rm
-eF
+nc
+NU
+At
+le
+hU
+vp
+mx
+tZ
+YD
+eK
+Fd
+nc
 GU
 GU
 GU
@@ -63915,18 +63927,18 @@ GU
 GU
 GU
 GU
-eF
-OK
-LM
-jq
-fn
-Up
-DF
-QL
-GF
-ic
-Ic
-eF
+nc
+vP
+zF
+UJ
+HK
+Mb
+mx
+iz
+lR
+TM
+AJ
+nc
 GU
 GU
 GU
@@ -64172,18 +64184,18 @@ GU
 GU
 GU
 GU
-eF
-eF
-eF
-eF
-eF
-Fd
-eF
-eF
-eF
-eF
-eF
-eF
+nc
+nc
+nc
+nc
+nc
+fn
+nc
+nc
+nc
+nc
+nc
+nc
 Yj
 Yj
 Yj

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -27,9 +27,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
-/obj/structure/flora/timber,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "abn" = (
 /obj/structure/table,
 /obj/item/rack_parts,
@@ -54,6 +55,12 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/workshop/nash)
+"abR" = (
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -83,10 +90,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "acE" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
+/obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
 "acI" = (
@@ -206,14 +210,14 @@
 "afx" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "countershutters";
 	name = "counter shutters";
 	req_one_access_txt = null
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -292,10 +296,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
-"ahq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "aht" = (
 /obj/structure/stairs/east,
 /obj/structure/railing,
@@ -439,14 +439,13 @@
 	},
 /area/f13/brotherhood)
 "akW" = (
-/obj/machinery/mineral/wasteland_vendor/crafting{
-	icon_state = "parts_idle"
+/obj/structure/sink/well{
+	pixel_y = 7;
+	pixel_x = -6;
+	layer = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "alu" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
@@ -637,6 +636,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"ars" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "arA" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -770,19 +773,11 @@
 	},
 /area/f13/wasteland)
 "aul" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/campfire/wallfire{
+	pixel_y = -1
 	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "aup" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -816,36 +811,18 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
-"avu" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "avv" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "avJ" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = -4;
-	layer = 2.8;
-	density = 0
+/obj/structure/fence/door{
+	dir = 8;
+	pixel_x = 15
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/waffles{
-	pixel_y = 13;
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "avK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -863,16 +840,9 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"awt" = (
-/obj/structure/sign/departments/examroom{
-	pixel_y = 2;
-	pixel_x = 29
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+"awl" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "awO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -998,9 +968,14 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "aAx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/workshop/nash)
 "aAz" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -1089,15 +1064,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"aDg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "aDh" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -1240,6 +1206,16 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"aHr" = (
+/obj/structure/sign/departments/examroom{
+	pixel_y = 2;
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "aHs" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced{
@@ -1548,14 +1524,30 @@
 	},
 /area/f13/building)
 "aQG" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/grains,
+/obj/item/storage/box/ingredients/grains,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "aRb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1569,14 +1561,13 @@
 /turf/open/indestructible/ground/bamboo/fourtysix,
 /area/f13/wasteland/city/newboston/sauna)
 "aRr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/libraryscanner{
-	pixel_x = 3;
-	pixel_y = 11;
-	density = 0
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "aRB" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -1590,10 +1581,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"aSt" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
 "aSS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1731,15 +1718,9 @@
 	},
 /area/f13/building)
 "aXi" = (
-/obj/machinery/smartfridge/chemistry{
-	density = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "aXQ" = (
 /obj/item/trash/candy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2086,16 +2067,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"bgF" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "bgG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -2232,13 +2203,17 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
 "bms" = (
-/obj/structure/sink/well{
-	pixel_y = -4;
-	pixel_x = -6;
-	layer = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/mineral/wasteland_trader{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "bmW" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -2298,18 +2273,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "boV" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 4
+/obj/item/storage/bag/money{
+	pixel_y = 14;
+	pixel_x = 33;
+	color = "#f3f233"
 	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/structure/sign/bank{
+	layer = 4.1;
+	pixel_y = -4;
+	pixel_x = 32
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
+/obj/machinery/vending/coffee,
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "bpk" = (
 /obj/structure/rack,
 /obj/item/binoculars,
@@ -2436,13 +2416,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"bsJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth{
-	color = "#EFCCC0"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "btc" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -2483,10 +2456,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"bus" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
 "buN" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -2680,36 +2649,22 @@
 /obj/machinery/autolathe{
 	pixel_y = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
-"bzW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "bAa" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/item/paper_bin{
+	pixel_y = 7;
+	pixel_x = -5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "bAd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glitter/blue,
@@ -2762,9 +2717,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "bBH" = (
-/obj/structure/fermenting_barrel,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
@@ -2849,21 +2804,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDj" = (
-/obj/machinery/vending/medical/nash{
-	pixel_x = 26;
-	density = 0
+/obj/machinery/computer/operating,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/custom/leechjar{
-	pixel_y = 18;
-	pixel_x = 21;
-	desc = "Why do the lumps in that jar look vaguely catlike?";
-	name = "Mereks brain juice"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
 "bDJ" = (
 /obj/structure/window/fulltile/wood_window,
@@ -2926,8 +2873,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bFG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 8;
+	pixel_y = 39
+	},
 /turf/open/indestructible/ground/outside/road{
 	color = "#999999";
 	icon_state = "horizontaltopborderbottom0"
@@ -3134,13 +3092,12 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "bKT" = (
 /obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "bLc" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -3318,6 +3275,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
+"bPu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "bPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/bench{
@@ -3752,8 +3716,13 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "cdB" = (
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/obj/effect/turf_decal/vg_decals/numbers/one,
 /turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/building/trader)
 "cdN" = (
 /obj/structure/debris/v2{
 	pixel_x = -12;
@@ -3765,9 +3734,6 @@
 /area/f13/building)
 "ceh" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
@@ -3999,10 +3965,20 @@
 	},
 /area/f13/building)
 "cmo" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/wood_common,
+/obj/machinery/button/door{
+	pixel_x = 3;
+	pixel_y = 42;
+	name = "counter shutters";
+	id = "bankdeskshutters"
+	},
+/obj/machinery/cardpuncher{
+	pixel_y = 24;
+	density = 0
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "cms" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4105,33 +4081,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"cpu" = (
-/obj/structure/table/wood{
-	layer = 3;
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -13;
-	pixel_y = 13
-	},
-/obj/item/trash/candle{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/trash/plate{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "cpx" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
@@ -4298,14 +4247,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"ctp" = (
-/obj/structure/beebox{
-	pixel_y = 11;
-	layer = 4;
-	density = 0
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "ctv" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -4568,13 +4509,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "czX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "cAa" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -4618,16 +4559,6 @@
 	color = "#999999"
 	},
 /area/f13/tunnel)
-"cBv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
 "cBE" = (
 /obj/machinery/mineral/wasteland_vendor/special,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4763,12 +4694,9 @@
 	},
 /area/f13/wasteland)
 "cEt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "cEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair1{
@@ -4910,12 +4838,18 @@
 	},
 /area/f13/wasteland)
 "cIm" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
+	},
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/window/reinforced,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/hospital/clinic/nash)
 "cIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4997,6 +4931,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
+"cKP" = (
+/obj/structure/sign/gunshop{
+	layer = 5;
+	pixel_y = 25
+	},
+/obj/machinery/status_display/supply{
+	pixel_y = 39;
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "cKR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5296,18 +5243,23 @@
 	},
 /area/f13/building)
 "cUd" = (
-/obj/structure/sign/gunshop{
-	layer = 5;
-	pixel_y = 25
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = 39;
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "cUm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5431,14 +5383,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cWw" = (
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "cWY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5447,19 +5394,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
 "cXg" = (
-/obj/item/trash/candle{
-	pixel_x = 3;
-	pixel_y = 19
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/libraryscanner{
+	pixel_x = 14;
+	pixel_y = 0;
+	density = 0
 	},
-/obj/item/candle/infinite{
-	pixel_x = -19;
-	pixel_y = 19
-	},
-/obj/item/clothing/head/helmet/skull{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/bookcase,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
 "cXj" = (
@@ -5626,6 +5566,13 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"dda" = (
+/obj/structure/simple_door/wood,
+/obj/item/lock_bolt{
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "ddi" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/railing{
@@ -5719,9 +5666,6 @@
 "dfD" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"dfZ" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland/city/newboston/outdoors)
 "dgl" = (
 /obj/structure/fence{
 	dir = 4
@@ -6192,17 +6136,11 @@
 	},
 /area/f13/building)
 "dtH" = (
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/trader)
 "dtO" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/f13/steak,
@@ -6951,9 +6889,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "dOt" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "dOu" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -6995,12 +6936,11 @@
 /area/f13/caves)
 "dPg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "dPs" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -7057,16 +6997,14 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
-"dQI" = (
-/obj/structure/window/reinforced{
-	dir = 8
+"dQO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/obj/machinery/mineral/wasteland_trader{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "dRf" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -7107,9 +7045,9 @@
 	},
 /area/f13/building/abandoned)
 "dRJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "dRN" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -7342,9 +7280,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "dYk" = (
-/obj/item/target,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "dYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -7810,21 +7753,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/city/newboston/outdoors)
-"elk" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	pixel_y = 14;
-	network = list("nash");
-	layer = 3;
-	alpha = 0;
-	mouse_opacity = 0
-	},
-/obj/machinery/mineral/wasteland_vendor/mining,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "elq" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13{
@@ -7915,12 +7843,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eoV" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "epa" = (
 /obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7967,6 +7889,10 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
+"eqe" = (
+/obj/machinery/mineral/wasteland_vendor/weapons,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "eqf" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8451,6 +8377,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eEr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/vg_decals/numbers/nine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "eEu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -8729,34 +8662,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"eKD" = (
+/obj/structure/beebox{
+	pixel_y = 11;
+	layer = 4;
+	density = 0
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "eKF" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"eKM" = (
-/obj/structure/sink/deep_water{
-	pixel_y = 3;
-	color = "#996633"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#996633"
-	},
-/area/f13/building/workshop/nash)
 "eLh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -9121,12 +9038,16 @@
 	},
 /area/f13/wasteland)
 "eUA" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/machinery/mineral/wasteland_vendor/general,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "eUU" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/dirt,
@@ -9195,13 +9116,11 @@
 	},
 /area/f13/building)
 "eWR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/building/trader)
+/area/f13/building/hospital/clinic/nash)
 "eXd" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9903,8 +9822,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "foy" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#222222";
+	opacity = 1
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "foK" = (
 /obj/effect/decal/cleanable/generic,
@@ -10085,9 +10008,13 @@
 	},
 /area/f13/building)
 "frU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/structure/chair/bench{
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "frX" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt,
@@ -10120,11 +10047,8 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "ftd" = (
@@ -10367,12 +10291,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fyF" = (
-/obj/machinery/mineral/wasteland_vendor/specialplus{
-	pixel_y = 20;
-	density = 0
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "fyL" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10811,9 +10732,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fKN" = (
-/obj/structure/closet/crate,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "fLZ" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -11069,21 +10989,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fSU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/north,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
 "fTf" = (
-/obj/effect/fake_stairs/west{
-	color = "#bb3333"
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
+/obj/structure/bed/dogbed,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/hospital/clinic/nash)
 "fTt" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/f13{
@@ -11115,19 +11030,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"fTT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
-"fUg" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
 "fUk" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -11149,6 +11051,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"fUC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/survivalcapsule{
+	pixel_y = 0
+	},
+/obj/item/survivalcapsule{
+	pixel_y = 9
+	},
+/obj/item/survivalcapsule/blacksmith{
+	pixel_y = -10
+	},
+/obj/item/survivalcapsule/farm{
+	pixel_x = 10
+	},
+/obj/item/survivalcapsule/fortuneteller{
+	pixel_x = -9
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "fUJ" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -11191,12 +11113,31 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fVx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
+/obj/structure/table/wood{
+	layer = 3;
+	pixel_y = -2
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -13;
+	pixel_y = 13
+	},
+/obj/item/trash/candle{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/trash/plate{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "fVX" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -11470,15 +11411,6 @@
 "gcX" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"gde" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/export/bottle/vodka{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "gdh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11503,12 +11435,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gej" = (
-/obj/structure/chair/bench{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "gel" = (
 /obj/structure/window/fulltile/house{
@@ -11726,6 +11663,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"glQ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "gmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11794,10 +11738,18 @@
 	},
 /area/f13/caves)
 "gor" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "goA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -12096,12 +12048,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gwL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - N"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/area/f13/building)
 "gwP" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -12190,12 +12142,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gzl" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/item/reagent_containers/food/snacks/burger/baseball{
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/building)
 "gzO" = (
 /obj/structure/simple_door/interior,
 /obj/structure/decoration/rag,
@@ -12290,8 +12238,20 @@
 	},
 /area/f13/building)
 "gDe" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/table/wood,
+/obj/structure/barricade/bars{
+	layer = 3.5;
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building/trader)
 "gDw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12567,6 +12527,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gLd" = (
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
+	},
+/obj/structure/window,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	pixel_y = 6
+	},
+/obj/structure/campfire/churchfire{
+	pixel_y = 7
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "gLP" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -12672,12 +12648,12 @@
 "gOo" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "bankdeskshutters"
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
@@ -12990,7 +12966,9 @@
 	},
 /area/f13/building)
 "gXv" = (
-/obj/structure/chair/stool/bar,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
 	name = "tile"
@@ -13059,6 +13037,14 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
+"gZZ" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "hae" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -13168,11 +13154,9 @@
 	},
 /area/f13/building)
 "hcF" = (
-/obj/effect/turf_decal/weather/dirtcorner{
-	dir = 8
-	},
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 10
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -13267,19 +13251,16 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "heQ" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/table/booth{
-	color = "#EFCCC0"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/sign/barsign{
-	light_color = "#FDB0C0";
-	pixel_x = 1;
-	pixel_y = 36
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/wasteland/city/newboston/outdoors)
 "heV" = (
 /obj/machinery/light/small{
 	color = "#FF0000";
@@ -13451,12 +13432,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "hiW" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2;
+	pixel_y = 0
+	},
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "hiY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13662,16 +13648,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hps" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/trader)
 "hpt" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -13699,6 +13675,15 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"hqo" = (
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "hrn" = (
 /obj/structure/flora/wasteplant/wild_prickly,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13805,14 +13790,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hsR" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "hti" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
@@ -13917,12 +13899,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
 "hvy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "hwp" = (
 /obj/machinery/autolathe/ammo,
@@ -14033,6 +14015,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"hAU" = (
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	icon_state = "sofamiddle"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "hBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -14110,11 +14099,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "hCQ" = (
-/obj/structure/simple_door/house{
-	req_access_txt = 139
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/computer/communications{
+	name = "quest console";
+	req_access = null
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "hDe" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14400,21 +14395,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hJN" = (
-/obj/machinery/mineral/wasteland_vendor/weapons,
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/wood_common,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
 /area/f13/building/trader)
 "hJP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
+	dir = 6
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -14566,37 +14562,28 @@
 	},
 /area/f13/trainstation)
 "hNN" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/machinery/vending/boozeomat/pubby_captain{
-	pixel_y = 32;
-	density = 0
-	},
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
-"hNR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal{
-	pixel_y = -2;
-	pixel_x = 3
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
-"hNT" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
+"hNR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/workshop/nash)
+"hNT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "hNU" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#00DD00";
@@ -14842,11 +14829,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"hTR" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/rug/big/rug_red,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "hTT" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -14895,21 +14877,14 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/workshop/nash)
 "hVl" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/iv_drip/telescopic,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/machinery/button/door{
-	pixel_x = -7;
-	pixel_y = 41;
-	name = "counter shutters";
-	id = "bankdeskshutters"
-	},
-/obj/machinery/cardpuncher{
-	pixel_y = 24;
-	density = 0
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "hVm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink{
@@ -15139,14 +15114,9 @@
 	},
 /area/f13/building)
 "icC" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "icD" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -15605,14 +15575,12 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "isg" = (
-/obj/machinery/mineral/equipment_vendor{
-	pixel_y = 14;
-	density = 0
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "isv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/securitron,
@@ -15659,14 +15627,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/workshop/nash)
 "ius" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/rug/mat{
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
 	},
-/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "iuy" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -15703,6 +15669,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"ivc" = (
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "ivk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16427,9 +16400,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iNQ" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "iNV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -16542,10 +16518,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"iRz" = (
-/obj/structure/closet/ammunitionlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "iRA" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13/wood,
@@ -17042,6 +17014,17 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"jas" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "jaI" = (
 /obj/structure/table/wood,
 /obj/structure/junk/small/tv{
@@ -17131,16 +17114,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/abandoned)
-"jef" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "jeg" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
@@ -17201,6 +17174,12 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"jeV" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "jfg" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17266,6 +17245,9 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
+"jgf" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "jgh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -17321,14 +17303,17 @@
 	},
 /area/f13/building)
 "jiy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs{
-	barefootstep = "woodbarefoot";
-	color = "#A47449";
-	dir = 8;
-	footstep = "wood"
+/obj/effect/fake_stairs/west{
+	color = "#bb3333"
 	},
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "jiz" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13{
@@ -17509,9 +17494,18 @@
 	},
 /area/f13/building/hospital/clinic/nash)
 "jnB" = (
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "jnR" = (
 /obj/structure/table/wood/settler,
 /obj/structure/bedsheetbin/empty,
@@ -17731,7 +17725,7 @@
 	dir = 1;
 	pixel_y = 12
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "jut" = (
 /obj/effect/spawner/lootdrop/f13/common,
@@ -17942,12 +17936,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jyY" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "jyZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -18012,11 +18012,17 @@
 	},
 /area/f13/building)
 "jBh" = (
-/obj/effect/turf_decal/siding/thinplating{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "jBp" = (
 /obj/structure/stone_tile/block{
 	layer = 5
@@ -18151,6 +18157,23 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland)
+"jEY" = (
+/obj/machinery/vending/medical/nash{
+	pixel_x = 26;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/custom/leechjar{
+	pixel_y = 18;
+	pixel_x = 21;
+	desc = "Why do the lumps in that jar look vaguely catlike?";
+	name = "Mereks brain juice"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "jFa" = (
 /obj/structure/closet/wardrobe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -18246,21 +18269,6 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jIC" = (
-/obj/structure/mirror{
-	pixel_y = 25;
-	pixel_x = -5
-	},
-/obj/machinery/shower{
-	pixel_y = 21;
-	pixel_x = 6
-	},
-/obj/structure/curtain,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "jIN" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/window/fulltile/house/broken,
@@ -18370,15 +18378,12 @@
 	},
 /area/f13/building)
 "jMc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/vending/dinnerware{
+	pixel_y = 19;
+	density = 0
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "jMg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -18486,10 +18491,17 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/abandoned)
 "jPG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "jQc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -19192,10 +19204,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"kjf" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "kji" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/road{
@@ -19363,11 +19371,11 @@
 	},
 /area/f13/building)
 "koc" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/bar)
 "koo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19491,14 +19499,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"krF" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "krI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -19700,13 +19700,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"kxw" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "kxz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19778,10 +19771,6 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"kAR" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "kBj" = (
 /obj/machinery/vending/games,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -19800,13 +19789,16 @@
 	},
 /area/f13/wasteland)
 "kBQ" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/obj/structure/curtain/directional/south{
-	color = "#1e549c"
+/obj/structure/table/wood,
+/obj/machinery/photocopier,
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
@@ -19990,6 +19982,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
+"kGv" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland/city/newboston/chapel)
 "kGH" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -20242,11 +20238,9 @@
 	},
 /area/f13/building)
 "kMX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "kNd" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -20289,12 +20283,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kNU" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "kNZ" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20347,6 +20342,22 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"kPv" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = -4;
+	layer = 2.8;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/waffles{
+	pixel_y = 13;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "kPz" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13{
@@ -20478,24 +20489,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kVa" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "kVi" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/bars{
-	layer = 3.5;
-	dir = 8
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building/trader)
+/area/f13/building/hospital/clinic/nash)
 "kVp" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -20573,15 +20579,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kWU" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/structure/curtain/directional/west{
-	color = "#450159"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "kXc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -20799,11 +20802,13 @@
 	},
 /area/f13/building)
 "lbs" = (
-/obj/machinery/vending/cola,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "lcb" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -20910,12 +20915,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"lfR" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "lgf" = (
 /obj/structure/table/greyscale,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21035,6 +21034,30 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"lhT" = (
+/obj/structure/sink/deep_water{
+	pixel_y = 3;
+	color = "#996633"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	color = "#996633"
+	},
+/area/f13/building/workshop/nash)
 "liA" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -21057,22 +21080,21 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ljb" = (
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
+/obj/machinery/chem_dispenser{
+	pixel_y = 19;
+	pixel_x = -12;
+	density = 0
 	},
-/obj/structure/window,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/chem_heater{
+	pixel_y = 17;
+	pixel_x = 8;
+	density = 0
 	},
-/obj/structure/campfire/churchfire{
-	pixel_y = 7
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/wasteland/city/newboston/chapel)
+/area/f13/building/hospital/clinic/nash)
 "ljd" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -21112,10 +21134,6 @@
 /obj/structure/bed/oldalt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"ljE" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "ljU" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -21398,13 +21416,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"ltu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "ltK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -21419,6 +21430,12 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ltR" = (
+/obj/machinery/vending/cola,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "ltT" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -21708,7 +21725,7 @@
 /obj/machinery/autolathe/ammo/unlocked{
 	pixel_y = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "lCf" = (
 /obj/structure/billboard/powerlines2{
@@ -22262,10 +22279,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "lUl" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
-/area/f13/city)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/outdoors)
 "lUv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
@@ -22365,16 +22384,6 @@
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lYp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/survivalcapsule,
-/obj/item/survivalcapsule,
-/obj/item/survivalcapsule/blacksmith,
-/obj/item/survivalcapsule/farm,
-/obj/item/survivalcapsule/fortuneteller,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "lYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22418,9 +22427,13 @@
 	},
 /area/f13/building)
 "lYY" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/rug/big/rug_red,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -22625,24 +22638,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "meY" = (
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/campfire/churchfire{
-	pixel_y = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "mfb" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -22996,12 +22996,6 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"moZ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "mpj" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23226,10 +23220,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mvv" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/city)
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "mvE" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -23274,9 +23267,18 @@
 	},
 /area/f13/building)
 "mwZ" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "mxb" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -23438,25 +23440,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"mBq" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "mBr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -23636,21 +23619,16 @@
 	},
 /area/f13/building)
 "mHJ" = (
-/obj/machinery/chem_dispenser{
-	pixel_y = 19;
-	pixel_x = -12;
-	density = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 15
 	},
-/obj/machinery/chem_heater{
-	pixel_y = 17;
-	pixel_x = 8;
-	density = 0
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999";
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "mHQ" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -23679,8 +23657,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mII" = (
-/obj/machinery/light/floor,
-/turf/open/floor/f13/wood,
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3;
+	pixel_x = -2
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "mIR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23721,6 +23705,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mJx" = (
+/obj/machinery/mineral/wasteland_vendor/badammo,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "mJJ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -23833,6 +23821,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
+"mMO" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/mob/living/simple_animal/cow/brahmin/cow/tan,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "mMX" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23930,30 +23930,41 @@
 	},
 /area/f13/wasteland)
 "mPB" = (
-/obj/item/storage/bag/money{
-	pixel_y = 14;
-	pixel_x = 33;
-	color = "#f3f233"
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
 	},
-/obj/structure/sign/bank{
-	layer = 4.1;
-	pixel_y = -4;
-	pixel_x = 32
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
-/obj/machinery/vending/coffee,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
+"mPW" = (
 /obj/structure/railing{
 	dir = 1;
 	color = "#bb3333"
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
-"mPW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	layer = 2.9
+	},
+/obj/item/toy/dummy,
+/obj/item/megaphone,
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "mPZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -24061,8 +24072,15 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "mTN" = (
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/obj/structure/chair/left{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "mUf" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -24201,15 +24219,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "mWi" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "mWm" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -24518,12 +24530,6 @@
 	color = "#999999"
 	},
 /area/f13/building)
-"ngm" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "ngs" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -24659,13 +24665,6 @@
 "njY" = (
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/city/newboston/outdoors)
-"nkj" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -16;
-	pixel_y = -12
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "nku" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24894,10 +24893,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/carpet,
 /area/f13/building)
-"nrx" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "nsl" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -25017,7 +25012,6 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "nwr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/lamp_post/doubles/bent{
 	dir = 4;
 	density = 0;
@@ -25209,8 +25203,12 @@
 	},
 /area/f13/building)
 "nBt" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "nBx" = (
 /obj/effect/decal/marking{
@@ -25261,27 +25259,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"nCU" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
-	},
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 39
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/city)
 "nDc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13,
@@ -25443,6 +25420,10 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"nHr" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nHJ" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -25726,16 +25707,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nPK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "nPS" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -25761,17 +25732,17 @@
 	},
 /area/f13/building)
 "nQu" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
+/obj/machinery/vending/boozeomat/pubby_captain{
+	pixel_y = 32;
 	density = 0
 	},
-/turf/open/floor/wood_worn,
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
 "nQv" = (
 /obj/structure/fence/handrail_corner{
@@ -25812,18 +25783,9 @@
 	},
 /area/f13/building)
 "nQU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "nRa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -25906,21 +25868,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
-"nTH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "nTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26051,17 +25998,9 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "nWz" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/mob/living/simple_animal/cow/brahmin/cow/tan,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/flora/timber,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "nWC" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26142,12 +26081,11 @@
 /area/f13/building)
 "nZK" = (
 /obj/structure/rack/shelf_metal{
-	pixel_x = -2;
-	pixel_y = -1
+	pixel_y = 3;
+	pixel_x = -1
 	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "nZL" = (
 /obj/structure/chair/stool/f13stool{
@@ -26264,18 +26202,9 @@
 	},
 /area/f13/wasteland)
 "ofN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "ofX" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr23";
@@ -26576,14 +26505,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"opB" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "opN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26745,6 +26666,19 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"ovp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "ovv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -26778,10 +26712,6 @@
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"owa" = (
-/obj/effect/turf_decal/vg_decals/numbers/zero,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "owx" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -26997,6 +26927,9 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
+"oFe" = (
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "oFv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
@@ -27466,7 +27399,11 @@
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/workshop/nash)
 "oUG" = (
 /obj/structure/fence/corner{
@@ -27516,10 +27453,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oVv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "oVz" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -27781,19 +27714,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"pdw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "pdK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -28018,12 +27938,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "pkF" = (
-/obj/machinery/iv_drip/telescopic,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/caves)
 "pkH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -28206,6 +28126,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ppJ" = (
+/obj/machinery/smartfridge/chemistry{
+	density = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "ppM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -28346,6 +28277,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"psT" = (
+/obj/machinery/status_display/supply{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "psW" = (
 /obj/structure/fence/end{
 	dir = 8
@@ -28369,9 +28310,31 @@
 /obj/structure/fluff/blocker,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"ptC" = (
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland)
+"ptA" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/item/shovel{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/outside/desert{
+	color = "#705454";
+	name = "sand pit"
+	},
+/area/f13/building/workshop/nash)
 "ptW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
@@ -28401,14 +28364,20 @@
 /turf/open/indestructible/ground/bamboo/fiftyeight,
 /area/f13/wasteland/city/newboston/sauna)
 "puk" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/machinery/vending/cola/starkist{
+	pixel_x = -9;
+	pixel_y = 21;
+	density = 0
 	},
-/obj/structure/curtain/directional/south,
-/turf/open/floor/wood_common{
-	color = "#775555"
+/obj/machinery/vending/cola/space_up{
+	pixel_x = 13;
+	pixel_y = 21;
+	density = 0
 	},
-/area/f13/wasteland/city/newboston/sauna)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "put" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -28622,10 +28591,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"pAu" = (
-/obj/effect/turf_decal/vg_decals/numbers/three,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "pAz" = (
 /obj/structure/sink{
 	dir = 1;
@@ -28659,9 +28624,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
-"pBs" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
 "pBB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -28707,6 +28669,14 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
+"pDA" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "pDJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -28912,6 +28882,15 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
+"pJt" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/export/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "pJI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -29027,6 +29006,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"pMY" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "pNj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -29064,14 +29049,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"pOy" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/obj/effect/turf_decal/vg_decals/numbers/one,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "pOz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -29165,8 +29142,10 @@
 	pixel_y = 3;
 	pixel_x = -1
 	},
-/obj/effect/spawner/lootdrop/f13/common_mats,
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "pQJ" = (
 /obj/structure/sign/departments/restroom,
@@ -29318,13 +29297,13 @@
 /area/f13/wasteland)
 "pXu" = (
 /obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -1
+	pixel_y = 4;
+	pixel_x = -3
 	},
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "pXJ" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -29367,15 +29346,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"pZk" = (
-/obj/machinery/vending/bigredvend{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "pZJ" = (
 /obj/item/stack/crafting/metalparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -29530,19 +29500,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "qez" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "qfd" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/bar,
@@ -29559,12 +29521,10 @@
 	},
 /area/f13/building)
 "qfR" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - E"
 	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "qgh" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -29621,18 +29581,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "qhp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west{
-	color = "#A47449";
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/hospital/clinic/nash)
+/obj/item/target,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "qhV" = (
 /obj/item/chair/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29650,18 +29601,14 @@
 	},
 /area/f13/wasteland)
 "qjw" = (
-/obj/machinery/computer/cargo{
-	dir = 1
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/machinery/button/door{
-	id = "countershutters";
-	name = "counter shutters";
-	pixel_x = -7;
-	pixel_y = -19;
-	req_one_access_txt = null;
-	layer = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "qjy" = (
 /obj/structure/window/fulltile/house/broken,
@@ -29680,16 +29627,6 @@
 	},
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"qjB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/survivalcapsule/kitchen,
-/obj/item/survivalcapsule/luxury,
-/obj/item/survivalcapsule/luxuryelite,
-/obj/item/survivalcapsule/merchant,
-/obj/machinery/light/floor,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "qjD" = (
 /obj/structure/sign/crosswalk{
 	pixel_x = 7;
@@ -29748,6 +29685,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
 "qlI" = (
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
 /area/f13/building/trader)
 "qlJ" = (
@@ -29822,6 +29760,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"qnB" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qnG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -29964,11 +29910,11 @@
 	},
 /area/f13/building/tribal/caveofforever)
 "qrX" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/machinery/bookbinder{
+	pixel_x = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "qse" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -29995,14 +29941,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"qst" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "qsz" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -30269,21 +30207,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qxw" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"qxT" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "qyc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -30466,13 +30389,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"qBA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "qBL" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -30568,8 +30484,11 @@
 	},
 /area/f13/building)
 "qDg" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/building)
+/obj/item/clothing/gloves/f13/baseball,
+/obj/item/twohanded/baseball,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "qDp" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr7";
@@ -30597,13 +30516,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"qDQ" = (
-/obj/machinery/computer/operating,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "qDY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -30635,6 +30547,16 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
+"qEK" = (
+/obj/structure/table/wood{
+	layer = 2.5;
+	alpha = 1
+	},
+/obj/structure/curtain/directional/east{
+	color = "#845f58"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "qEL" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -30664,9 +30586,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qFm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "qFn" = (
 /obj/structure/bookcase,
@@ -30741,12 +30667,26 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qHR" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 19
+	},
+/obj/structure/table/wood{
+	layer = 2.5;
+	alpha = 1
+	},
+/obj/structure/wood_counter{
+	layer = 2
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "qHX" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -31053,6 +30993,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
+"qQB" = (
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "qQD" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -31086,6 +31040,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
+"qRw" = (
+/obj/structure/nightstand/small{
+	pixel_x = 9;
+	pixel_y = 20
+	},
+/obj/item/flashlight/littlelamp{
+	pixel_y = 23;
+	pixel_x = 9
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 24;
+	pixel_x = -8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "qRA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -31215,8 +31184,13 @@
 /area/f13/building)
 "qWv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/recycler,
-/turf/open/floor/f13/wood,
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "qWB" = (
 /obj/structure/nest/randomized{
@@ -31472,9 +31446,15 @@
 	},
 /area/f13/building/abandoned)
 "rdO" = (
-/obj/structure/bookshelf,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -16;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "ref" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood,
@@ -31644,10 +31624,6 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/f13/building)
-"rjW" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
 "rjX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -31660,26 +31636,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rki" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/wood{
-	layer = 2.9
-	},
-/obj/item/toy/dummy,
-/obj/item/megaphone,
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/trader)
 "rkj" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
@@ -31854,15 +31814,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rnN" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_x = -3
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
 	},
-/obj/structure/table/wood,
-/obj/machinery/bookbinder{
-	pixel_x = -3
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/campfire/churchfire{
+	pixel_y = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/wasteland/city/newboston/chapel)
 "rnS" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -31906,12 +31869,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"rpa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - S"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "rpz" = (
 /obj/machinery/light/small{
 	light_color = "#884444"
@@ -32108,10 +32065,17 @@
 	},
 /area/f13/building)
 "ruk" = (
-/turf/closed/wall/r_wall/f13/vault{
-	opacity = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "ruz" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -32264,14 +32228,7 @@
 	},
 /area/f13/wasteland)
 "rxK" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "rxO" = (
 /obj/machinery/light{
@@ -32658,10 +32615,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"rJd" = (
-/obj/machinery/mineral/wasteland_vendor/badammo,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "rJi" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/chapel{
@@ -32760,6 +32713,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"rKP" = (
+/obj/machinery/computer/cargo/request{
+	dir = 1
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "rLa" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
@@ -33095,24 +33054,11 @@
 	},
 /area/f13/building)
 "rUy" = (
-/obj/structure/statue_fal{
-	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
-	icon_state = "statue2";
-	pixel_x = -14;
-	layer = 6;
-	pixel_y = -20
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "rUB" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -33223,17 +33169,15 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
 "rXj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/grown/log/tree{
-	pixel_x = 10;
-	pixel_y = -3
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/item/grown/log/tree{
-	pixel_x = 10;
-	pixel_y = -3
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "rXx" = (
 /obj/structure/decoration/clock/active{
 	pixel_y = 24
@@ -33760,13 +33704,14 @@
 	},
 /area/f13/building)
 "shO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/campfire/stove{
-	pixel_x = 7;
-	pixel_y = -7
+/obj/item/book{
+	pixel_y = 32;
+	anchored = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "shR" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -33937,14 +33882,24 @@
 	},
 /area/f13/brotherhood)
 "soW" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
 	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 1;
+	pixel_y = 39;
+	layer = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "spi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/recharge_station,
@@ -34028,8 +33983,11 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "sri" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/workshop/nash)
 "srl" = (
 /obj/structure/chair/right{
@@ -34046,10 +34004,19 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "srI" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/city)
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "ssg" = (
 /obj/machinery/light{
 	dir = 1
@@ -34071,14 +34038,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"ssX" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "stn" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34105,10 +34064,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"stz" = (
-/obj/machinery/vending/medical/becomingnook,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "stG" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -34286,21 +34241,6 @@
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"syx" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_x = -9;
-	pixel_y = 21;
-	density = 0
-	},
-/obj/machinery/vending/cola/space_up{
-	pixel_x = 13;
-	pixel_y = 21;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "syB" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -34637,12 +34577,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sHE" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = 19;
-	density = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal{
+	pixel_y = 21
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "sHQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
@@ -34674,6 +34614,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"sIw" = (
+/obj/effect/landmark/party{
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "sIE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -35001,6 +34947,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
+"sRK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "sRP" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -35191,6 +35141,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"sUQ" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "sVi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -35213,14 +35169,14 @@
 /area/f13/building)
 "sWl" = (
 /obj/structure/table/wood,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "countershutters";
 	name = "counter shutters";
 	req_one_access_txt = null
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -35852,12 +35808,6 @@
 "tot" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
-"toG" = (
-/obj/item/clothing/gloves/f13/baseball,
-/obj/item/twohanded/baseball,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "toQ" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -36091,6 +36041,16 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tuf" = (
+/obj/structure/fermenting_barrel{
+	pixel_y = 9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "tum" = (
 /obj/structure/sink/puddle,
 /obj/effect/decal/cleanable/dirt,
@@ -36175,26 +36135,6 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"twS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
-	},
-/obj/structure/sink/kitchen{
-	pixel_y = 19
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "twX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36287,14 +36227,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/caveofforever)
 "tza" = (
-/obj/structure/rack/shelf_metal{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "tzc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -36401,12 +36336,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "tBN" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/machinery/reagentgrinder,
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -36553,20 +36482,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tFZ" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 10
-	},
-/obj/structure/wood_counter/bend{
-	dir = 4;
-	layer = 2
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/item/storage/fancy/pickles_jar,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/closet/ammunitionlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tGJ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36575,6 +36493,13 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
+"tGZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "tHh" = (
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/stack/sheet/glass/ten,
@@ -36598,11 +36523,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tHs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/vg_decals/numbers/nine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_common,
 /area/f13/building/trader)
 "tHN" = (
 /obj/structure/curtain/directional/south{
@@ -36642,7 +36563,7 @@
 /obj/machinery/workbench/forge{
 	pixel_y = 7
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "tJK" = (
 /obj/structure/barricade/wooden,
@@ -36708,7 +36629,7 @@
 	pixel_y = -1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "tLa" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36851,6 +36772,12 @@
 /obj/item/soap,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"tNI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "tOp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/blamco,
@@ -36894,9 +36821,7 @@
 	color = "#ACD1E9";
 	alpha = 200
 	},
-/turf/open/floor/wood_common{
-	color = "#775555"
-	},
+/turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/sauna)
 "tPi" = (
 /obj/machinery/chem_heater,
@@ -36905,10 +36830,12 @@
 	},
 /area/f13/building)
 "tPo" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/workshop/nash)
 "tPu" = (
 /obj/structure/rack,
@@ -37004,17 +36931,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tRs" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 5
 	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "tRy" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -37069,13 +36994,22 @@
 	},
 /area/f13/building)
 "tSy" = (
-/obj/structure/rack/shelf_metal{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/structure/mirror{
+	pixel_y = 25;
+	pixel_x = -5
 	},
-/obj/effect/spawner/lootdrop/f13/common_mats,
-/turf/open/floor/f13/wood,
-/area/f13/building/workshop/nash)
+/obj/machinery/shower{
+	pixel_y = 21;
+	pixel_x = 6
+	},
+/obj/structure/curtain,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "tSI" = (
 /obj/structure/window/fulltile/house,
 /obj/effect/decal/cleanable/dirt,
@@ -37090,16 +37024,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "tTx" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/machinery/light{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "tTF" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/bed/mattress/pregame,
@@ -37383,23 +37315,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ueL" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 25;
+	density = 0
 	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "ueX" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -37553,9 +37474,9 @@
 	},
 /area/f13/building)
 "uiu" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "uiB" = (
 /obj/structure/stairs/west{
 	dir = 2
@@ -37687,11 +37608,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
 "ulP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/city)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "ulR" = (
 /obj/structure/wreck/trash/halftire,
 /obj/effect/decal/cleanable/dirt,
@@ -37814,12 +37733,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"uoR" = (
-/obj/effect/landmark/party{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "upe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -37893,9 +37806,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "utJ" = (
@@ -38122,9 +38032,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "uAy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/f13/wood,
+/obj/structure/rack/shelf_metal{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "uAH" = (
 /turf/open/floor/wood_fancy,
@@ -38266,12 +38180,11 @@
 /turf/open/floor/plasteel/neutral,
 /area/f13/building)
 "uEN" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/structure/rug/big/rug_red{
+	pixel_x = 19
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "uEQ" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
@@ -38361,14 +38274,12 @@
 	},
 /area/f13/wasteland)
 "uHp" = (
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - S"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/processor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "uHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -38424,17 +38335,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
-"uJb" = (
-/obj/structure/sacredwell{
-	light_power = 20;
-	max_integrity = 9999;
-	light_color = "#33BE24";
-	light_range = 3;
-	color = "#BE446e";
-	desc = "That used to be the tribes sacred well.  Why is it here...?"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "uJe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -38490,20 +38390,37 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
-"uKH" = (
+"uKX" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	pixel_y = 14;
+	network = list("nash");
+	layer = 3;
+	alpha = 0;
+	mouse_opacity = 0
+	},
+/obj/machinery/mineral/wasteland_vendor/mining,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
+"uLf" = (
+/turf/closed/wall/f13/store,
+/turf/closed/wall/f13/store,
+/area/f13/building)
+"uLk" = (
 /obj/structure/rack/shelf_metal{
-	pixel_y = 7;
+	pixel_y = 3;
 	pixel_x = -4
 	},
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
-"uLf" = (
-/turf/closed/wall/f13/store,
-/turf/closed/wall/f13/store,
-/area/f13/building)
 "uLv" = (
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38934,12 +38851,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"uZH" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "vac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -39071,14 +38982,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vdH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "vdR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -39396,12 +39303,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vlH" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
 	},
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/obj/structure/sign/barsign{
+	light_color = "#FDB0C0";
+	pixel_x = 1;
+	pixel_y = 36
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "vlV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -39474,10 +39388,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
-"vnC" = (
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
 "vnY" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 8;
@@ -39500,6 +39410,24 @@
 	color = "#A1BFFF"
 	},
 /area/f13/tribe)
+"voN" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/obj/structure/wood_counter/bend{
+	dir = 4;
+	layer = 2
+	},
+/obj/structure/table/wood{
+	layer = 2.5;
+	alpha = 1
+	},
+/obj/item/storage/fancy/pickles_jar,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "vpj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -39644,19 +39572,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "vsv" = (
-/obj/machinery/light{
+/obj/structure/closet/crate/bin{
+	pixel_y = 3;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
+"vsz" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
-"vsz" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/computer/cargo,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "vsB" = (
@@ -39754,15 +39683,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"vuQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "vuT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -39857,9 +39777,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "vxh" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt,
-/turf/open/floor/wood_fancy/wood_fancy_light,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/general,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
 /area/f13/building/trader)
 "vxi" = (
 /obj/structure/table/reinforced,
@@ -40075,6 +39999,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
+"vEa" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "vEc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40095,13 +40027,15 @@
 	},
 /area/f13/building/abandoned)
 "vEK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
-"vEW" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/chair/sofa/corner{
+	dir = 1
+	},
+/obj/structure/rug/carpet3{
+	pixel_y = 13;
+	pixel_x = 14
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "vFA" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -40263,11 +40197,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vMM" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 12
+/obj/structure/rack/shelf_metal{
+	pixel_y = 7;
+	pixel_x = -4
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "vMN" = (
 /obj/item/storage/trash_stack,
@@ -40289,6 +40226,16 @@
 "vNf" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"vNr" = (
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/obj/structure/curtain/directional/west{
+	color = "#450159"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "vNt" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -40301,19 +40248,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vNJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west{
-	color = "#A47449";
-	dir = 2;
-	pixel_y = 0
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "vNL" = (
 /obj/structure/chair{
 	dir = 8
@@ -40404,6 +40338,14 @@
 "vPo" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
+"vPE" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "vPN" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -40412,12 +40354,12 @@
 	},
 /area/f13/building)
 "vPX" = (
-/obj/structure/holohoop{
-	pixel_y = 20;
-	pixel_x = 16
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "vQb" = (
 /obj/structure/stairs,
 /turf/open/floor/f13{
@@ -40489,11 +40431,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vSN" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "vSW" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt,
@@ -40556,18 +40496,11 @@
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
 "vUt" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "vUF" = (
 /obj/structure/sink{
 	dir = 4;
@@ -40592,13 +40525,6 @@
 /obj/structure/table,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
-"vWq" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "vWL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -40646,13 +40572,6 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"vYg" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/hospital/clinic/nash)
 "vYw" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /obj/effect/decal/cleanable/dirt,
@@ -40935,15 +40854,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wfi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/holohoop{
+	pixel_y = 20;
+	pixel_x = 16
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "wfu" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Senior Paladin";
@@ -41131,15 +41052,28 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wlP" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
+/obj/structure/sacredwell{
+	light_power = 20;
+	max_integrity = 9999;
+	light_color = "#33BE24";
+	light_range = 3;
+	color = "#BE446e";
+	desc = "That used to be the tribes sacred well.  Why is it here...?"
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "wlQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wmi" = (
+/obj/item/reagent_containers/food/snacks/burger/baseball{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wmo" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/beakers,
@@ -41181,6 +41115,14 @@
 /obj/machinery/icecream_vat,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
+"wmM" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "wmT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41397,6 +41339,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
+"wuq" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -3
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "wus" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -41621,14 +41572,19 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wzP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
 "wAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/building)
+"wAj" = (
+/obj/machinery/mineral/equipment_vendor{
+	pixel_y = 14;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "wAB" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -41851,27 +41807,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wGH" = (
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/grains,
-/obj/item/storage/box/ingredients/grains,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "wHr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -41910,7 +41848,7 @@
 	},
 /area/f13/wasteland)
 "wIP" = (
-/obj/structure/legion_extractor,
+/obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
 "wJg" = (
@@ -42014,12 +41952,14 @@
 /area/f13/building/workshop/nash)
 "wLd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "wLg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
@@ -42403,14 +42343,8 @@
 /turf/open/floor/wood_worn,
 /area/f13/wasteland/city/newboston/bar)
 "wVD" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "wVY" = (
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -42557,13 +42491,14 @@
 	},
 /area/f13/wasteland)
 "wZe" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0;
-	pixel_x = -3
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/closed/wall/f13/coyote/oldwood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "wZE" = (
 /obj/structure/simple_door/brokenglass,
@@ -42628,31 +42563,6 @@
 "xbw" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/tribal/cave)
-"xcf" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/item/shovel{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	color = "#705454";
-	name = "sand pit"
-	},
-/area/f13/building/workshop/nash)
 "xcu" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -42747,8 +42657,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xen" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/building)
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "xeu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -42979,14 +42904,16 @@
 	},
 /area/f13/building)
 "xkz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal{
-	pixel_y = 4;
-	pixel_x = -3
+	pixel_y = -2;
+	pixel_x = 3
 	},
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "xlb" = (
 /obj/structure/rack,
@@ -43197,10 +43124,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
-"xpO" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
 "xqN" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -43241,20 +43164,24 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "xrJ" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
+/obj/structure/statue_fal{
+	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
+	icon_state = "statue2";
+	pixel_x = -14;
+	layer = 6;
+	pixel_y = -20
 	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
 	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/wasteland/city/newboston/outdoors)
 "xrP" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43297,16 +43224,13 @@
 	},
 /area/f13/building)
 "xtx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/vending/bigredvend{
+	pixel_x = -7;
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "xtG" = (
 /obj/structure/simple_door/house,
@@ -43484,16 +43408,21 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/item/trash/candle{
+	pixel_x = 3;
+	pixel_y = 19
 	},
-/obj/item/book{
-	pixel_y = 32;
-	anchored = 1
+/obj/item/candle/infinite{
+	pixel_x = -9;
+	pixel_y = 19
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/clothing/head/helmet/skull{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/bookcase,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "xyu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -43650,6 +43579,13 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
+"xCx" = (
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "xCC" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -44036,8 +43972,10 @@
 /area/f13/building)
 "xOu" = (
 /obj/item/toy/beach_ball/holoball,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "xOF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -44190,6 +44128,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"xRq" = (
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/south,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/sauna)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -44224,6 +44169,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"xSo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "xSA" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -44351,14 +44311,23 @@
 	},
 /area/f13/wasteland)
 "xVz" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
+/obj/machinery/computer/cargo{
 	dir = 1
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/machinery/button/door{
+	id = "countershutters";
+	name = "counter shutters";
+	pixel_x = -7;
+	pixel_y = -22;
+	req_one_access_txt = null;
+	layer = 4
+	},
+/obj/structure/railing{
+	color = "#bb3333";
+	dir = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "xVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44439,10 +44408,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"xWR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/wasteland/city/newboston/outdoors)
 "xXa" = (
 /obj/structure/railing{
 	dir = 8
@@ -44667,6 +44632,13 @@
 /obj/item/clipboard,
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/carpet/green,
+/area/f13/building/trader)
+"yes" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "yev" = (
 /obj/structure/chair/stool/f13stool{
@@ -67677,14 +67649,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-ptC
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-ptC
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -68682,22 +68654,22 @@ pll
 pll
 hhp
 vJk
-aDg
+oQS
+rom
 hQs
-hQs
-hQs
-hQs
-hQs
-ofN
-ofN
-ofN
-ofN
-nPK
+gej
+gej
+gej
+gej
+gej
+gej
+gej
+rXj
 rom
 hQs
 hQs
 hQs
-xtx
+jBh
 tEZ
 rom
 hQs
@@ -68710,7 +68682,7 @@ hQs
 hQs
 hQs
 hQs
-fDY
+pJc
 fDY
 fgh
 kuU
@@ -68939,25 +68911,25 @@ hVc
 mCq
 hVc
 hVc
-xlf
-xlf
+aAx
 hVc
 hVc
-hVc
-hVc
-nRa
-nRa
-hVc
-hVc
-hVc
-hVc
+tNI
+tNI
+tNI
+tNI
+tNI
+dOt
+awl
+dOt
+kWU
 xZc
 xZc
 xZc
 xZc
-cIm
+tGZ
 wTa
-vuQ
+qFm
 xZc
 xZc
 xZc
@@ -68965,10 +68937,10 @@ xZc
 xZc
 xZc
 xZc
-xZc
+rdO
 hcF
-lQM
-fgh
+lYY
+dPg
 fgh
 nWv
 hEQ
@@ -69196,17 +69168,17 @@ hVc
 bpA
 wKZ
 nYg
-aST
-aST
-xlf
-bus
-boV
+wVD
+nZK
 hVc
-tPQ
-qrX
-xcf
+awl
+awl
+awl
+awl
+meY
+ptA
 oUB
-eKM
+lhT
 hVc
 ifw
 ifw
@@ -69221,11 +69193,11 @@ pll
 pll
 pll
 pll
-nkj
-jnB
-hTR
+pll
+pll
+noh
+wmi
 lQM
-fDY
 fgh
 fca
 sGD
@@ -69452,18 +69424,18 @@ pll
 mCq
 ifN
 kjL
-xlf
-xlf
-xlf
-xlf
-xlf
-bus
+rxK
+rxK
+uLk
 hVc
-tPQ
-qrX
-uEN
-gDe
-nWz
+awl
+awl
+awl
+awl
+awl
+sri
+awl
+mMO
 hVc
 pwM
 isE
@@ -69479,10 +69451,10 @@ pll
 pll
 pll
 pll
-noh
-gzl
+nWz
+pll
+qDg
 lQM
-fDY
 fDY
 fDY
 xOW
@@ -69708,19 +69680,19 @@ jri
 pll
 mCq
 lBZ
-xlf
-xlf
+rxK
+rxK
+rxK
 pQD
-pQD
-tSy
-xlf
-lvG
 hVc
-tPQ
-qrX
-kjf
-kjf
-gDe
+awl
+awl
+awl
+awl
+awl
+ofN
+ofN
+awl
 hVc
 wJl
 isE
@@ -69735,11 +69707,11 @@ pll
 pll
 pll
 pll
-abe
 pll
-toG
-avu
-fDY
+pll
+pll
+vJk
+lQM
 fDY
 kwu
 fgh
@@ -69965,19 +69937,19 @@ hzj
 pll
 mCq
 jtS
-xlf
-xlf
-xlf
+rxK
+cEt
+rxK
 mII
-xlf
-xlf
-lvG
 hVc
-tPQ
-qrX
-gDe
-gDe
-gDe
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
 hVc
 ifw
 qHX
@@ -69985,6 +69957,7 @@ ifw
 ifw
 pll
 gFY
+gje
 pll
 pll
 pll
@@ -69992,8 +69965,7 @@ pll
 pll
 pll
 pll
-pll
-pll
+sIw
 pll
 ute
 lQM
@@ -70222,25 +70194,25 @@ iJo
 pll
 mCq
 bzN
-xlf
-xlf
+rxK
+rxK
 rxK
 pXu
-tza
-xlf
-xlf
 hVc
-hVc
-hVc
-hVc
-hCQ
-hVc
+tPo
+tPo
+tPo
+tPo
+tPo
+avJ
+tPo
+tPo
 hVc
 isE
 isE
-aSt
+kGv
 qGt
-vWq
+dda
 ifw
 pll
 pll
@@ -70249,7 +70221,7 @@ pll
 pll
 pll
 pll
-uoR
+pll
 pll
 pll
 cUU
@@ -70258,7 +70230,7 @@ pJc
 pJc
 pJc
 pJc
-aQG
+hJP
 kXC
 hRg
 tPQ
@@ -70479,19 +70451,19 @@ aBY
 pll
 mCq
 tJH
-xlf
-aST
-aST
-aST
-xlf
-xlf
-aST
-gDe
-gDe
+rxK
 wVD
-acE
-gDe
-gDe
+wVD
+wVD
+fKN
+fKN
+bBH
+bBH
+bBH
+bBH
+fKN
+bBH
+fKN
 hVc
 isE
 isE
@@ -70499,9 +70471,9 @@ isE
 kzV
 isE
 ifw
-fsW
-ssX
-gej
+vEa
+czX
+vEa
 bCw
 kIY
 pll
@@ -70735,31 +70707,31 @@ tvO
 bAz
 pll
 mCq
-xlf
-xlf
-aST
-uKH
+rxK
+rxK
+hNR
+rxK
 bKT
-nZK
-xlf
-xlf
 hVc
-ctp
-gDe
-gDe
-gDe
-wIP
+eKD
+fKN
+fKN
+fKN
+fKN
+fKN
+fKN
+mWi
 hVc
-ljb
-jiy
+gLd
+kzV
 sfn
 vYz
-meY
+rnN
 ifw
 tlI
 qlW
 lYg
-kMX
+kIY
 vqW
 pll
 pll
@@ -70993,19 +70965,19 @@ ddi
 pll
 hVc
 vMM
-xlf
-xlf
-xlf
+rxK
+rxK
+rxK
 uAy
-xlf
-xlf
-aST
 hVc
+tuf
 bBH
-acE
-acE
-acE
-iNQ
+bBH
+bBH
+bBH
+bBH
+bBH
+kMX
 hVc
 rOW
 isE
@@ -71014,9 +70986,9 @@ isE
 rOW
 ifw
 kIY
-rUy
+xrJ
 mrr
-qxT
+qnB
 wze
 pll
 pll
@@ -71249,20 +71221,20 @@ njY
 soG
 pll
 hVc
-xlf
-xlf
-xlf
-cBv
+qWv
+rxK
+rxK
+rxK
 xkz
-hNR
-xlf
-xlf
 hVc
-bms
-gDe
-gDe
-gDe
-sri
+akW
+fKN
+fKN
+fKN
+fKN
+fKN
+fKN
+wIP
 hVc
 jGw
 ott
@@ -71507,19 +71479,19 @@ cgZ
 uiB
 hVc
 qWv
-xlf
-xlf
-xlf
-uAy
-xlf
-xlf
-kVa
+rxK
+cEt
+wVD
+pXu
 hVc
-opB
+vPE
+bBH
+bBH
+bBH
+bBH
+bBH
+bBH
 acE
-acE
-acE
-vEW
 hVc
 jGw
 ott
@@ -71764,19 +71736,19 @@ iqu
 sbq
 hVc
 tKS
-xlf
-aST
-aST
-xlf
-aST
-xlf
-xlf
-tPo
-gDe
-gDe
-gDe
+rxK
+wVD
+rxK
+nZK
+hVc
+fKN
+fKN
+fKN
+fKN
+fKN
+fKN
 lUv
-gDe
+fKN
 hVc
 dNH
 qFz
@@ -71790,8 +71762,8 @@ avK
 avK
 avK
 avK
-qst
-qst
+gZZ
+gZZ
 avK
 bGv
 vJk
@@ -72025,7 +71997,7 @@ gIm
 gIm
 gIm
 gIm
-gIm
+ajZ
 bKF
 gIm
 gIm
@@ -72053,7 +72025,7 @@ ekg
 nRM
 vJk
 byj
-puk
+xRq
 lzG
 pfP
 fMx
@@ -72528,7 +72500,7 @@ vqy
 "}
 (108,1,1) = {"
 hRl
-alu
+gao
 vIQ
 jqA
 klQ
@@ -72545,7 +72517,7 @@ brC
 brC
 brC
 brC
-hsR
+brC
 brC
 brC
 brC
@@ -72565,7 +72537,7 @@ eLP
 rLl
 mdh
 bgu
-hJP
+ruk
 nDA
 bZu
 pfP
@@ -72787,15 +72759,15 @@ gcX
 hRl
 gao
 hJN
-akW
-elk
-qHR
-eUA
-dQI
-ruk
-cUd
+uKX
+dYk
+vxh
+bms
+rki
+cKP
 avK
 avK
+abR
 avK
 avK
 avK
@@ -73042,38 +73014,38 @@ hRl
 "}
 (110,1,1) = {"
 hRl
-rJd
-qlI
-qlI
-qlI
-qlI
-qlI
-qlI
-qlI
-ngm
+mJx
+dtH
+dtH
+dtH
+dtH
+dtH
+dtH
+dtH
+dtH
 gln
-ngm
-koc
-koc
-koc
-koc
-koc
+dtH
+eWR
+eWR
+eWR
+eWR
+eWR
 uzU
-koc
-koc
-koc
+eWR
+eWR
+eWR
 ayi
-jBh
-jBh
-jBh
+rUy
+rUy
+rUy
 ayi
-jBh
-jBh
+rUy
+rUy
 wVC
 qda
 qda
 fft
-mBq
+soW
 nRM
 rHb
 rce
@@ -73300,25 +73272,25 @@ hRl
 (111,1,1) = {"
 hRl
 tHW
+tHs
+tHs
 qlI
+tHs
+tHs
 qlI
-mwZ
+tHs
+tHs
 qlI
-qlI
-mwZ
-qlI
-qlI
-mwZ
-qlI
-rjW
-xpO
-cdB
-cdB
-xpO
-cdB
-cdB
-xpO
-cdB
+tHs
+oFe
+fyF
+oFe
+oFe
+fyF
+oFe
+oFe
+fyF
+oFe
 tRA
 rXa
 tRA
@@ -73326,9 +73298,9 @@ tRA
 rXa
 tRA
 tRA
-nQu
-cWw
-cWw
+jyY
+hqo
+hqo
 vOY
 mdh
 etn
@@ -73557,34 +73529,34 @@ hRl
 (112,1,1) = {"
 hRl
 rLL
-qlI
-qlI
-qlI
-qlI
-qlI
-eWR
-qlI
-qlI
-qlI
-qlI
-cdB
-cdB
-cdB
-cdB
-cdB
-cdB
-cdB
-cdB
-dOt
-ljE
+tHs
+tHs
+tHs
+tHs
+tHs
+kNU
+tHs
+tHs
+tHs
+tHs
+oFe
+oFe
+oFe
+oFe
+oFe
+oFe
+oFe
+fTf
+nQU
+ulP
 iep
-ljE
+ulP
 nZa
 iep
 tRA
 tRA
-fTf
-rki
+jiy
+mPW
 vzp
 vOY
 mdh
@@ -73813,27 +73785,27 @@ hRl
 "}
 (113,1,1) = {"
 hRl
-gao
-qlI
-qlI
-pAu
+eqe
+tHs
+tHs
+wGH
 qTx
-pOy
-cmo
-mPB
-moZ
-qlI
+cdB
+rKP
+boV
+qez
+tHs
 cZU
-qez
-qez
-qCp
-qez
-qez
-qez
-bAa
+qQB
+qQB
+mPB
+qQB
+qQB
+qQB
+gor
 tKO
 qCp
-heQ
+vlH
 tdE
 tdE
 tdE
@@ -74071,12 +74043,12 @@ hRl
 (114,1,1) = {"
 hRl
 gao
-gao
-kWU
+gDe
+vNr
 afx
 afx
 sWl
-kVi
+gDe
 gao
 gOo
 nVE
@@ -74085,18 +74057,18 @@ jxT
 gXv
 tBN
 uIt
-icC
-icC
+gXv
+gXv
 uIt
-bgF
-wzP
+vsv
+ars
 qgK
 ogc
 qei
 ogc
 woy
 tRA
-ahq
+tza
 tHN
 wWW
 srl
@@ -74333,29 +74305,29 @@ iXY
 qxf
 wMb
 gHl
-qjw
+xVz
 gao
-hVl
+cmo
 iXY
 gao
-mHJ
+ljb
 uIt
-qfR
-uIt
-uIt
+mwZ
 uIt
 uIt
-avJ
-wzP
+uIt
+uIt
+kPv
+ars
 wBB
 ogc
 ogc
 ogc
 cNZ
 tRA
-tRA
+rXa
 tHN
-bsJ
+vPX
 mjx
 vOY
 wbp
@@ -74590,15 +74562,15 @@ iXY
 iXY
 lsj
 iXY
+fUC
+gao
+ueL
 iXY
-vxh
-iXY
-lsj
-kBQ
+qjw
 uIt
+eUA
 uIt
-uIt
-bDj
+jEY
 uIt
 uIt
 uIt
@@ -74610,13 +74582,13 @@ iCv
 ogc
 qlE
 tRA
-ahq
+tza
 tHN
 kYy
-mWi
+mTN
 vOY
-mdh
-klQ
+frU
+cwC
 aqT
 rJa
 mdh
@@ -74847,23 +74819,23 @@ iXY
 iXY
 iXY
 iXY
-gyr
-gao
-fyF
+iXY
+ivc
+hvy
 iXY
 gao
 qCp
 qCp
 qCp
 qCp
-ueL
+xen
 jnu
 uIt
-aXi
+ppJ
 qCp
-twS
+qHR
 lzk
-xrJ
+lzk
 kef
 hdy
 tRA
@@ -74872,9 +74844,9 @@ vOY
 vOY
 vOY
 vOY
-aHM
-uHp
-aqT
+tlI
+lUl
+mHJ
 rJa
 mdh
 rEv
@@ -75104,23 +75076,23 @@ iXY
 iXY
 iXY
 iXY
-bzW
+fUC
 gao
 gao
 nVE
 gao
 qCp
-qDQ
+bDj
 sYT
-sYT
-jyY
+pDA
+uiu
 hBy
 uIt
 uIt
 qCp
 vOY
+qEK
 elX
-vOY
 vOY
 vOY
 omk
@@ -75360,30 +75332,30 @@ cqF
 iXY
 iXY
 lsj
-lYp
-qjB
+iXY
+cUd
 gao
-vEK
-vEK
-rdO
+sHE
+rvM
+isg
 qCp
 iUQ
 sYT
 sYT
-stz
+mvv
 hBy
 uIt
 uIt
 qCp
-wGH
+aQG
 weC
-jef
-tFZ
+weC
+voN
 vOY
 vDv
-tRA
+rXa
 tHN
-bsJ
+vPX
 mjx
 vOY
 tlI
@@ -75617,12 +75589,12 @@ okY
 iXY
 iXY
 iXY
+iXY
 iOa
 gao
-gao
+hsR
 rvM
-fUg
-soW
+rvM
 qCp
 evI
 sYT
@@ -75632,8 +75604,8 @@ mEG
 uIt
 uIt
 qCp
-vUt
-iCv
+uHp
+ogc
 ogc
 cxm
 vOY
@@ -75641,11 +75613,11 @@ tjm
 tRA
 tHN
 kYy
-mWi
+mTN
 vOY
 tlI
 ghS
-bFG
+rHb
 rce
 mdh
 ccQ
@@ -75874,17 +75846,17 @@ gyr
 iXY
 iXY
 iXY
+iXY
 eNj
-gao
-soW
-vnC
+kBQ
 aMZ
 vEc
+rvM
 qCp
-jIC
+tSy
 vUF
 sYT
-pkF
+hVl
 hBy
 uIt
 uIt
@@ -75894,14 +75866,14 @@ ogc
 ogc
 oIv
 uQa
-vsv
+koc
 tRA
 vOY
 vOY
 vOY
 vOY
-nCU
-wlP
+tlI
+tlI
 bFG
 rce
 mdh
@@ -76132,11 +76104,11 @@ iXY
 iXY
 lsj
 iXY
-gao
-gao
-rvM
+gyr
+hCQ
 bSa
 yer
+rvM
 qCp
 qCp
 qCp
@@ -76144,7 +76116,7 @@ qCp
 qCp
 hBy
 uIt
-uIt
+glQ
 qCp
 fpl
 ogc
@@ -76154,13 +76126,13 @@ vOY
 fft
 eOo
 vOY
-mvv
-mvv
-mvv
-mTN
-ulP
-rHb
-rLl
+hNN
+nxO
+nxO
+nxO
+nxO
+uWY
+rce
 mdh
 klQ
 pll
@@ -76384,26 +76356,26 @@ hRl
 (123,1,1) = {"
 hRl
 gao
-fKN
+icC
 iXY
 iXY
 iXY
 iXY
-iXY
-cEt
-qBA
-frU
-iXY
-vYg
+vdH
+gao
+foy
+foy
+foy
+qCp
+uIt
+uIt
+jas
 uIt
 uIt
 uIt
 uIt
-uIt
-uIt
-uIt
-bAa
-vSN
+kVi
+pMY
 ogc
 ogc
 oUn
@@ -76411,12 +76383,12 @@ fft
 jeH
 jUN
 vOY
-vPX
+wfi
 xOu
-mTN
-mTN
-lUl
-rHb
+uWY
+uWY
+uWY
+uWY
 rce
 mdh
 klQ
@@ -76641,26 +76613,26 @@ hRl
 (124,1,1) = {"
 hRl
 gao
-jMc
-nbZ
-nbZ
-nbZ
-nbZ
-hiW
-gao
+iXY
+iXY
+iXY
+iXY
+iXY
+icC
 gao
 iXY
-vNJ
-qCp
+iXY
+iXY
+kVi
 uIt
 uIt
-vdH
-awt
-qhp
+eUA
+aHr
+cIm
 uIt
 uIt
 uIt
-hNN
+nQu
 bEN
 lzk
 aLL
@@ -76668,12 +76640,12 @@ vOY
 sPL
 qps
 vOY
-mTN
-mTN
-mTN
-mTN
-lUl
-rHb
+fsW
+uWY
+uWY
+uWY
+uWY
+uWY
 rce
 mdh
 klQ
@@ -76898,16 +76870,16 @@ hRl
 (125,1,1) = {"
 hRl
 gao
-fTT
-whF
-whF
-foy
-whF
-whF
-ceh
-gao
-hps
 wZe
+nbZ
+nbZ
+nbZ
+nbZ
+yes
+ivc
+iXY
+lsj
+hiW
 qCp
 qCp
 qCp
@@ -76915,7 +76887,7 @@ qCp
 qCp
 qCp
 qCp
-bAa
+kVi
 qCp
 vOY
 vOY
@@ -76925,12 +76897,12 @@ vOY
 vOY
 vOY
 vOY
-srI
-srI
-srI
-mTN
-lUl
-aqT
+heQ
+brC
+brC
+brC
+brC
+uWY
 rce
 mdh
 klQ
@@ -77155,14 +77127,17 @@ hRl
 (126,1,1) = {"
 hRl
 gao
-vsz
+psT
 whF
 whF
-owa
+dRJ
 whF
-whF
-jPG
+ceh
 gao
+iXY
+iXY
+wuq
+pkF
 iLF
 iLF
 iLF
@@ -77171,22 +77146,19 @@ iLF
 iLF
 iLF
 iLF
-iLF
-iLF
-iLF
-oVv
-aRr
+vSN
 auL
-cpu
+auL
+fVx
 raI
 seq
-cXg
-oVv
 xyl
-wLd
-fVx
-mdh
-klQ
+vSN
+shO
+avK
+avK
+avK
+bGv
 rHb
 rce
 mdh
@@ -77194,8 +77166,8 @@ lVZ
 avK
 avK
 avK
-qst
-qst
+gZZ
+gZZ
 kXC
 kJF
 kXC
@@ -77415,10 +77387,10 @@ gmg
 bPn
 qRl
 xPV
-tHs
-gwL
-qRl
-hvy
+eEr
+vsz
+aRr
+gao
 wHT
 wHT
 wHT
@@ -77431,21 +77403,21 @@ wHT
 wHT
 iLF
 iLF
-oVv
-rnN
-fSU
+vSN
+cXg
+auL
+uEN
 auL
 auL
 auL
-fSU
-hNT
+xCx
 ius
-ius
-fgh
-mdh
+jqA
+jqA
+jqA
 klQ
 rHb
-rLl
+rce
 nwr
 gIm
 gIm
@@ -77688,18 +77660,18 @@ qOI
 wHT
 iLF
 iLF
-oVv
-nrx
-fSU
-fSU
-fSU
-fSU
+vSN
+qrX
 auL
-vlH
-ltu
-qxw
-mPW
-mdh
+auL
+auL
+auL
+vEK
+fSU
+aHM
+gIm
+gIm
+qfR
 klQ
 aqT
 mLI
@@ -77945,17 +77917,17 @@ qOI
 wHT
 iLF
 iLF
-oVv
-tTx
-lfR
-shO
-rXj
-dtH
-uZH
-vlH
-jgs
-jgs
-ltu
+vSN
+wmM
+auL
+auL
+aul
+auL
+hAU
+fSU
+hNT
+hNT
+hNT
 mdh
 klQ
 rHb
@@ -78202,14 +78174,14 @@ qOI
 wHT
 iLF
 iLF
+vSN
+tRs
+sUQ
+bAa
 iqa
-iqa
-iqa
-iqa
-iqa
-iqa
-iqa
-iqa
+qRw
+jeV
+fSU
 jgs
 jgs
 jgs
@@ -78459,14 +78431,14 @@ qOI
 wHT
 iLF
 iLF
-jgs
-jgs
-jgs
-jgs
-jgs
-jgs
-jgs
-jgs
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
 jgs
 jgs
 jgs
@@ -79236,12 +79208,12 @@ ump
 vOc
 hTd
 qNK
-kAR
-gde
-krF
-czX
+cWw
+pJt
+nBt
+dQO
 qNK
-syx
+puk
 klQ
 rHb
 rLl
@@ -79493,9 +79465,9 @@ jRP
 niY
 xjv
 qNK
-sHE
-kxw
-dPg
+jMc
+iNQ
+lbs
 oms
 qNK
 mdh
@@ -79750,12 +79722,12 @@ jIg
 qNK
 qNK
 qNK
-nTH
-dRJ
-dRJ
-kNU
+xSo
+sRK
+sRK
+bPu
 qNK
-isg
+wAj
 klQ
 rHb
 rJa
@@ -80011,7 +79983,7 @@ uKk
 uKk
 hmh
 uKk
-qDg
+gzl
 fdm
 cwC
 rHb
@@ -81013,7 +80985,7 @@ iLF
 iLF
 hay
 unP
-wfi
+wLd
 iLF
 iLF
 xxj
@@ -81039,13 +81011,13 @@ sKy
 jkD
 jkD
 qNK
-qDg
+gzl
 lIo
 avK
 avK
 iRT
-qFm
-rpa
+dsp
+nRM
 kXC
 uvN
 hGt
@@ -81296,7 +81268,7 @@ eCM
 uJn
 jkD
 bLR
-lbs
+ltR
 dsp
 jqA
 jqA
@@ -81526,7 +81498,7 @@ hRl
 nXP
 iLF
 hIg
-pdw
+ovp
 jVv
 fKe
 iLF
@@ -81553,11 +81525,11 @@ umG
 uJn
 jkD
 bLR
-pZk
+xtx
 gIm
 gIm
-iEq
-iEq
+bKF
+bKF
 gIm
 cwC
 kXC
@@ -81814,9 +81786,9 @@ kcx
 kcx
 uKk
 uKk
+gwL
 sAR
-sAR
-aAx
+dGj
 kXC
 mQz
 kMK
@@ -82045,7 +82017,7 @@ swG
 iLF
 iLF
 iLF
-uJb
+wlP
 iLF
 hay
 hIg
@@ -82073,7 +82045,7 @@ cnN
 qNK
 vMp
 vMp
-pBs
+vMp
 tlI
 wBY
 snD
@@ -82328,9 +82300,9 @@ cBK
 rpE
 wuh
 qNK
-iRz
+tFZ
 vMp
-pBs
+vMp
 tlI
 mQz
 vac
@@ -82585,9 +82557,9 @@ sHQ
 oMM
 tRQ
 kcx
-uiu
-lYY
-pBs
+aXi
+nHr
+vMp
 tlI
 wBY
 ozV
@@ -82842,9 +82814,9 @@ sHQ
 oMM
 waI
 qNK
-eoV
+vUt
 vMp
-pBs
+vMp
 tlI
 hix
 fPa
@@ -83099,9 +83071,9 @@ sHQ
 oMM
 egN
 qNK
-nBt
-nBt
-pBs
+kVa
+kVa
+jgf
 tlI
 snD
 sXy
@@ -83356,9 +83328,9 @@ qHc
 rGP
 qrG
 qNK
-pBs
-lYY
-pBs
+jgf
+nHr
+jgf
 kXC
 lDW
 edk
@@ -83613,9 +83585,9 @@ sKy
 jkD
 xGQ
 qNK
-pBs
-pBs
-pBs
+jgf
+jgf
+jgf
 kXC
 tPQ
 vac
@@ -83853,8 +83825,8 @@ iLF
 iLF
 iLF
 vqf
-nQU
-xVz
+jnB
+tTx
 cuO
 swG
 cQD
@@ -83870,9 +83842,9 @@ kcx
 qNK
 qNK
 qNK
-pBs
-pBs
-pBs
+jgf
+jgf
+jgf
 kXC
 pYR
 iXy
@@ -84111,25 +84083,25 @@ iLF
 hTD
 hIg
 wRR
-tRs
-aul
+jPG
+srI
 eCS
 swG
 hTD
 swG
 iLF
 cxU
-dfZ
-dfZ
-dfZ
-xWR
-xWR
-gor
-dfZ
-pBs
-pBs
-pBs
-pBs
+iLF
+iLF
+iLF
+swG
+swG
+abe
+iLF
+jgf
+jgf
+jgf
+jgf
 kXC
 dVq
 eiW
@@ -84376,17 +84348,17 @@ iLF
 iLF
 iLF
 iLF
-dfZ
-dfZ
-dfZ
-dfZ
-dfZ
-dfZ
-dfZ
-pBs
-dYk
-dYk
-dYk
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+jgf
+qhp
+qhp
+qhp
 kXC
 tPQ
 wBY
@@ -84640,10 +84612,10 @@ kXC
 kXC
 kXC
 kXC
-xen
-xen
-xen
-xen
+kXC
+kXC
+kXC
+kXC
 kXC
 kXC
 kXC

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -36983,13 +36983,16 @@
 	opacity = 1
 	},
 /obj/machinery/computer/communications{
-	name = "quest console";
+	name = "quest console - not quite working edition";
 	req_access = null
 	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
+	},
+/obj/structure/barricade/wooden{
+	name = "machinery under repair lock out boards"
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -27,10 +27,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/item/book{
+	pixel_y = 32;
+	anchored = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "abn" = (
 /obj/structure/table,
 /obj/item/rack_parts,
@@ -56,11 +60,21 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/workshop/nash)
 "abR" = (
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = -4;
+	layer = 2.8;
+	density = 0
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/waffles{
+	pixel_y = 13;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -296,6 +310,10 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"ahq" = (
+/obj/item/target,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "aht" = (
 /obj/structure/stairs/east,
 /obj/structure/railing,
@@ -439,13 +457,17 @@
 	},
 /area/f13/brotherhood)
 "akW" = (
-/obj/structure/sink/well{
-	pixel_y = 7;
-	pixel_x = -6;
-	layer = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/mineral/wasteland_trader{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "alu" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
@@ -637,9 +659,9 @@
 	},
 /area/f13/building)
 "ars" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "arA" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -772,12 +794,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"aul" = (
-/obj/structure/campfire/wallfire{
-	pixel_y = -1
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "aup" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -811,18 +827,22 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
+"avu" = (
+/obj/structure/chair/bench{
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "avv" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "avJ" = (
-/obj/structure/fence/door{
-	dir = 8;
-	pixel_x = 15
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/building)
 "avK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -841,8 +861,19 @@
 	},
 /area/f13/building)
 "awl" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
+"awt" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "awO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -968,14 +999,12 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "aAx" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/vg_decals/numbers/nine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "aAz" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -1064,6 +1093,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"aDg" = (
+/obj/machinery/vending/cola,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "aDh" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/f13/wood,
@@ -1207,15 +1242,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aHr" = (
-/obj/structure/sign/departments/examroom{
-	pixel_y = 2;
-	pixel_x = 29
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "aHs" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced{
@@ -1523,31 +1555,6 @@
 	dir = 8
 	},
 /area/f13/building)
-"aQG" = (
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/grains,
-/obj/item/storage/box/ingredients/grains,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "aRb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1560,14 +1567,6 @@
 	},
 /turf/open/indestructible/ground/bamboo/fourtysix,
 /area/f13/wasteland/city/newboston/sauna)
-"aRr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "aRB" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -1580,6 +1579,13 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
+/area/f13/building)
+"aSt" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "aSS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1716,10 +1722,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
 	},
-/area/f13/building)
-"aXi" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "aXQ" = (
 /obj/item/trash/candy,
@@ -2067,6 +2069,10 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"bgF" = (
+/obj/machinery/mineral/wasteland_vendor/badammo,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "bgG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -2160,6 +2166,11 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"biT" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "bjl" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr25";
@@ -2203,17 +2214,8 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
 "bms" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_trader{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "bmW" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -2272,24 +2274,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"boV" = (
-/obj/item/storage/bag/money{
-	pixel_y = 14;
-	pixel_x = 33;
-	color = "#f3f233"
-	},
-/obj/structure/sign/bank{
-	layer = 4.1;
-	pixel_y = -4;
-	pixel_x = 32
-	},
-/obj/machinery/vending/coffee,
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "bpk" = (
 /obj/structure/rack,
 /obj/item/binoculars,
@@ -2416,6 +2400,16 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
+"bsJ" = (
+/obj/structure/chair/sofa/corner{
+	dir = 1
+	},
+/obj/structure/rug/carpet3{
+	pixel_y = 13;
+	pixel_x = 14
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "btc" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -2652,16 +2646,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
 "bAa" = (
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = 2
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	icon_state = "sofamiddle"
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
@@ -2671,6 +2658,11 @@
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/fakespace,
 /area/f13/building/tribal/caveofforever)
+"bAu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "bAz" = (
 /obj/effect/landmark/start/f13/followersscientist,
 /obj/structure/railing{
@@ -2716,13 +2708,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
-"bBH" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "bBI" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/ausbushes/genericbush,
@@ -2804,7 +2789,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDj" = (
-/obj/machinery/computer/operating,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -6;
@@ -3275,13 +3259,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
-"bPu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "bPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/bench{
@@ -3716,13 +3693,8 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "cdB" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/obj/effect/turf_decal/vg_decals/numbers/one,
 /turf/open/floor/wood_common,
-/area/f13/building/trader)
+/area/f13/building/hospital/clinic/nash)
 "cdN" = (
 /obj/structure/debris/v2{
 	pixel_x = -12;
@@ -3732,11 +3704,6 @@
 	color = "#999999"
 	},
 /area/f13/building)
-"ceh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "cej" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4081,6 +4048,16 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
+"cpu" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "cpx" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
@@ -4509,13 +4486,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "czX" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/workshop/nash)
 "cAa" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -4693,10 +4671,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"cEt" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "cEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair1{
@@ -4837,19 +4811,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"cIm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west{
-	color = "#A47449";
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/hospital/clinic/nash)
 "cIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4931,19 +4892,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"cKP" = (
-/obj/structure/sign/gunshop{
-	layer = 5;
-	pixel_y = 25
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = 39;
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "cKR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5169,6 +5117,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cSq" = (
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 25;
+	density = 0
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "cSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5242,24 +5197,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"cUd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "cUm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5382,10 +5319,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cWw" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "cWY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5393,15 +5326,6 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
-"cXg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/libraryscanner{
-	pixel_x = 14;
-	pixel_y = 0;
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "cXj" = (
 /obj/effect/landmark/start/f13/preacher,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -5566,13 +5490,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"dda" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "ddi" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/railing{
@@ -6889,12 +6806,10 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "dOt" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "dOu" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -6934,13 +6849,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"dPg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "dPs" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -6997,14 +6905,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
-"dQO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "dRf" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -7045,9 +6945,13 @@
 	},
 /area/f13/building/abandoned)
 "dRJ" = (
-/obj/effect/turf_decal/vg_decals/numbers/zero,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "dRN" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -7279,15 +7183,6 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"dYk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "dYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -7843,6 +7738,21 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"eoV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "epa" = (
 /obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7890,9 +7800,9 @@
 	},
 /area/f13/wasteland)
 "eqe" = (
-/obj/machinery/mineral/wasteland_vendor/weapons,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "eqf" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8378,12 +8288,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eEr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/vg_decals/numbers/nine,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/area/f13/building)
 "eEu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -8663,13 +8570,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eKD" = (
-/obj/structure/beebox{
-	pixel_y = 11;
-	layer = 4;
-	density = 0
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "eKF" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
@@ -9038,16 +8941,16 @@
 	},
 /area/f13/wasteland)
 "eUA" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
+	dir = 1;
+	pixel_y = 15
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999";
+	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "eUU" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/dirt,
@@ -9116,11 +9019,14 @@
 	},
 /area/f13/building)
 "eWR" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "eXd" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9822,13 +9728,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "foy" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#222222";
-	opacity = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "foK" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -10008,13 +9911,11 @@
 	},
 /area/f13/building)
 "frU" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "frX" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt,
@@ -10043,14 +9944,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"fsW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ftd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -10291,8 +10184,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fyF" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
+/obj/structure/mirror{
+	pixel_y = 25;
+	pixel_x = -5
+	},
+/obj/machinery/shower{
+	pixel_y = 21;
+	pixel_x = 6
+	},
+/obj/structure/curtain,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
 "fyL" = (
 /obj/structure/toilet,
@@ -10482,10 +10388,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"fDm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "fDq" = (
 /obj/structure/wreck/bus/rusted,
 /turf/open/indestructible/ground/outside/road{
@@ -10732,8 +10634,23 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fKN" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "fLZ" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -10989,16 +10906,27 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fSU" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/structure/curtain/directional/north,
+/obj/effect/turf_decal/vg_decals/numbers/one,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/trader)
 "fTf" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/obj/structure/sign/barsign{
+	light_color = "#FDB0C0";
+	pixel_x = 1;
+	pixel_y = 36
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "fTt" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/f13{
@@ -11030,6 +10958,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
+"fTT" = (
+/obj/structure/sacredwell{
+	light_power = 20;
+	max_integrity = 9999;
+	light_color = "#33BE24";
+	light_range = 3;
+	color = "#BE446e";
+	desc = "That used to be the tribes sacred well.  Why is it here...?"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"fUg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "fUk" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -11052,25 +10995,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fUC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/survivalcapsule{
-	pixel_y = 0
+/obj/effect/fake_stairs/west{
+	color = "#bb3333"
 	},
-/obj/item/survivalcapsule{
-	pixel_y = 9
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/obj/item/survivalcapsule/blacksmith{
-	pixel_y = -10
-	},
-/obj/item/survivalcapsule/farm{
-	pixel_x = 10
-	},
-/obj/item/survivalcapsule/fortuneteller{
-	pixel_x = -9
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "fUJ" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -11113,29 +11048,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fVx" = (
-/obj/structure/table/wood{
-	layer = 3;
-	pixel_y = -2
+/obj/structure/rug/big/rug_red{
+	pixel_x = 19
 	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -13;
-	pixel_y = 13
-	},
-/obj/item/trash/candle{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/trash/plate{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
 "fVX" = (
@@ -11411,6 +11326,10 @@
 "gcX" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
+"gde" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "gdh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11435,17 +11354,23 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gej" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/statue_fal{
+	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
+	icon_state = "statue2";
+	pixel_x = -14;
+	layer = 6;
+	pixel_y = -20
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
 	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "gel" = (
 /obj/structure/window/fulltile/house{
@@ -11582,6 +11507,22 @@
 /obj/structure/chair,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
+"gjN" = (
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
+	},
+/obj/structure/window,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9;
+	pixel_y = 6
+	},
+/obj/structure/campfire/churchfire{
+	pixel_y = 7
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "gjW" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards{
@@ -11664,12 +11605,26 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "glQ" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
 	},
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 19
+	},
+/obj/structure/table/wood{
+	layer = 2.5;
+	alpha = 1
+	},
+/obj/structure/wood_counter{
+	layer = 2
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "gmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11737,19 +11692,6 @@
 	color = "#448822"
 	},
 /area/f13/caves)
-"gor" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "goA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -12048,12 +11990,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gwL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - N"
+/obj/machinery/vending/medical/nash{
+	pixel_x = 26;
+	density = 0
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/custom/leechjar{
+	pixel_y = 18;
+	pixel_x = 21;
+	desc = "Why do the lumps in that jar look vaguely catlike?";
+	name = "Mereks brain juice"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "gwP" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -12141,9 +12093,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gzl" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/building)
 "gzO" = (
 /obj/structure/simple_door/interior,
 /obj/structure/decoration/rag,
@@ -12237,21 +12186,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"gDe" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/bars{
-	layer = 3.5;
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building/trader)
 "gDw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12527,22 +12461,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gLd" = (
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/window,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9;
-	pixel_y = 6
-	},
-/obj/structure/campfire/churchfire{
-	pixel_y = 7
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "gLP" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -13037,14 +12955,6 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
-"gZZ" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "hae" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -13250,17 +13160,6 @@
 "heJ" = (
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"heQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "heV" = (
 /obj/machinery/light/small{
 	color = "#FF0000";
@@ -13648,6 +13547,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"hps" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "hpt" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -13675,15 +13578,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"hqo" = (
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
 "hrn" = (
 /obj/structure/flora/wasteplant/wild_prickly,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13790,11 +13684,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hsR" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "hti" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
@@ -13899,13 +13800,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
 "hvy" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
+/obj/structure/fence/door{
+	dir = 8;
+	pixel_x = 15
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "hwp" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood{
@@ -14015,13 +13915,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"hAU" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofamiddle"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "hBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -14099,17 +13992,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "hCQ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	color = "#222222";
-	opacity = 1
+/obj/machinery/smartfridge/chemistry{
+	density = 0;
+	pixel_y = -32
 	},
-/obj/machinery/computer/communications{
-	name = "quest console";
-	req_access = null
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/area/f13/building/hospital/clinic/nash)
 "hDe" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14406,13 +14298,12 @@
 	},
 /area/f13/building/trader)
 "hJP" = (
+/obj/structure/rug/big/rug_red,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/gravel,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "hKi" = (
 /obj/structure/simple_door/dirtyglass,
@@ -14562,28 +14453,24 @@
 	},
 /area/f13/trainstation)
 "hNN" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/machinery/mineral/wasteland_vendor/general,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/trader)
 "hNR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
-"hNT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/chair/left{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "hNU" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#00DD00";
@@ -14756,6 +14643,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"hTc" = (
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "hTd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14829,6 +14719,22 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"hTR" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1";
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/photocopier,
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "hTT" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -14876,15 +14782,6 @@
 "hVc" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/workshop/nash)
-"hVl" = (
-/obj/machinery/iv_drip/telescopic,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "hVm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink{
@@ -15114,9 +15011,11 @@
 	},
 /area/f13/building)
 "icC" = (
-/obj/structure/closet/crate,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/structure/chair/sofa/corner{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "icD" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -15627,13 +15526,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/workshop/nash)
 "ius" = (
-/obj/structure/rug/mat{
-	pixel_y = 2
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "iuy" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/structure/chair/left{
@@ -15669,13 +15567,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"ivc" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "ivk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16399,13 +16290,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"iNQ" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "iNV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -16518,6 +16402,22 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"iRz" = (
+/obj/item/trash/candle{
+	pixel_x = 3;
+	pixel_y = 19
+	},
+/obj/item/candle/infinite{
+	pixel_x = -9;
+	pixel_y = 19
+	},
+/obj/item/clothing/head/helmet/skull{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/bookcase,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "iRA" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13/wood,
@@ -17175,11 +17075,8 @@
 	},
 /area/f13/building)
 "jeV" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/trader)
 "jfg" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17246,8 +17143,12 @@
 	},
 /area/f13/wasteland)
 "jgf" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "jgh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -17303,17 +17204,9 @@
 	},
 /area/f13/building)
 "jiy" = (
-/obj/effect/fake_stairs/west{
-	color = "#bb3333"
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "jiz" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13{
@@ -17412,6 +17305,14 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
+"jlc" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#222222";
+	opacity = 1
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "jlw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17486,26 +17387,19 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"jnu" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "jnB" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
 	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
+/obj/structure/window/reinforced,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/hospital/clinic/nash)
 "jnR" = (
 /obj/structure/table/wood/settler,
 /obj/structure/bedsheetbin/empty,
@@ -17936,18 +17830,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jyY" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/structure/sink/well{
+	pixel_y = 7;
+	pixel_x = -6;
+	layer = 4
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "jyZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -18013,13 +17902,10 @@
 /area/f13/building)
 "jBh" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 6
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -18158,22 +18044,12 @@
 	},
 /area/f13/wasteland)
 "jEY" = (
-/obj/machinery/vending/medical/nash{
-	pixel_x = 26;
-	density = 0
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/custom/leechjar{
-	pixel_y = 18;
-	pixel_x = 21;
-	desc = "Why do the lumps in that jar look vaguely catlike?";
-	name = "Mereks brain juice"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - N"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/building)
 "jFa" = (
 /obj/structure/closet/wardrobe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -18378,12 +18254,12 @@
 	},
 /area/f13/building)
 "jMc" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = 19;
-	density = 0
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "jMg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -18490,18 +18366,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/abandoned)
-"jPG" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "jQc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -19204,6 +19068,21 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"kjf" = (
+/obj/structure/nightstand/small{
+	pixel_x = 9;
+	pixel_y = 20
+	},
+/obj/item/flashlight/littlelamp{
+	pixel_y = 23;
+	pixel_x = 9
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 24;
+	pixel_x = -8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "kji" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/road{
@@ -19371,11 +19250,11 @@
 	},
 /area/f13/building)
 "koc" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/hospital/clinic/nash)
 "koo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19499,6 +19378,16 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"krF" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -16;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "krI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -19700,6 +19589,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"kxw" = (
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "kxz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19771,6 +19664,13 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"kAR" = (
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/south,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/sauna)
 "kBj" = (
 /obj/machinery/vending/games,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -19789,19 +19689,18 @@
 	},
 /area/f13/wasteland)
 "kBQ" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/sign/gunshop{
+	layer = 5;
+	pixel_y = 25
 	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier,
-/obj/structure/window/reinforced{
-	dir = 1;
-	color = "#222222";
-	opacity = 1
+/obj/machinery/status_display/supply{
+	pixel_y = 39;
+	layer = 6
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "kBU" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -19982,10 +19881,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"kGv" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
 "kGH" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -20237,10 +20132,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kMX" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "kNd" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -20282,14 +20173,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"kNU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "kNZ" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20343,21 +20226,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "kPv" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = -4;
-	layer = 2.8;
-	density = 0
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/waffles{
-	pixel_y = 13;
-	pixel_x = -5
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "kPz" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13{
@@ -20489,9 +20363,25 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kVa" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/survivalcapsule{
+	pixel_y = 0
+	},
+/obj/item/survivalcapsule{
+	pixel_y = 9
+	},
+/obj/item/survivalcapsule/blacksmith{
+	pixel_y = -10
+	},
+/obj/item/survivalcapsule/farm{
+	pixel_x = 10
+	},
+/obj/item/survivalcapsule/fortuneteller{
+	pixel_x = -9
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "kVi" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
@@ -20583,8 +20473,14 @@
 	dir = 1;
 	color = "#bb3333"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "kXc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -20802,13 +20698,31 @@
 	},
 /area/f13/building)
 "lbs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/structure/table/wood{
+	layer = 3;
+	pixel_y = -2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -13;
+	pixel_y = 13
+	},
+/obj/item/trash/candle{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/trash/plate{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "lcb" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -21035,29 +20949,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "lhT" = (
-/obj/structure/sink/deep_water{
-	pixel_y = 3;
-	color = "#996633"
-	},
 /obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
 	dir = 1
 	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/water{
-	color = "#996633"
+	light_color = null;
+	color = "#448822"
 	},
-/area/f13/building/workshop/nash)
+/area/f13/caves)
 "liA" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -21079,22 +20982,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"ljb" = (
-/obj/machinery/chem_dispenser{
-	pixel_y = 19;
-	pixel_x = -12;
-	density = 0
-	},
-/obj/machinery/chem_heater{
-	pixel_y = 17;
-	pixel_x = 8;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "ljd" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -21430,12 +21317,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ltR" = (
-/obj/machinery/vending/cola,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ltT" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -21453,6 +21334,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
+"lvH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "lwh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -22384,6 +22273,15 @@
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lYp" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "lYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22426,14 +22324,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"lYY" = (
-/obj/structure/rug/big/rug_red,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -22638,11 +22528,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "meY" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "mfb" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -22983,6 +22875,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"mnP" = (
+/obj/structure/closet/ammunitionlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mog" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -23219,10 +23115,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mvv" = (
-/obj/machinery/vending/medical/becomingnook,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "mvE" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -23267,18 +23159,9 @@
 	},
 /area/f13/building)
 "mwZ" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/machinery/reagentgrinder,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/flora/timber,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "mxb" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -23316,12 +23199,32 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"myf" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "myo" = (
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
+"myL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "myM" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -23440,6 +23343,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"mBq" = (
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "mBr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -23620,15 +23530,19 @@
 /area/f13/building)
 "mHJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 15
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
+"mHP" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "mHQ" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -23705,10 +23619,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"mJx" = (
-/obj/machinery/mineral/wasteland_vendor/badammo,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "mJJ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -23822,17 +23732,13 @@
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
 "mMO" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/structure/table/glass,
+/obj/machinery/light{
 	dir = 8
 	},
-/mob/living/simple_animal/cow/brahmin/cow/tan,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "mMX" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23945,26 +23851,11 @@
 	},
 /area/f13/building/hospital/clinic/nash)
 "mPW" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/structure/campfire/wallfire{
+	pixel_y = -1
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/wood{
-	layer = 2.9
-	},
-/obj/item/toy/dummy,
-/obj/item/megaphone,
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "mPZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -24071,16 +23962,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"mTN" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "mUf" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -24218,10 +24099,6 @@
 /obj/item/shovel,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"mWi" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "mWm" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -24530,6 +24407,16 @@
 	color = "#999999"
 	},
 /area/f13/building)
+"ngm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "ngs" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -25203,13 +25090,14 @@
 	},
 /area/f13/building)
 "nBt" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/vending/bigredvend{
+	pixel_x = -7;
+	pixel_y = 1
 	},
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "nBx" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -25421,9 +25309,30 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "nHr" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/item/shovel{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/outside/desert{
+	color = "#705454";
+	name = "sand pit"
+	},
+/area/f13/building/workshop/nash)
 "nHJ" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -25707,6 +25616,19 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nPK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "nPS" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -25732,18 +25654,15 @@
 	},
 /area/f13/building)
 "nQu" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/structure/fermenting_barrel{
+	pixel_y = 9
 	},
-/obj/machinery/vending/boozeomat/pubby_captain{
-	pixel_y = 32;
-	density = 0
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 15
 	},
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "nQv" = (
 /obj/structure/fence/handrail_corner{
 	dir = 4
@@ -25783,9 +25702,12 @@
 	},
 /area/f13/building)
 "nQU" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "nRa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -25868,6 +25790,13 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
+"nTH" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "nTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25998,9 +25927,15 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "nWz" = (
-/obj/structure/flora/timber,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/obj/structure/curtain/directional/west{
+	color = "#450159"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "nWC" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26079,14 +26014,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nZK" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -1
-	},
-/obj/effect/spawner/lootdrop/f13/common_mats,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "nZL" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 1;
@@ -26150,6 +26077,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
+"odp" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland/city/newboston/chapel)
 "odI" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -26202,9 +26133,18 @@
 	},
 /area/f13/wasteland)
 "ofN" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/machinery/vending/boozeomat/pubby_captain{
+	pixel_y = 32;
+	density = 0
+	},
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "ofX" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr23";
@@ -26505,6 +26445,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"opB" = (
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "opN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26665,19 +26614,6 @@
 "ovk" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"ovp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
 /area/f13/caves)
 "ovv" = (
 /obj/structure/rack,
@@ -26928,8 +26864,13 @@
 	},
 /area/f13/building)
 "oFe" = (
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/rug/mat{
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "oFv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
@@ -27453,6 +27394,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"oVv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "oVz" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -27938,12 +27883,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "pkF" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/caves)
+/obj/machinery/processor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "pkH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -28127,16 +28072,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ppJ" = (
-/obj/machinery/smartfridge/chemistry{
-	density = 0;
-	pixel_y = -32
+/obj/item/paper_bin{
+	pixel_y = 7;
+	pixel_x = -5
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "ppM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -28278,14 +28226,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "psT" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 28
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/computer/communications{
+	name = "quest console";
+	req_access = null
 	},
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "psW" = (
 /obj/structure/fence/end{
@@ -28311,30 +28261,15 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ptA" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/structure/closet/crate/bin{
+	pixel_y = 3;
+	density = 0
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/item/shovel{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	color = "#705454";
-	name = "sand pit"
-	},
-/area/f13/building/workshop/nash)
+/area/f13/building/hospital/clinic/nash)
 "ptW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
@@ -28364,20 +28299,12 @@
 /turf/open/indestructible/ground/bamboo/fiftyeight,
 /area/f13/wasteland/city/newboston/sauna)
 "puk" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_x = -9;
-	pixel_y = 21;
-	density = 0
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/machinery/vending/cola/space_up{
-	pixel_x = 13;
-	pixel_y = 21;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/caves)
 "put" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -28552,6 +28479,24 @@
 "pyH" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
+"pyK" = (
+/obj/item/storage/bag/money{
+	pixel_y = 14;
+	pixel_x = 33;
+	color = "#f3f233"
+	},
+/obj/structure/sign/bank{
+	layer = 4.1;
+	pixel_y = -4;
+	pixel_x = 32
+	},
+/obj/machinery/vending/coffee,
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "pzz" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -28624,6 +28569,12 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
+"pBs" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "pBB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -28669,14 +28620,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"pDA" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "pDJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -28883,14 +28826,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
 "pJt" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/export/bottle/vodka{
-	pixel_x = 6;
-	pixel_y = 10
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "pJI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -29007,11 +28947,9 @@
 	},
 /area/f13/building)
 "pMY" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "pNj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -29049,6 +28987,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"pOy" = (
+/obj/effect/landmark/party{
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pOz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -29127,6 +29071,10 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland)
+"pPK" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "pQu" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/gravel,
@@ -29500,11 +29448,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "qez" = (
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
-/area/f13/building/trader)
+/area/f13/wasteland/city/newboston/bar)
 "qfd" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/bar,
@@ -29521,10 +29467,13 @@
 	},
 /area/f13/building)
 "qfR" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - E"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "qgh" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -29581,9 +29530,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "qhp" = (
-/obj/item/target,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "qhV" = (
 /obj/item/chair/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29627,6 +29576,10 @@
 	},
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
+"qjB" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "qjD" = (
 /obj/structure/sign/crosswalk{
 	pixel_x = 7;
@@ -29685,9 +29638,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
 "qlI" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "qlJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -29761,13 +29723,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "qnB" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/sign/departments/examroom{
+	pixel_y = 2;
+	pixel_x = 29
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/hospital/clinic/nash)
 "qnG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -29909,12 +29873,6 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal/caveofforever)
-"qrX" = (
-/obj/machinery/bookbinder{
-	pixel_x = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "qse" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -29941,6 +29899,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"qst" = (
+/obj/item/clothing/gloves/f13/baseball,
+/obj/item/twohanded/baseball,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "qsz" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -30207,6 +30171,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"qxT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "qyc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -30389,6 +30366,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"qBA" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qBL" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -30484,11 +30469,29 @@
 	},
 /area/f13/building)
 "qDg" = (
-/obj/item/clothing/gloves/f13/baseball,
-/obj/item/twohanded/baseball,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/sink/deep_water{
+	pixel_y = 3;
+	color = "#996633"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	color = "#996633"
+	},
+/area/f13/building/workshop/nash)
 "qDp" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr7";
@@ -30516,6 +30519,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
+"qDQ" = (
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qDY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -30586,14 +30593,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qFm" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/machinery/camera/autoname{
+	dir = 5;
+	pixel_y = 14;
+	network = list("nash");
+	layer = 3;
+	alpha = 0;
+	mouse_opacity = 0
+	},
+/obj/machinery/mineral/wasteland_vendor/mining,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/trader)
 "qFn" = (
 /obj/structure/bookcase,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -30667,26 +30682,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qHR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 19
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/mob/living/simple_animal/cow/brahmin/cow/tan,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "qHX" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -30740,6 +30746,14 @@
 /obj/item/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"qJK" = (
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3;
+	pixel_x = -1
+	},
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "qJZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -30994,19 +31008,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "qQB" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "qQD" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -31041,20 +31046,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "qRw" = (
-/obj/structure/nightstand/small{
-	pixel_x = 9;
-	pixel_y = 20
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
 	},
-/obj/item/flashlight/littlelamp{
-	pixel_y = 23;
-	pixel_x = 9
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 31
 	},
-/obj/item/kirbyplants/random{
-	pixel_y = 24;
-	pixel_x = -8
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 1;
+	pixel_y = 39;
+	layer = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qRA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -31446,13 +31455,10 @@
 	},
 /area/f13/building/abandoned)
 "rdO" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -16;
-	pixel_y = -12
-	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "ref" = (
@@ -31635,11 +31641,6 @@
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"rki" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "rkj" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
@@ -31991,6 +31992,18 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"rtc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "rtg" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/oil,
@@ -32615,6 +32628,22 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
+"rJd" = (
+/obj/machinery/chem_dispenser{
+	pixel_y = 19;
+	pixel_x = -12;
+	density = 0
+	},
+/obj/machinery/chem_heater{
+	pixel_y = 17;
+	pixel_x = 8;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "rJi" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/chapel{
@@ -32714,10 +32743,14 @@
 	},
 /area/f13/building)
 "rKP" = (
-/obj/machinery/computer/cargo/request{
+/obj/machinery/status_display/supply{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/wood_common,
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "rLa" = (
 /obj/structure/decoration/rag,
@@ -32930,6 +32963,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"rPK" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "rPR" = (
 /obj/structure/fence{
 	dir = 1;
@@ -33054,11 +33095,11 @@
 	},
 /area/f13/building)
 "rUy" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
+/obj/machinery/computer/cargo/request{
+	dir = 1
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/trader)
 "rUB" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -33165,19 +33206,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "rXa" = (
-/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
 "rXj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/bookbinder{
+	pixel_x = 8
 	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "rXx" = (
 /obj/structure/decoration/clock/active{
 	pixel_y = 24
@@ -33704,14 +33740,13 @@
 	},
 /area/f13/building)
 "shO" = (
-/obj/item/book{
-	pixel_y = 32;
-	anchored = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "shR" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -33882,24 +33917,30 @@
 	},
 /area/f13/brotherhood)
 "soW" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/grains,
+/obj/item/storage/box/ingredients/grains,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
 	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "spi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/recharge_station,
@@ -33983,12 +34024,20 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "sri" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/machinery/vending/cola/starkist{
+	pixel_x = -9;
+	pixel_y = 21;
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/vending/cola/space_up{
+	pixel_x = 13;
+	pixel_y = 21;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "srl" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -34003,20 +34052,6 @@
 /obj/structure/bed/oldalt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"srI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "ssg" = (
 /obj/machinery/light{
 	dir = 1
@@ -34038,6 +34073,11 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"ssX" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "stn" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34241,6 +34281,14 @@
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"syx" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "syB" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -34577,12 +34625,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sHE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal{
-	pixel_y = 21
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "sHQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
@@ -34615,11 +34668,9 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sIw" = (
-/obj/effect/landmark/party{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "sIE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -34947,10 +34998,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"sRK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "sRP" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -35141,12 +35188,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"sUQ" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "sVi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -35486,6 +35527,15 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
+/area/f13/building)
+"thp" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/export/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "thJ" = (
 /obj/structure/table/wood,
@@ -36042,12 +36092,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tuf" = (
-/obj/structure/fermenting_barrel{
-	pixel_y = 9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 15
+/obj/structure/beebox{
+	pixel_y = 11;
+	layer = 4;
+	density = 0
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
@@ -36227,9 +36275,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/caveofforever)
 "tza" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/iv_drip/telescopic,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "tzc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -36354,6 +36407,17 @@
 /obj/structure/fence,
 /turf/open/floor/plating/dirt,
 /area/f13/building)
+"tCv" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "tCw" = (
 /obj/structure/flora/chomp/bones/lribs1{
 	pixel_y = 14;
@@ -36482,9 +36546,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tFZ" = (
-/obj/structure/closet/ammunitionlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "tGJ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36494,12 +36572,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "tGZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3;
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "tHh" = (
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/stack/sheet/glass/ten,
@@ -36523,6 +36604,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tHs" = (
+/obj/machinery/mineral/wasteland_vendor/weapons,
 /turf/open/floor/wood_common,
 /area/f13/building/trader)
 "tHN" = (
@@ -36829,14 +36911,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"tPo" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "tPu" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/spring,
@@ -36931,15 +37005,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tRs" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 5
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/workshop/nash)
 "tRy" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -36949,6 +37017,7 @@
 	},
 /area/f13/wasteland)
 "tRA" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
 "tRH" = (
@@ -36994,22 +37063,11 @@
 	},
 /area/f13/building)
 "tSy" = (
-/obj/structure/mirror{
-	pixel_y = 25;
-	pixel_x = -5
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/shower{
-	pixel_y = 21;
-	pixel_x = 6
-	},
-/obj/structure/curtain,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "tSI" = (
 /obj/structure/window/fulltile/house,
 /obj/effect/decal/cleanable/dirt,
@@ -37023,20 +37081,26 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"tTx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "tTF" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"tTG" = (
+/obj/structure/table/wood,
+/obj/structure/barricade/bars{
+	layer = 3.5;
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building/trader)
 "tTN" = (
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/f13{
@@ -37314,13 +37378,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ueL" = (
-/obj/machinery/mineral/wasteland_vendor/specialplus{
-	pixel_y = 25;
-	density = 0
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "ueX" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -37474,9 +37531,9 @@
 	},
 /area/f13/building)
 "uiu" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "uiB" = (
 /obj/structure/stairs/west{
 	dir = 2
@@ -37607,10 +37664,6 @@
 /obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
-"ulP" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "ulR" = (
 /obj/structure/wreck/trash/halftire,
 /obj/effect/decal/cleanable/dirt,
@@ -37733,6 +37786,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"uoR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "upe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -38179,12 +38238,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/f13/building)
-"uEN" = (
-/obj/structure/rug/big/rug_red{
-	pixel_x = 19
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "uEQ" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
@@ -38274,12 +38327,12 @@
 	},
 /area/f13/wasteland)
 "uHp" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/simple_door/wood,
+/obj/item/lock_bolt{
+	dir = 4
 	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "uHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -38390,37 +38443,34 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
+"uKH" = (
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/north,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "uKX" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	pixel_y = 14;
-	network = list("nash");
-	layer = 3;
-	alpha = 0;
-	mouse_opacity = 0
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/obj/machinery/mineral/wasteland_vendor/mining,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "uLf" = (
 /turf/closed/wall/f13/store,
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "uLk" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "uLv" = (
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38458,6 +38508,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
+"uMI" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "uMJ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -38851,6 +38905,18 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"uZH" = (
+/obj/structure/holohoop{
+	pixel_y = 20;
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "vac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -38982,10 +39048,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "vdH" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "vdR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -39302,20 +39374,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"vlH" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/structure/table/booth{
-	color = "#EFCCC0"
-	},
-/obj/structure/sign/barsign{
-	light_color = "#FDB0C0";
-	pixel_x = 1;
-	pixel_y = 36
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "vlV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -39571,16 +39629,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
-"vsv" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "vsz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39777,14 +39825,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "vxh" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/libraryscanner{
+	pixel_x = 14;
+	pixel_y = 0;
+	density = 0
 	},
-/obj/machinery/mineral/wasteland_vendor/general,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "vxi" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -39999,14 +40047,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
-"vEa" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "vEc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40027,15 +40067,17 @@
 	},
 /area/f13/building/abandoned)
 "vEK" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
-	},
-/obj/structure/rug/carpet3{
-	pixel_y = 13;
-	pixel_x = 14
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
+"vEW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/trader)
 "vFA" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -40226,16 +40268,6 @@
 "vNf" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
-"vNr" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/obj/structure/curtain/directional/west{
-	color = "#450159"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "vNt" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -40248,6 +40280,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"vNJ" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "vNL" = (
 /obj/structure/chair{
 	dir = 8
@@ -40339,13 +40377,14 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
 "vPE" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_x = -2;
-	pixel_y = 5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "vPN" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -40354,12 +40393,16 @@
 	},
 /area/f13/building)
 "vPX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth{
-	color = "#EFCCC0"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "vQb" = (
 /obj/structure/stairs,
 /turf/open/floor/f13{
@@ -40372,6 +40415,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
+"vQW" = (
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "vRd" = (
 /obj/effect/landmark/start/f13/barkeep,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -40430,10 +40487,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vSN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "vSW" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt,
@@ -40495,12 +40548,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
-"vUt" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "vUF" = (
 /obj/structure/sink{
 	dir = 4;
@@ -40525,6 +40572,9 @@
 /obj/structure/table,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
+"vWq" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "vWL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -40854,17 +40904,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wfi" = (
-/obj/structure/holohoop{
-	pixel_y = 20;
-	pixel_x = 16
+/obj/machinery/computer/operating,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "wfu" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Senior Paladin";
@@ -41051,17 +41098,6 @@
 "wlD" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"wlP" = (
-/obj/structure/sacredwell{
-	light_power = 20;
-	max_integrity = 9999;
-	light_color = "#33BE24";
-	light_range = 3;
-	color = "#BE446e";
-	desc = "That used to be the tribes sacred well.  Why is it here...?"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "wlQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -41115,14 +41151,14 @@
 /obj/machinery/icecream_vat,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
-"wmM" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 11
+"wmS" = (
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "wmT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -41572,19 +41608,17 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"wzP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal{
+	pixel_y = 21
+	},
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "wAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"wAj" = (
-/obj/machinery/mineral/equipment_vendor{
-	pixel_y = 14;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "wAB" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -41806,10 +41840,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"wGH" = (
-/obj/effect/turf_decal/vg_decals/numbers/three,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "wHr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -41950,16 +41980,6 @@
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/nash)
-"wLd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "wLg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
@@ -42343,9 +42363,11 @@
 /turf/open/floor/wood_worn,
 /area/f13/wasteland/city/newboston/bar)
 "wVD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "wVY" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -42490,16 +42512,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"wZe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "wZE" = (
 /obj/structure/simple_door/brokenglass,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -42563,6 +42575,13 @@
 "xbw" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/tribal/cave)
+"xcf" = (
+/obj/machinery/vending/dinnerware{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "xcu" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -42656,24 +42675,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xen" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
 "xeu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -42793,6 +42794,10 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xgZ" = (
+/obj/structure/bed/dogbed,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "xht" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -43000,6 +43005,12 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"xow" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "xoy" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -43124,6 +43135,10 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
+"xpO" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "xqN" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -43163,25 +43178,6 @@
 	},
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"xrJ" = (
-/obj/structure/statue_fal{
-	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
-	icon_state = "statue2";
-	pixel_x = -14;
-	layer = 6;
-	pixel_y = -20
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "xrP" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43224,12 +43220,11 @@
 	},
 /area/f13/building)
 "xtx" = (
-/obj/machinery/vending/bigredvend{
-	pixel_x = -7;
-	pixel_y = 1
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "xtG" = (
@@ -43408,21 +43403,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xyl" = (
-/obj/item/trash/candle{
-	pixel_x = 3;
-	pixel_y = 19
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/item/candle/infinite{
-	pixel_x = -9;
-	pixel_y = 19
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
 	},
-/obj/item/clothing/head/helmet/skull{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/bookcase,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/wasteland/city/newboston/outdoors)
 "xyu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -43580,12 +43567,12 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "xCx" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "xCC" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -43885,6 +43872,13 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"xKM" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "xKT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -44129,12 +44123,26 @@
 	},
 /area/f13/building)
 "xRq" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/structure/curtain/directional/south,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	layer = 2.9
+	},
+/obj/item/toy/dummy,
+/obj/item/megaphone,
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -44170,20 +44178,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "xSo" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/mineral/equipment_vendor{
+	pixel_y = 14;
+	density = 0
 	},
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "xSA" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -44634,12 +44636,9 @@
 /turf/open/floor/carpet/green,
 /area/f13/building/trader)
 "yes" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "yev" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -68657,19 +68656,19 @@ vJk
 oQS
 rom
 hQs
-gej
-gej
-gej
-gej
-gej
-gej
-gej
-rXj
+nPK
+nPK
+nPK
+nPK
+nPK
+nPK
+nPK
+cpu
 rom
 hQs
 hQs
 hQs
-jBh
+sHE
 tEZ
 rom
 hQs
@@ -68911,7 +68910,7 @@ hVc
 mCq
 hVc
 hVc
-aAx
+czX
 hVc
 hVc
 tNI
@@ -68919,28 +68918,28 @@ tNI
 tNI
 tNI
 tNI
-dOt
-awl
-dOt
-kWU
-xZc
-xZc
-xZc
-xZc
-tGZ
-wTa
-qFm
-xZc
-xZc
-xZc
+xCx
+hTc
+xCx
+jgf
 xZc
 xZc
 xZc
 xZc
 rdO
+wTa
+vPE
+xZc
+xZc
+xZc
+xZc
+xZc
+xZc
+xZc
+krF
 hcF
-lYY
-dPg
+hJP
+mHJ
 fgh
 nWv
 hEQ
@@ -69168,17 +69167,17 @@ hVc
 bpA
 wKZ
 nYg
-wVD
-nZK
+tRs
+qJK
 hVc
-awl
-awl
-awl
-awl
-meY
-ptA
+hTc
+hTc
+hTc
+hTc
+pBs
+nHr
 oUB
-lhT
+qDg
 hVc
 ifw
 ifw
@@ -69426,16 +69425,16 @@ ifN
 kjL
 rxK
 rxK
-uLk
+tGZ
 hVc
-awl
-awl
-awl
-awl
-awl
-sri
-awl
-mMO
+hTc
+hTc
+hTc
+hTc
+hTc
+jMc
+hTc
+qHR
 hVc
 pwM
 isE
@@ -69451,9 +69450,9 @@ pll
 pll
 pll
 pll
-nWz
+mwZ
 pll
-qDg
+qst
 lQM
 fDY
 fDY
@@ -69685,14 +69684,14 @@ rxK
 rxK
 pQD
 hVc
-awl
-awl
-awl
-awl
-awl
-ofN
-ofN
-awl
+hTc
+hTc
+hTc
+hTc
+hTc
+qjB
+qjB
+hTc
 hVc
 wJl
 isE
@@ -69938,18 +69937,18 @@ pll
 mCq
 jtS
 rxK
-cEt
+qhp
 rxK
 mII
 hVc
-awl
-awl
-awl
-awl
-awl
-awl
-awl
-awl
+hTc
+hTc
+hTc
+hTc
+hTc
+hTc
+hTc
+hTc
 hVc
 ifw
 qHX
@@ -69965,7 +69964,7 @@ pll
 pll
 pll
 pll
-sIw
+pOy
 pll
 ute
 lQM
@@ -70199,20 +70198,20 @@ rxK
 rxK
 pXu
 hVc
-tPo
-tPo
-tPo
-tPo
-tPo
-avJ
-tPo
-tPo
+syx
+syx
+syx
+syx
+syx
+hvy
+syx
+syx
 hVc
 isE
 isE
-kGv
+odp
 qGt
-dda
+uHp
 ifw
 pll
 pll
@@ -70230,7 +70229,7 @@ pJc
 pJc
 pJc
 pJc
-hJP
+jBh
 kXC
 hRg
 tPQ
@@ -70452,18 +70451,18 @@ pll
 mCq
 tJH
 rxK
-wVD
-wVD
-wVD
-fKN
-fKN
-bBH
-bBH
-bBH
-bBH
-fKN
-bBH
-fKN
+tRs
+tRs
+tRs
+bms
+bms
+uKX
+uKX
+uKX
+uKX
+bms
+uKX
+bms
 hVc
 isE
 isE
@@ -70471,9 +70470,9 @@ isE
 kzV
 isE
 ifw
-vEa
-czX
-vEa
+dRJ
+wmS
+dRJ
 bCw
 kIY
 pll
@@ -70709,20 +70708,20 @@ pll
 mCq
 rxK
 rxK
-hNR
+bAu
 rxK
 bKT
 hVc
-eKD
-fKN
-fKN
-fKN
-fKN
-fKN
-fKN
-mWi
+tuf
+bms
+bms
+bms
+bms
+bms
+bms
+uMI
 hVc
-gLd
+gjN
 kzV
 sfn
 vYz
@@ -70970,14 +70969,14 @@ rxK
 rxK
 uAy
 hVc
-tuf
-bBH
-bBH
-bBH
-bBH
-bBH
-bBH
-kMX
+nQu
+uKX
+uKX
+uKX
+uKX
+uKX
+uKX
+sIw
 hVc
 rOW
 isE
@@ -70986,9 +70985,9 @@ isE
 rOW
 ifw
 kIY
-xrJ
+gej
 mrr
-qnB
+xtx
 wze
 pll
 pll
@@ -71227,13 +71226,13 @@ rxK
 rxK
 xkz
 hVc
-akW
-fKN
-fKN
-fKN
-fKN
-fKN
-fKN
+jyY
+bms
+bms
+bms
+bms
+bms
+bms
 wIP
 hVc
 jGw
@@ -71480,17 +71479,17 @@ uiB
 hVc
 qWv
 rxK
-cEt
-wVD
+qhp
+tRs
 pXu
 hVc
-vPE
-bBH
-bBH
-bBH
-bBH
-bBH
-bBH
+mHP
+uKX
+uKX
+uKX
+uKX
+uKX
+uKX
 acE
 hVc
 jGw
@@ -71737,18 +71736,18 @@ sbq
 hVc
 tKS
 rxK
-wVD
+tRs
 rxK
-nZK
+qJK
 hVc
-fKN
-fKN
-fKN
-fKN
-fKN
-fKN
+bms
+bms
+bms
+bms
+bms
+bms
 lUv
-fKN
+bms
 hVc
 dNH
 qFz
@@ -71762,8 +71761,8 @@ avK
 avK
 avK
 avK
-gZZ
-gZZ
+qBA
+qBA
 avK
 bGv
 vJk
@@ -72025,7 +72024,7 @@ ekg
 nRM
 vJk
 byj
-xRq
+kAR
 lzG
 pfP
 fMx
@@ -72759,15 +72758,15 @@ gcX
 hRl
 gao
 hJN
-uKX
-dYk
-vxh
-bms
-rki
-cKP
+qFm
+lYp
+hNN
+akW
+biT
+kBQ
 avK
 avK
-abR
+wVD
 avK
 avK
 avK
@@ -73014,7 +73013,7 @@ hRl
 "}
 (110,1,1) = {"
 hRl
-mJx
+bgF
 dtH
 dtH
 dtH
@@ -73025,27 +73024,27 @@ dtH
 dtH
 gln
 dtH
-eWR
-eWR
-eWR
-eWR
-eWR
+koc
+koc
+koc
+koc
+koc
 uzU
-eWR
-eWR
-eWR
+koc
+koc
+koc
 ayi
-rUy
-rUy
-rUy
+xow
+xow
+xow
 ayi
-rUy
-rUy
+xow
+xow
 wVC
 qda
 qda
 fft
-soW
+qRw
 nRM
 rHb
 rce
@@ -73272,35 +73271,35 @@ hRl
 (111,1,1) = {"
 hRl
 tHW
-tHs
-tHs
-qlI
-tHs
-tHs
-qlI
-tHs
-tHs
-qlI
-tHs
-oFe
-fyF
-oFe
-oFe
-fyF
-oFe
-oFe
-fyF
-oFe
-tRA
+jeV
+jeV
+uiu
+jeV
+jeV
+uiu
+jeV
+jeV
+uiu
+jeV
+cdB
+xpO
+cdB
+cdB
+xpO
+cdB
+cdB
+xpO
+cdB
 rXa
-tRA
-tRA
+qez
 rXa
-tRA
-tRA
-jyY
-hqo
-hqo
+rXa
+qez
+rXa
+rXa
+kWU
+opB
+opB
 vOY
 mdh
 etn
@@ -73529,34 +73528,34 @@ hRl
 (112,1,1) = {"
 hRl
 rLL
-tHs
-tHs
-tHs
-tHs
-tHs
-kNU
-tHs
-tHs
-tHs
-tHs
-oFe
-oFe
-oFe
-oFe
-oFe
-oFe
-oFe
-fTf
-nQU
-ulP
+jeV
+jeV
+jeV
+jeV
+jeV
+vEW
+jeV
+jeV
+jeV
+jeV
+cdB
+cdB
+cdB
+cdB
+cdB
+cdB
+cdB
+xgZ
+yes
+pPK
 iep
-ulP
+pPK
 nZa
 iep
-tRA
-tRA
-jiy
-mPW
+rXa
+rXa
+fUC
+xRq
 vzp
 vOY
 mdh
@@ -73785,33 +73784,33 @@ hRl
 "}
 (113,1,1) = {"
 hRl
-eqe
 tHs
-tHs
-wGH
+jeV
+jeV
+ars
 qTx
-cdB
-rKP
-boV
-qez
-tHs
+fSU
+rUy
+pyK
+tSy
+jeV
 cZU
-qQB
-qQB
+vQW
+vQW
 mPB
-qQB
-qQB
-qQB
-gor
+vQW
+vQW
+vQW
+hsR
 tKO
 qCp
-vlH
+fTf
 tdE
 tdE
 tdE
 xiY
-tRA
-tRA
+rXa
+rXa
 vOY
 vOY
 vOY
@@ -74043,12 +74042,12 @@ hRl
 (114,1,1) = {"
 hRl
 gao
-gDe
-vNr
+tTG
+nWz
 afx
 afx
 sWl
-gDe
+tTG
 gao
 gOo
 nVE
@@ -74060,15 +74059,15 @@ uIt
 gXv
 gXv
 uIt
-vsv
-ars
+ptA
+fUg
 qgK
 ogc
 qei
 ogc
 woy
+rXa
 tRA
-tza
 tHN
 wWW
 srl
@@ -74310,24 +74309,24 @@ gao
 cmo
 iXY
 gao
-ljb
+rJd
 uIt
-mwZ
-uIt
-uIt
+qlI
 uIt
 uIt
-kPv
-ars
+uIt
+uIt
+abR
+fUg
 wBB
 ogc
 ogc
 ogc
 cNZ
-tRA
 rXa
+qez
 tHN
-vPX
+kPv
 mjx
 vOY
 wbp
@@ -74562,15 +74561,15 @@ iXY
 iXY
 lsj
 iXY
-fUC
+kVa
 gao
-ueL
+cSq
 iXY
 qjw
 uIt
-eUA
+tCv
 uIt
-jEY
+gwL
 uIt
 uIt
 uIt
@@ -74581,13 +74580,13 @@ ogc
 iCv
 ogc
 qlE
+rXa
 tRA
-tza
 tHN
 kYy
-mTN
+hNR
 vOY
-frU
+avu
 cwC
 aqT
 rJa
@@ -74820,33 +74819,33 @@ iXY
 iXY
 iXY
 iXY
-ivc
-hvy
+mBq
+meY
 iXY
 gao
 qCp
 qCp
 qCp
 qCp
-xen
-jnu
+fKN
+awl
 uIt
-ppJ
+hCQ
 qCp
-qHR
+glQ
 lzk
 lzk
 kef
 hdy
-tRA
-tRA
+rXa
+rXa
 vOY
 vOY
 vOY
 vOY
 tlI
 lUl
-mHJ
+eUA
 rJa
 mdh
 rEv
@@ -75076,16 +75075,16 @@ iXY
 iXY
 iXY
 iXY
-fUC
+kVa
 gao
 gao
 nVE
 gao
 qCp
-bDj
+wfi
 sYT
-pDA
-uiu
+bDj
+gde
 hBy
 uIt
 uIt
@@ -75096,7 +75095,7 @@ elX
 vOY
 vOY
 omk
-tRA
+rXa
 tHN
 wWW
 srl
@@ -75333,29 +75332,29 @@ iXY
 iXY
 lsj
 iXY
-cUd
+tFZ
 gao
-sHE
+wzP
 rvM
 isg
 qCp
 iUQ
 sYT
 sYT
-mvv
+eKD
 hBy
 uIt
 uIt
 qCp
-aQG
+soW
 weC
 weC
 voN
 vOY
 vDv
-rXa
+qez
 tHN
-vPX
+kPv
 mjx
 vOY
 tlI
@@ -75592,28 +75591,28 @@ iXY
 iXY
 iOa
 gao
-hsR
+vNJ
 rvM
 rvM
 qCp
 evI
 sYT
 sYT
-fDm
+vEK
 mEG
 uIt
 uIt
 qCp
-uHp
+pkF
 ogc
 ogc
 cxm
 vOY
 tjm
-tRA
+rXa
 tHN
 kYy
-mTN
+hNR
 vOY
 tlI
 ghS
@@ -75848,15 +75847,15 @@ iXY
 iXY
 iXY
 eNj
-kBQ
+hTR
 aMZ
 vEc
 rvM
 qCp
-tSy
+fyF
 vUF
 sYT
-hVl
+tza
 hBy
 uIt
 uIt
@@ -75866,8 +75865,8 @@ ogc
 ogc
 oIv
 uQa
-koc
-tRA
+uoR
+rXa
 vOY
 vOY
 vOY
@@ -76105,7 +76104,7 @@ iXY
 lsj
 iXY
 gyr
-hCQ
+psT
 bSa
 yer
 rvM
@@ -76116,7 +76115,7 @@ qCp
 qCp
 hBy
 uIt
-glQ
+xKM
 qCp
 fpl
 ogc
@@ -76126,7 +76125,7 @@ vOY
 fft
 eOo
 vOY
-hNN
+vdH
 nxO
 nxO
 nxO
@@ -76356,16 +76355,16 @@ hRl
 (123,1,1) = {"
 hRl
 gao
-icC
+pMY
 iXY
 iXY
 iXY
 iXY
-vdH
+qQB
 gao
-foy
-foy
-foy
+jlc
+jlc
+jlc
 qCp
 uIt
 uIt
@@ -76375,7 +76374,7 @@ uIt
 uIt
 uIt
 kVi
-pMY
+myf
 ogc
 ogc
 oUn
@@ -76383,7 +76382,7 @@ fft
 jeH
 jUN
 vOY
-wfi
+uZH
 xOu
 uWY
 uWY
@@ -76618,7 +76617,7 @@ iXY
 iXY
 iXY
 iXY
-icC
+pMY
 gao
 iXY
 iXY
@@ -76626,13 +76625,13 @@ iXY
 kVi
 uIt
 uIt
-eUA
-aHr
-cIm
+tCv
+qnB
+jnB
 uIt
 uIt
 uIt
-nQu
+ofN
 bEN
 lzk
 aLL
@@ -76640,7 +76639,7 @@ vOY
 sPL
 qps
 vOY
-fsW
+xyl
 uWY
 uWY
 uWY
@@ -76870,13 +76869,13 @@ hRl
 (125,1,1) = {"
 hRl
 gao
-wZe
+uLk
 nbZ
 nbZ
 nbZ
 nbZ
-yes
-ivc
+nTH
+mBq
 iXY
 lsj
 hiW
@@ -76897,7 +76896,7 @@ vOY
 vOY
 vOY
 vOY
-heQ
+vPX
 brC
 brC
 brC
@@ -77127,17 +77126,17 @@ hRl
 (126,1,1) = {"
 hRl
 gao
-psT
+rKP
 whF
 whF
-dRJ
+kxw
 whF
-ceh
+dOt
 gao
 iXY
 iXY
 wuq
-pkF
+puk
 iLF
 iLF
 iLF
@@ -77146,15 +77145,15 @@ iLF
 iLF
 iLF
 iLF
-vSN
+oVv
 auL
 auL
-fVx
+lbs
 raI
 seq
-xyl
-vSN
-shO
+iRz
+oVv
+abe
 avK
 avK
 avK
@@ -77166,8 +77165,8 @@ lVZ
 avK
 avK
 avK
-gZZ
-gZZ
+qBA
+qBA
 kXC
 kJF
 kXC
@@ -77387,9 +77386,9 @@ gmg
 bPn
 qRl
 xPV
-eEr
+aAx
 vsz
-aRr
+lvH
 gao
 wHT
 wHT
@@ -77403,15 +77402,15 @@ wHT
 wHT
 iLF
 iLF
-vSN
-cXg
+oVv
+vxh
 auL
-uEN
+fVx
 auL
 auL
 auL
-xCx
 ius
+oFe
 jqA
 jqA
 jqA
@@ -77660,18 +77659,18 @@ qOI
 wHT
 iLF
 iLF
-vSN
-qrX
+oVv
+rXj
 auL
 auL
 auL
 auL
-vEK
-fSU
+bsJ
+uKH
 aHM
 gIm
 gIm
-qfR
+ssX
 klQ
 aqT
 mLI
@@ -77917,17 +77916,17 @@ qOI
 wHT
 iLF
 iLF
-vSN
-wmM
+oVv
+rPK
 auL
 auL
-aul
+mPW
 auL
-hAU
-fSU
-hNT
-hNT
-hNT
+bAa
+uKH
+nQU
+nQU
+nQU
 mdh
 klQ
 rHb
@@ -78174,14 +78173,14 @@ qOI
 wHT
 iLF
 iLF
-vSN
-tRs
-sUQ
-bAa
+oVv
+awt
+pJt
+ppJ
 iqa
-qRw
-jeV
-fSU
+kjf
+icC
+uKH
 jgs
 jgs
 jgs
@@ -79208,12 +79207,12 @@ ump
 vOc
 hTd
 qNK
-cWw
-pJt
-nBt
-dQO
+jiy
+thp
+mMO
+qfR
 qNK
-puk
+sri
 klQ
 rHb
 rLl
@@ -79465,9 +79464,9 @@ jRP
 niY
 xjv
 qNK
-jMc
-iNQ
-lbs
+xcf
+aHr
+shO
 oms
 qNK
 mdh
@@ -79722,12 +79721,12 @@ jIg
 qNK
 qNK
 qNK
-xSo
-sRK
-sRK
-bPu
+eoV
+eqe
+eqe
+aSt
 qNK
-wAj
+xSo
 klQ
 rHb
 rJa
@@ -79983,7 +79982,7 @@ uKk
 uKk
 hmh
 uKk
-gzl
+avJ
 fdm
 cwC
 rHb
@@ -80985,7 +80984,7 @@ iLF
 iLF
 hay
 unP
-wLd
+ngm
 iLF
 iLF
 xxj
@@ -81011,7 +81010,7 @@ sKy
 jkD
 jkD
 qNK
-gzl
+avJ
 lIo
 avK
 avK
@@ -81268,7 +81267,7 @@ eCM
 uJn
 jkD
 bLR
-ltR
+aDg
 dsp
 jqA
 jqA
@@ -81498,7 +81497,7 @@ hRl
 nXP
 iLF
 hIg
-ovp
+qxT
 jVv
 fKe
 iLF
@@ -81525,7 +81524,7 @@ umG
 uJn
 jkD
 bLR
-xtx
+nBt
 gIm
 gIm
 bKF
@@ -81786,7 +81785,7 @@ kcx
 kcx
 uKk
 uKk
-gwL
+jEY
 sAR
 dGj
 kXC
@@ -82017,7 +82016,7 @@ swG
 iLF
 iLF
 iLF
-wlP
+fTT
 iLF
 hay
 hIg
@@ -82300,7 +82299,7 @@ cBK
 rpE
 wuh
 qNK
-tFZ
+mnP
 vMp
 vMp
 tlI
@@ -82557,8 +82556,8 @@ sHQ
 oMM
 tRQ
 kcx
-aXi
-nHr
+qDQ
+hps
 vMp
 tlI
 wBY
@@ -82814,7 +82813,7 @@ sHQ
 oMM
 waI
 qNK
-vUt
+frU
 vMp
 vMp
 tlI
@@ -83071,9 +83070,9 @@ sHQ
 oMM
 egN
 qNK
-kVa
-kVa
-jgf
+eEr
+eEr
+vWq
 tlI
 snD
 sXy
@@ -83328,9 +83327,9 @@ qHc
 rGP
 qrG
 qNK
-jgf
-nHr
-jgf
+vWq
+hps
+vWq
 kXC
 lDW
 edk
@@ -83585,9 +83584,9 @@ sKy
 jkD
 xGQ
 qNK
-jgf
-jgf
-jgf
+vWq
+vWq
+vWq
 kXC
 tPQ
 vac
@@ -83825,8 +83824,8 @@ iLF
 iLF
 iLF
 vqf
-jnB
-tTx
+lhT
+eWR
 cuO
 swG
 cQD
@@ -83842,9 +83841,9 @@ kcx
 qNK
 qNK
 qNK
-jgf
-jgf
-jgf
+vWq
+vWq
+vWq
 kXC
 pYR
 iXy
@@ -84083,8 +84082,8 @@ iLF
 hTD
 hIg
 wRR
-jPG
-srI
+rtc
+myL
 eCS
 swG
 hTD
@@ -84096,12 +84095,12 @@ iLF
 iLF
 swG
 swG
-abe
+foy
 iLF
-jgf
-jgf
-jgf
-jgf
+vWq
+vWq
+vWq
+vWq
 kXC
 dVq
 eiW
@@ -84355,10 +84354,10 @@ iLF
 iLF
 iLF
 iLF
-jgf
-qhp
-qhp
-qhp
+vWq
+ahq
+ahq
+ahq
 kXC
 tPQ
 wBY

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -27,14 +27,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
-/obj/item/book{
-	pixel_y = 32;
-	anchored = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "abn" = (
 /obj/structure/table,
 /obj/item/rack_parts,
@@ -60,21 +55,23 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/workshop/nash)
 "abR" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = -4;
-	layer = 2.8;
-	density = 0
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/waffles{
-	pixel_y = 13;
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -311,8 +308,12 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "ahq" = (
-/obj/item/target,
-/turf/open/indestructible/ground/inside/subway,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "aht" = (
 /obj/structure/stairs/east,
@@ -456,18 +457,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
-"akW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_trader{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "alu" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
@@ -658,10 +647,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"ars" = (
-/obj/effect/turf_decal/vg_decals/numbers/three,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "arA" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -794,6 +779,10 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"aul" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "aup" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -828,20 +817,19 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "avu" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
+/obj/structure/sign/departments/examroom{
+	pixel_y = 2;
+	pixel_x = 29
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/hospital/clinic/nash)
 "avv" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
-"avJ" = (
-/turf/closed/wall/r_wall/f13/vault,
 /area/f13/building)
 "avK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -861,19 +849,17 @@
 	},
 /area/f13/building)
 "awl" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "awt" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement{
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_x = -2;
 	pixel_y = 5
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "awO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -999,12 +985,15 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "aAx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/turf_decal/vg_decals/numbers/nine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "aAz" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -1094,9 +1083,22 @@
 	},
 /area/f13/building)
 "aDg" = (
-/obj/machinery/vending/cola,
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 1;
+	pixel_y = 39;
+	layer = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
+	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "aDh" = (
@@ -1242,12 +1244,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aHr" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "aHs" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced{
@@ -1555,6 +1558,15 @@
 	dir = 8
 	},
 /area/f13/building)
+"aQG" = (
+/obj/machinery/vending/bigredvend{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "aRb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1567,6 +1579,10 @@
 	},
 /turf/open/indestructible/ground/bamboo/fourtysix,
 /area/f13/wasteland/city/newboston/sauna)
+"aRr" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland/city/newboston/chapel)
 "aRB" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -1579,13 +1595,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/building)
-"aSt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "aSS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2069,10 +2078,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"bgF" = (
-/obj/machinery/mineral/wasteland_vendor/badammo,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "bgG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -2167,10 +2172,8 @@
 	},
 /area/f13/wasteland)
 "biT" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "bjl" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr25";
@@ -2179,6 +2182,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bjr" = (
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "bjE" = (
 /obj/structure/fence/handrail{
 	dir = 8
@@ -2214,8 +2225,30 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
 "bms" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/american,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/grains,
+/obj/item/storage/box/ingredients/grains,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "bmW" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -2274,6 +2307,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"boV" = (
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "bpk" = (
 /obj/structure/rack,
 /obj/item/binoculars,
@@ -2400,16 +2447,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"bsJ" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
-	},
-/obj/structure/rug/carpet3{
-	pixel_y = 13;
-	pixel_x = 14
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "btc" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -2645,24 +2682,12 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/workshop/nash)
-"bAa" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofamiddle"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "bAd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glitter/blue,
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/fakespace,
 /area/f13/building/tribal/caveofforever)
-"bAu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "bAz" = (
 /obj/effect/landmark/start/f13/followersscientist,
 /obj/structure/railing{
@@ -2707,6 +2732,10 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/building)
+"bBH" = (
+/obj/item/target,
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
 "bBI" = (
 /obj/structure/flora/bush,
@@ -2789,6 +2818,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDj" = (
+/obj/machinery/computer/operating,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -6;
@@ -3692,9 +3722,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"cdB" = (
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
 "cdN" = (
 /obj/structure/debris/v2{
 	pixel_x = -12;
@@ -3704,6 +3731,17 @@
 	color = "#999999"
 	},
 /area/f13/building)
+"ceh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "cej" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4049,15 +4087,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "cpu" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/nightstand/small{
+	pixel_x = 9;
+	pixel_y = 20
 	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/item/flashlight/littlelamp{
+	pixel_y = 23;
+	pixel_x = 9
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/kirbyplants/random{
+	pixel_y = 24;
+	pixel_x = -8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "cpx" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
@@ -4224,6 +4267,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"ctp" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "ctv" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -4485,15 +4535,6 @@
 /obj/item/clothing/shoes/sneakers/orange,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
-"czX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/building/workshop/nash)
 "cAa" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -4671,6 +4712,13 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"cEt" = (
+/obj/structure/fence/door{
+	dir = 8;
+	pixel_x = 15
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "cEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair1{
@@ -4811,6 +4859,16 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
+"cIm" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 5
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "cIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4892,6 +4950,22 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
+"cKP" = (
+/obj/machinery/chem_dispenser{
+	pixel_y = 19;
+	pixel_x = -12;
+	density = 0
+	},
+/obj/machinery/chem_heater{
+	pixel_y = 17;
+	pixel_x = 8;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "cKR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5118,10 +5192,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cSq" = (
-/obj/machinery/mineral/wasteland_vendor/specialplus{
-	pixel_y = 25;
-	density = 0
-	},
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "cSr" = (
@@ -5197,6 +5269,27 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"cUd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 19
+	},
+/obj/structure/table/wood{
+	layer = 2.5;
+	alpha = 1
+	},
+/obj/structure/wood_counter{
+	layer = 2
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "cUm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5319,6 +5412,14 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"cWw" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "cWY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5326,6 +5427,13 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
+"cXg" = (
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "cXj" = (
 /obj/effect/landmark/start/f13/preacher,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -6806,10 +6914,21 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "dOt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = -4;
+	layer = 2.8;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/waffles{
+	pixel_y = 13;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "dOu" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -6905,6 +7024,25 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/rust,
 /area/f13/building)
+"dQI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
+"dQO" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "dRf" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -6945,13 +7083,13 @@
 	},
 /area/f13/building/abandoned)
 "dRJ" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "dRN" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -7183,6 +7321,20 @@
 /obj/machinery/light,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"dYk" = (
+/obj/item/paper_bin{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "dYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -7739,20 +7891,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eoV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "epa" = (
 /obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7800,9 +7941,15 @@
 	},
 /area/f13/wasteland)
 "eqe" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/structure/closet/crate/bin{
+	pixel_y = 3;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "eqf" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8288,9 +8435,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eEr" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 25;
+	density = 0
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "eEu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -8570,9 +8720,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eKD" = (
-/obj/machinery/vending/medical/becomingnook,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/item/trash/candle{
+	pixel_x = 3;
+	pixel_y = 19
+	},
+/obj/item/candle/infinite{
+	pixel_x = -9;
+	pixel_y = 19
+	},
+/obj/item/clothing/head/helmet/skull{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/structure/bookcase,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "eKF" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
@@ -8696,14 +8858,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "eNj" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/export_scanner,
-/obj/item/export_scanner,
-/obj/item/export_scanner,
-/obj/item/export_scanner,
-/obj/item/export_scanner,
-/obj/item/export_scanner,
-/turf/open/floor/wood_fancy/wood_fancy_light,
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#222222";
+	opacity = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#222222";
+	opacity = 1
+	},
+/turf/open/floor/carpet/green,
 /area/f13/building/trader)
 "eNy" = (
 /obj/structure/nest/randomized{
@@ -8941,16 +9106,15 @@
 	},
 /area/f13/wasteland)
 "eUA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 15
+/obj/structure/curtain/directional/west{
+	color = "#efe434"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "eUU" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/inside/dirt,
@@ -9019,14 +9183,13 @@
 	},
 /area/f13/building)
 "eWR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 11
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "eXd" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -9727,11 +9890,6 @@
 /obj/structure/table/optable/primitive,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"foy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "foK" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -9910,12 +10068,6 @@
 	dir = 4
 	},
 /area/f13/building)
-"frU" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "frX" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt,
@@ -9944,6 +10096,16 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"fsW" = (
+/obj/structure/fluff/rails{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building/trader)
 "ftd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -10184,22 +10346,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fyF" = (
-/obj/structure/mirror{
-	pixel_y = 25;
-	pixel_x = -5
+/obj/structure/statue_fal{
+	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
+	icon_state = "statue2";
+	pixel_x = -14;
+	layer = 6;
+	pixel_y = -20
 	},
-/obj/machinery/shower{
-	pixel_y = 21;
-	pixel_x = 6
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
 	},
-/obj/structure/curtain,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "fyL" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10634,23 +10798,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fKN" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "fLZ" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -10905,28 +11054,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"fSU" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/obj/effect/turf_decal/vg_decals/numbers/one,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "fTf" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/structure/table/booth{
-	color = "#EFCCC0"
-	},
-/obj/structure/sign/barsign{
-	light_color = "#FDB0C0";
-	pixel_x = 1;
-	pixel_y = 36
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "fTt" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/f13{
@@ -10958,21 +11088,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"fTT" = (
-/obj/structure/sacredwell{
-	light_power = 20;
-	max_integrity = 9999;
-	light_color = "#33BE24";
-	light_range = 3;
-	color = "#BE446e";
-	desc = "That used to be the tribes sacred well.  Why is it here...?"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "fUg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "fUk" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -10995,17 +11115,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fUC" = (
-/obj/effect/fake_stairs/west{
-	color = "#bb3333"
+/obj/structure/campfire/wallfire{
+	pixel_y = -1
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "fUJ" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -11326,10 +11440,6 @@
 "gcX" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"gde" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "gdh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11353,25 +11463,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"gej" = (
-/obj/structure/statue_fal{
-	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
-	icon_state = "statue2";
-	pixel_x = -14;
-	layer = 6;
-	pixel_y = -20
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "gel" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11508,21 +11599,9 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "gjN" = (
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/window,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9;
-	pixel_y = 6
-	},
-/obj/structure/campfire/churchfire{
-	pixel_y = 7
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "gjW" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards{
@@ -11605,26 +11684,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "glQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 19
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "gmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11990,16 +12057,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gwL" = (
-/obj/machinery/vending/medical/nash{
-	pixel_x = 26;
-	density = 0
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/custom/leechjar{
-	pixel_y = 18;
-	pixel_x = 21;
-	desc = "Why do the lumps in that jar look vaguely catlike?";
-	name = "Mereks brain juice"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -12186,6 +12249,11 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
+"gDe" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - E"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "gDw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12461,6 +12529,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"gLd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/survivalcapsule{
+	pixel_y = 0
+	},
+/obj/item/survivalcapsule{
+	pixel_y = 9
+	},
+/obj/item/survivalcapsule/blacksmith{
+	pixel_y = -10
+	},
+/obj/item/survivalcapsule/farm{
+	pixel_x = 10
+	},
+/obj/item/survivalcapsule/fortuneteller{
+	pixel_x = -9
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "gLP" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -13160,6 +13248,14 @@
 "heJ" = (
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"heQ" = (
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3;
+	pixel_x = -1
+	},
+/obj/effect/spawner/lootdrop/f13/common_mats,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "heV" = (
 /obj/machinery/light/small{
 	color = "#FF0000";
@@ -13548,9 +13644,14 @@
 	},
 /area/f13/building)
 "hps" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "hpt" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -13686,16 +13787,10 @@
 "hsR" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
-	req_one_access_txt = "34"
+	req_one_access_txt = "138"
 	},
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "hti" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
@@ -13800,12 +13895,18 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
 "hvy" = (
-/obj/structure/fence/door{
-	dir = 8;
-	pixel_x = 15
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal{
+	pixel_y = 21
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1";
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "hwp" = (
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/f13/wood{
@@ -13821,6 +13922,15 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"hwt" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/general,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "hwu" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/legslave,
@@ -13915,6 +14025,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
+"hAU" = (
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "hBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -13991,17 +14107,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"hCQ" = (
-/obj/machinery/smartfridge/chemistry{
-	density = 0;
-	pixel_y = -32
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "hDe" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14298,13 +14403,9 @@
 	},
 /area/f13/building/trader)
 "hJP" = (
-/obj/structure/rug/big/rug_red,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "hKi" = (
 /obj/structure/simple_door/dirtyglass,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -14452,25 +14553,17 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/trainstation)
-"hNN" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_vendor/general,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "hNR" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
+"hNT" = (
+/obj/structure/simple_door/wood,
+/obj/item/lock_bolt{
+	dir = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/wasteland/city/newboston/chapel)
 "hNU" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#00DD00";
@@ -14720,20 +14813,16 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "hTR" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1";
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier,
 /obj/structure/window/reinforced{
-	dir = 1;
-	color = "#222222";
-	opacity = 1
+	dir = 8
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
+/obj/machinery/mineral/wasteland_trader{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
 /area/f13/building/trader)
 "hTT" = (
 /obj/structure/window/fulltile/house{
@@ -15011,11 +15100,18 @@
 	},
 /area/f13/building)
 "icC" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#222222";
+	opacity = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#222222";
+	opacity = 1
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "icD" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -15526,12 +15622,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/workshop/nash)
 "ius" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/structure/rug/mat{
+	pixel_y = 2
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "iuy" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/structure/chair/left{
@@ -15567,6 +15664,14 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
+"ivc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "ivk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16402,22 +16507,6 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
-"iRz" = (
-/obj/item/trash/candle{
-	pixel_x = 3;
-	pixel_y = 19
-	},
-/obj/item/candle/infinite{
-	pixel_x = -9;
-	pixel_y = 19
-	},
-/obj/item/clothing/head/helmet/skull{
-	pixel_x = 7;
-	pixel_y = 16
-	},
-/obj/structure/bookcase,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "iRA" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13/wood,
@@ -17074,9 +17163,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"jeV" = (
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "jfg" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17143,12 +17229,9 @@
 	},
 /area/f13/wasteland)
 "jgf" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/bed/dogbed,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "jgh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -17204,7 +17287,10 @@
 	},
 /area/f13/building)
 "jiy" = (
-/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
 "jiz" = (
@@ -17306,13 +17392,18 @@
 	},
 /area/f13/wasteland)
 "jlc" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#222222";
-	opacity = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "jlw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17387,19 +17478,22 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"jnB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west{
-	color = "#A47449";
-	dir = 2
+"jnu" = (
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/obj/machinery/computer/communications{
+	name = "quest console";
+	req_access = null
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/hospital/clinic/nash)
+/area/f13/building/trader)
+"jnB" = (
+/obj/structure/sink/well{
+	pixel_y = 7;
+	pixel_x = -6;
+	layer = 4
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "jnR" = (
 /obj/structure/table/wood/settler,
 /obj/structure/bedsheetbin/empty,
@@ -17829,14 +17923,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jyY" = (
-/obj/structure/sink/well{
-	pixel_y = 7;
-	pixel_x = -6;
-	layer = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "jyZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -17901,14 +17987,11 @@
 	},
 /area/f13/building)
 "jBh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "jBp" = (
 /obj/structure/stone_tile/block{
 	layer = 5
@@ -18044,12 +18127,9 @@
 	},
 /area/f13/wasteland)
 "jEY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - N"
-	},
-/area/f13/building)
+/obj/structure/flora/timber,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "jFa" = (
 /obj/structure/closet/wardrobe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -18145,6 +18225,10 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"jIC" = (
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "jIN" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/window/fulltile/house/broken,
@@ -18196,7 +18280,7 @@
 "jKt" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
-	req_one_access_txt = "34"
+	req_one_access_txt = "138"
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
@@ -18254,12 +18338,13 @@
 	},
 /area/f13/building)
 "jMc" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "jMg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -19068,21 +19153,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"kjf" = (
-/obj/structure/nightstand/small{
-	pixel_x = 9;
-	pixel_y = 20
-	},
-/obj/item/flashlight/littlelamp{
-	pixel_y = 23;
-	pixel_x = 9
-	},
-/obj/item/kirbyplants/random{
-	pixel_y = 24;
-	pixel_x = -8
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "kji" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/road{
@@ -19250,11 +19320,10 @@
 	},
 /area/f13/building)
 "koc" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "koo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19379,15 +19448,12 @@
 	},
 /area/f13/wasteland)
 "krF" = (
-/obj/structure/flora/tree/jungle/small{
-	pixel_x = -16;
-	pixel_y = -12
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/curtain/directional/north,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "krI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -19589,10 +19655,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"kxw" = (
-/obj/effect/turf_decal/vg_decals/numbers/zero,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "kxz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19665,12 +19727,19 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "kAR" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
 	},
-/obj/structure/curtain/directional/south,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/obj/structure/sign/barsign{
+	light_color = "#FDB0C0";
+	pixel_x = 1;
+	pixel_y = 36
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "kBj" = (
 /obj/machinery/vending/games,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -19688,19 +19757,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
-"kBQ" = (
-/obj/structure/sign/gunshop{
-	layer = 5;
-	pixel_y = 25
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = 39;
-	layer = 6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "kBU" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -19881,6 +19937,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
+"kGv" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "kGH" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -20132,6 +20192,24 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"kMX" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "kNd" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -20173,6 +20251,19 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"kNU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/hospital/clinic/nash)
 "kNZ" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20226,11 +20317,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "kPv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth{
-	color = "#EFCCC0"
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/turf/open/floor/wood_common,
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/turf/open/floor/wood_worn,
 /area/f13/wasteland/city/newboston/bar)
 "kPz" = (
 /obj/structure/closet/crate/large,
@@ -20362,30 +20459,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kVa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/survivalcapsule{
-	pixel_y = 0
-	},
-/obj/item/survivalcapsule{
-	pixel_y = 9
-	},
-/obj/item/survivalcapsule/blacksmith{
-	pixel_y = -10
-	},
-/obj/item/survivalcapsule/farm{
-	pixel_x = 10
-	},
-/obj/item/survivalcapsule/fortuneteller{
-	pixel_x = -9
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "kVi" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
-	req_one_access_txt = "34"
+	req_one_access_txt = "138"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -20469,18 +20546,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kWU" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/wasteland/city/newboston/outdoors)
 "kXc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -20698,31 +20770,8 @@
 	},
 /area/f13/building)
 "lbs" = (
-/obj/structure/table/wood{
-	layer = 3;
-	pixel_y = -2
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -13;
-	pixel_y = 13
-	},
-/obj/item/trash/candle{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/trash/plate{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "lcb" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -20828,6 +20877,12 @@
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
 	},
+/area/f13/building)
+"lfR" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lgf" = (
 /obj/structure/table/greyscale,
@@ -20948,19 +21003,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"lhT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "liA" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -21223,6 +21265,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lqr" = (
+/obj/effect/landmark/party{
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "lqs" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -21335,13 +21383,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "lvH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/chair/sofa/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "lwh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -22273,15 +22319,6 @@
 /mob/living/simple_animal/hostile/mirelurk/hunter,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"lYp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "lYr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22527,14 +22564,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"meY" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "mfb" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -22875,10 +22904,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mnP" = (
-/obj/structure/closet/ammunitionlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "mog" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -22892,6 +22917,13 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
+"moZ" = (
+/obj/machinery/vending/dinnerware{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "mpj" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23158,10 +23190,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"mwZ" = (
-/obj/structure/flora/timber,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "mxb" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -23200,11 +23228,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "myf" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/structure/fermenting_barrel{
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "myo" = (
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/f13{
@@ -23213,18 +23245,11 @@
 /area/f13/building)
 "myL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner - N"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
+/area/f13/building)
 "myM" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -23343,13 +23368,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"mBq" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "mBr" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -23529,20 +23547,18 @@
 	},
 /area/f13/building)
 "mHJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "mHP" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_x = -2;
-	pixel_y = 5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "mHQ" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -23619,6 +23635,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"mJx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "mJJ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -23731,14 +23753,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
-"mMO" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "mMX" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23836,26 +23850,27 @@
 	},
 /area/f13/wasteland)
 "mPB" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
+/obj/item/storage/bag/money{
+	pixel_y = 14;
+	pixel_x = 33;
+	color = "#f3f233"
 	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
+/obj/structure/sign/bank{
+	layer = 4.1;
+	pixel_y = -4;
+	pixel_x = 32
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/machinery/vending/coffee,
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "mPW" = (
-/obj/structure/campfire/wallfire{
-	pixel_y = -1
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "mPZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -24408,15 +24423,17 @@
 	},
 /area/f13/building)
 "ngm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_y = 5
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	color = "#a98c5d";
+	dir = 8
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/mob/living/simple_animal/cow/brahmin/cow/tan,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "ngs" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -24553,6 +24570,10 @@
 /obj/effect/landmark/start/f13/shopkeeper,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
+"nkj" = (
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "nku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -24780,6 +24801,14 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/carpet,
 /area/f13/building)
+"nrx" = (
+/obj/structure/beebox{
+	pixel_y = 11;
+	layer = 4;
+	density = 0
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "nsl" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -25090,14 +25119,12 @@
 	},
 /area/f13/building)
 "nBt" = (
-/obj/machinery/vending/bigredvend{
-	pixel_x = -7;
-	pixel_y = 1
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "nBx" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -25309,30 +25336,15 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "nHr" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/item/shovel{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	color = "#705454";
-	name = "sand pit"
-	},
-/area/f13/building/workshop/nash)
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "nHJ" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -25616,19 +25628,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nPK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "nPS" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -25654,15 +25653,11 @@
 	},
 /area/f13/building)
 "nQu" = (
-/obj/structure/fermenting_barrel{
-	pixel_y = 9
+/obj/machinery/computer/cargo/request{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 15
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "nQv" = (
 /obj/structure/fence/handrail_corner{
 	dir = 4
@@ -25701,13 +25696,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"nQU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "nRa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -25791,11 +25779,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "nTH" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/rack/shelf_metal,
+/obj/structure/window/reinforced{
+	dir = 2;
+	color = "#222222";
+	opacity = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "nTI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25862,9 +25852,9 @@
 "nVE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
-	req_one_access_txt = "34"
+	req_one_access_txt = "138"
 	},
-/obj/structure/curtain/directional/west{
+/obj/structure/curtain/directional/east{
 	color = "#efe434"
 	},
 /turf/open/floor/wood_fancy/wood_fancy_light,
@@ -25927,15 +25917,20 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "nWz" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
 	},
-/obj/structure/curtain/directional/west{
-	color = "#450159"
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "nWC" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26014,6 +26009,10 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"nZK" = (
+/obj/structure/closet/ammunitionlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nZL" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 1;
@@ -26078,9 +26077,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "odp" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "odI" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -26133,18 +26140,12 @@
 	},
 /area/f13/wasteland)
 "ofN" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/vending/boozeomat/pubby_captain{
-	pixel_y = 32;
-	density = 0
-	},
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/vg_decals/numbers/nine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "ofX" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr23";
@@ -26446,14 +26447,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "opB" = (
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/export/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "opN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26529,6 +26530,31 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
+"osc" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/item/shovel{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/outside/desert{
+	color = "#705454";
+	name = "sand pit"
+	},
+/area/f13/building/workshop/nash)
 "ose" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -26615,6 +26641,9 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"ovp" = (
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/building)
 "ovv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -26864,13 +26893,9 @@
 	},
 /area/f13/building)
 "oFe" = (
-/obj/structure/rug/mat{
-	pixel_y = 2
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/mineral/wasteland_vendor/badammo,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "oFv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
@@ -26989,6 +27014,10 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"oJI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "oKm" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -27394,10 +27423,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"oVv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "oVz" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -27882,13 +27907,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"pkF" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "pkH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -28071,20 +28089,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ppJ" = (
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "ppM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -28225,18 +28229,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"psT" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	color = "#222222";
-	opacity = 1
-	},
-/obj/machinery/computer/communications{
-	name = "quest console";
-	req_access = null
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "psW" = (
 /obj/structure/fence/end{
 	dir = 8
@@ -28261,15 +28253,19 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "ptA" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
-	density = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
+"ptC" = (
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/caves)
 "ptW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
@@ -28299,12 +28295,9 @@
 /turf/open/indestructible/ground/bamboo/fiftyeight,
 /area/f13/wasteland/city/newboston/sauna)
 "puk" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#ff6433";
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/caves)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "put" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -28480,23 +28473,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "pyK" = (
-/obj/item/storage/bag/money{
-	pixel_y = 14;
-	pixel_x = 33;
-	color = "#f3f233"
+/obj/structure/chair/left{
+	dir = 8
 	},
-/obj/structure/sign/bank{
-	layer = 4.1;
-	pixel_y = -4;
-	pixel_x = 32
-	},
-/obj/machinery/vending/coffee,
 /obj/structure/railing{
-	dir = 1;
+	dir = 4;
 	color = "#bb3333"
 	},
 /turf/open/floor/wood_common,
-/area/f13/building/trader)
+/area/f13/wasteland/city/newboston/bar)
 "pzz" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -28570,11 +28555,11 @@
 	},
 /area/f13/building/tribal)
 "pBs" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
+/obj/item/clothing/gloves/f13/baseball,
+/obj/item/twohanded/baseball,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "pBB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -28620,6 +28605,13 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
+"pDA" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "pDJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -28826,11 +28818,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
 "pJt" = (
-/obj/structure/chair/office/dark{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "pJI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -28946,10 +28944,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"pMY" = (
-/obj/structure/closet/crate,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "pNj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -28987,12 +28981,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
-"pOy" = (
-/obj/effect/landmark/party{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "pOz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -29072,9 +29060,10 @@
 	},
 /area/f13/wasteland)
 "pPK" = (
-/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/workshop/nash)
 "pQu" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/gravel,
@@ -29294,6 +29283,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"pZk" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/machinery/vending/boozeomat/pubby_captain{
+	pixel_y = 32;
+	density = 0
+	},
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "pZJ" = (
 /obj/item/stack/crafting/metalparts/three,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -29403,6 +29405,9 @@
 	desc = "A stage for dancing.";
 	density = 0
 	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
 /turf/open/floor/wood_worn,
 /area/f13/wasteland/city/newboston/bar)
 "qdC" = (
@@ -29448,7 +29453,7 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "qez" = (
-/obj/machinery/light/floor,
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
 "qfd" = (
@@ -29467,13 +29472,8 @@
 	},
 /area/f13/building)
 "qfR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "qgh" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -29530,9 +29530,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "qhp" = (
-/obj/machinery/light/floor,
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/south,
 /turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/area/f13/wasteland/city/newboston/sauna)
 "qhV" = (
 /obj/item/chair/wood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -29552,7 +29555,7 @@
 "qjw" = (
 /obj/machinery/door/airlock/engineering/glass{
 	color = "#ff6433";
-	req_one_access_txt = "34"
+	req_one_access_txt = "138"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -29577,9 +29580,20 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "qjB" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/vending/cola/starkist{
+	pixel_x = -9;
+	pixel_y = 21;
+	density = 0
+	},
+/obj/machinery/vending/cola/space_up{
+	pixel_x = 13;
+	pixel_y = 21;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qjD" = (
 /obj/structure/sign/crosswalk{
 	pixel_x = 7;
@@ -29637,19 +29651,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
-"qlI" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/machinery/reagentgrinder,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "qlJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -29723,15 +29724,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "qnB" = (
-/obj/structure/sign/departments/examroom{
-	pixel_y = 2;
-	pixel_x = 29
+/obj/structure/chair/sofa/corner{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/structure/rug/carpet3{
+	pixel_y = 13;
+	pixel_x = 14
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "qnG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -29873,6 +29874,10 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal/caveofforever)
+"qrX" = (
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "qse" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -29899,12 +29904,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"qst" = (
-/obj/item/clothing/gloves/f13/baseball,
-/obj/item/twohanded/baseball,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "qsz" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -30144,9 +30143,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qxf" = (
-/obj/effect/turf_decal/vg_decals/numbers/three,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "qxl" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr26";
@@ -30171,19 +30173,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"qxT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "qyc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -30367,13 +30356,15 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "qBA" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "qBL" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -30469,29 +30460,13 @@
 	},
 /area/f13/building)
 "qDg" = (
-/obj/structure/sink/deep_water{
-	pixel_y = 3;
-	color = "#996633"
+/obj/structure/chair/bench{
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - E"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#996633"
-	},
-/area/f13/building/workshop/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "qDp" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr7";
@@ -30519,10 +30494,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"qDQ" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "qDY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -30592,23 +30563,6 @@
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qFm" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	pixel_y = 14;
-	network = list("nash");
-	layer = 3;
-	alpha = 0;
-	mouse_opacity = 0
-	},
-/obj/machinery/mineral/wasteland_vendor/mining,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/building/trader)
 "qFn" = (
 /obj/structure/bookcase,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -30681,18 +30635,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qHR" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/mob/living/simple_animal/cow/brahmin/cow/tan,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "qHX" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -30746,14 +30688,6 @@
 /obj/item/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qJK" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -1
-	},
-/obj/effect/spawner/lootdrop/f13/common_mats,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "qJZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -31008,10 +30942,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "qQB" = (
-/obj/machinery/light/small,
-/obj/structure/closet/crate,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/structure/mirror{
+	pixel_y = 25;
+	pixel_x = -5
+	},
+/obj/machinery/shower{
+	pixel_y = 21;
+	pixel_x = 6
+	},
+/obj/structure/curtain,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "qQD" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -31045,25 +30991,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
-"qRw" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "qRA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -31455,12 +31382,9 @@
 	},
 /area/f13/building/abandoned)
 "rdO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "ref" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood,
@@ -31641,6 +31565,21 @@
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"rki" = (
+/obj/structure/table/wood,
+/obj/structure/barricade/bars{
+	layer = 3.5;
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building/trader)
 "rkj" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
@@ -31870,6 +31809,17 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"rpa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999";
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "rpz" = (
 /obj/machinery/light/small{
 	light_color = "#884444"
@@ -31992,18 +31942,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"rtc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#448822"
-	},
-/area/f13/caves)
 "rtg" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/oil,
@@ -32077,18 +32015,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"ruk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "ruz" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -32629,21 +32555,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "rJd" = (
-/obj/machinery/chem_dispenser{
-	pixel_y = 19;
-	pixel_x = -12;
-	density = 0
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
 	},
-/obj/machinery/chem_heater{
-	pixel_y = 17;
-	pixel_x = 8;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "rJi" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/chapel{
@@ -32742,16 +32658,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"rKP" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "rLa" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
@@ -32963,14 +32869,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rPK" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 11
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "rPR" = (
 /obj/structure/fence{
 	dir = 1;
@@ -33095,11 +32993,13 @@
 	},
 /area/f13/building)
 "rUy" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "rUB" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -33206,14 +33106,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "rXa" = (
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/bar)
 "rXj" = (
-/obj/machinery/bookbinder{
-	pixel_x = 8
+/obj/structure/holohoop{
+	pixel_y = 20;
+	pixel_x = 16
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "rXx" = (
 /obj/structure/decoration/clock/active{
 	pixel_y = 24
@@ -33739,14 +33646,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
-"shO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "shR" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -33917,30 +33816,13 @@
 	},
 /area/f13/brotherhood)
 "soW" = (
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/american,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/fiesta,
-/obj/item/storage/box/ingredients/grains,
-/obj/item/storage/box/ingredients/grains,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "spi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/recharge_station,
@@ -34024,20 +33906,14 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "sri" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_x = -9;
-	pixel_y = 21;
-	density = 0
+/obj/machinery/iv_drip/telescopic,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/machinery/vending/cola/space_up{
-	pixel_x = 13;
-	pixel_y = 21;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "srl" = (
 /obj/structure/chair/right{
 	dir = 4
@@ -34052,6 +33928,27 @@
 /obj/structure/bed/oldalt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"srI" = (
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	layer = 2.9
+	},
+/obj/item/toy/dummy,
+/obj/item/megaphone,
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "ssg" = (
 /obj/machinery/light{
 	dir = 1
@@ -34073,11 +33970,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"ssX" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "stn" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34104,6 +33996,12 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"stz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "stG" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -34626,16 +34524,13 @@
 /area/f13/building)
 "sHE" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "sHQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
@@ -34668,9 +34563,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sIw" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "sIE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -35188,6 +35085,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"sUQ" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "sVi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -35529,14 +35439,16 @@
 	},
 /area/f13/building)
 "thp" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/export/bottle/vodka{
-	pixel_x = 6;
-	pixel_y = 10
+/obj/machinery/smartfridge/chemistry{
+	density = 0;
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "thJ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/swimsuit/green{
@@ -35858,6 +35770,22 @@
 "tot" = (
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
+"toG" = (
+/obj/structure/table/wood,
+/obj/machinery/photocopier,
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1";
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "toQ" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -36092,13 +36020,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tuf" = (
-/obj/structure/beebox{
-	pixel_y = 11;
-	layer = 4;
+/obj/machinery/mineral/equipment_vendor{
+	pixel_y = 14;
 	density = 0
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "tum" = (
 /obj/structure/sink/puddle,
 /obj/effect/decal/cleanable/dirt,
@@ -36183,6 +36112,10 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"twS" = (
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "twX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36275,14 +36208,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/caveofforever)
 "tza" = (
-/obj/machinery/iv_drip/telescopic,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tzc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -36546,23 +36474,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tFZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/obj/item/choice_beacon/box/weapons_common,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/machinery/bookbinder{
+	pixel_x = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "tGJ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt,
@@ -36572,15 +36488,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "tGZ" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/area/f13/building/trader)
 "tHh" = (
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/stack/sheet/glass/ten,
@@ -36608,11 +36518,20 @@
 /turf/open/floor/wood_common,
 /area/f13/building/trader)
 "tHN" = (
-/obj/structure/curtain/directional/south{
-	color = "#5c131b"
+/obj/structure/rack/shelf_metal,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/item/export_scanner,
+/obj/structure/window/reinforced{
+	dir = 2;
+	color = "#222222";
+	opacity = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "tHR" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/ruins,
@@ -36683,12 +36602,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"tKO" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/f13/coyote/oldwood{
-	opacity = 0
-	},
-/area/f13/building/hospital/clinic/nash)
 "tKP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -36855,11 +36768,12 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "tNI" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "tOp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/blamco,
@@ -36911,6 +36825,10 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
+"tPo" = (
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "tPu" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/spring,
@@ -37004,10 +36922,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tRs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "tRy" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -37063,10 +36977,21 @@
 	},
 /area/f13/building)
 "tSy" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1;
+	color = "#222222";
+	opacity = 1
 	},
-/turf/open/floor/wood_common,
+/obj/machinery/computer/communications{
+	name = "quest console";
+	req_access = null
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/trader)
 "tSI" = (
 /obj/structure/window/fulltile/house,
@@ -37081,24 +37006,25 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"tTx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "tTF" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tTG" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/bars{
-	layer = 3.5;
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/closed/wall/f13/coyote/oldwood{
+	opacity = 0
 	},
 /area/f13/building/trader)
 "tTN" = (
@@ -37378,6 +37304,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"ueL" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "ueX" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -37530,10 +37463,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"uiu" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/building/trader)
 "uiB" = (
 /obj/structure/stairs/west{
 	dir = 2
@@ -37664,6 +37593,12 @@
 /obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
+"ulP" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "ulR" = (
 /obj/structure/wreck/trash/halftire,
 /obj/effect/decal/cleanable/dirt,
@@ -37787,11 +37722,19 @@
 	},
 /area/f13/building)
 "uoR" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "upe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -38238,6 +38181,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/f13/building)
+"uEN" = (
+/obj/structure/rack/shelf_metal{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
+/area/f13/building/workshop/nash)
 "uEQ" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
@@ -38327,12 +38280,14 @@
 	},
 /area/f13/wasteland)
 "uHp" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "uHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -38444,33 +38399,29 @@
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
 "uKH" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
-"uKX" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/dirt,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/workshop/nash)
+"uKI" = (
+/obj/structure/sacredwell{
+	light_power = 20;
+	max_integrity = 9999;
+	light_color = "#33BE24";
+	light_range = 3;
+	color = "#BE446e";
+	desc = "That used to be the tribes sacred well.  Why is it here...?"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "uLf" = (
 /turf/closed/wall/f13/store,
 /turf/closed/wall/f13/store,
 /area/f13/building)
-"uLk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "uLv" = (
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/dirt,
@@ -38509,9 +38460,22 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "uMI" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/vending/medical/nash{
+	pixel_x = 26;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/custom/leechjar{
+	pixel_y = 18;
+	pixel_x = 21;
+	desc = "Why do the lumps in that jar look vaguely catlike?";
+	name = "Mereks brain juice"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "uMJ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -38588,6 +38552,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
+"uPd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/libraryscanner{
+	pixel_x = 14;
+	pixel_y = 0;
+	density = 0
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "uPk" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -38906,16 +38879,12 @@
 	},
 /area/f13/wasteland)
 "uZH" = (
-/obj/structure/holohoop{
-	pixel_y = 20;
-	pixel_x = 16
-	},
+/obj/structure/rug/big/rug_red,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "vac" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39047,17 +39016,6 @@
 /obj/structure/chair/stool,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"vdH" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "vdR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -39374,6 +39332,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"vlH" = (
+/obj/machinery/vending/cola,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "vlV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -39629,6 +39593,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
+"vsv" = (
+/obj/structure/curtain/directional/south{
+	color = "#5c131b"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "vsz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39731,6 +39701,16 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"vuQ" = (
+/obj/machinery/status_display/supply{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "vuT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -39825,14 +39805,17 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "vxh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/libraryscanner{
-	pixel_x = 14;
-	pixel_y = 0;
+/obj/effect/fake_stairs/west{
+	color = "#bb3333"
+	},
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
 	density = 0
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/wasteland/city/newboston/bar)
 "vxi" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -40047,6 +40030,10 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
+"vEa" = (
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "vEc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40066,17 +40053,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
-"vEK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "vEW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/wood_common,
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
 /area/f13/building/trader)
 "vFA" = (
 /obj/item/chair,
@@ -40268,6 +40252,14 @@
 "vNf" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
+"vNr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "vNt" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -40280,12 +40272,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"vNJ" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
 "vNL" = (
 /obj/structure/chair{
 	dir = 8
@@ -40376,15 +40362,6 @@
 "vPo" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
-"vPE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "vPN" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -40393,16 +40370,12 @@
 	},
 /area/f13/building)
 "vPX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "vQb" = (
 /obj/structure/stairs,
 /turf/open/floor/f13{
@@ -40416,19 +40389,31 @@
 	},
 /area/f13/building)
 "vQW" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
+/obj/structure/table/wood{
+	layer = 3;
+	pixel_y = -2
 	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -13;
+	pixel_y = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/item/trash/candle{
+	pixel_x = 1;
+	pixel_y = 4
 	},
-/area/f13/building/hospital/clinic/nash)
+/obj/item/trash/plate{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/effect/spawner/lootdrop/f13/common,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "vRd" = (
 /obj/effect/landmark/start/f13/barkeep,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -40487,6 +40472,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vSN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "vSW" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt,
@@ -40572,9 +40561,6 @@
 /obj/structure/table,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
-"vWq" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building)
 "vWL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -40695,6 +40681,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"vZX" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "wah" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -40904,14 +40894,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wfi" = (
-/obj/machinery/computer/operating,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 3
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/building/workshop/nash)
 "wfu" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Senior Paladin";
@@ -41098,6 +41086,23 @@
 "wlD" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"wlP" = (
+/obj/machinery/camera/autoname{
+	dir = 5;
+	pixel_y = 14;
+	network = list("nash");
+	layer = 3;
+	alpha = 0;
+	mouse_opacity = 0
+	},
+/obj/machinery/mineral/wasteland_vendor/mining,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/building/trader)
 "wlQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -41152,11 +41157,16 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "wmS" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/structure/sign/gunshop{
+	layer = 5;
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/machinery/status_display/supply{
+	pixel_y = 39;
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wmT" = (
@@ -41609,12 +41619,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wzP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal{
-	pixel_y = 21
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	icon_state = "sofamiddle"
 	},
-/turf/open/floor/carpet/green,
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "wAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
@@ -41878,7 +41888,10 @@
 	},
 /area/f13/wasteland)
 "wIP" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
 "wJg" = (
@@ -41980,6 +41993,16 @@
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/nash)
+"wLd" = (
+/obj/structure/flora/tree/jungle/small{
+	pixel_x = -16;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wLg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
@@ -42360,14 +42383,35 @@
 	desc = "A stage for dancing.";
 	density = 0
 	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
 /turf/open/floor/wood_worn,
 /area/f13/wasteland/city/newboston/bar)
 "wVD" = (
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
+/obj/structure/sink/deep_water{
+	pixel_y = 3;
+	color = "#996633"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	color = "#996633"
+	},
+/area/f13/building/workshop/nash)
 "wVY" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -42512,6 +42556,14 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
+"wZe" = (
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "wZE" = (
 /obj/structure/simple_door/brokenglass,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -42575,13 +42627,6 @@
 "xbw" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/tribal/cave)
-"xcf" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
-/area/f13/building)
 "xcu" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -42795,8 +42840,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xgZ" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/hospital/clinic/nash)
 "xht" = (
 /obj/structure/lamp_post/doubles/bent{
@@ -43010,7 +43055,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building/hospital/clinic/nash)
 "xoy" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -43178,6 +43223,19 @@
 	},
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
+"xrJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "xrP" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43219,14 +43277,6 @@
 	dir = 4
 	},
 /area/f13/building)
-"xtx" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "xtG" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt,
@@ -43403,11 +43453,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xyl" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/item/book{
+	pixel_y = 32;
+	anchored = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "xyu" = (
@@ -43567,12 +43618,20 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "xCx" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "xCC" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -44123,26 +44182,21 @@
 	},
 /area/f13/building)
 "xRq" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
+/obj/structure/window,
 /obj/machinery/light{
-	dir = 4
+	dir = 1;
+	layer = 2.9;
+	pixel_y = 6
 	},
-/obj/structure/table/wood{
-	layer = 2.9
+/obj/structure/campfire/churchfire{
+	pixel_y = 7
 	},
-/obj/item/toy/dummy,
-/obj/item/megaphone,
-/turf/open/floor/wood_worn,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -44178,14 +44232,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "xSo" = (
-/obj/machinery/mineral/equipment_vendor{
-	pixel_y = 14;
-	density = 0
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "138"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/structure/curtain/directional/east{
+	color = "#450159"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "xSA" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -44410,6 +44465,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"xWR" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "xXa" = (
 /obj/structure/railing{
 	dir = 8
@@ -44635,10 +44698,6 @@
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/carpet/green,
 /area/f13/building/trader)
-"yes" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_common,
-/area/f13/building/hospital/clinic/nash)
 "yev" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -44925,6 +44984,18 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
+"ykZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "ylc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
@@ -68656,19 +68727,19 @@ vJk
 oQS
 rom
 hQs
-nPK
-nPK
-nPK
-nPK
-nPK
-nPK
-nPK
-cpu
+xrJ
+xrJ
+xrJ
+xrJ
+xrJ
+xrJ
+xrJ
+aAx
 rom
 hQs
 hQs
 hQs
-sHE
+odp
 tEZ
 rom
 hQs
@@ -68910,25 +68981,25 @@ hVc
 mCq
 hVc
 hVc
-czX
+uKH
 hVc
 hVc
-tNI
-tNI
-tNI
-tNI
-tNI
-xCx
+mJx
+mJx
+mJx
+mJx
+mJx
+wfi
 hTc
-xCx
-jgf
+wfi
+tNI
 xZc
 xZc
 xZc
 xZc
-rdO
+mHP
 wTa
-vPE
+glQ
 xZc
 xZc
 xZc
@@ -68936,10 +69007,10 @@ xZc
 xZc
 xZc
 xZc
-krF
+wLd
 hcF
-hJP
-mHJ
+uZH
+qxf
 fgh
 nWv
 hEQ
@@ -69167,17 +69238,17 @@ hVc
 bpA
 wKZ
 nYg
-tRs
-qJK
+oJI
+heQ
 hVc
 hTc
 hTc
 hTc
 hTc
-pBs
-nHr
+ulP
+osc
 oUB
-qDg
+wVD
 hVc
 ifw
 ifw
@@ -69425,16 +69496,16 @@ ifN
 kjL
 rxK
 rxK
-tGZ
+uEN
 hVc
 hTc
 hTc
 hTc
 hTc
 hTc
-jMc
+ctp
 hTc
-qHR
+ngm
 hVc
 pwM
 isE
@@ -69450,9 +69521,9 @@ pll
 pll
 pll
 pll
-mwZ
+jEY
 pll
-qst
+pBs
 lQM
 fDY
 fDY
@@ -69689,8 +69760,8 @@ hTc
 hTc
 hTc
 hTc
-qjB
-qjB
+twS
+twS
 hTc
 hVc
 wJl
@@ -69937,7 +70008,7 @@ pll
 mCq
 jtS
 rxK
-qhp
+jIC
 rxK
 mII
 hVc
@@ -69964,7 +70035,7 @@ pll
 pll
 pll
 pll
-pOy
+lqr
 pll
 ute
 lQM
@@ -70203,15 +70274,15 @@ syx
 syx
 syx
 syx
-hvy
+cEt
 syx
 syx
 hVc
 isE
 isE
-odp
+aRr
 qGt
-uHp
+hNT
 ifw
 pll
 pll
@@ -70229,7 +70300,7 @@ pJc
 pJc
 pJc
 pJc
-jBh
+hps
 kXC
 hRg
 tPQ
@@ -70451,18 +70522,18 @@ pll
 mCq
 tJH
 rxK
-tRs
-tRs
-tRs
-bms
-bms
-uKX
-uKX
-uKX
-uKX
-bms
-uKX
-bms
+oJI
+oJI
+oJI
+lbs
+lbs
+wIP
+wIP
+wIP
+wIP
+lbs
+wIP
+lbs
 hVc
 isE
 isE
@@ -70470,9 +70541,9 @@ isE
 kzV
 isE
 ifw
-dRJ
-wmS
-dRJ
+wZe
+kWU
+wZe
 bCw
 kIY
 pll
@@ -70708,20 +70779,20 @@ pll
 mCq
 rxK
 rxK
-bAu
+pPK
 rxK
 bKT
 hVc
-tuf
-bms
-bms
-bms
-bms
-bms
-bms
-uMI
+nrx
+lbs
+lbs
+lbs
+lbs
+lbs
+lbs
+qrX
 hVc
-gjN
+xRq
 kzV
 sfn
 vYz
@@ -70969,14 +71040,14 @@ rxK
 rxK
 uAy
 hVc
-nQu
-uKX
-uKX
-uKX
-uKX
-uKX
-uKX
-sIw
+myf
+wIP
+wIP
+wIP
+wIP
+wIP
+wIP
+eoV
 hVc
 rOW
 isE
@@ -70985,9 +71056,9 @@ isE
 rOW
 ifw
 kIY
-gej
+fyF
 mrr
-xtx
+cWw
 wze
 pll
 pll
@@ -71226,14 +71297,14 @@ rxK
 rxK
 xkz
 hVc
-jyY
-bms
-bms
-bms
-bms
-bms
-bms
-wIP
+jnB
+lbs
+lbs
+lbs
+lbs
+lbs
+lbs
+rdO
 hVc
 jGw
 ott
@@ -71479,17 +71550,17 @@ uiB
 hVc
 qWv
 rxK
-qhp
-tRs
+jIC
+oJI
 pXu
 hVc
-mHP
-uKX
-uKX
-uKX
-uKX
-uKX
-uKX
+awt
+wIP
+wIP
+wIP
+wIP
+wIP
+wIP
 acE
 hVc
 jGw
@@ -71736,18 +71807,18 @@ sbq
 hVc
 tKS
 rxK
-tRs
+oJI
 rxK
-qJK
+heQ
 hVc
-bms
-bms
-bms
-bms
-bms
-bms
+lbs
+lbs
+lbs
+lbs
+lbs
+lbs
 lUv
-bms
+lbs
 hVc
 dNH
 qFz
@@ -71761,8 +71832,8 @@ avK
 avK
 avK
 avK
-qBA
-qBA
+rUy
+rUy
 avK
 bGv
 vJk
@@ -72024,7 +72095,7 @@ ekg
 nRM
 vJk
 byj
-kAR
+qhp
 lzG
 pfP
 fMx
@@ -72536,7 +72607,7 @@ eLP
 rLl
 mdh
 bgu
-ruk
+pJt
 nDA
 bZu
 pfP
@@ -72758,15 +72829,15 @@ gcX
 hRl
 gao
 hJN
-qFm
-lYp
-hNN
-akW
-biT
-kBQ
+wlP
+vEW
+hwt
+hTR
+tTG
+wmS
 avK
 avK
-wVD
+hAU
 avK
 avK
 avK
@@ -73013,7 +73084,7 @@ hRl
 "}
 (110,1,1) = {"
 hRl
-bgF
+oFe
 dtH
 dtH
 dtH
@@ -73024,27 +73095,27 @@ dtH
 dtH
 gln
 dtH
-koc
-koc
-koc
-koc
-koc
+xow
+xow
+xow
+xow
+xow
 uzU
-koc
-koc
-koc
-ayi
 xow
 xow
 xow
 ayi
-xow
-xow
+jBh
+jBh
+jBh
+ayi
+jBh
+jBh
 wVC
 qda
 qda
 fft
-qRw
+aDg
 nRM
 rHb
 rce
@@ -73271,35 +73342,35 @@ hRl
 (111,1,1) = {"
 hRl
 tHW
-jeV
-jeV
-uiu
-jeV
-jeV
-uiu
-jeV
-jeV
-uiu
-jeV
-cdB
+qfR
+qfR
+tGZ
+qfR
+qfR
+tGZ
+qfR
+qfR
+tGZ
+qfR
+fTf
 xpO
-cdB
-cdB
+fTf
+fTf
 xpO
-cdB
-cdB
+fTf
+fTf
 xpO
-cdB
+fTf
+biT
 rXa
-qez
+biT
+biT
 rXa
-rXa
-qez
-rXa
-rXa
-kWU
-opB
-opB
+biT
+biT
+kPv
+uHp
+uHp
 vOY
 mdh
 etn
@@ -73528,34 +73599,34 @@ hRl
 (112,1,1) = {"
 hRl
 rLL
-jeV
-jeV
-jeV
-jeV
-jeV
-vEW
-jeV
-jeV
-jeV
-jeV
-cdB
-cdB
-cdB
-cdB
-cdB
-cdB
-cdB
-xgZ
-yes
-pPK
+qfR
+qfR
+qfR
+qfR
+qfR
+dRJ
+qfR
+qfR
+qfR
+qfR
+fTf
+fTf
+fTf
+fTf
+fTf
+fTf
+fTf
+jgf
+kGv
+qez
 iep
-pPK
+qez
 nZa
 iep
-rXa
-rXa
-fUC
-xRq
+biT
+biT
+vxh
+srI
 vzp
 vOY
 mdh
@@ -73785,32 +73856,32 @@ hRl
 (113,1,1) = {"
 hRl
 tHs
-jeV
-jeV
-ars
+qfR
+qfR
+nkj
 qTx
-fSU
-rUy
-pyK
-tSy
-jeV
-cZU
-vQW
-vQW
+bjr
+nQu
 mPB
-vQW
-vQW
-vQW
-hsR
-tKO
+dQO
+qfR
+cZU
+boV
+boV
+nWz
+boV
+boV
+boV
+gwL
+tPo
 qCp
-fTf
+kAR
 tdE
 tdE
 tdE
 xiY
-rXa
-rXa
+biT
+biT
 vOY
 vOY
 vOY
@@ -74042,12 +74113,12 @@ hRl
 (114,1,1) = {"
 hRl
 gao
-tTG
-nWz
+rki
+xSo
 afx
 afx
 sWl
-tTG
+rki
 gao
 gOo
 nVE
@@ -74059,16 +74130,16 @@ uIt
 gXv
 gXv
 uIt
-ptA
-fUg
+eqe
+xgZ
 qgK
 ogc
 qei
 ogc
 woy
-rXa
+biT
 tRA
-tHN
+vsv
 wWW
 srl
 vOY
@@ -74301,7 +74372,7 @@ hRl
 gao
 nhV
 iXY
-qxf
+jnu
 wMb
 gHl
 xVz
@@ -74309,24 +74380,24 @@ gao
 cmo
 iXY
 gao
-rJd
+cKP
 uIt
-qlI
-uIt
-uIt
+sUQ
 uIt
 uIt
-abR
-fUg
+uIt
+uIt
+dOt
+xgZ
 wBB
 ogc
 ogc
 ogc
 cNZ
+biT
 rXa
-qez
-tHN
-kPv
+vsv
+vPX
 mjx
 vOY
 wbp
@@ -74561,15 +74632,15 @@ iXY
 iXY
 lsj
 iXY
-kVa
+gLd
 gao
-cSq
+eEr
 iXY
 qjw
 uIt
 tCv
 uIt
-gwL
+uMI
 uIt
 uIt
 uIt
@@ -74580,13 +74651,13 @@ ogc
 iCv
 ogc
 qlE
-rXa
+biT
 tRA
-tHN
+vsv
 kYy
-hNR
+pyK
 vOY
-avu
+qDg
 cwC
 aqT
 rJa
@@ -74819,33 +74890,33 @@ iXY
 iXY
 iXY
 iXY
-mBq
-meY
+hsR
+jMc
 iXY
 gao
 qCp
 qCp
 qCp
 qCp
-fKN
-awl
+kMX
+vZX
 uIt
-hCQ
+thp
 qCp
-glQ
+cUd
 lzk
 lzk
 kef
 hdy
-rXa
-rXa
+biT
+biT
 vOY
 vOY
 vOY
 vOY
 tlI
 lUl
-eUA
+rpa
 rJa
 mdh
 rEv
@@ -75075,16 +75146,16 @@ iXY
 iXY
 iXY
 iXY
-kVa
+gLd
 gao
 gao
-nVE
+eUA
 gao
 qCp
-wfi
-sYT
 bDj
-gde
+sYT
+xWR
+puk
 hBy
 uIt
 uIt
@@ -75095,8 +75166,8 @@ elX
 vOY
 vOY
 omk
-rXa
-tHN
+biT
+vsv
 wWW
 srl
 vOY
@@ -75332,29 +75403,29 @@ iXY
 iXY
 lsj
 iXY
-tFZ
+abR
 gao
-wzP
+hvy
 rvM
 isg
 qCp
 iUQ
 sYT
 sYT
-eKD
+vEa
 hBy
 uIt
 uIt
 qCp
-soW
+bms
 weC
 weC
 voN
 vOY
 vDv
-qez
-tHN
-kPv
+rXa
+vsv
+vPX
 mjx
 vOY
 tlI
@@ -75591,28 +75662,28 @@ iXY
 iXY
 iOa
 gao
-vNJ
+mHJ
 rvM
 rvM
 qCp
 evI
 sYT
 sYT
-vEK
+hJP
 mEG
 uIt
 uIt
 qCp
-pkF
+pDA
 ogc
 ogc
 cxm
 vOY
 tjm
-rXa
-tHN
+biT
+vsv
 kYy
-hNR
+pyK
 vOY
 tlI
 ghS
@@ -75846,16 +75917,16 @@ iXY
 iXY
 iXY
 iXY
-eNj
-hTR
+tHN
+toG
 aMZ
 vEc
 rvM
 qCp
-fyF
+qQB
 vUF
 sYT
-tza
+sri
 hBy
 uIt
 uIt
@@ -75865,8 +75936,8 @@ ogc
 ogc
 oIv
 uQa
-uoR
-rXa
+stz
+biT
 vOY
 vOY
 vOY
@@ -76103,8 +76174,8 @@ iXY
 iXY
 lsj
 iXY
-gyr
-psT
+nTH
+tSy
 bSa
 yer
 rvM
@@ -76125,7 +76196,7 @@ vOY
 fft
 eOo
 vOY
-vdH
+ceh
 nxO
 nxO
 nxO
@@ -76355,16 +76426,16 @@ hRl
 (123,1,1) = {"
 hRl
 gao
-pMY
+hNR
 iXY
 iXY
 iXY
 iXY
-qQB
+cSq
 gao
-jlc
-jlc
-jlc
+eNj
+eNj
+eNj
 qCp
 uIt
 uIt
@@ -76374,7 +76445,7 @@ uIt
 uIt
 uIt
 kVi
-myf
+rJd
 ogc
 ogc
 oUn
@@ -76382,7 +76453,7 @@ fft
 jeH
 jUN
 vOY
-uZH
+rXj
 xOu
 uWY
 uWY
@@ -76612,26 +76683,26 @@ hRl
 (124,1,1) = {"
 hRl
 gao
+hNR
 iXY
 iXY
 iXY
 iXY
-iXY
-pMY
+hNR
 gao
-iXY
-iXY
-iXY
+icC
+icC
+icC
 kVi
 uIt
 uIt
 tCv
-qnB
-jnB
+avu
+kNU
 uIt
 uIt
 uIt
-ofN
+pZk
 bEN
 lzk
 aLL
@@ -76639,7 +76710,7 @@ vOY
 sPL
 qps
 vOY
-xyl
+ivc
 uWY
 uWY
 uWY
@@ -76869,13 +76940,13 @@ hRl
 (125,1,1) = {"
 hRl
 gao
-uLk
+nHr
 nbZ
 nbZ
 nbZ
 nbZ
-nTH
-mBq
+ueL
+hsR
 iXY
 lsj
 hiW
@@ -76896,7 +76967,7 @@ vOY
 vOY
 vOY
 vOY
-vPX
+tTx
 brC
 brC
 brC
@@ -77126,17 +77197,17 @@ hRl
 (126,1,1) = {"
 hRl
 gao
-rKP
+vuQ
 whF
 whF
-kxw
+gjN
 whF
-dOt
+fUg
 gao
 iXY
 iXY
 wuq
-puk
+ptC
 iLF
 iLF
 iLF
@@ -77145,15 +77216,15 @@ iLF
 iLF
 iLF
 iLF
-oVv
+vSN
 auL
 auL
-lbs
+vQW
 raI
 seq
-iRz
-oVv
-abe
+eKD
+vSN
+xyl
 avK
 avK
 avK
@@ -77165,8 +77236,8 @@ lVZ
 avK
 avK
 avK
-qBA
-qBA
+rUy
+rUy
 kXC
 kJF
 kXC
@@ -77386,9 +77457,9 @@ gmg
 bPn
 qRl
 xPV
-aAx
+ofN
 vsz
-lvH
+aHr
 gao
 wHT
 wHT
@@ -77402,15 +77473,15 @@ wHT
 wHT
 iLF
 iLF
-oVv
-vxh
+vSN
+uPd
 auL
 fVx
 auL
 auL
 auL
+nBt
 ius
-oFe
 jqA
 jqA
 jqA
@@ -77659,18 +77730,18 @@ qOI
 wHT
 iLF
 iLF
-oVv
-rXj
+vSN
+tFZ
 auL
 auL
 auL
 auL
-bsJ
-uKH
+qnB
+krF
 aHM
 gIm
 gIm
-ssX
+gDe
 klQ
 aqT
 mLI
@@ -77916,17 +77987,17 @@ qOI
 wHT
 iLF
 iLF
-oVv
-rPK
+vSN
+eWR
 auL
 auL
-mPW
+fUC
 auL
-bAa
-uKH
-nQU
-nQU
-nQU
+wzP
+krF
+ptA
+ptA
+ptA
 mdh
 klQ
 rHb
@@ -78173,14 +78244,14 @@ qOI
 wHT
 iLF
 iLF
-oVv
-awt
-pJt
-ppJ
+vSN
+cIm
+sIw
+dYk
 iqa
-kjf
-icC
-uKH
+cpu
+lvH
+krF
 jgs
 jgs
 jgs
@@ -79189,7 +79260,7 @@ iaR
 iaR
 iaR
 iaR
-iaR
+fsW
 iaR
 iaR
 iaR
@@ -79207,12 +79278,12 @@ ump
 vOc
 hTd
 qNK
-jiy
-thp
-mMO
-qfR
+aul
+opB
+ahq
+soW
 qNK
-sri
+qjB
 klQ
 rHb
 rLl
@@ -79464,9 +79535,9 @@ jRP
 niY
 xjv
 qNK
-xcf
-aHr
-shO
+moZ
+cXg
+vNr
 oms
 qNK
 mdh
@@ -79721,12 +79792,12 @@ jIg
 qNK
 qNK
 qNK
-eoV
-eqe
-eqe
-aSt
+xCx
+abe
+abe
+jiy
 qNK
-xSo
+tuf
 klQ
 rHb
 rJa
@@ -79982,7 +80053,7 @@ uKk
 uKk
 hmh
 uKk
-avJ
+ovp
 fdm
 cwC
 rHb
@@ -80984,7 +81055,7 @@ iLF
 iLF
 hay
 unP
-ngm
+qBA
 iLF
 iLF
 xxj
@@ -81010,7 +81081,7 @@ sKy
 jkD
 jkD
 qNK
-avJ
+ovp
 lIo
 avK
 avK
@@ -81267,7 +81338,7 @@ eCM
 uJn
 jkD
 bLR
-aDg
+vlH
 dsp
 jqA
 jqA
@@ -81497,7 +81568,7 @@ hRl
 nXP
 iLF
 hIg
-qxT
+jlc
 jVv
 fKe
 iLF
@@ -81524,7 +81595,7 @@ umG
 uJn
 jkD
 bLR
-nBt
+aQG
 gIm
 gIm
 bKF
@@ -81785,7 +81856,7 @@ kcx
 kcx
 uKk
 uKk
-jEY
+myL
 sAR
 dGj
 kXC
@@ -82016,7 +82087,7 @@ swG
 iLF
 iLF
 iLF
-fTT
+uKI
 iLF
 hay
 hIg
@@ -82299,7 +82370,7 @@ cBK
 rpE
 wuh
 qNK
-mnP
+nZK
 vMp
 vMp
 tlI
@@ -82556,8 +82627,8 @@ sHQ
 oMM
 tRQ
 kcx
-qDQ
-hps
+awl
+tza
 vMp
 tlI
 wBY
@@ -82813,7 +82884,7 @@ sHQ
 oMM
 waI
 qNK
-frU
+lfR
 vMp
 vMp
 tlI
@@ -83070,9 +83141,9 @@ sHQ
 oMM
 egN
 qNK
-eEr
-eEr
-vWq
+mPW
+mPW
+fKN
 tlI
 snD
 sXy
@@ -83327,9 +83398,9 @@ qHc
 rGP
 qrG
 qNK
-vWq
-hps
-vWq
+fKN
+tza
+fKN
 kXC
 lDW
 edk
@@ -83584,9 +83655,9 @@ sKy
 jkD
 xGQ
 qNK
-vWq
-vWq
-vWq
+fKN
+fKN
+fKN
 kXC
 tPQ
 vac
@@ -83824,8 +83895,8 @@ iLF
 iLF
 iLF
 vqf
-lhT
-eWR
+dQI
+sHE
 cuO
 swG
 cQD
@@ -83841,9 +83912,9 @@ kcx
 qNK
 qNK
 qNK
-vWq
-vWq
-vWq
+fKN
+fKN
+fKN
 kXC
 pYR
 iXy
@@ -84082,8 +84153,8 @@ iLF
 hTD
 hIg
 wRR
-rtc
-myL
+ykZ
+uoR
 eCS
 swG
 hTD
@@ -84095,12 +84166,12 @@ iLF
 iLF
 swG
 swG
-foy
+koc
 iLF
-vWq
-vWq
-vWq
-vWq
+fKN
+fKN
+fKN
+fKN
 kXC
 dVq
 eiW
@@ -84354,10 +84425,10 @@ iLF
 iLF
 iLF
 iLF
-vWq
-ahq
-ahq
-ahq
+fKN
+bBH
+bBH
+bBH
 kXC
 tPQ
 wBY

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -27,9 +27,6 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
 /obj/structure/flora/timber,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -57,10 +54,6 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/building/workshop/nash)
-"abR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -90,14 +83,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "acE" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "acI" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
@@ -213,18 +204,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "afx" = (
-/obj/item/storage/bag/money{
-	pixel_y = 14;
-	pixel_x = 33;
-	color = "#f3f233"
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 8
 	},
-/obj/structure/sign/bank{
-	layer = 4.1;
-	pixel_y = -4;
-	pixel_x = 32
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/city)
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building/trader)
 "afE" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -299,23 +293,9 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "ahq" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14
-	},
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "aht" = (
 /obj/structure/stairs/east,
 /obj/structure/railing,
@@ -459,15 +439,14 @@
 	},
 /area/f13/brotherhood)
 "akW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/left{
-	dir = 8;
-	pixel_x = 8;
-	pixel_y = 12
+/obj/machinery/mineral/wasteland_vendor/crafting{
+	icon_state = "parts_idle"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "alu" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
@@ -658,15 +637,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"ars" = (
-/obj/machinery/door/unpowered/securedoor{
-	max_integrity = 800;
-	name = "Store Backroom";
-	obj_integrity = 800;
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "arA" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars{
@@ -800,9 +770,19 @@
 	},
 /area/f13/wasteland)
 "aul" = (
-/obj/structure/glowshroom,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "aup" = (
 /turf/open/floor/f13/wood,
 /area/f13/caves)
@@ -810,15 +790,6 @@
 /obj/item/trash/f13/cram_large,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"auC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/campfire/stove{
-	pixel_y = 10
-	},
-/obj/item/grown/log/tree,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "auL" = (
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
@@ -846,21 +817,29 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "avu" = (
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "avv" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "avJ" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Clinic";
-	req_access_txt = null;
-	req_access = "124"
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = -4;
+	layer = 2.8;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/waffles{
+	pixel_y = 13;
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -884,26 +863,16 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"awl" = (
-/obj/structure/mirror{
-	pixel_y = 25;
-	pixel_x = -5
-	},
-/obj/machinery/shower{
-	pixel_y = 21;
-	pixel_x = 6
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "awt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/structure/sign/departments/examroom{
+	pixel_y = 2;
+	pixel_x = 29
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "awO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -947,19 +916,12 @@
 	},
 /area/f13/building/abandoned)
 "ayi" = (
-/obj/structure/railing{
-	color = "#bb3333";
-	dir = 8;
-	pixel_x = -2
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "ayl" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 10;
@@ -1036,8 +998,9 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "aAx" = (
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "aAz" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -1205,6 +1168,7 @@
 "aEY" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/table/wood,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "aFx" = (
@@ -1276,20 +1240,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aHr" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "aHs" = (
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced{
@@ -1598,15 +1548,14 @@
 	},
 /area/f13/building)
 "aQG" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 4;
-	pixel_y = -16
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_y = -6
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "aRb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1620,11 +1569,14 @@
 /turf/open/indestructible/ground/bamboo/fourtysix,
 /area/f13/wasteland/city/newboston/sauna)
 "aRr" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/libraryscanner{
+	pixel_x = 3;
+	pixel_y = 11;
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/caves)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "aRB" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -1639,9 +1591,9 @@
 	},
 /area/f13/building)
 "aSt" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland/city/newboston/chapel)
 "aSS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1779,13 +1731,15 @@
 	},
 /area/f13/building)
 "aXi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/jukebox{
-	pixel_y = 21;
-	density = 0
+/obj/machinery/smartfridge/chemistry{
+	density = 0;
+	pixel_y = -32
 	},
-/turf/open/floor/wood_common,
-/area/f13/city)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "aXQ" = (
 /obj/item/trash/candy,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2133,20 +2087,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "bgF" = (
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
+/obj/structure/closet/crate/bin{
+	pixel_y = 3;
+	density = 0
 	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/area/f13/building/hospital/clinic/nash)
 "bgG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
@@ -2240,19 +2189,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
-"biT" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/city)
 "bjl" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr25";
@@ -2261,12 +2197,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"bjr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "bjE" = (
 /obj/structure/fence/handrail{
 	dir = 8
@@ -2274,12 +2204,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"bke" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "bko" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2308,16 +2232,13 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel)
 "bms" = (
-/obj/machinery/chem_dispenser,
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1
+/obj/structure/sink/well{
+	pixel_y = -4;
+	pixel_x = -6;
+	layer = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "bmW" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -2516,19 +2437,12 @@
 	},
 /area/f13/building)
 "bsJ" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "btc" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
@@ -2770,16 +2684,26 @@
 /area/f13/building/workshop/nash)
 "bzW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/side{
-	dir = 8
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_uncommon,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/obj/item/choice_beacon/box/weapons_common,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "bAa" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/obj/structure/curtain/directional/west{
-	color = "#1e549c"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -2792,21 +2716,6 @@
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/fakespace,
 /area/f13/building/tribal/caveofforever)
-"bAu" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/bars{
-	layer = 3.5;
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/city)
 "bAz" = (
 /obj/effect/landmark/start/f13/followersscientist,
 /obj/structure/railing{
@@ -2853,15 +2762,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "bBH" = (
-/obj/machinery/chem_master,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/fermenting_barrel,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "bBI" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/ausbushes/genericbush,
@@ -2943,9 +2849,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bDj" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/machinery/vending/medical/nash{
+	pixel_x = 26;
+	density = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/custom/leechjar{
+	pixel_y = 18;
+	pixel_x = 21;
+	desc = "Why do the lumps in that jar look vaguely catlike?";
+	name = "Mereks brain juice"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "bDJ" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/planks,
@@ -3399,23 +3318,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
-"bPu" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
-	},
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "bPy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
 /obj/structure/chair/bench{
 	dir = 8
 	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "bPL" = (
@@ -3844,14 +3752,8 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "cdB" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/structure/table/booth{
-	color = "#EFCCC0"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "cdN" = (
 /obj/structure/debris/v2{
 	pixel_x = -12;
@@ -3862,12 +3764,13 @@
 	},
 /area/f13/building)
 "ceh" = (
-/obj/structure/chair/f13chair2{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/side,
-/area/f13/building)
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "cej" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4096,21 +3999,11 @@
 	},
 /area/f13/building)
 "cmo" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
+/obj/machinery/computer/cargo/request{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "cms" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -4406,16 +4299,13 @@
 	},
 /area/f13/building)
 "ctp" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
+/obj/structure/beebox{
+	pixel_y = 11;
+	layer = 4;
 	density = 0
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "ctv" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -4678,11 +4568,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "czX" = (
-/obj/structure/stone_tile/block{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cult,
-/area/f13/building/tribal/cave)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "cAa" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -4871,9 +4763,12 @@
 	},
 /area/f13/wasteland)
 "cEt" = (
-/obj/structure/barricade/bars,
-/turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "cEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair1{
@@ -5015,9 +4910,12 @@
 	},
 /area/f13/wasteland)
 "cIm" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "cIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5099,22 +4997,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"cKP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/dancing_pole{
-	pixel_x = -5;
-	pixel_y = -8
-	},
-/obj/structure/railing/dancing_pole{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
 "cKR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5340,20 +5222,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cSq" = (
-/obj/structure/filingcabinet{
-	pixel_x = -5
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "cSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5428,21 +5296,18 @@
 	},
 /area/f13/building)
 "cUd" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 8;
-	layer = 2.8;
-	density = 0
+/obj/structure/sign/gunshop{
+	layer = 5;
+	pixel_y = 25
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/waffles{
-	pixel_y = 11;
-	pixel_x = 7
+/obj/machinery/status_display/supply{
+	pixel_y = 39;
+	layer = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "cUm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5494,14 +5359,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cUU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8
 	},
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "cUW" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -5569,14 +5431,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "cWw" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/obj/structure/curtain/directional/west{
-	color = "#efe434"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "cWY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -5644,14 +5506,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cZU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/trader)
 "cZV" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13{
@@ -5769,13 +5626,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"dda" = (
-/obj/item/restraints/handcuffs/fake/kinky,
-/obj/structure/closet/cabinet/anchored,
-/obj/item/toy/lewd/dildo/double,
-/obj/item/toy/lewd/fleshlight/red,
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
 "ddi" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/structure/railing{
@@ -5870,9 +5720,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "dfZ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland/city/newboston/outdoors)
 "dgl" = (
 /obj/structure/fence{
@@ -6344,15 +6192,17 @@
 	},
 /area/f13/building)
 "dtH" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/paper_bin{
+	pixel_y = 7;
+	pixel_x = -5
 	},
-/obj/machinery/mineral/wasteland_trader{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/item/pen,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/library)
 "dtO" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/f13/steak,
@@ -7053,8 +6903,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dNH" = (
-/turf/open/floor/f13/wood,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 23
+	},
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 1;
+	pixel_y = 39;
+	layer = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/chapel)
 "dNR" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt,
@@ -7085,15 +6951,9 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "dOt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood_common,
+/area/f13/building/hospital/clinic/nash)
 "dOu" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -7134,12 +6994,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "dPg" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10";
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "dPs" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
@@ -7197,22 +7058,15 @@
 /turf/open/floor/plating/rust,
 /area/f13/building)
 "dQI" = (
-/obj/structure/rug/carpet{
-	layer = 1;
-	pixel_y = 10
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/junk/small/tv{
-	pixel_x = -5;
-	pixel_y = 19
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
-"dQO" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1
+/obj/machinery/mineral/wasteland_trader{
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/trader)
 "dRf" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -7253,11 +7107,9 @@
 	},
 /area/f13/building/abandoned)
 "dRJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "dRN" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -7490,16 +7342,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "dYk" = (
-/obj/structure/stone_tile/block{
-	dir = 8;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/obj/item/target,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "dYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -7966,22 +7811,20 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/city/newboston/outdoors)
 "elk" = (
-/obj/structure/chair/sofa{
-	color = "#475340"
+/obj/machinery/camera/autoname{
+	dir = 5;
+	pixel_y = 14;
+	network = list("nash");
+	layer = 3;
+	alpha = 0;
+	mouse_opacity = 0
 	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/obj/machinery/mineral/wasteland_vendor/mining,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "elq" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13{
@@ -8073,13 +7916,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eoV" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_x = 5
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "epa" = (
 /obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8126,12 +7967,6 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
-"eqe" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
 "eqf" = (
 /mob/living/simple_animal/chicken,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8616,15 +8451,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"eEr" = (
-/obj/machinery/door/unpowered/securedoor{
-	max_integrity = 800;
-	name = "Store Backroom";
-	obj_integrity = 800;
-	req_one_access_txt = "34"
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "eEu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
@@ -8800,9 +8626,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "eHA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
 /obj/structure/chair/bench{
 	dir = 8
 	},
@@ -8906,29 +8729,34 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"eKD" = (
-/obj/structure/stairs/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "eKF" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "eKM" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
+/obj/structure/sink/deep_water{
+	pixel_y = 3;
+	color = "#996633"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	color = "#996633"
+	},
+/area/f13/building/workshop/nash)
 "eLh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -9293,9 +9121,11 @@
 	},
 /area/f13/wasteland)
 "eUA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/general,
+/turf/open/floor/wood_common,
 /area/f13/building/trader)
 "eUU" = (
 /obj/structure/flora/grass/wasteland,
@@ -9365,10 +9195,13 @@
 	},
 /area/f13/building)
 "eWR" = (
-/turf/closed/wall/r_wall/f13/vault{
-	opacity = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "eXd" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -10284,12 +10117,16 @@
 	},
 /area/f13/wasteland)
 "fsW" = (
-/obj/structure/chair/sofa/left{
-	dir = 8;
-	pixel_x = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "ftd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -10530,9 +10367,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "fyF" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/machinery/mineral/wasteland_vendor/specialplus{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "fyL" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -10722,12 +10562,9 @@
 	},
 /area/f13/wasteland)
 "fDm" = (
-/obj/structure/fermenting_barrel,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "fDq" = (
 /obj/structure/wreck/bus/rusted,
 /turf/open/indestructible/ground/outside/road{
@@ -10974,9 +10811,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fKN" = (
-/obj/machinery/trading_machine/medical,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/closet/crate,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "fLZ" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -11236,9 +11073,17 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/library)
 "fTf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/fake_stairs/west{
+	color = "#bb3333"
+	},
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/bar)
 "fTt" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/f13{
@@ -11271,20 +11116,18 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "fTT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "fUg" = (
-/obj/structure/chair/sofa/right{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "fUk" = (
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -11305,12 +11148,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"fUC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/side{
-	dir = 1
-	},
 /area/f13/building)
 "fUJ" = (
 /obj/structure/debris/v3,
@@ -11354,8 +11191,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fVx" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "fVX" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -11630,11 +11471,14 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
 "gde" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/export/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "gdh" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -11659,31 +11503,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gej" = (
-/obj/item/statuebust{
-	can_be_unanchored = 1;
-	density = 1;
-	desc = "A priceless ancient marble bust of some rando. Who the hell even is this guy?";
-	pixel_y = 8
+/obj/structure/chair/bench{
+	dir = 8
 	},
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
 	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -2
-	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/wasteland/city/newboston/chapel)
+/area/f13/wasteland/city/newboston/outdoors)
 "gel" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -11819,26 +11645,6 @@
 /obj/structure/chair,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
-"gjN" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14
-	},
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
 "gjW" = (
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards{
@@ -11895,12 +11701,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/caves)
 "gln" = (
-/obj/structure/window/reinforced{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/trader)
 "glz" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("wastebot","junker");
@@ -11920,15 +11726,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"glQ" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "gmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11997,9 +11794,10 @@
 	},
 /area/f13/caves)
 "gor" = (
-/obj/structure/glowshroom/shadowshroom,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland/city/newboston/outdoors)
 "goA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -12298,11 +12096,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gwL" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "gwP" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/knife,
@@ -12491,13 +12290,8 @@
 	},
 /area/f13/building)
 "gDe" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/spawner/lootdrop/f13/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "gDw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12560,16 +12354,12 @@
 	},
 /area/f13/building)
 "gFY" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_x = -14;
-	pixel_y = 19
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/structure/chair/sofa/left{
-	icon_state = "sofacorner"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "gGl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/cram_large,
@@ -12679,19 +12469,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "gHl" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bankdeskshutters"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/city)
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "gHA" = (
 /obj/effect/decal/waste,
 /turf/open/floor/plasteel/barber{
@@ -12783,19 +12567,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"gLd" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
-	},
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
 "gLP" = (
 /obj/effect/landmark/start/f13/followersdoctor,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -12899,13 +12670,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "gOo" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 8
 	},
-/obj/effect/turf_decal/vg_decals/numbers/two,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/machinery/door/poddoor/shutters{
+	id = "bankdeskshutters"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "gOA" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -13215,9 +12990,12 @@
 	},
 /area/f13/building)
 "gXv" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "gXY" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -13281,17 +13059,6 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/wasteland)
-"gZZ" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/barswindow,
-/obj/structure/curtain/directional/north{
-	color = "#1e549c"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "hae" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -13500,9 +13267,19 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "heQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/obj/structure/sign/barsign{
+	light_color = "#FDB0C0";
+	pixel_x = 1;
+	pixel_y = 36
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "heV" = (
 /obj/machinery/light/small{
 	color = "#FF0000";
@@ -13886,11 +13663,15 @@
 	},
 /area/f13/building)
 "hps" = (
-/obj/structure/stone_tile/surrounding_tile{
-	pixel_y = 16
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/trader)
 "hpt" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -13918,22 +13699,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"hqo" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 4;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "hrn" = (
 /obj/structure/flora/wasteplant/wild_prickly,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14040,11 +13805,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hsR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/bar/heaven)
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "hti" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
@@ -14149,9 +13917,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland)
 "hvy" = (
-/obj/effect/turf_decal/vg_decals/numbers/zero{
-	pixel_y = -17
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
 "hwp" = (
@@ -14169,10 +13939,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hwt" = (
-/obj/machinery/iv_drip/telescopic,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "hwu" = (
 /obj/structure/closet/wardrobe,
 /obj/item/clothing/under/f13/legslave,
@@ -14267,15 +14033,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"hAU" = (
-/obj/machinery/mineral/wasteland_vendor/crafting{
-	icon_state = "parts_idle"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "hBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/followersadministrator,
@@ -14353,22 +14110,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "hCQ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
-"hCY" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/simple_door/house{
+	req_access_txt = 139
 	},
 /turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/area/f13/building/workshop/nash)
 "hDe" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/indestructible/ground/outside/ruins{
@@ -14654,23 +14400,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hJN" = (
-/obj/effect/landmark/start/f13/wastelander/clubmanager,
-/obj/machinery/mineral/wasteland_vendor/mining{
-	pixel_y = 31
+/obj/machinery/mineral/wasteland_vendor/weapons,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "hJP" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "hKi" = (
 /obj/structure/simple_door/dirtyglass,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -14819,9 +14566,18 @@
 	},
 /area/f13/trainstation)
 "hNN" = (
-/obj/machinery/door/unpowered/securedoor,
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 5
+	},
+/obj/machinery/vending/boozeomat/pubby_captain{
+	pixel_y = 32;
+	density = 0
+	},
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "hNR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14835,15 +14591,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "hNT" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 1;
-	pixel_y = -16
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
 	},
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "hNU" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#00DD00";
@@ -15016,11 +14769,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"hTc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "hTd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15391,25 +15139,14 @@
 	},
 /area/f13/building)
 "icC" = (
-/obj/structure/statue_fal{
-	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
-	icon_state = "statue2";
-	pixel_x = -21;
-	layer = 6;
-	pixel_y = -20
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/landmark/observer_start,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/hospital/clinic/nash)
 "icD" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -15463,26 +15200,10 @@
 /turf/open/indestructible/ground/bamboo/tatamiblack,
 /area/f13/wasteland/city/newboston/sauna)
 "iep" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/wood{
-	layer = 2.9
-	},
-/obj/item/toy/dummy,
-/obj/item/megaphone,
-/turf/open/floor/wood_worn,
-/area/f13/city)
+/obj/structure/chair/stool/bar,
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "ieq" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -15884,18 +15605,14 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "isg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack/shelf_metal,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/obj/item/choice_beacon/box/weapons_uncommon,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/obj/machinery/mineral/equipment_vendor{
+	pixel_y = 14;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "isv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/securitron,
@@ -15943,8 +15660,14 @@
 /area/f13/building/workshop/nash)
 "ius" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "iuy" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/structure/chair/left{
@@ -15980,20 +15703,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"ivc" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/obj/structure/sign/poster/contraband/pinup_pink{
-	pixel_x = -29
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "ivk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -16718,10 +16427,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iNQ" = (
-/obj/structure/table,
-/obj/effect/spawner/bundle/costume/maid,
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "iNV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish1{
@@ -16835,11 +16543,9 @@
 	},
 /area/f13/wasteland)
 "iRz" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/ammunitionlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "iRA" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13/wood,
@@ -17336,11 +17042,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"jas" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "jaI" = (
 /obj/structure/table/wood,
 /obj/structure/junk/small/tv{
@@ -17500,10 +17201,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"jeV" = (
-/obj/machinery/mineral/wasteland_vendor/badammo,
-/turf/open/floor/wood_common,
-/area/f13/city)
 "jfg" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -17569,19 +17266,6 @@
 	icon_state = "verticalrightborderright2"
 	},
 /area/f13/wasteland)
-"jgf" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
-	},
-/obj/structure/chair/f13chair2{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "jgh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -17743,13 +17427,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"jlc" = (
-/obj/structure/ladder/unbreakable{
-	id = "hn2";
-	height = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "jlw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18226,13 +17903,21 @@
 	},
 /area/f13/building)
 "jxT" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/machinery/chem_master{
+	pixel_y = 20;
+	density = 0;
+	pixel_x = -6
 	},
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "jye" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -18257,25 +17942,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jyY" = (
-/obj/effect/decal/marking,
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14
-	},
-/obj/effect/turf_decal/trimline/neutral{
-	color = "#000000";
-	icon_state = "trimline_fill"
-	},
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "jyZ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -18340,23 +18012,11 @@
 	},
 /area/f13/building)
 "jBh" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
-/obj/structure/railing{
-	color = "#bb3333";
-	dir = 8;
-	pixel_x = -2
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "jBp" = (
 /obj/structure/stone_tile/block{
 	layer = 5
@@ -18491,15 +18151,6 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland)
-"jEY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "jFa" = (
 /obj/structure/closet/wardrobe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -18596,16 +18247,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "jIC" = (
-/obj/structure/chair/sofa/right{
-	dir = 8;
-	pixel_x = 8
+/obj/structure/mirror{
+	pixel_y = 25;
+	pixel_x = -5
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/shower{
+	pixel_y = 21;
+	pixel_x = 6
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/structure/curtain,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "jIN" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/window/fulltile/house/broken,
@@ -18655,9 +18310,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "jKt" = (
-/obj/structure/kitchenspike,
-/turf/open/indestructible/ground/outside/road,
-/area/f13/caves)
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "jKC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -18712,17 +18370,15 @@
 	},
 /area/f13/building)
 "jMc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/campfire/stove{
-	density = 0;
-	pixel_x = 8;
-	pixel_y = 11
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/storage/box/matches,
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "jMg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -18830,14 +18486,10 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/abandoned)
 "jPG" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "jQc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -19541,12 +19193,9 @@
 	},
 /area/f13/building)
 "kjf" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "kji" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/indestructible/ground/outside/road{
@@ -19714,19 +19363,11 @@
 	},
 /area/f13/building)
 "koc" = (
-/obj/structure/sign/gunshop{
-	layer = 5;
-	pixel_y = 25
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = 39;
-	layer = 6
-	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/hospital/clinic/nash)
 "koo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19851,9 +19492,13 @@
 	},
 /area/f13/wasteland)
 "krF" = (
-/obj/structure/table/plasmaglass,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "krI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -20056,11 +19701,12 @@
 	},
 /area/f13/building)
 "kxw" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/chair/f13chair2{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "kxz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -20133,12 +19779,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "kAR" = (
-/obj/structure/chair/sofa/left{
-	dir = 4;
-	pixel_x = -6
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "kBj" = (
 /obj/machinery/vending/games,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -20147,13 +19790,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
-"kBq" = (
-/obj/structure/ladder/unbreakable{
-	id = "hn";
-	height = 2
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "kBJ" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -38;
@@ -20164,12 +19800,16 @@
 	},
 /area/f13/wasteland)
 "kBQ" = (
-/obj/structure/chair/sofa/right{
-	dir = 1;
-	pixel_x = -6
+/obj/structure/table/reinforced,
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
 	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/structure/curtain/directional/south{
+	color = "#1e549c"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "kBU" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
@@ -20350,10 +19990,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"kGv" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "kGH" = (
 /obj/structure/table/wood/settler,
 /obj/item/trash/plate,
@@ -20606,37 +20242,11 @@
 	},
 /area/f13/building)
 "kMX" = (
-/obj/item/statuebust{
-	can_be_unanchored = 1;
-	density = 1;
-	desc = "A priceless ancient marble bust of some rando. Who the hell even is this guy?";
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
 	},
-/obj/structure/window{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -2
-	},
-/obj/structure/window,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/camera/autoname{
-	dir = 5;
-	pixel_y = 14;
-	network = list("nash");
-	layer = 3;
-	alpha = 0;
-	mouse_opacity = 0
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/wasteland/city/newboston/chapel)
+/area/f13/wasteland/city/newboston/outdoors)
 "kNd" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -20679,15 +20289,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "kNU" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	color = "black";
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "kNZ" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -20740,15 +20347,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"kPv" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/melee/chainofcommand/fake{
-	pixel_x = -14;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
 "kPz" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/f13{
@@ -20884,11 +20482,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "kVi" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#836433";
-	req_one_access_txt = "34"
+/obj/structure/table/wood,
+/obj/structure/barricade/bars{
+	layer = 3.5;
+	dir = 8
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building/trader)
 "kVp" = (
 /obj/machinery/light/small/broken{
@@ -20967,13 +20573,15 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kWU" = (
-/obj/structure/table/plasmaglass,
-/obj/item/pen,
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/curtain/directional/west{
+	color = "#450159"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "kXc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -21068,9 +20676,16 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "kYy" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/structure/chair/right{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "kYz" = (
 /obj/machinery/shower{
 	dir = 4
@@ -21184,26 +20799,11 @@
 	},
 /area/f13/building)
 "lbs" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
+/obj/machinery/vending/cola,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
 	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "lcb" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -21311,13 +20911,11 @@
 	},
 /area/f13/building)
 "lfR" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "lgf" = (
 /obj/structure/table/greyscale,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21437,21 +21035,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"lhT" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	color = "black";
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
 "liA" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt,
@@ -21474,11 +21057,22 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ljb" = (
-/obj/structure/chair/sofa{
-	color = "#475340"
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/window,
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/campfire/churchfire{
+	pixel_y = 7
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/wasteland/city/newboston/chapel)
 "ljd" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -21519,13 +21113,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "ljE" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1;
-	pixel_x = -6
-	},
-/obj/structure/rug/big/rug_red,
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "ljU" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -21728,15 +21318,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"lqr" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "lqs" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -21818,14 +21399,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "ltu" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/turf_decal/vg_decals/numbers/one,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "ltK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -21840,13 +21419,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ltR" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
 "ltT" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -21864,11 +21436,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
-"lvH" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "lwh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -22695,27 +22262,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "lUl" = (
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/city)
 "lUv" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/barswindow{
-	dir = 4
-	},
-/obj/structure/curtain/directional/west{
-	color = "#1e549c"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "lUx" = (
 /obj/structure/window/fulltile/house/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -22864,21 +22418,8 @@
 	},
 /area/f13/building)
 "lYY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/corner{
-	dir = 8
-	},
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23084,18 +22625,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "meY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west,
-/obj/structure/sign/departments/examroom{
-	pixel_x = -31
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 2
 	},
-/obj/structure/railing{
+/obj/machinery/light{
 	dir = 1;
-	color = "#bb3333"
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/campfire/churchfire{
+	pixel_y = 4
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/wasteland/city/newboston/chapel)
 "mfb" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -23244,17 +22791,24 @@
 	},
 /area/f13/building)
 "mjx" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_y = 5
+/obj/machinery/light,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 5;
+	pixel_y = 18
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_y = 21;
+	pixel_x = -3
 	},
-/mob/living/simple_animal/cow/brahmin/cow/tan,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_y = 14;
+	pixel_x = 6
+	},
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "mjS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/lighter,
@@ -23429,13 +22983,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mnP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "mog" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -23450,12 +22997,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "moZ" = (
-/obj/structure/curtain{
-	color = "#c40e0e";
-	open = 0
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "mpj" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -23680,11 +23226,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mvv" = (
-/obj/structure/simple_door/metal/fence/wooden{
-	dir = 2
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/area/f13/city)
 "mvE" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish2"
@@ -23729,12 +23274,9 @@
 	},
 /area/f13/building)
 "mwZ" = (
-/obj/structure/chair/sofa/right{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "mxb" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -23772,32 +23314,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"myf" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofacorner"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "myo" = (
 /obj/structure/closet/crate/engineering,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building)
-"myL" = (
-/obj/structure/sacredwell{
-	light_power = 20;
-	pixel_x = 16;
-	pixel_y = 23;
-	density = 0;
-	max_integrity = 9999
-	},
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/f13/building/tribal/cave)
 "myM" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -23917,11 +23439,23 @@
 	},
 /area/f13/building)
 "mBq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
 	},
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/indestructible/ground/outside/gravel,
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 1;
+	pixel_y = 39;
+	layer = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
 /area/f13/wasteland/city/newboston/outdoors)
 "mBr" = (
 /turf/open/indestructible/ground/outside/dirt,
@@ -24102,23 +23636,21 @@
 	},
 /area/f13/building)
 "mHJ" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/machinery/chem_dispenser{
+	pixel_y = 19;
+	pixel_x = -12;
+	density = 0
 	},
-/obj/structure/curtain/directional/west{
-	color = "#1e549c"
+/obj/machinery/chem_heater{
+	pixel_y = 17;
+	pixel_x = 8;
+	density = 0
 	},
-/turf/open/floor/wood_common{
-	color = "#775555"
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
 /area/f13/building/hospital/clinic/nash)
-"mHP" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/city)
 "mHQ" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -24189,15 +23721,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"mJx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "mJJ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -24310,11 +23833,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
-"mMO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
 "mMX" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24412,15 +23930,30 @@
 	},
 /area/f13/wasteland)
 "mPB" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/city)
-"mPW" = (
-/obj/structure/filingcabinet{
-	pixel_x = 9
+/obj/item/storage/bag/money{
+	pixel_y = 14;
+	pixel_x = 33;
+	color = "#f3f233"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
+/obj/structure/sign/bank{
+	layer = 4.1;
+	pixel_y = -4;
+	pixel_x = 32
+	},
+/obj/machinery/vending/coffee,
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
+"mPW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "mPZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -24528,17 +24061,8 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "mTN" = (
-/obj/machinery/vending/bigredvend{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/machinery/vending/cola/space_up{
-	pixel_x = 16
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/city)
 "mUf" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -24677,13 +24201,15 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "mWi" = (
-/obj/structure/chair/sofa/left{
-	dir = 8;
-	icon_state = "sofacorner"
+/obj/structure/chair/left{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/wasteland/city/newboston/bar)
 "mWm" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -24993,12 +24519,11 @@
 	},
 /area/f13/building)
 "ngm" = (
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/trader)
 "ngs" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -25684,14 +25209,9 @@
 	},
 /area/f13/building)
 "nBt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "nBx" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -25742,13 +25262,26 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "nCU" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_x = -2;
-	pixel_y = 5
+/obj/structure/chair/bench{
+	pixel_y = 12
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 23
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 31
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 8;
+	pixel_y = 39
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - N"
+	},
+/area/f13/city)
 "nDc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13,
@@ -25910,9 +25443,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"nHr" = (
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "nHJ" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -26197,13 +25727,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nPK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/lock_bolt{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/dark,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "nPS" = (
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -26229,26 +25761,18 @@
 	},
 /area/f13/building)
 "nQu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/obj/structure/chair/sofa/corp/right{
-	color = "#BED0FD";
-	dir = 4
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "nQv" = (
 /obj/structure/fence/handrail_corner{
 	dir = 4
@@ -26288,22 +25812,18 @@
 	},
 /area/f13/building)
 "nQU" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-18";
-	pixel_x = -3;
-	pixel_y = 17
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/chair/sofa/left{
-	dir = 4;
-	icon_state = "sofacorner"
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/chair/sofa/left{
-	dir = 4;
-	icon_state = "sofaend_right_armrest";
-	pixel_y = -11
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/caves)
 "nRa" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -26387,20 +25907,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/farm)
 "nTH" = (
-/obj/structure/table/wood,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "countershutters";
-	name = "counter shutters";
-	req_one_access_txt = null
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/city)
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "nTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -26464,13 +25984,15 @@
 	},
 /area/f13/wasteland)
 "nVE" = (
-/obj/structure/railing{
-	dir = 1;
-	color = "#bb3333"
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/effect/turf_decal/vg_decals/numbers/one,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/curtain/directional/west{
+	color = "#efe434"
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "nVO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -26529,9 +26051,17 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "nWz" = (
-/obj/structure/chair/office,
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/mob/living/simple_animal/cow/brahmin/cow/tan,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "nWC" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -26588,17 +26118,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "nZa" = (
-/obj/effect/fake_stairs/west{
-	color = "#bb3333"
-	},
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/bar)
 "nZb" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -26689,14 +26212,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"odp" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340";
-	dir = 4;
-	icon_state = "sofacorner"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "odI" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -26749,10 +26264,18 @@
 	},
 /area/f13/wasteland)
 "ofN" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "ofX" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr23";
@@ -26969,11 +26492,13 @@
 	},
 /area/f13/wasteland)
 "omk" = (
-/obj/structure/chair/right{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/jukebox{
+	pixel_y = 21;
+	density = 0
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/bar)
 "oms" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/building)
@@ -27052,12 +26577,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "opB" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_3";
+	pixel_x = -2;
+	pixel_y = 5
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "opN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27133,12 +26659,6 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
-"osc" = (
-/obj/machinery/vending/medical{
-	pixel_y = -1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building/hospital/clinic/nash)
 "ose" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -27225,14 +26745,6 @@
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"ovp" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ovv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -27267,10 +26779,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "owa" = (
-/obj/structure/table,
-/obj/effect/spawner/bundle/costume/nyangirl,
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
 "owx" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/outside/road{
@@ -27486,11 +26997,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
-"oFe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood_common,
-/area/f13/city)
 "oFv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
@@ -27609,12 +27115,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"oJI" = (
-/obj/structure/filingcabinet{
-	pixel_x = -5
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "oKm" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -27962,12 +27462,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
 "oUB" = (
-/obj/machinery/vending/medical/becomingnook,
-/obj/machinery/light{
-	dir = 8
+/mob/living/simple_animal/cow/brahmin/cow,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "oUG" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -28017,15 +27517,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oVv" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/library)
 "oVz" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -28288,12 +27782,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "pdw" = (
-/obj/machinery/light/small,
-/obj/structure/chair/wood{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building/hospital/clinic/nash)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "pdK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -28518,13 +28018,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "pkF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
+/obj/machinery/iv_drip/telescopic,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "pkH" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal{
@@ -28707,12 +28206,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"ppJ" = (
-/obj/structure/simple_door/house{
-	req_access_txt = 139
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
 "ppM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -28853,10 +28346,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"psT" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "psW" = (
 /obj/structure/fence/end{
 	dir = 8
@@ -28880,11 +28369,6 @@
 /obj/structure/fluff/blocker,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"ptA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/nukacolavendfull,
-/turf/open/floor/wood_common,
-/area/f13/city)
 "ptC" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland)
@@ -29099,22 +28583,6 @@
 "pyH" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
-"pyK" = (
-/obj/effect/decal/marking,
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14
-	},
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
 "pzz" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -29155,12 +28623,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "pAu" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite{
-	pixel_y = 11
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "pAz" = (
 /obj/structure/sink{
 	dir = 1;
@@ -29195,16 +28660,8 @@
 	},
 /area/f13/building/tribal)
 "pBs" = (
-/obj/structure/campfire/stove{
-	pixel_x = -16;
-	pixel_y = 1
-	},
-/obj/item/grown/log/tree{
-	pixel_x = 10;
-	pixel_y = -3
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/building)
 "pBB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -29250,13 +28707,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"pDA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
 "pDJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -29462,31 +28912,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/abandoned)
-"pJt" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/railing/wood/post{
-	pixel_x = 16;
-	pixel_y = 2
-	},
-/obj/structure/railing/wood/post{
-	pixel_x = -13;
-	pixel_y = 1
-	},
-/obj/structure/curtain{
-	color = "#5c131b";
-	layer = 5;
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/structure/rug/mat{
-	color = "#CC4444";
-	layer = 6;
-	pixel_x = 2;
-	pixel_y = 15
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
 "pJI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -29602,13 +29027,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"pMY" = (
-/obj/structure/stone_tile/surrounding_tile{
-	dir = 8;
-	pixel_y = 16
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
 "pNj" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -29647,15 +29065,13 @@
 	},
 /area/f13/wasteland)
 "pOy" = (
-/obj/structure/holohoop{
-	pixel_y = 20;
-	pixel_x = 16
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
-/obj/item/toy/beach_ball/holoball,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "pOz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -29734,12 +29150,6 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland)
-"pPK" = (
-/obj/machinery/vending/cola,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "pQu" = (
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/gravel,
@@ -29958,18 +29368,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "pZk" = (
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
-"pZn" = (
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/machinery/vending/bigredvend{
+	pixel_x = -7;
+	pixel_y = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
+	icon_state = "outerborder - E"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "pZJ" = (
@@ -30070,17 +29474,19 @@
 	},
 /area/f13/brotherhood)
 "qda" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
 /obj/structure/railing{
+	color = "#bb3333";
 	dir = 8;
-	pixel_y = -6
+	pixel_x = -2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#883300"
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "qdC" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -30124,8 +29530,19 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "qez" = (
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/table/reinforced,
+/obj/structure/curtain/directional/east{
+	color = "#1e549c"
+	},
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "qfd" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/bar,
@@ -30142,9 +29559,12 @@
 	},
 /area/f13/building)
 "qfR" = (
-/obj/machinery/mineral/wasteland_vendor/badattachments,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "qgh" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -30201,15 +29621,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "qhp" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building/hospital/clinic/nash)
 "qhV" = (
 /obj/item/chair/wood,
@@ -30326,20 +29748,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/wasteland/city/newboston/bar)
 "qlI" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	pixel_y = 14;
-	network = list("nash");
-	layer = 3;
-	alpha = 0;
-	mouse_opacity = 0
-	},
-/obj/machinery/mineral/wasteland_vendor/mining,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/trader)
 "qlJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -30412,18 +29822,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"qnB" = (
-/obj/item/trash/candle{
-	pixel_x = 3;
-	pixel_y = 16
-	},
-/obj/item/candle/infinite{
-	pixel_x = -14;
-	pixel_y = 16
-	},
-/obj/structure/bookcase,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "qnG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
@@ -30567,11 +29965,10 @@
 /area/f13/building/tribal/caveofforever)
 "qrX" = (
 /obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+	color = "#a98c5d"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "qse" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -30599,8 +29996,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "qst" = (
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qsz" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -30868,27 +30270,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qxw" = (
-/obj/structure/sign/poster/contraband/pinup_topless,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
-"qxT" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/machinery/reagentgrinder,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
+"qxT" = (
+/obj/structure/railing{
+	dir = 1
 	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#888888"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "qyc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -31173,11 +30568,8 @@
 	},
 /area/f13/building)
 "qDg" = (
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
+/turf/closed/wall/r_wall/f13/vault,
+/area/f13/building)
 "qDp" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr7";
@@ -31243,19 +30635,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/wasteland)
-"qEK" = (
-/obj/machinery/vending/cola{
-	pixel_y = 21;
-	pixel_x = -8;
-	density = 0
-	},
-/obj/machinery/vending/snack{
-	density = 0;
-	pixel_y = 20;
-	pixel_x = 15
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "qEL" = (
 /obj/structure/simple_door/metal/fence{
 	door_type = "fence_wood";
@@ -31286,9 +30665,9 @@
 /area/f13/building)
 "qFm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/city/newboston/outdoors)
 "qFn" = (
 /obj/structure/bookcase,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -31318,13 +30697,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qGt" = (
-/obj/machinery/libraryscanner{
-	pixel_x = 3;
-	pixel_y = 11;
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland/city/newboston/chapel)
 "qGu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -31366,9 +30741,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qHR" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "qHX" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -31422,17 +30800,6 @@
 /obj/item/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qJK" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "qJZ" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticaldegraded"
@@ -31686,10 +31053,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
-"qQB" = (
-/obj/structure/table,
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "qQD" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt,
@@ -31723,9 +31086,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/trader)
-"qRw" = (
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
 "qRA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -31799,13 +31159,13 @@
 	},
 /area/f13/wasteland)
 "qTx" = (
-/obj/machinery/mineral/wasteland_vendor/special,
 /obj/structure/railing{
-	dir = 4;
+	dir = 1;
 	color = "#bb3333"
 	},
+/obj/effect/turf_decal/vg_decals/numbers/two,
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/trader)
 "qTO" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 4
@@ -32285,9 +31645,9 @@
 /turf/open/floor/plasteel/chapel,
 /area/f13/building)
 "rjW" = (
-/obj/item/kirbyplants/random,
+/obj/structure/bed/dogbed,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/hospital/clinic/nash)
 "rjX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -32300,9 +31660,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "rki" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
+	},
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	layer = 2.9
+	},
+/obj/item/toy/dummy,
+/obj/item/megaphone,
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "rkj" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
@@ -32657,13 +32034,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"rtc" = (
-/obj/machinery/mineral/wasteland_vendor/weapons,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "rtg" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/decal/cleanable/oil,
@@ -32738,11 +32108,10 @@
 	},
 /area/f13/building)
 "ruk" = (
-/obj/structure/chair/sofa{
-	dir = 8
+/turf/closed/wall/r_wall/f13/vault{
+	opacity = 0
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building/trader)
 "ruz" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -33290,12 +32659,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "rJd" = (
-/obj/structure/chair/sofa/corner{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/mineral/wasteland_vendor/badammo,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "rJi" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/chapel{
@@ -33394,15 +32760,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"rKP" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/export/bottle/vodka{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/side,
-/area/f13/building)
 "rLa" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/tentwall,
@@ -33436,9 +32793,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rLL" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/mineral/wasteland_vendor/special,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "rLO" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/f13/wood,
@@ -33614,16 +32971,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rPK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/sofa/corp/left{
-	color = "#BED0FD";
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "rPR" = (
 /obj/structure/fence{
 	dir = 1;
@@ -33748,13 +33095,24 @@
 	},
 /area/f13/building)
 "rUy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/barsign{
-	light_color = "#FDB0C0";
-	pixel_x = 1
+/obj/structure/statue_fal{
+	desc = "A statue of a Texas ranger.  Protectors of the people.  This one is made of all the brass used to defend the area for the last century.";
+	icon_state = "statue2";
+	pixel_x = -14;
+	layer = 6;
+	pixel_y = -20
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/city)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "rUB" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -33861,18 +33219,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "rXa" = (
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
-	},
-/turf/open/floor/wood_worn,
-/area/f13/city)
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "rXj" = (
-/obj/item/target,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/grown/log/tree{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "rXx" = (
 /obj/structure/decoration/clock/active{
 	pixel_y = 24
@@ -34399,14 +33760,13 @@
 	},
 /area/f13/building)
 "shO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/campfire/stove{
+	pixel_x = 7;
+	pixel_y = -7
 	},
-/obj/effect/turf_decal/vg_decals/numbers/nine{
-	pixel_y = -17
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "shR" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -34668,36 +34028,15 @@
 /turf/closed/wall/f13/store,
 /area/f13/building)
 "sri" = (
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "srl" = (
-/obj/structure/sink/deep_water{
-	pixel_y = 3;
-	color = "#996633"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/structure/chair/right{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#996633"
-	},
-/area/f13/wasteland/city/newboston/farm)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "srq" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -34707,9 +34046,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "srI" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0"
+	},
+/area/f13/city)
 "ssg" = (
 /obj/machinery/light{
 	dir = 1
@@ -34732,9 +34072,13 @@
 	},
 /area/f13/wasteland)
 "ssX" = (
-/obj/structure/simple_door/repaired,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#883300"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "stn" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -34742,13 +34086,11 @@
 	},
 /area/f13/wasteland)
 "stq" = (
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/gravel,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "stv" = (
 /obj/structure/flora/grass/wasteland{
@@ -34764,10 +34106,9 @@
 	},
 /area/f13/wasteland)
 "stz" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/machinery/vending/medical/becomingnook,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building/hospital/clinic/nash)
 "stG" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -34946,16 +34287,20 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "syx" = (
-/obj/machinery/vending/medical/nash,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/custom/leechjar{
-	pixel_y = 18;
-	pixel_x = -5;
-	desc = "Why do the lumps in that jar look vaguely catlike?";
-	name = "Mereks brain juice"
+/obj/machinery/vending/cola/starkist{
+	pixel_x = -9;
+	pixel_y = 21;
+	density = 0
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/vending/cola/space_up{
+	pixel_x = 13;
+	pixel_y = 21;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "syB" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -35292,11 +34637,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sHE" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/vending/dinnerware{
+	pixel_y = 19;
+	density = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
+/area/f13/building)
 "sHQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
@@ -35328,23 +34674,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"sIw" = (
-/obj/machinery/vending/boozeomat/pubby_captain{
-	pixel_y = 32;
-	density = 0
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/wasteland/city/newboston/bar)
 "sIE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -35672,18 +35001,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"sRK" = (
-/obj/structure/sink/greyscale{
-	dir = 4;
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/obj/structure/mirror{
-	pixel_x = 25;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "sRP" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -35874,10 +35191,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"sUQ" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
 "sVi" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/f13{
@@ -35899,11 +35212,20 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "sWl" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/barricade/barswindow{
+	layer = 3.5;
+	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/machinery/door/poddoor/shutters{
+	id = "countershutters";
+	name = "counter shutters";
+	req_one_access_txt = null
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building/trader)
 "sWm" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -36209,11 +35531,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"thp" = (
-/obj/structure/table/plasmaglass,
-/obj/item/restraints/handcuffs/fake/kinky,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "thJ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/swimsuit/green{
@@ -36337,15 +35654,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tjm" = (
-/obj/structure/chair/left{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/machinery/vending/dinnerware{
+	pixel_y = 20;
+	pixel_x = 6;
+	density = 0
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/bar)
 "tjv" = (
 /obj/structure/table,
 /obj/item/clothing/head/cowboyhat/black,
@@ -36538,11 +35853,9 @@
 /turf/closed/mineral/random/low_chance/underground,
 /area/f13/caves)
 "toG" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
 /obj/item/clothing/gloves/f13/baseball,
 /obj/item/twohanded/baseball,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "toQ" = (
@@ -36778,12 +36091,6 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tuf" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "tum" = (
 /obj/structure/sink/puddle,
 /obj/effect/decal/cleanable/dirt,
@@ -37094,9 +36401,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "tBN" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/wood_common,
-/area/f13/city)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/machinery/reagentgrinder,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building/hospital/clinic/nash)
 "tBV" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/luchador/rudos,
@@ -37109,18 +36425,6 @@
 /obj/structure/fence,
 /turf/open/floor/plating/dirt,
 /area/f13/building)
-"tCv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/west{
-	color = "#A47449";
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/building/trader)
 "tCw" = (
 /obj/structure/flora/chomp/bones/lribs1{
 	pixel_y = 14;
@@ -37218,6 +36522,9 @@
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 4
 	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "tFc" = (
@@ -37268,13 +36575,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"tGZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/pinup_vixen,
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
-	},
-/area/f13/bar/heaven)
 "tHh" = (
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/stack/sheet/glass/ten,
@@ -37298,42 +36598,26 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tHs" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"tHN" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/effect/turf_decal/vg_decals/numbers/nine,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building/trader)
+"tHN" = (
+/obj/structure/curtain/directional/south{
+	color = "#5c131b"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/item/shovel{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	color = "#705454";
-	name = "sand pit"
-	},
-/area/f13/wasteland/city/newboston/farm)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "tHR" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "tHW" = (
-/obj/structure/closet/ammunitionlocker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/mineral/wasteland_vendor/badattachments,
+/turf/open/floor/wood_common,
+/area/f13/building/trader)
 "tIj" = (
 /obj/structure/closet/wardrobe,
 /obj/effect/decal/cleanable/dirt,
@@ -37567,17 +36851,6 @@
 /obj/item/soap,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"tNI" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/turf/open/floor/wood_common{
-	color = "#775555"
-	},
-/area/f13/building/hospital/clinic/nash)
 "tOp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/blamco,
@@ -37632,9 +36905,11 @@
 	},
 /area/f13/building)
 "tPo" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "tPu" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/spring,
@@ -37729,28 +37004,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tRs" = (
-/obj/structure/table/bronze{
-	color = "#533B62";
-	name = "stage";
-	desc = "A stage for dancing.";
-	density = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/item/instrument/eguitar,
-/obj/item/instrument/banjo,
-/obj/item/instrument/accordion,
-/obj/item/instrument/harmonica,
-/obj/item/instrument/musicalmoth,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/recorder,
-/obj/item/instrument/saxophone,
-/obj/item/instrument/shamisen,
-/obj/item/instrument/trombone,
-/obj/item/instrument/trumpet,
-/obj/item/instrument/violin,
-/obj/item/instrument/bikehorn,
-/turf/open/floor/wood_worn,
-/area/f13/city)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	light_color = null;
+	color = "#448822"
+	},
+/area/f13/caves)
 "tRy" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -37760,8 +37024,8 @@
 	},
 /area/f13/wasteland)
 "tRA" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/city)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "tRH" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -37841,14 +37105,6 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tTG" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = 20;
-	pixel_x = 6;
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "tTN" = (
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/floor/f13{
@@ -38127,12 +37383,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ueL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 11
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/item/storage/box/medsprays{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "ueX" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt,
@@ -38286,21 +37553,9 @@
 	},
 /area/f13/building)
 "uiu" = (
-/obj/structure/table/plasmaglass,
-/obj/structure/railing/dancing_pole{
-	pixel_y = 31
-	},
-/obj/structure/railing/dancing_pole{
-	pixel_y = 10
-	},
-/obj/structure/fence/pole_b{
-	pixel_y = 7
-	},
-/obj/structure/fence/pole_t{
-	pixel_y = 36
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "uiB" = (
 /obj/structure/stairs/west{
 	dir = 2
@@ -38432,13 +37687,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
 "ulP" = (
-/obj/structure/chair/sofa/corner{
-	pixel_x = 8;
-	pixel_y = 12
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/city)
 "ulR" = (
 /obj/structure/wreck/trash/halftire,
 /obj/effect/decal/cleanable/dirt,
@@ -38562,14 +37815,11 @@
 	},
 /area/f13/building)
 "uoR" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/effect/landmark/party{
+	pixel_y = 9
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "upe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -38639,14 +37889,14 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "ute" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirtcorner{
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/gravel,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "utJ" = (
 /obj/structure/nest/randomized{
@@ -38778,17 +38028,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"uyA" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "uyD" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain{
@@ -38866,7 +38105,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/hospital/clinic/nash)
 "uAa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -39027,13 +38266,12 @@
 /turf/open/floor/plasteel/neutral,
 /area/f13/building)
 "uEN" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
 	dir = 8
 	},
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/corner,
-/area/f13/building)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "uEQ" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt,
@@ -39123,19 +38361,14 @@
 	},
 /area/f13/wasteland)
 "uHp" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/railing{
+	dir = 4;
+	color = "#bb3333"
 	},
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 8;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - S"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
+/area/f13/wasteland/city/newboston/outdoors)
 "uHx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -39192,14 +38425,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "uJb" = (
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -5
+/obj/structure/sacredwell{
+	light_power = 20;
+	max_integrity = 9999;
+	light_color = "#33BE24";
+	light_range = 3;
+	color = "#BE446e";
+	desc = "That used to be the tribes sacred well.  Why is it here...?"
 	},
-/obj/item/pen,
-/obj/structure/table/wood,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "uJe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -39265,43 +38500,10 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
-"uKI" = (
-/obj/structure/sink/well{
-	pixel_y = -4;
-	pixel_x = -6;
-	layer = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
-"uKX" = (
-/obj/structure/table,
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
-	},
-/obj/structure/curtain/directional/south{
-	color = "#1e549c"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
 "uLf" = (
 /turf/closed/wall/f13/store,
 /turf/closed/wall/f13/store,
 /area/f13/building)
-"uLk" = (
-/obj/structure/chair/right{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "uLv" = (
 /obj/item/fishingrod,
 /turf/open/indestructible/ground/outside/dirt,
@@ -39339,16 +38541,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"uMI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/vending/dinnerware,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/corner{
-	dir = 1
-	},
-/area/f13/building)
 "uMJ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -39425,19 +38617,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"uPd" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	dir = 1;
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = 13
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "uPk" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -39962,7 +39141,20 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "vfp" = (
-/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/science{
+	icon_state = "direction_supply";
+	dir = 8;
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 24
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
 	},
@@ -40204,15 +39396,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vlH" = (
-/obj/structure/chair/bench{
-	icon_state = "bench";
-	dir = 8;
-	pixel_y = 10
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/curtain/directional/north,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/library)
 "vlV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -40286,12 +39475,9 @@
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/building)
 "vnC" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
 "vnY" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 8;
@@ -40314,12 +39500,6 @@
 	color = "#A1BFFF"
 	},
 /area/f13/tribe)
-"voN" = (
-/obj/structure/curtain/directional/south{
-	color = "#5c131b"
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "vpj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt,
@@ -40464,12 +39644,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "vsv" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "vsz" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 32
@@ -40576,10 +39755,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "vuQ" = (
-/obj/machinery/light/floor,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "vuT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -40674,8 +39857,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "vxh" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt,
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "vxi" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -40743,11 +39928,28 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "vzp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/instrument/eguitar,
+/obj/item/instrument/banjo,
+/obj/item/instrument/accordion,
+/obj/item/instrument/harmonica,
+/obj/item/instrument/musicalmoth,
+/obj/item/instrument/piano_synth,
+/obj/item/instrument/recorder,
+/obj/item/instrument/saxophone,
+/obj/item/instrument/shamisen,
+/obj/item/instrument/trombone,
+/obj/item/instrument/trumpet,
+/obj/item/instrument/violin,
+/obj/item/instrument/bikehorn,
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "vzy" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -40853,24 +40055,18 @@
 	},
 /area/f13/building)
 "vDv" = (
-/obj/machinery/light,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 5;
-	pixel_y = 18
-	},
-/obj/item/reagent_containers/food/condiment/ketchup{
+/obj/machinery/vending/cola{
 	pixel_y = 21;
-	pixel_x = -3
+	pixel_x = -8;
+	density = 0
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_y = 14;
-	pixel_x = 6
-	},
-/obj/structure/table/booth{
-	color = "#EFCCC0"
+/obj/machinery/vending/snack{
+	density = 0;
+	pixel_y = 20;
+	pixel_x = 15
 	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/bar)
 "vDW" = (
 /obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -40879,28 +40075,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
-"vEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = 32
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 40
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "vEc" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/terminal{
@@ -40921,24 +40095,13 @@
 	},
 /area/f13/building/abandoned)
 "vEK" = (
-/obj/machinery/light/small{
-	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
-"vEW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/corp/left{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/open/floor/carpet/green,
+/area/f13/building/trader)
+"vEW" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "vFA" = (
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -41126,25 +40289,6 @@
 "vNf" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
-"vNr" = (
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	pixel_y = 23
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "vNt" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -41158,11 +40302,18 @@
 	},
 /area/f13/building)
 "vNJ" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2;
+	pixel_y = 0
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
+	},
+/turf/open/floor/wood_fancy/wood_fancy_light,
+/area/f13/building/trader)
 "vNL" = (
 /obj/structure/chair{
 	dir = 8
@@ -41253,12 +40404,6 @@
 "vPo" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
-"vPE" = (
-/obj/machinery/smartfridge/chemistry{
-	density = 0
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/hospital/clinic/nash)
 "vPN" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt,
@@ -41267,8 +40412,12 @@
 	},
 /area/f13/building)
 "vPX" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/structure/holohoop{
+	pixel_y = 20;
+	pixel_x = 16
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/city)
 "vQb" = (
 /obj/structure/stairs,
 /turf/open/floor/f13{
@@ -41280,14 +40429,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/building)
-"vQW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess,
 /area/f13/building)
 "vRd" = (
 /obj/effect/landmark/start/f13/barkeep,
@@ -41349,10 +40490,10 @@
 /area/f13/building)
 "vSN" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland/city/newboston/bar)
 "vSW" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt,
@@ -41451,19 +40592,13 @@
 /obj/structure/table,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
-"vWh" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/obj/structure/curtain/directional/east{
-	color = "#efe434"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "vWq" = (
-/obj/effect/turf_decal/vg_decals/numbers/three,
+/obj/structure/simple_door/wood,
+/obj/item/lock_bolt{
+	dir = 4
+	},
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/wasteland/city/newboston/chapel)
 "vWL" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -41512,12 +40647,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "vYg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/door/airlock/engineering/glass{
+	color = "#ff6433";
+	req_one_access_txt = "34"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
+/area/f13/building/hospital/clinic/nash)
 "vYw" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /obj/effect/decal/cleanable/dirt,
@@ -41591,28 +40726,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vZX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
-	},
-/obj/structure/stairs/north,
-/obj/structure/stairs/north,
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "wah" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -41694,8 +40807,8 @@
 	},
 /area/f13/caves)
 "wbp" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/chair/bench{
+	pixel_y = 12
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -41822,13 +40935,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wfi" = (
-/obj/structure/table/plasmaglass,
-/obj/item/paper_bin,
-/obj/structure/curtain{
-	color = "#c40e0e"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "wfu" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Senior Paladin";
@@ -42016,43 +41131,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "wlP" = (
-/obj/structure/sink{
-	pixel_x = -8;
-	pixel_y = 24
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder - W"
 	},
-/obj/structure/mirror{
-	layer = 4;
-	pixel_x = -8;
-	pixel_y = 31
-	},
-/obj/structure/mirror{
-	pixel_x = 8;
-	pixel_y = 31
-	},
-/obj/structure/sink{
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/structure/rug/mat{
-	layer = 1;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/bar/heaven)
+/area/f13/city)
 "wlQ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wmi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/landmark/party{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "wmo" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/beakers,
@@ -42094,20 +41181,6 @@
 /obj/machinery/icecream_vat,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
-"wmM" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
-"wmS" = (
-/obj/structure/chair/sofa/corp/left{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/bar/heaven)
 "wmT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42294,18 +41367,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/f13/building)
-"wtt" = (
-/obj/structure/stone_tile/block{
-	dir = 4;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building/tribal/cave)
 "wtw" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -42336,10 +41397,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
-"wuq" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/trader)
 "wus" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -42565,22 +41622,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wzP" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/bar/heaven)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/hospital/clinic/nash)
 "wAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"wAj" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "wAB" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -42862,12 +41910,9 @@
 	},
 /area/f13/wasteland)
 "wIP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "wJg" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/f13/biker{
@@ -42968,9 +42013,13 @@
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/nash)
 "wLd" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wLg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
@@ -43336,27 +42385,33 @@
 	},
 /area/f13/wasteland)
 "wVC" = (
-/obj/structure/chair/bench{
-	dir = 8
+/obj/structure/railing{
+	dir = 1;
+	color = "#bb3333"
 	},
 /obj/structure/railing{
+	color = "#bb3333";
 	dir = 8;
-	pixel_y = -6
+	pixel_x = -2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#888888"
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland/city/newboston/bar)
 "wVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+/obj/machinery/hydroponics/soil{
+	name = "riverbed soil";
+	yieldmod = 1.3
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building/hospital/clinic/nash)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building/workshop/nash)
 "wVY" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -43417,12 +42472,12 @@
 	},
 /area/f13/building)
 "wWW" = (
-/mob/living/simple_animal/cow/brahmin/cow,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/structure/chair/left{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/wasteland/city/newboston/bar)
 "wXk" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -43502,12 +42557,14 @@
 	},
 /area/f13/wasteland)
 "wZe" = (
-/obj/structure/table/plasmaglass,
-/obj/effect/decal/cleanable/glitter/white{
-	color = "#884444"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -3
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building/trader)
 "wZE" = (
 /obj/structure/simple_door/brokenglass,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -43572,10 +42629,30 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/tribal/cave)
 "xcf" = (
-/turf/closed/wall/f13/sunset/brick_small_dark{
-	color = "#AA5555"
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
 	},
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/obj/item/shovel{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/outside/desert{
+	color = "#705454";
+	name = "sand pit"
+	},
+/area/f13/building/workshop/nash)
 "xcu" = (
 /obj/structure/bed/dogbed,
 /obj/effect/decal/cleanable/dirt,
@@ -43670,9 +42747,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xen" = (
-/obj/structure/stone_tile/block,
-/turf/open/floor/plasteel/cult,
-/area/f13/building/tribal/cave)
+/turf/closed/wall/f13/tunnel,
+/area/f13/building)
 "xeu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -43792,10 +42868,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xgZ" = (
-/obj/structure/rug/big/rug_blue_shag,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "xht" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -44001,12 +43073,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"xow" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "xoy" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -44132,9 +43198,9 @@
 	},
 /area/f13/building/tribal)
 "xpO" = (
-/obj/structure/chair/stool/bar,
+/obj/machinery/light/floor,
 /turf/open/floor/wood_common,
-/area/f13/city)
+/area/f13/building/hospital/clinic/nash)
 "xqN" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -44231,13 +43297,17 @@
 	},
 /area/f13/building)
 "xtx" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "pink";
-	dir = 8;
-	pixel_x = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "xtG" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt,
@@ -44414,12 +43484,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xyl" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/item/book{
+	pixel_y = 32;
+	anchored = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "xyu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -44576,13 +43650,6 @@
 /obj/structure/stone_tile/slab/burnt,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
-"xCx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/booth{
-	color = "#EFCCC0"
-	},
-/turf/open/floor/wood_common,
-/area/f13/city)
 "xCC" = (
 /obj/structure/decoration/clock/old/active,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -44882,24 +43949,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"xKM" = (
-/obj/structure/chair/sofa{
-	color = "#475340";
-	dir = 1
-	},
-/obj/machinery/light/small{
-	color = "#444499";
-	light_color = "#444499";
-	light_power = 2;
-	light_range = 2;
-	pixel_y = -13
-	},
-/obj/effect/decal/cleanable/glitter/blue{
-	color = "#444499";
-	layer = 3
-	},
-/turf/open/floor/carpet/black,
-/area/f13/bar/heaven)
 "xKT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -44986,9 +44035,9 @@
 	},
 /area/f13/building)
 "xOu" = (
-/obj/structure/legion_extractor,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/item/toy/beach_ball/holoball,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/city)
 "xOF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -45141,13 +44190,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"xRq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rug/big/rug_yellow{
-	layer = 2.8
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/bar/heaven)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -45182,13 +44224,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
-"xSo" = (
-/obj/structure/table/optable/primitive,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/road,
-/area/f13/caves)
 "xSA" = (
 /obj/structure/window/fulltile/ruins{
 	icon_state = "ruinswindowbroken"
@@ -45316,14 +44351,14 @@
 	},
 /area/f13/wasteland)
 "xVz" = (
-/obj/machinery/door/airlock/engineering/glass{
-	color = "#836433";
-	req_one_access_txt = "34"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "xVA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -45405,13 +44440,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "xWR" = (
-/obj/structure/beebox{
-	pixel_y = 11;
-	layer = 4;
-	density = 0
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/wasteland/city/newboston/farm)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/wasteland/city/newboston/outdoors)
 "xXa" = (
 /obj/structure/railing{
 	dir = 8
@@ -45637,19 +44668,6 @@
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/carpet/green,
 /area/f13/building/trader)
-"yes" = (
-/obj/structure/simple_door/room,
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "fog";
-	opacity = 1;
-	pixel_x = -1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
 "yev" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 4;
@@ -45936,15 +44954,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"ykZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "ylc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
@@ -51179,9 +50188,9 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
 gcG
 hTW
 hTW
@@ -51438,8 +50447,8 @@ hRl
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 hTW
 hTW
 hTW
@@ -51696,8 +50705,8 @@ hRl
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 rvy
 uFG
 hTW
@@ -51954,8 +50963,8 @@ hRl
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 gcG
 hTW
 hTW
@@ -51974,7 +50983,7 @@ xbw
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52203,7 +51212,7 @@ hTW
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52212,7 +51221,7 @@ hRl
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 hTW
@@ -52231,7 +51240,7 @@ xbw
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52461,7 +51470,7 @@ hTW
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52469,7 +51478,7 @@ hRl
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52488,7 +51497,7 @@ xbw
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52718,7 +51727,7 @@ rvy
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52727,7 +51736,7 @@ hRl
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52745,7 +51754,7 @@ hTW
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52976,7 +51985,7 @@ hTW
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -52985,7 +51994,7 @@ hRl
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53002,11 +52011,11 @@ gxV
 hTW
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53234,7 +52243,7 @@ hTW
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53259,11 +52268,11 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53492,7 +52501,7 @@ hTW
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53516,11 +52525,11 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53749,8 +52758,8 @@ rvy
 hTW
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -53772,17 +52781,17 @@ hTW
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -53999,7 +53008,7 @@ hTW
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 hTW
@@ -54007,8 +53016,8 @@ hTW
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -54029,17 +53038,17 @@ gcG
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -54256,7 +53265,7 @@ bYm
 hTW
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 hTW
@@ -54265,7 +53274,7 @@ hTW
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -54290,12 +53299,12 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -54514,7 +53523,7 @@ hTW
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 fbp
@@ -54523,7 +53532,7 @@ gcG
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -54542,16 +53551,16 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -54771,8 +53780,8 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
+txY
 gcG
 hTW
 hTW
@@ -54797,18 +53806,18 @@ hTW
 gcG
 gcG
 gcG
+txY
+txY
 gcG
 gcG
 gcG
 gcG
+txY
+txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -55060,11 +54069,11 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -55316,11 +54325,11 @@ gcG
 gcG
 gcG
 gcG
+txY
+txY
 gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -55535,16 +54544,16 @@ hRl
 gcG
 gcG
 gcG
-hTW
-gxV
-hTW
+gcG
+gcG
+gcG
 gcG
 gcG
 hRl
 hRl
 gcG
 gcG
-gcG
+txY
 gcG
 hTW
 hTW
@@ -55571,12 +54580,12 @@ gcG
 gcG
 gcG
 gcG
+txY
+txY
+txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -55792,16 +54801,16 @@ gcG
 gcG
 gcG
 gcG
-hTW
-bYm
-uFG
+gcG
+gcG
+gcG
 gcG
 gcG
 hRl
 hRl
 gcG
 gcG
-gcG
+txY
 gcG
 hTW
 cps
@@ -55828,11 +54837,11 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -56046,11 +55055,11 @@ hRl
 hRl
 hRl
 gcG
+txY
+txY
+txY
 gcG
 gcG
-gcG
-hTW
-hTW
 gcG
 gcG
 gcG
@@ -56058,7 +55067,7 @@ hRl
 hRl
 gcG
 gcG
-gcG
+txY
 gcG
 hTW
 hTW
@@ -56088,7 +55097,7 @@ gcG
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -56302,12 +55311,12 @@ hRl
 hRl
 hRl
 hRl
+txY
+txY
 gcG
+txY
+txY
 gcG
-gcG
-gcG
-hTW
-hTW
 gcG
 gcG
 gcG
@@ -56315,7 +55324,7 @@ hRl
 hRl
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 hTW
@@ -56344,7 +55353,7 @@ gcG
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -56557,22 +55566,22 @@ hRl
 "}
 (42,1,1) = {"
 hRl
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
 hRl
 hRl
 gcG
 gcG
-gcG
-gcG
-hTW
-hTW
-gcG
-gcG
-gcG
-hRl
-hRl
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -56814,22 +55823,22 @@ hRl
 "}
 (43,1,1) = {"
 hRl
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
 hRl
 hRl
 gcG
 gcG
-gcG
-hTW
-hTW
-hTW
-gcG
-gcG
-gcG
-hRl
-hRl
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -57071,22 +56080,22 @@ hRl
 "}
 (44,1,1) = {"
 hRl
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
 hRl
 hRl
 gcG
 gcG
-gcG
-hTW
-hTW
-hTW
-gcG
-gcG
-gcG
-hRl
-hRl
-gcG
-gcG
-gcG
+txY
 gcG
 hTW
 hTW
@@ -57328,15 +56337,15 @@ hRl
 "}
 (45,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
+txY
 gcG
-hTW
-hTW
-uFG
 gcG
+txY
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -57585,16 +56594,16 @@ hRl
 "}
 (46,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
-gcG
-hTW
-hTW
+txY
 gcG
 gcG
+txY
+txY
 gcG
+gcG
+txY
 gcG
 hRl
 hRl
@@ -57842,16 +56851,16 @@ hRl
 "}
 (47,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
 gcG
-hTW
-hTW
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+txY
 gcG
 gcG
 hRl
@@ -58099,16 +57108,16 @@ hRl
 "}
 (48,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
 gcG
-hTW
-hTW
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+txY
 gcG
 gcG
 hRl
@@ -58356,13 +57365,13 @@ hRl
 "}
 (49,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
 gcG
-hTW
-eMl
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -58613,13 +57622,13 @@ hRl
 "}
 (50,1,1) = {"
 hRl
-hRl
 gcG
 gcG
 gcG
-hTW
-hTW
-hTW
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -58870,13 +57879,13 @@ hRl
 "}
 (51,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
-hTW
-hTW
-hTW
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -59127,13 +58136,13 @@ hRl
 "}
 (52,1,1) = {"
 hRl
-hRl
-hRl
 gcG
 gcG
-hTW
-hTW
-hTW
+gcG
+txY
+txY
+txY
+gcG
 gcG
 gcG
 gcG
@@ -59384,13 +58393,13 @@ hRl
 "}
 (53,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
-hTW
-hTW
 gcG
+txY
+txY
+gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -59642,13 +58651,13 @@ hRl
 (54,1,1) = {"
 hRl
 gcG
-hRl
-hRl
-hRl
-hTW
-hTW
-hRl
+txY
 gcG
+gcG
+gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -59899,13 +58908,13 @@ hRl
 (55,1,1) = {"
 hRl
 gcG
+txY
 gcG
 gcG
 gcG
-gor
-hTW
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
@@ -60157,10 +59166,10 @@ hRl
 hRl
 gcG
 gcG
-gxV
-hTW
-hTW
-hTW
+txY
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -60413,12 +59422,12 @@ hRl
 (57,1,1) = {"
 hRl
 gcG
-gxV
-hTW
-hTW
-hTW
-hTW
-hTW
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -60672,10 +59681,10 @@ hRl
 gcG
 gcG
 gcG
-aul
-hTW
-hTW
-hTW
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -60928,14 +59937,14 @@ hRl
 hRl
 gcG
 gcG
-gor
-hTW
-hTW
-hTW
-hTW
 gcG
 gcG
 gcG
+txY
+txY
+txY
+txY
+txY
 gcG
 gcG
 gcG
@@ -61184,16 +60193,16 @@ hRl
 (60,1,1) = {"
 hRl
 gcG
-gxV
-aQG
-dYk
-lfR
-pMY
-hTW
 gcG
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -61440,17 +60449,17 @@ hRl
 "}
 (61,1,1) = {"
 hRl
-aul
-hTW
-hTW
-xen
-myL
-hTW
-hTW
 gcG
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -61698,16 +60707,16 @@ hRl
 (62,1,1) = {"
 hRl
 gcG
-hTW
-hTW
-xen
-czX
-hTW
-hTW
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
 gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -61955,15 +60964,15 @@ hRl
 (63,1,1) = {"
 hRl
 gcG
-gor
-hNT
-qrX
-wtt
-hps
-gor
 gcG
 gcG
 gcG
+gcG
+gcG
+txY
+txY
+txY
+txY
 gcG
 gcG
 gcG
@@ -62213,10 +61222,10 @@ hRl
 hRl
 gcG
 gcG
-hTW
-hTW
-hTW
-aul
+gcG
+txY
+txY
+txY
 gcG
 gcG
 gcG
@@ -62469,10 +61478,10 @@ hRl
 (65,1,1) = {"
 hRl
 gcG
-aul
-hTW
-hTW
-hTW
+gcG
+gcG
+txY
+gcG
 gcG
 gcG
 gcG
@@ -62726,13 +61735,13 @@ hRl
 (66,1,1) = {"
 hRl
 gcG
-hTW
-gor
-hTW
-gxV
+gcG
+txY
+txY
 gcG
 gcG
-hRl
+gcG
+gcG
 hRl
 gcG
 gcG
@@ -62984,12 +61993,12 @@ hRl
 hRl
 gcG
 gcG
-hTW
-hTW
+txY
 gcG
 gcG
 gcG
-hRl
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -63245,8 +62254,8 @@ gcG
 gcG
 gcG
 gcG
-hRl
-hRl
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -63496,14 +62505,14 @@ hRl
 "}
 (69,1,1) = {"
 hRl
-hRl
 gcG
 gcG
 gcG
 gcG
 gcG
 gcG
-hRl
+gcG
+gcG
 hRl
 gcG
 gcG
@@ -63759,7 +62768,7 @@ gcG
 gcG
 gcG
 gcG
-hRl
+gcG
 hRl
 gcG
 gcG
@@ -64015,8 +63024,8 @@ gcG
 gcG
 gcG
 gcG
-hRl
-hRl
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -69679,18 +68688,18 @@ hQs
 hQs
 hQs
 hQs
+ofN
+ofN
+ofN
+ofN
+nPK
+rom
 hQs
 hQs
 hQs
-hQs
-hQs
-hQs
-hQs
-hQs
-hQs
-hQs
+xtx
 tEZ
-hQs
+rom
 hQs
 hQs
 hQs
@@ -69935,20 +68944,20 @@ xlf
 hVc
 hVc
 hVc
-qCp
-qCp
-tNI
-qCp
-qCp
-qCp
-tNI
-jPG
-qCp
-qCp
-iRz
-wTa
-dRJ
+hVc
+nRa
+nRa
+hVc
+hVc
+hVc
+hVc
 xZc
+xZc
+xZc
+xZc
+cIm
+wTa
+vuQ
 xZc
 xZc
 xZc
@@ -70192,30 +69201,30 @@ aST
 xlf
 bus
 boV
-qCp
-qDQ
-sYT
-sYT
+hVc
+tPQ
+qrX
+xcf
 oUB
-hBy
-cUd
-uIt
-ctp
-qCp
-vJk
-jEY
+eKM
+hVc
+ifw
+ifw
+ifw
+ifw
+pll
+wTa
 gje
 pll
 pll
-ifw
-ifw
-ifw
-ifw
-ifw
+pll
+pll
+pll
+pll
 nkj
 jnB
 hTR
-wmi
+lQM
 fDY
 fgh
 fca
@@ -70449,26 +69458,26 @@ xlf
 xlf
 xlf
 bus
-qCp
-iUQ
-sYT
-sYT
-hTc
-hBy
-uIt
-uIt
-qCp
-qCp
-iqa
-vnC
-vWh
-iqa
-iqa
-ifw
-isE
+hVc
+tPQ
+qrX
+uEN
+gDe
+nWz
+hVc
 pwM
+isE
 bLA
 ifw
+pll
+wTa
+gje
+pll
+pll
+pll
+pll
+pll
+pll
 pll
 noh
 gzl
@@ -70706,30 +69715,30 @@ pQD
 tSy
 xlf
 lvG
-qCp
-evI
-sYT
-sYT
-sYT
-mEG
-wIP
-uIt
-meY
-qCp
-uJb
-auL
-nQU
-pBs
-myf
-ifw
-isE
+hVc
+tPQ
+qrX
+kjf
+kjf
+gDe
+hVc
 wJl
+isE
 sQy
 ifw
+pll
+wTa
+gje
+pll
+pll
+pll
+pll
+pll
+pll
 abe
-syK
+pll
 toG
-lQM
+avu
 fDY
 fDY
 kwu
@@ -70963,34 +69972,34 @@ mII
 xlf
 xlf
 lvG
-qCp
-awl
-vUF
-sYT
-hwt
-hBy
-uIt
-uIt
-uIt
-qCp
-uZH
-auL
-gFY
-ruk
-mWi
+hVc
+tPQ
+qrX
+gDe
+gDe
+gDe
+hVc
 ifw
 qHX
 ifw
 ifw
-ifw
-ykZ
-hQs
-hQs
+pll
+gFY
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 ute
-mBq
-pJc
-pJc
-pJc
+lQM
+fDY
+fDY
+fDY
 eHA
 bPy
 kXC
@@ -71220,36 +70229,36 @@ pXu
 tza
 xlf
 xlf
-tPo
-qCp
-qCp
-qCp
-qCp
-syx
-fTT
-uIt
-mnP
-qCp
+hVc
+hVc
+hVc
+hVc
+hCQ
+hVc
+hVc
+isE
+isE
+aSt
 qGt
-auL
-auL
-xgZ
-cpu
+vWq
 ifw
-isE
-isE
-mMO
-ifw
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 uoR
-ifw
-ifw
+pll
+pll
 cUU
-jfA
-jfA
-jfA
-jfA
-jfA
-jfA
+lQM
+pJc
+pJc
+pJc
+pJc
+aQG
 kXC
 hRg
 tPQ
@@ -71477,37 +70486,37 @@ aST
 xlf
 xlf
 aST
-uKX
-glQ
+gDe
+gDe
 wVD
-lbs
-jnu
-uIt
-wIP
-uIt
-fTT
-qCp
-iqa
-tTx
-ueL
-auL
-raI
-ifw
+acE
+gDe
+gDe
+hVc
+isE
 isE
 isE
 kzV
-kzV
-isE
 isE
 ifw
+fsW
+ssX
+gej
+bCw
+kIY
+pll
+pll
+pll
+pll
+pll
+vJk
 wTa
 jfA
-wba
-dgU
-drL
-vrK
-jzg
-kXC
+jfA
+jfA
+jfA
+jfA
+jfA
 hRg
 tPQ
 tPQ
@@ -71734,37 +70743,37 @@ bKT
 nZK
 xlf
 xlf
-fKN
-uIt
+hVc
+ctp
+gDe
+gDe
+gDe
 wIP
-uIt
-uIt
-wIP
-vdH
-uIt
-uIt
-qCp
-iqa
-rnN
-fSU
-auL
-qnB
-ifw
-kMX
+hVc
+ljb
 jiy
 sfn
 vYz
-jiy
-gej
+meY
 ifw
+tlI
+qlW
+lYg
+kMX
+vqW
+pll
+pll
+pll
+pll
+pll
+vJk
 wTa
 jfA
-fay
-qAj
-jfA
-jfA
+wba
+dgU
+drL
+vrK
 jzg
-kXC
 hRg
 tPQ
 tPQ
@@ -71991,37 +71000,37 @@ uAy
 xlf
 xlf
 aST
-tPo
+hVc
 bBH
+acE
+acE
+acE
+iNQ
+hVc
+rOW
+isE
+isE
+isE
+rOW
+ifw
+kIY
+rUy
+mrr
 qxT
-uIt
-wIP
-wIP
-qCp
-vPE
-avJ
-qCp
-iqa
-nrx
-fSU
-auL
-seq
-ifw
-rOW
-isE
-isE
-isE
-isE
-rOW
-ifw
+wze
+pll
+pll
+pll
+pll
+pll
+vJk
 wTa
-pWt
-izz
-izz
-drL
-quI
-nMc
-kXC
+jfA
+fay
+qAj
+jfA
+jfA
+jzg
 hRg
 tPQ
 tPQ
@@ -72248,37 +71257,37 @@ xkz
 hNR
 xlf
 xlf
-qCp
+hVc
 bms
 gDe
-wIP
-wIP
-wIP
-gZZ
-dNH
-dNH
-osc
-iqa
-dPg
-auL
-fSU
-cXg
-ifw
+gDe
+gDe
+sri
+hVc
 jGw
 ott
 kzV
-isE
 jGw
 ott
 ifw
-byj
-jfA
+tlI
+lKQ
+fnt
+kIY
+vqW
+pll
+pll
+pll
+pll
+pll
+vJk
+wTa
+pWt
+izz
+izz
+drL
+quI
 nMc
-jzg
-jzg
-jfA
-nMc
-kXC
 hRg
 tPQ
 tPQ
@@ -72504,38 +71513,38 @@ xlf
 uAy
 xlf
 xlf
-xlf
-qCp
+kVa
+hVc
 opB
-qhp
-uIt
 acE
 acE
-gZZ
-dNH
-dNH
-gde
-iqa
-cWw
-cWw
-aSt
-iqa
-ifw
+acE
+vEW
+hVc
 jGw
 ott
-kzV
 kzV
 jGw
 ott
 ifw
-byj
+ybW
+aYt
+ybW
+bCw
+kIY
+pll
+pll
+pll
+pll
+pll
+vJk
+wTa
 jfA
-wbT
-vfd
-kgw
-jVa
+nMc
+jzg
+jzg
 jfA
-kXC
+nMc
 hRg
 tPQ
 tPQ
@@ -72761,38 +71770,38 @@ aST
 xlf
 aST
 xlf
-kVa
+xlf
 tPo
-qCp
-mHJ
-bAa
+gDe
+gDe
+gDe
 lUv
-lUv
-tKO
+gDe
+hVc
 dNH
-dNH
-pdw
-wAj
-vNr
-tuf
-auL
-rjW
-ifw
 qFz
-qFz
-eUj
 eUj
 qFz
 qFz
 ifw
+avK
+avK
+avK
+avK
+avK
+avK
+qst
+qst
+avK
+bGv
+vJk
 byj
-puk
-lzG
-pfP
-fMx
-pxr
 jfA
-kXC
+wbT
+vfd
+kgw
+jVa
+jfA
 hRg
 tPQ
 tPQ
@@ -73019,7 +72028,7 @@ gIm
 gIm
 bKF
 gIm
-ajZ
+gIm
 gIm
 gIm
 gIm
@@ -73029,27 +72038,27 @@ gyo
 gIm
 gIm
 bKF
-ajZ
+gIm
 bKF
-gIm
-gIm
-gIm
 ajZ
+gIm
+gIm
+gIm
 gIm
 gIm
 gIm
 gIm
 gIm
 ekg
-twx
+nRM
+vJk
 byj
-jfA
-kHd
-izz
+puk
+lzG
 pfP
-kgw
+fMx
+pxr
 jfA
-kXC
 hRg
 tPQ
 tPQ
@@ -73298,15 +72307,15 @@ nxO
 iUe
 ftw
 mdh
-bgu
+nRM
 stq
-bZu
-pfP
-izz
-epk
-rbX
+byj
 jfA
-kXC
+kHd
+izz
+pfP
+kgw
+jfA
 hRg
 tPQ
 tPQ
@@ -73536,7 +72545,7 @@ brC
 brC
 brC
 brC
-brC
+hsR
 brC
 brC
 brC
@@ -73555,14 +72564,14 @@ brC
 eLP
 rLl
 mdh
-ccQ
-xZc
-jfA
-jfA
-jfA
-jfA
-nMc
-jfA
+bgu
+hJP
+nDA
+bZu
+pfP
+izz
+epk
+rbX
 jfA
 hRg
 tPQ
@@ -73776,10 +72785,15 @@ gcX
 "}
 (109,1,1) = {"
 hRl
-alu
+gao
 hJN
-jqA
-lVZ
+akW
+elk
+qHR
+eUA
+dQI
+ruk
+cUd
 avK
 avK
 avK
@@ -73793,7 +72807,6 @@ avK
 avK
 avK
 avK
-iRT
 avK
 avK
 avK
@@ -73804,22 +72817,18 @@ avK
 avK
 avK
 avK
-avK
-avK
-avK
-avK
-pZn
+bGv
 aqT
 rce
 mcT
-klQ
-jgs
+ccQ
+xZc
 jfA
-jmQ
 jfA
-cwG
 jfA
-wvd
+jfA
+nMc
+jfA
 jfA
 hRg
 tPQ
@@ -74033,50 +73042,50 @@ hRl
 "}
 (110,1,1) = {"
 hRl
-alu
-oUX
-oUX
-alu
-tRA
-rtc
-hAU
+rJd
+qlI
+qlI
+qlI
+qlI
+qlI
+qlI
 qlI
 ngm
 gln
-dtH
-eWR
+ngm
 koc
-xow
-xow
-xow
+koc
+koc
+koc
+koc
 uzU
-xow
-xow
-xow
-uzU
-xow
-xow
+koc
+koc
+koc
+ayi
+jBh
+jBh
 jBh
 ayi
-ayi
-rUy
+jBh
+jBh
 wVC
 qda
-bCw
-kIY
-tlI
-vZX
+qda
+fft
+mBq
+nRM
 rHb
 rce
 mdh
 klQ
 jgs
 jfA
-fFk
-wxa
-uAH
-hUc
-uAH
+jmQ
+jfA
+cwG
+jfA
+wvd
 jfA
 hRg
 tPQ
@@ -74291,49 +73300,49 @@ hRl
 (111,1,1) = {"
 hRl
 tHW
-oUX
-oUX
-alu
-jeV
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-fTf
-qez
-fyF
+qlI
+qlI
+mwZ
+qlI
+qlI
+mwZ
+qlI
+qlI
+mwZ
+qlI
+rjW
 xpO
-ofN
+cdB
+cdB
 xpO
-oFe
-ofN
-qez
-qez
-biT
-rXa
+cdB
+cdB
+xpO
+cdB
+tRA
 rXa
 tRA
-kIY
-bCw
-kIY
-vzp
-tlI
-eKD
+tRA
+rXa
+tRA
+tRA
+nQu
+cWw
+cWw
+vOY
+mdh
+etn
 aqT
 rce
 mdh
 nRM
 jgs
 jfA
-beC
-jfA
-tlW
-jfA
-jfA
+fFk
+wxa
+uAH
+hUc
+uAH
 jfA
 hRg
 tPQ
@@ -74548,49 +73557,49 @@ hRl
 (112,1,1) = {"
 hRl
 rLL
-oUX
-oUX
-alu
-qfR
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-qez
-vOY
+qlI
+qlI
+qlI
+qlI
+qlI
+eWR
+qlI
+qlI
+qlI
+qlI
 cdB
-tdE
-tdE
-tdE
-xiY
-qez
-qez
+cdB
+cdB
+cdB
+cdB
+cdB
+cdB
+cdB
+dOt
+ljE
+iep
+ljE
 nZa
 iep
-tRs
 tRA
-qlW
-lYg
+tRA
+fTf
+rki
 vzp
-wze
-wbp
+vOY
+mdh
 nRM
 rHb
 rJa
 mdh
 etn
 jgs
-nMc
-nMc
 jfA
-uAH
-hUc
-wvd
+beC
+jfA
+tlW
+jfA
+jfA
 jfA
 hRg
 tPQ
@@ -74804,38 +73813,38 @@ hRl
 "}
 (113,1,1) = {"
 hRl
-tHs
-oUX
-tHs
-alu
+gao
+qlI
+qlI
+pAu
 qTx
-qez
-qez
+pOy
+cmo
 mPB
-qez
-qez
+moZ
+qlI
 cZU
 qez
 qez
-mPB
+qCp
 qez
-fft
-qgK
-ogc
-qei
-ogc
-woy
 qez
-fTf
+qez
+bAa
+tKO
+qCp
+heQ
+tdE
+tdE
+tdE
+xiY
 tRA
 tRA
-tRA
-tRA
-icC
-mrr
-ovp
-vqW
-wbp
+vOY
+vOY
+vOY
+vOY
+mdh
 klQ
 aqT
 rJa
@@ -74843,11 +73852,11 @@ mdh
 klQ
 jgs
 nMc
-eHl
-hvb
+nMc
+jfA
 uAH
-jfA
-jfA
+hUc
+wvd
 jfA
 hRg
 tPQ
@@ -75061,37 +74070,37 @@ hRl
 "}
 (114,1,1) = {"
 hRl
-oUX
-oUX
-oUX
-alu
+gao
+gao
+kWU
+afx
 afx
 sWl
-qez
-vWq
+kVi
+gao
 gOo
 nVE
-dQO
+gao
 jxT
 gXv
 tBN
-ptA
-fft
-wBB
+uIt
+icC
+icC
+uIt
+bgF
+wzP
+qgK
 ogc
+qei
 ogc
-ogc
-cNZ
-qez
-qez
-voN
-mHP
-omk
+woy
 tRA
-lKQ
-fnt
-bCw
-wze
+ahq
+tHN
+wWW
+srl
+vOY
 wbp
 klQ
 aqT
@@ -75100,11 +74109,11 @@ mdh
 klQ
 jgs
 nMc
-qKJ
+eHl
+hvb
 uAH
-uAH
-uAH
-tvw
+jfA
+jfA
 jfA
 kJF
 tPQ
@@ -75318,38 +74327,38 @@ hRl
 "}
 (115,1,1) = {"
 hRl
-sHE
-oUX
-oUX
-oUX
-tRA
+gao
+nhV
+iXY
+qxf
+wMb
 gHl
-xVz
-cmo
-cmo
-nTH
-bAu
+qjw
 gao
+hVl
+iXY
 gao
-gao
-gao
-vOY
-muK
+mHJ
+uIt
+qfR
+uIt
+uIt
+uIt
+uIt
+avJ
+wzP
+wBB
 ogc
-iCv
 ogc
-qlE
-qez
-fTf
-voN
-xCx
-vDv
+ogc
+cNZ
 tRA
-kIY
-bCw
-kIY
-bCw
-mdh
+tRA
+tHN
+bsJ
+mjx
+vOY
+wbp
 klQ
 aqT
 rce
@@ -75357,7 +74366,7 @@ mdh
 nRM
 jgs
 nMc
-thJ
+qKJ
 uAH
 uAH
 uAH
@@ -75575,50 +74584,50 @@ hRl
 "}
 (116,1,1) = {"
 hRl
-kGv
-kGv
-kGv
-oUX
 gao
-hVl
+lje
 iXY
-qxf
-wMb
-ltu
-qjw
-gao
-eUA
+iXY
+lsj
+iXY
+iXY
+vxh
+iXY
+lsj
+kBQ
+uIt
+uIt
+uIt
 bDj
-bDj
-vOY
-twS
-lzk
-xrJ
-kef
-hdy
-qez
-qez
-voN
-uLk
-tjm
+uIt
+uIt
+uIt
+uIt
+qCp
+muK
+ogc
+iCv
+ogc
+qlE
 tRA
-ybW
-aYt
-bCw
-kIY
+ahq
+tHN
+kYy
+mWi
+vOY
 mdh
 klQ
 aqT
 rJa
 mdh
-rEv
-suy
-jfA
-jfA
-aUg
-aUg
-jfA
-jfA
+klQ
+jgs
+nMc
+thJ
+uAH
+uAH
+uAH
+tvw
 jfA
 hRg
 tPQ
@@ -75832,50 +74841,50 @@ hRl
 "}
 (117,1,1) = {"
 hRl
-oUX
-oUX
-oUX
-oUX
 gao
-nhV
-iXY
-lsj
-lsj
+bQl
 iXY
 iXY
-eEr
-whF
-whF
-vuQ
-vOY
-vOY
-elX
-vOY
-vOY
-vOY
+iXY
+iXY
+gyr
+gao
+fyF
+iXY
+gao
+qCp
+qCp
+qCp
+qCp
+ueL
+jnu
+uIt
 aXi
-qez
+qCp
+twS
+lzk
+xrJ
+kef
+hdy
 tRA
 tRA
-tRA
-tRA
-fVx
-fVx
-fVx
-fVx
-mdh
-lUl
+vOY
+vOY
+vOY
+vOY
+aHM
+uHp
 aqT
 rJa
 mdh
-twx
-oQS
-qZI
+rEv
+suy
+jfA
+jfA
 aUg
-fJf
-fJf
-fJf
-pUR
+aUg
+jfA
+jfA
 jfA
 hRg
 tPQ
@@ -76089,50 +75098,50 @@ hRl
 "}
 (118,1,1) = {"
 hRl
-tHs
-oUX
-oUX
-tHs
 gao
-lje
+iyT
 iXY
 iXY
 iXY
 iXY
-gyr
+bzW
 gao
-bDj
-bDj
-bDj
+gao
+nVE
+gao
+qCp
+qDQ
+sYT
+sYT
+jyY
+hBy
+uIt
+uIt
+qCp
 vOY
-wGH
-weC
-jef
-tFZ
+elX
 vOY
-qEK
-qez
-voN
-mHP
+vOY
+vOY
 omk
 tRA
 tHN
 wWW
 srl
-fVx
+vOY
 tlI
 ygf
 rHb
 rJa
 mdh
-bgu
-oII
-nDA
-ied
-rVG
-rVG
-rVG
-gOH
+twx
+oQS
+qZI
+aUg
+fJf
+fJf
+fJf
+pUR
 jfA
 hRg
 tPQ
@@ -76346,50 +75355,50 @@ hRl
 "}
 (119,1,1) = {"
 hRl
-rXj
-rXj
-rXj
-rXj
-gao
-bQl
+ppc
+cqF
 iXY
 iXY
-iXY
-iXY
-isg
+lsj
+lYp
+qjB
 gao
-gao
-gao
-gao
+vEK
+vEK
+rdO
+qCp
+iUQ
+sYT
+sYT
+stz
+hBy
+uIt
+uIt
+qCp
+wGH
+weC
+jef
+tFZ
 vOY
-vUt
-iCv
-ogc
-cxm
-vOY
-tTG
-qez
-voN
-xCx
 vDv
 tRA
-vsv
-vPX
+tHN
+bsJ
 mjx
-fVx
+vOY
 tlI
-eKD
+ygf
 aqT
 rJa
 mdh
-ccQ
-xZc
-xZc
-jfA
-qGQ
-pui
-pHH
-aRi
+bgu
+oII
+nDA
+ied
+rVG
+rVG
+rVG
+gOH
 jfA
 kJF
 tPQ
@@ -76603,50 +75612,50 @@ hRl
 "}
 (120,1,1) = {"
 hRl
-syE
-syE
-syE
-syE
-ppc
-iyT
-iXY
-lsj
-lsj
-iXY
-qjB
 gao
+okY
+iXY
+iXY
+iXY
+iOa
+gao
+gao
+rvM
+fUg
 soW
-vEc
-rdO
+qCp
+evI
+sYT
+sYT
+fDm
+mEG
+uIt
+uIt
+qCp
+vUt
+iCv
+ogc
+cxm
 vOY
-tpM
-ogc
-ogc
-oIv
-uQa
-bjr
-qez
-voN
-uLk
 tjm
 tRA
+tHN
 kYy
-kYy
-vPX
-fVx
-pOy
-nRM
+mWi
+vOY
+tlI
+ghS
 bFG
 rce
 mdh
-klQ
-pll
-pll
-tPe
-atg
-atg
-atg
-atg
+ccQ
+xZc
+xZc
+jfA
+qGQ
+pui
+pHH
+aRi
 jfA
 vyX
 tPQ
@@ -76860,39 +75869,39 @@ hRl
 "}
 (121,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-cqF
+gyr
 iXY
 iXY
 iXY
-iXY
-lYp
+eNj
 gao
+soW
+vnC
 aMZ
-bSa
-frU
-vOY
-fpl
+vEc
+qCp
+jIC
+vUF
+sYT
+pkF
+hBy
+uIt
+uIt
+qCp
+tpM
 ogc
 ogc
-reu
+oIv
+uQa
+vsv
+tRA
 vOY
-fft
-eOo
-tRA
-tRA
-tRA
-tRA
-fVx
-ppJ
-fVx
-fVx
-mdh
-klQ
+vOY
+vOY
+vOY
+nCU
+wlP
 bFG
 rce
 mdh
@@ -76902,7 +75911,7 @@ pll
 tPe
 atg
 atg
-mWc
+atg
 atg
 jfA
 hRg
@@ -77117,39 +76126,39 @@ hRl
 "}
 (122,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-okY
+gyr
 iXY
 iXY
+lsj
 iXY
-iXY
-iOa
 gao
-yer
+gao
 rvM
-frU
+bSa
+yer
+qCp
+qCp
+qCp
+qCp
+qCp
+hBy
+uIt
+uIt
+qCp
+fpl
+ogc
+ogc
+reu
 vOY
-sIw
-ogc
-ogc
-oUn
 fft
-jeH
-jUN
-fVx
-vPX
-xyl
-xyl
-hCY
-vPX
-vPX
+eOo
+vOY
 mvv
-mdh
-nRM
+mvv
+mvv
+mTN
+ulP
 rHb
 rLl
 mdh
@@ -77159,7 +76168,7 @@ pll
 tPe
 atg
 atg
-atg
+mWc
 atg
 jfA
 hRg
@@ -77374,39 +76383,39 @@ hRl
 "}
 (123,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-gyr
+fKN
 iXY
-lsj
-lsj
 iXY
-eNj
-gao
-auC
 iXY
-jas
+iXY
+iXY
+cEt
+qBA
+frU
+iXY
+vYg
+uIt
+uIt
+uIt
+uIt
+uIt
+uIt
+uIt
+bAa
+vSN
+ogc
+ogc
+oUn
+fft
+jeH
+jUN
 vOY
-bPu
-lzk
-bEN
-aLL
-vOY
-sPL
-qps
-fVx
-xWR
-vPX
-vPX
-vPX
 vPX
 xOu
-fVx
-pPK
-klQ
+mTN
+mTN
+lUl
 rHb
 rce
 mdh
@@ -77414,8 +76423,8 @@ klQ
 pll
 pll
 tPe
+vAD
 atg
-xXJ
 atg
 atg
 jfA
@@ -77631,39 +76640,39 @@ hRl
 "}
 (124,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-gyr
+jMc
+nbZ
+nbZ
+nbZ
+nbZ
+hiW
+gao
+gao
 iXY
-iXY
-iXY
-iXY
-iXY
-kVi
-qBA
-frU
-tCv
+vNJ
+qCp
+uIt
+uIt
+vdH
+awt
+qhp
+uIt
+uIt
+uIt
+hNN
+bEN
+lzk
+aLL
 vOY
+sPL
+qps
 vOY
-nPK
-vOY
-vOY
-vOY
-vOY
-vOY
-fVx
-fDm
-xyl
-xyl
-xyl
-xyl
-sUQ
-fVx
 mTN
-klQ
+mTN
+mTN
+mTN
+lUl
 rHb
 rce
 mdh
@@ -77671,8 +76680,8 @@ klQ
 pll
 pll
 tPe
-vAD
 atg
+xXJ
 atg
 atg
 jfA
@@ -77888,38 +76897,38 @@ hRl
 "}
 (125,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-mJx
-nbZ
-nbZ
-nbZ
-nbZ
-hiW
+fTT
+whF
+whF
+foy
+whF
+whF
+ceh
 gao
-gao
-ars
-gao
-gao
-iLF
-iLF
-lky
-iLF
-xSo
+hps
+wZe
+qCp
+qCp
+qCp
+qCp
+qCp
+qCp
+qCp
+bAa
+qCp
+vOY
+vOY
 jKt
-jKt
-fVx
-uKI
-vPX
-vPX
-vPX
-vPX
+vOY
+vOY
+vOY
+vOY
+vOY
 srI
-fVx
-eoV
+srI
+srI
+mTN
 lUl
 aqT
 rce
@@ -78145,39 +77154,39 @@ hRl
 "}
 (126,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
 gao
-bke
+vsz
 whF
-foy
-foy
 whF
-wuq
+owa
+whF
+whF
+jPG
 gao
-gao
-iLF
-lky
 iLF
 iLF
 iLF
 iLF
 iLF
-vSN
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+oVv
 aRr
-aRr
-fVx
-nCU
-xyl
-xyl
+auL
+cpu
+raI
+seq
+cXg
 oVv
 xyl
 wLd
 fVx
-tlI
-ygf
+mdh
+klQ
 rHb
 rce
 mdh
@@ -78185,8 +77194,8 @@ lVZ
 avK
 avK
 avK
-avK
-avK
+qst
+qst
 kXC
 kJF
 kXC
@@ -78402,39 +77411,39 @@ gcX
 "}
 (127,1,1) = {"
 hRl
-hRl
-hRl
-hRl
-hRl
-gao
-vsz
-whF
+gmg
+bPn
+qRl
+xPV
+tHs
+gwL
+qRl
 hvy
-whF
-whF
-wuq
-gao
-gao
-cIm
-cIm
+wHT
+wHT
+wHT
+wHT
+wHT
+wHT
+wHT
+wHT
+wHT
+wHT
 iLF
 iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-fVx
-ppJ
+oVv
+rnN
+fSU
+auL
+auL
+auL
+fSU
+hNT
 ius
 ius
-ius
-ius
-fVx
-fVx
-tlI
-ghS
+fgh
+mdh
+klQ
 rHb
 rLl
 nwr
@@ -78443,7 +77452,7 @@ gIm
 bKF
 bKF
 gIm
-vlH
+gIm
 kXC
 kJF
 kXC
@@ -78659,37 +77668,37 @@ vqy
 "}
 (128,1,1) = {"
 hRl
-cEt
-cEt
-cEt
-cEt
-gmg
-bPn
-xPV
-shO
-qRl
-xPV
-vYg
 wHT
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+peg
+qOI
 wHT
-cEt
-cEt
-cEt
-cEt
-cEt
 iLF
 iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-lky
-iLF
-iLF
-iLF
-iLF
-iLF
+oVv
+nrx
+fSU
+fSU
+fSU
+fSU
+auL
+vlH
+ltu
+qxw
+mPW
 mdh
 klQ
 aqT
@@ -78935,18 +77944,18 @@ peg
 qOI
 wHT
 iLF
-gWi
 iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-gWi
+oVv
+tTx
+lfR
+shO
+rXj
+dtH
+uZH
+vlH
+jgs
+jgs
+ltu
 mdh
 klQ
 rHb
@@ -79191,20 +78200,20 @@ iaR
 iaR
 qOI
 wHT
-mLg
-kcx
-uKk
-uKk
-kcx
-qNK
-uKk
-qNK
-qNK
-kcx
-qNK
-qNK
-hRg
-vEa
+iLF
+iLF
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
+iqa
+jgs
+jgs
+jgs
+mdh
 klQ
 rHb
 mLI
@@ -79449,18 +78458,18 @@ peg
 qOI
 wHT
 iLF
-kcx
-pOK
-gah
-ump
-vOc
-hTd
-qNK
-rKP
-uEN
-vQW
-fUC
-hRg
+iLF
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
 mdh
 klQ
 rHb
@@ -79706,18 +78715,18 @@ peg
 qOI
 wHT
 iLF
-kcx
-yiG
-jRP
-jRP
-niY
-xjv
-qNK
-ceh
-pkF
-oms
-fUC
-hRg
+gWi
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
+jgs
 mdh
 klQ
 rHb
@@ -79962,19 +78971,19 @@ peg
 peg
 qOI
 wHT
-iLF
+mLg
+kcx
+uKk
+uKk
 kcx
 qNK
-pxB
-jIg
+uKk
+qNK
+qNK
+kcx
 qNK
 qNK
 qNK
-lYY
-bzW
-sKy
-uMI
-hRg
 vfp
 klQ
 rHb
@@ -80221,19 +79230,19 @@ qOI
 wHT
 iLF
 kcx
-uJT
-jRP
-kLr
-fRA
-uKk
+pOK
+gah
+ump
+vOc
+hTd
 qNK
-uKk
-uKk
-hmh
-uKk
-vxh
-fdm
-cwC
+kAR
+gde
+krF
+czX
+qNK
+syx
+klQ
 rHb
 rLl
 mdh
@@ -80478,20 +79487,20 @@ qOI
 wHT
 iLF
 kcx
-tZM
-tBH
-tBH
-sJj
-bLR
-fHm
-umG
-sXH
-sKy
+yiG
+jRP
+jRP
+niY
+xjv
 qNK
-qnW
-qex
-gNz
-mLI
+sHE
+kxw
+dPg
+oms
+qNK
+mdh
+klQ
+rHb
 rJa
 mdh
 isS
@@ -80734,21 +79743,21 @@ wHT
 wHT
 wHT
 iLF
+kcx
 qNK
-bJk
-kLr
-tBH
-fsE
-bLR
-nku
-pVi
-dtm
-fjt
-swF
-szu
-nbV
+pxB
+jIg
+qNK
+qNK
+qNK
+nTH
+dRJ
+dRJ
+kNU
+qNK
+isg
+klQ
 rHb
-mLI
 rJa
 mdh
 klQ
@@ -80991,22 +80000,22 @@ iLF
 iLF
 iLF
 iLF
-qNK
-eip
+kcx
+uJT
 jRP
-tBH
-eVF
-bLR
-jQt
-umG
-jkD
-jkD
+kLr
+fRA
+uKk
 qNK
-hHP
-kEZ
-jgp
-rYw
-wvX
+uKk
+uKk
+hmh
+uKk
+qDg
+fdm
+cwC
+rHb
+rLl
 mdh
 klQ
 kXC
@@ -81232,7 +80241,7 @@ hRl
 apm
 iLF
 iLF
-iLF
+hTD
 iLF
 sgW
 swG
@@ -81248,23 +80257,23 @@ iLF
 iLF
 iLF
 iLF
-qNK
-jKC
-dka
-jRP
+kcx
+tZM
 tBH
-eYt
-kGP
+tBH
+sJj
+bLR
+fHm
+umG
+sXH
 sKy
-jkD
-jkD
 qNK
-vxh
-lIo
-avK
-avK
-iRT
-dsp
+qnW
+qex
+gNz
+mLI
+rJa
+mdh
 klQ
 kXC
 syK
@@ -81506,23 +80515,23 @@ iLF
 iLF
 iLF
 qNK
-qKx
+bJk
+kLr
 tBH
-tBH
-tBH
-pIl
-umG
-eCM
-uJn
-jkD
+fsE
 bLR
-dfZ
-dsp
-jqA
-jqA
-iqu
-jqA
-nRM
+nku
+pVi
+dtm
+fjt
+swF
+szu
+nbV
+rHb
+mLI
+rJa
+mdh
+klQ
 kXC
 oQS
 rom
@@ -81745,7 +80754,7 @@ hRl
 hRl
 iLF
 swG
-swG
+cNK
 iLF
 iLF
 pdv
@@ -81761,25 +80770,25 @@ swG
 swG
 iLF
 iLF
-gWi
-kcx
-pmL
-miw
-fwY
-oVR
+iLF
+qNK
+eip
+jRP
+tBH
+eVF
 bLR
-qam
+jQt
 umG
-uJn
 jkD
-bLR
-aHM
-gIm
-gIm
-dOt
-gIm
-iEq
-rpa
+jkD
+qNK
+hHP
+kEZ
+jgp
+rYw
+wvX
+mdh
+nRM
 ePP
 oII
 pJc
@@ -82003,8 +81012,8 @@ hRl
 iLF
 iLF
 hay
-swG
-swG
+unP
+wfi
 iLF
 iLF
 xxj
@@ -82017,26 +81026,26 @@ cuO
 qnn
 qBj
 iLF
-mLg
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-obz
-sKy
-ddB
-uKk
-kcx
-kcx
-kcx
-uKk
-uKk
-xyf
 iLF
-hRg
+iLF
+qNK
+jKC
+dka
+jRP
+tBH
+eYt
+kGP
+sKy
+jkD
+jkD
+qNK
+qDg
+lIo
+avK
+avK
+iRT
+qFm
+rpa
 kXC
 uvN
 hGt
@@ -82259,10 +81268,10 @@ hRl
 hRl
 swG
 iLF
-iLF
-iLF
-iLF
-hTD
+hIg
+dzT
+sGF
+eCS
 iLF
 swG
 iLF
@@ -82275,25 +81284,25 @@ fiu
 swG
 hTD
 iLF
-qNK
-fAk
-gTF
-his
-kLP
-gQz
-bLR
-qam
-umG
-sKy
-bLR
-aBX
-jkD
-jkD
-cnN
-qNK
-swG
 iLF
-hRg
+qNK
+qKx
+tBH
+tBH
+tBH
+pIl
+umG
+eCM
+uJn
+jkD
+bLR
+lbs
+dsp
+jqA
+jqA
+iqu
+jqA
+klQ
 kXC
 vac
 mPZ
@@ -82516,10 +81525,10 @@ hRl
 hRl
 nXP
 iLF
-iLF
-swG
-iLF
-iLF
+hIg
+pdw
+jVv
+fKe
 iLF
 nXP
 iLF
@@ -82532,25 +81541,25 @@ fKe
 ulR
 iLF
 iLF
-qNK
-qyu
-kYI
-tzl
-kYI
-hne
+gWi
+kcx
+pmL
+miw
+fwY
+oVR
 bLR
-izY
+qam
 umG
 uJn
+jkD
 bLR
-qgh
-cBK
-rpE
-wuh
-qNK
-hay
-iLF
-hRg
+pZk
+gIm
+gIm
+iEq
+iEq
+gIm
+cwC
 kXC
 oqx
 nRa
@@ -82774,8 +81783,8 @@ hRl
 swG
 iLF
 cNK
-iLF
-iLF
+maH
+maH
 pdv
 swG
 swG
@@ -82788,26 +81797,26 @@ gnZ
 fKe
 swG
 cQD
-iLF
+mLg
 qNK
-hHN
-kYI
-mTe
-bvr
-qnX
-bLR
-rxO
-iIr
-sHQ
-bLR
-wDu
-sHQ
-oMM
-tRQ
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+obz
+sKy
+ddB
+uKk
 kcx
-hay
-hay
-hRg
+kcx
+kcx
+uKk
+uKk
+sAR
+sAR
+aAx
 kXC
 mQz
 kMK
@@ -83036,7 +82045,7 @@ swG
 iLF
 iLF
 iLF
-iLF
+uJb
 iLF
 hay
 hIg
@@ -83047,25 +82056,25 @@ iLF
 swG
 iLF
 qNK
-bNb
-kYI
-kYI
-kYI
-kYI
-nsA
-oMM
-sXH
-uJn
+fAk
+gTF
+his
+kLP
+gQz
 bLR
-lnC
-sHQ
-oMM
-waI
+qam
+umG
+sKy
+bLR
+aBX
+jkD
+jkD
+cnN
 qNK
-iLF
-hay
-hRg
-kXC
+vMp
+vMp
+pBs
+tlI
 wBY
 snD
 mTJ
@@ -83304,25 +82313,25 @@ mzT
 swG
 swG
 qNK
-nyo
-izJ
-jut
-rKs
-atZ
+qyu
+kYI
+tzl
+kYI
+hne
+bLR
+izY
+umG
+uJn
+bLR
+qgh
+cBK
+rpE
+wuh
 qNK
-qNK
-ipD
-sHQ
-bYl
-jkD
-sHQ
-oMM
-egN
-qNK
-iLF
-hay
-hRg
-kXC
+iRz
+vMp
+pBs
+tlI
 mQz
 vac
 vpj
@@ -83559,27 +82568,27 @@ cQD
 iLF
 iLF
 iLF
-hZI
+swG
 qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-lsq
+hHN
+kYI
+mTe
+bvr
+qnX
+bLR
+rxO
+iIr
 sHQ
 bLR
-jkD
-qHc
-rGP
-qrG
-qNK
-swG
-swG
-hRg
-kXC
+wDu
+sHQ
+oMM
+tRQ
+kcx
+uiu
+lYY
+pBs
+tlI
 wBY
 ozV
 xTD
@@ -83817,26 +82826,26 @@ mPb
 lSE
 hTD
 iLF
-cxU
-swG
-swG
-swG
-swG
-hTD
-iLF
 qNK
-nnK
+bNb
+kYI
+kYI
+kYI
+kYI
+nsA
+oMM
+sXH
+uJn
+bLR
+lnC
 sHQ
-kcx
-rXx
-sKy
-jkD
-xGQ
+oMM
+waI
 qNK
-hay
-swG
-hRg
-kXC
+eoV
+vMp
+pBs
+tlI
 hix
 fPa
 cyq
@@ -84074,26 +83083,26 @@ iLF
 hTD
 iLF
 iLF
-iLF
-hTD
-swG
-cQD
-hay
-swG
-lQN
+qNK
+nyo
+izJ
+jut
+rKs
+atZ
 qNK
 qNK
+ipD
+sHQ
+bYl
+jkD
+sHQ
+oMM
+egN
 qNK
-qNK
-qNK
-kcx
-qNK
-qNK
-qNK
-tzc
-iLF
-hRg
-kXC
+nBt
+nBt
+pBs
+tlI
 snD
 sXy
 ikc
@@ -84329,27 +83338,27 @@ hTD
 iLF
 iLF
 iLF
-qyo
-eZg
-eZg
-utX
-swG
 iLF
-swG
-swG
-hay
-lqr
-swG
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-cxU
-hay
-iLF
-hRg
+mLg
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+lsq
+sHQ
+bLR
+jkD
+qHc
+rGP
+qrG
+qNK
+pBs
+lYY
+pBs
 kXC
 lDW
 edk
@@ -84586,27 +83595,27 @@ swG
 iLF
 iLF
 nXP
-hIg
-dzT
-sGF
-pDA
+iLF
+eZg
+cxU
+swG
+swG
+swG
+swG
 hTD
-swG
-hTD
-swG
-swG
 iLF
-hay
-hay
-iLF
-swG
-swG
-swG
-bLM
-swG
-swG
-iLF
-hRg
+qNK
+nnK
+sHQ
+kcx
+rXx
+sKy
+jkD
+xGQ
+qNK
+pBs
+pBs
+pBs
 kXC
 tPQ
 vac
@@ -84844,26 +83853,26 @@ iLF
 iLF
 iLF
 vqf
-rKj
-mQa
-sGF
-fiu
-iLF
+nQU
+xVz
+cuO
 swG
-hTD
-iLF
-swG
-hay
-jFf
-jFf
-jFf
-hay
-hay
+cQD
 hay
 swG
-swG
-iLF
-hRg
+lQN
+qNK
+qNK
+qNK
+qNK
+qNK
+kcx
+qNK
+qNK
+qNK
+pBs
+pBs
+pBs
 kXC
 pYR
 iXy
@@ -85102,25 +84111,25 @@ iLF
 hTD
 hIg
 wRR
-qum
-wbm
+tRs
+aul
 eCS
 swG
 hTD
 swG
 iLF
-iLF
-iLF
-iLF
-iLF
-swG
-swG
-swG
-iLF
-iLF
-iLF
-iLF
-hRg
+cxU
+dfZ
+dfZ
+dfZ
+xWR
+xWR
+gor
+dfZ
+pBs
+pBs
+pBs
+pBs
 kXC
 dVq
 eiW
@@ -85345,39 +84354,39 @@ hRg
 hRg
 hRg
 hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
-hRg
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+maH
+maH
+maH
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+dfZ
+dfZ
+dfZ
+dfZ
+dfZ
+dfZ
+dfZ
+pBs
+dYk
+dYk
+dYk
 kXC
 tPQ
 wBY
@@ -85631,10 +84640,10 @@ kXC
 kXC
 kXC
 kXC
-kXC
-kXC
-kXC
-kXC
+xen
+xen
+xen
+xen
 kXC
 kXC
 kXC
@@ -86142,13 +85151,13 @@ gcG
 hRl
 gcG
 tPQ
-rNu
-lvH
 tPQ
-cUv
-rNu
-rNu
-rNu
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86383,14 +85392,14 @@ gcG
 gcG
 gcG
 gcG
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
 gcG
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -86400,9 +85409,9 @@ hRl
 hRl
 tPQ
 tPQ
-lvH
 tPQ
-cUv
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86632,21 +85641,21 @@ gcG
 gcG
 gcG
 gcG
-jyY
-jyY
-pyK
-pyK
-ahq
-ahq
-xcf
-xcf
-xcf
-odp
-hJP
-eKM
-rJd
-xcf
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
@@ -86657,9 +85666,9 @@ gcG
 hRl
 tPQ
 tPQ
-ppv
 tPQ
-gIL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86889,20 +85898,20 @@ gcG
 gcG
 gcG
 gcG
-jyY
-aAx
-aAx
-dQI
-aAx
-gLd
-qst
-qst
-xcf
-elk
-krF
-krF
-xKM
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -86914,11 +85923,11 @@ gcG
 hRl
 tPQ
 tPQ
-ppv
 tPQ
-cUv
 tPQ
-ppv
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87146,38 +86155,38 @@ gcG
 gcG
 gcG
 gcG
-jyY
-jMc
-jIC
-fsW
-aAx
-gjN
-qst
-sri
-xcf
-ljb
-krF
-uiu
-kjf
-xcf
+gcG
+gcG
+txY
 gcG
 gcG
 gcG
-xcf
-xcf
-xcf
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 hRl
 tPQ
 tPQ
-ppv
-ppv
-ppv
-gIL
 tPQ
-ppv
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87402,41 +86411,41 @@ gcG
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
 txY
-jyY
-jyY
-pyK
-pyK
-ahq
-ahq
-qJK
-pZk
-xcf
-vNJ
-wZe
-thp
-mwZ
-xcf
-xcf
-xcf
-xcf
-xcf
-lhT
-uHp
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 hRl
 tPQ
 tPQ
-ppv
-ppv
 tPQ
 tPQ
-gIL
 tPQ
-gIL
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87659,42 +86668,42 @@ gcG
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
 txY
-jyY
-heQ
-kAR
-ljE
-aAx
-ahq
-qst
-qst
-xcf
-qJK
-sri
-qst
-vEK
-xcf
-qHR
-cSq
-oJI
-xcf
-wlP
-qDg
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
 hRl
 hRl
 tPQ
 tPQ
 tPQ
-ppv
-gIL
 tPQ
 tPQ
-gIL
 tPQ
-gIL
 tPQ
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87917,27 +86926,27 @@ gcG
 gcG
 txY
 gcG
-jyY
-jMc
-cKP
-kBQ
-aAx
-gjN
-sri
-qst
-xcf
-qst
-qst
-qst
-pZk
-xcf
-qst
-qst
-kxw
-xcf
-nBt
-kNU
-xcf
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
 hRl
 gcG
 tPQ
@@ -87945,13 +86954,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88174,43 +87183,43 @@ gcG
 gcG
 txY
 gcG
-jyY
-jyY
-pyK
-pyK
-ahq
-ahq
-qJK
-qst
-xcf
-xcf
-hCQ
-ssX
-xcf
-xcf
-ssX
-kWU
-wfi
-xcf
-yes
-xcf
-xcf
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+txY
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 hRl
 gcG
 tPQ
 tPQ
 tPQ
 tPQ
-gwL
-tPQ
-gIL
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
-cUv
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88431,27 +87440,27 @@ gcG
 gcG
 txY
 gcG
-jyY
-heQ
-aAx
-xRq
-heQ
-gjN
-qst
-qst
-qst
-aHr
-qst
-qst
-uyA
-moZ
-qst
-pZk
-qst
-ivc
-qst
-bgF
-hsR
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
 hRl
 gcG
 tPQ
@@ -88459,15 +87468,15 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-tPQ
-gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88688,27 +87697,27 @@ gcG
 gcG
 txY
 gcG
-jyY
-jMc
-awt
-heQ
-pJt
-ahq
-qst
-pZk
-qst
-qst
-sri
-qst
-qst
-moZ
-sri
-qst
-kBq
-qst
-abR
-jlc
-hsR
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+txY
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+txY
+txY
+gcG
+gcG
 hRl
 tPQ
 tPQ
@@ -88717,16 +87726,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-gIL
-gIL
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
 tPQ
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88945,27 +87954,27 @@ gcG
 gcG
 gcG
 gcG
-jyY
-jyY
-pyK
-pyK
-ahq
-ahq
-xcf
-xcf
-xcf
-xcf
-xcf
-psT
-xcf
-xcf
-bsJ
-qst
-qst
-qst
-qst
-pZk
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+gcG
+gcG
 gcG
 tPQ
 tPQ
@@ -88975,16 +87984,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-ppv
-gIL
 tPQ
-gIL
 tPQ
-ppv
-cUv
-ppv
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89202,27 +88211,27 @@ txY
 gcG
 gcG
 gcG
+txY
 gcG
-xcf
-dda
-qRw
-wmM
-eqe
-qRw
-xcf
-uPd
-qQB
-nHr
-nHr
-jgf
-xcf
-hCQ
-ssX
-hCQ
-hCQ
-hCQ
-hCQ
-xcf
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+txY
+gcG
+gcG
 gcG
 tPQ
 tPQ
@@ -89233,16 +88242,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
 tPQ
-ppv
 tPQ
-gIL
-gIL
-gIL
-gIL
-cUv
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89460,26 +88469,26 @@ gcG
 gcG
 gcG
 gcG
-xcf
-ltR
-nWz
-kPv
-eqe
-qRw
-hNN
-nHr
-nHr
-nHr
-nHr
-owa
-xcf
-qJK
-pZk
-uyA
-stz
-rPK
-nQu
-hsR
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
 gcG
 tPQ
 tPQ
@@ -89496,11 +88505,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
 tPQ
-gIL
-gIL
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89716,27 +88725,27 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
-xcf
-rki
-qRw
-qRw
-qRw
-qRw
-xcf
-sRK
-nHr
-nHr
-nHr
-avu
-qxw
-fUg
-qst
-pZk
-sri
-qst
-pZk
-tGZ
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+txY
+txY
+txY
+gcG
 gcG
 tPQ
 tPQ
@@ -89750,14 +88759,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-tPQ
-gIL
 tPQ
 tPQ
 tPQ
-gIL
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89974,26 +88983,26 @@ gcG
 gcG
 gcG
 gcG
-xcf
-xcf
-mPW
-wzP
-mPW
-xcf
-xcf
-xcf
-iNQ
-hqo
-wmS
-xcf
-xcf
-ulP
-akW
-pAu
-stz
-xtx
-vEW
-hsR
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+txY
+gcG
+gcG
+gcG
 gcG
 tPQ
 tPQ
@@ -90009,13 +89018,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-cUv
 tPQ
 tPQ
 tPQ
 tPQ
-cUv
-ppv
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -90230,27 +89239,27 @@ gcG
 gcG
 gcG
 gcG
+txY
+txY
 gcG
 gcG
-xcf
-xcf
-xcf
-xcf
-xcf
 gcG
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
-xcf
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 hRl
 tPQ
 tPQ
@@ -90266,13 +89275,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-cUv
-gIL
 tPQ
 tPQ
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -90490,6 +89499,16 @@ txY
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
 gcG
 gcG
@@ -90497,16 +89516,6 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
 gcG
 hRl
 hRl
@@ -90524,12 +89533,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-gIL
-gIL
 tPQ
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -90743,17 +89752,10 @@ gcG
 gcG
 gcG
 gcG
-gcG
 txY
 txY
 gcG
 gcG
-txY
-gcG
-gcG
-gcG
-gcG
-txY
 gcG
 gcG
 gcG
@@ -90764,7 +89766,14 @@ gcG
 gcG
 gcG
 gcG
-txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 hRl
 tPQ
@@ -90779,14 +89788,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-mql
-mQz
-mQz
-tPQ
-gIL
 tPQ
 tPQ
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91037,14 +90046,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-ppv
-ppv
 tPQ
 tPQ
-gIL
 tPQ
 tPQ
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91293,17 +90302,17 @@ tPQ
 tPQ
 tPQ
 tPQ
-mQz
-tPQ
-ppv
-mQz
-tPQ
-gIL
 tPQ
 tPQ
-gIL
-ouU
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91553,14 +90562,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-qFm
-tPQ
-gIL
 tPQ
 tPQ
-ppv
-cUv
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91811,13 +90820,13 @@ dVq
 tPQ
 tPQ
 tPQ
-ppv
 tPQ
-gIL
 tPQ
-ppv
-ppv
-ouU
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92065,13 +91074,13 @@ tPQ
 tPQ
 mQz
 mql
-dVq
 tPQ
-mQz
-ppv
 tPQ
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92322,17 +91331,17 @@ mQz
 tPQ
 tPQ
 dVq
-dVq
-mQz
-dVq
-ppv
-tPQ
-gIL
 tPQ
 tPQ
-gIL
 tPQ
-qFm
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92579,17 +91588,17 @@ tPQ
 tPQ
 mQz
 mQz
-mQz
-dVq
-tPQ
-ppv
 tPQ
 tPQ
-gIL
 tPQ
 tPQ
-gIL
-mQz
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92836,14 +91845,14 @@ tPQ
 mQz
 mQz
 tPQ
-dVq
-dVq
-tPQ
-ppv
 tPQ
 tPQ
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 upt
@@ -93093,14 +92102,14 @@ tPQ
 tPQ
 mQz
 mQz
-mQz
-tPQ
-mQz
-qFm
 tPQ
 tPQ
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 yde
@@ -93350,14 +92359,14 @@ tPQ
 tPQ
 mQz
 mQz
-dVq
-dVq
-tPQ
-qFm
 tPQ
 tPQ
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 yde
@@ -93607,14 +92616,14 @@ tPQ
 tPQ
 mQz
 dVq
-mQz
-mQz
-mQz
 tPQ
-qFm
 tPQ
-gIL
-ppv
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 yde
@@ -93867,11 +92876,11 @@ mQz
 dVq
 dVq
 tPQ
-mQz
-qFm
 tPQ
-gIL
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 upt
@@ -94123,12 +93132,12 @@ gcG
 tPQ
 tPQ
 mql
-mQz
 tPQ
-qFm
 tPQ
-gIL
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 yde
@@ -94381,11 +93390,11 @@ gcG
 gcG
 gcG
 tPQ
-mQz
-ppv
 tPQ
-gIL
-cUv
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 yde
@@ -100559,7 +99568,7 @@ gcG
 gcG
 gcG
 gcG
-ewt
+gcG
 gcG
 gcG
 gcG
@@ -101074,7 +100083,7 @@ gcG
 gcG
 gcG
 gcG
-txY
+gcG
 gcG
 gcG
 gcG
@@ -101328,10 +100337,10 @@ txY
 gcG
 gcG
 gcG
-txY
 gcG
 gcG
-txY
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -101585,10 +100594,10 @@ txY
 gcG
 gcG
 gcG
-txY
-txY
-txY
 gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -101842,11 +100851,11 @@ txY
 gcG
 gcG
 txY
+gcG
+gcG
 txY
+gcG
 txY
-gcG
-gcG
-gcG
 gcG
 gcG
 gcG
@@ -102099,11 +101108,11 @@ txY
 gcG
 gcG
 txY
+gcG
+gcG
 txY
+gcG
 txY
-gcG
-gcG
-gcG
 gcG
 gcG
 gcG
@@ -102356,11 +101365,11 @@ gcG
 gcG
 gcG
 txY
+gcG
+gcG
 txY
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -102613,12 +101622,12 @@ txY
 gcG
 gcG
 txY
-txY
-txY
-txY
 gcG
 gcG
+txY
 gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -102872,10 +101881,10 @@ txY
 txY
 gcG
 gcG
+txY
+txY
 gcG
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -103128,11 +102137,11 @@ gcG
 txY
 txY
 gcG
+gcG
+txY
 txY
 gcG
-gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -103379,16 +102388,16 @@ gcG
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
-gcG
 txY
-txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
 gcG
 gcG
 gcG
@@ -103637,16 +102646,16 @@ gcG
 gcG
 gcG
 gcG
-txY
-txY
-txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 txY
-gcG
-gcG
-gcG
-gcG
 gcG
 gcG
 gcG
@@ -103891,19 +102900,19 @@ txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
 txY
-gcG
 txY
 txY
 gcG
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
 txY
 gcG
+txY
 gcG
 gcG
 gcG
@@ -104148,18 +103157,18 @@ txY
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
+txY
+gcG
+txY
 txY
 gcG
 gcG
 gcG
 txY
-eRR
-gcG
-gcG
 txY
-gcG
 gcG
 gcG
 gcG
@@ -104404,18 +103413,18 @@ txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
 txY
-gcG
-gcG
 gcG
 txY
 txY
+gcG
+txY
+gcG
+gcG
 txY
 txY
-txY
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -104621,10 +103630,10 @@ txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
+tot
+tot
+tot
+tot
 tot
 tot
 tot
@@ -104662,17 +103671,17 @@ gcG
 gcG
 gcG
 gcG
+txY
+txY
+txY
+gcG
+gcG
+gcG
 gcG
 txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-txY
-txY
-txY
 gcG
 gcG
 gcG
@@ -104875,13 +103884,13 @@ hRl
 hRl
 txY
 gcG
-txY
 gcG
-txY
+tot
 gcG
-gcG
-gcG
-gcG
+tot
+tot
+tot
+tot
 tot
 tot
 tot
@@ -104919,16 +103928,16 @@ gcG
 gcG
 gcG
 gcG
-txY
-txY
-gcG
-gcG
-gcG
 gcG
 gcG
 gcG
 txY
 txY
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -105132,13 +104141,13 @@ hRl
 hRl
 txY
 gcG
-txY
 gcG
-txY
+tot
 gcG
-gcG
-gcG
-gcG
+tot
+tot
+tot
+tot
 tot
 tot
 tot
@@ -105177,16 +104186,16 @@ gcG
 gcG
 gcG
 txY
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
 gcG
 gcG
 txY
 gcG
-txY
+gcG
+gcG
+gcG
 gcG
 gcG
 txY
@@ -105390,12 +104399,12 @@ hRl
 gcG
 gcG
 gcG
-txY
+tot
 gcG
-gcG
-gcG
-gcG
-gcG
+tot
+tot
+tot
+tot
 tot
 tot
 tot
@@ -105432,20 +104441,20 @@ gcG
 gcG
 gcG
 gcG
-txY
-gcG
-gcG
-gcG
 gcG
 txY
 gcG
 gcG
 txY
 txY
-txY
 gcG
-txY
-txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
 gcG
 gcG
@@ -105647,12 +104656,12 @@ hRl
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+tot
+txY
+tot
+tot
+tot
+tot
 tot
 tot
 tot
@@ -105690,20 +104699,20 @@ gcG
 gcG
 gcG
 gcG
+txY
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
 gcG
 gcG
 txY
-txY
-txY
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
 gcG
 txY
 cOr
@@ -105903,13 +104912,13 @@ hRl
 hRl
 gcG
 gcG
+txY
+tot
+txY
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+tot
+tot
+tot
 tot
 tot
 tot
@@ -105948,18 +104957,18 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
 txY
 txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
 gcG
 txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 txY
 txY
@@ -106160,13 +105169,13 @@ hRl
 hRl
 gcG
 gcG
+txY
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 txY
-txY
+tot
 tot
 tot
 tot
@@ -106207,15 +105216,9 @@ gcG
 gcG
 gcG
 gcG
-txY
 gcG
 txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
 txY
 txY
 txY
@@ -106223,11 +105226,17 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-fRl
-gcG
 txY
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -106417,6 +105426,7 @@ hRl
 hRl
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
@@ -106424,7 +105434,6 @@ gcG
 txY
 gcG
 txY
-gcG
 tot
 tot
 tot
@@ -106469,20 +105478,20 @@ txY
 gcG
 gcG
 gcG
+txY
 gcG
+gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
 gcG
 txY
-gcG
-gcG
-ewt
-gcG
-fRl
-gcG
-fRl
 txY
+txY
+gcG
 gcG
 gcG
 txY
@@ -106679,9 +105688,9 @@ gcG
 gcG
 gcG
 txY
-gcG
 txY
-gcG
+txY
+txY
 gcG
 txY
 tot
@@ -106721,24 +105730,24 @@ gcG
 gcG
 gcG
 gcG
-txY
 gcG
 txY
-txY
-txY
-gcG
-gcG
 gcG
 gcG
 txY
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
 gcG
-fRl
-fRl
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -106930,14 +105939,14 @@ hRl
 (238,1,1) = {"
 hRl
 gcG
-gcG
-gcG
-gcG
+tot
 gcG
 gcG
 txY
 txY
-gcG
+txY
+txY
+txY
 gcG
 gcG
 txY
@@ -106977,15 +105986,13 @@ gcG
 gcG
 gcG
 gcG
-eRR
-gcG
-txY
 gcG
 gcG
 txY
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
@@ -106993,10 +106000,12 @@ gcG
 gcG
 gcG
 gcG
-fRl
 gcG
-cOr
 gcG
+gcG
+gcG
+gcG
+txY
 gcG
 gcG
 lBo
@@ -107190,11 +106199,11 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
+txY
+txY
 gcG
 txY
 txY
@@ -107233,6 +106242,11 @@ gcG
 txY
 gcG
 gcG
+gcG
+gcG
+gcG
+gcG
+txY
 txY
 txY
 gcG
@@ -107243,19 +106257,14 @@ gcG
 gcG
 gcG
 gcG
+gcG
+txY
+txY
+gcG
+txY
 txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-cOr
-fRl
-gcG
-gcG
-cOr
 lao
 gcG
 gcG
@@ -107449,9 +106458,9 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
-gcG
-gcG
+txY
 gcG
 txY
 gcG
@@ -107488,31 +106497,31 @@ gcG
 gcG
 gcG
 gcG
-txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
-gcG
-fRl
-fRl
-fRl
-gcG
-cOr
 fRl
 gcG
 gcG
@@ -107705,10 +106714,10 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
+txY
 gcG
 gcG
 gcG
@@ -107746,29 +106755,29 @@ gcG
 gcG
 txY
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
 txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
-gcG
-fRl
-fRl
-gcG
-gcG
-txY
 gcG
 gcG
 gcG
@@ -107957,6 +106966,59 @@ hRl
 "}
 (242,1,1) = {"
 hRl
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+txY
+gcG
+txY
+gcG
+txY
+gcG
+txY
+txY
+gcG
+txY
+txY
+gcG
+txY
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+txY
+gcG
+txY
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+txY
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
@@ -107968,67 +107030,14 @@ gcG
 gcG
 gcG
 txY
-gcG
 txY
 gcG
-txY
 txY
 gcG
 txY
 txY
 gcG
 txY
-txY
-gcG
-gcG
-gcG
-gcG
-txY
-txY
-txY
-gcG
-txY
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
-gcG
-txY
-txY
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-fRl
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
 txY
 txY
 gcG
@@ -108214,15 +107223,15 @@ hRl
 "}
 (243,1,1) = {"
 hRl
+txY
+txY
+txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
+txY
 gcG
 txY
 gcG
@@ -108259,10 +107268,6 @@ txY
 txY
 gcG
 gcG
-txY
-gcG
-gcG
-txY
 gcG
 gcG
 gcG
@@ -108270,10 +107275,6 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-txY
 gcG
 gcG
 gcG
@@ -108282,11 +107283,19 @@ gcG
 gcG
 gcG
 txY
+gcG
+gcG
 txY
 txY
+txY
+txY
+gcG
+txY
+gcG
+gcG
 cOr
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -108471,14 +107480,14 @@ hRl
 "}
 (244,1,1) = {"
 hRl
+txY
+txY
+txY
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
+txY
+tot
+tot
 gcG
 gcG
 ewt
@@ -108520,8 +107529,6 @@ gcG
 gcG
 gcG
 gcG
-txY
-txY
 gcG
 gcG
 gcG
@@ -108529,22 +107536,24 @@ gcG
 gcG
 gcG
 gcG
-txY
+gcG
+gcG
+gcG
 txY
 gcG
 gcG
-txY
-txY
-txY
-txY
-txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 txY
-fRl
-gcG
 txY
 txY
-gcG
 gcG
 gcG
 gcG
@@ -108729,13 +107738,13 @@ hRl
 (245,1,1) = {"
 hRl
 gcG
+txY
 gcG
 gcG
 gcG
+txY
 gcG
-gcG
-gcG
-gcG
+txY
 gcG
 txY
 gcG
@@ -108791,18 +107800,18 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
-gcG
-gcG
-gcG
-gcG
-cOr
-cOr
 gcG
 gcG
 gcG
 txY
 gcG
+gcG
+gcG
+gcG
+txY
+txY
 gcG
 gcG
 gcG
@@ -108989,44 +107998,10 @@ gcG
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-txY
-txY
-gcG
-gcG
 txY
 txY
 txY
 txY
-txY
-txY
-txY
-txY
-gcG
-txY
-txY
-gcG
-txY
-txY
-txY
-txY
-txY
-gcG
-txY
-gcG
-gcG
 gcG
 txY
 gcG
@@ -109040,20 +108015,54 @@ txY
 txY
 gcG
 gcG
+txY
+txY
+txY
+txY
+txY
+txY
+txY
+txY
+gcG
+txY
+txY
+gcG
+txY
+txY
+txY
+txY
+txY
+gcG
+txY
+gcG
+gcG
+gcG
+txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 gcG
 txY
 txY
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
 gcG
 gcG
 txY
+txY
 gcG
+txY
+gcG
+gcG
+txY
+txY
+txY
 txY
 gcG
 fRl
@@ -109245,10 +108254,10 @@ hRl
 gcG
 gcG
 gcG
-gcG
-gcG
-gcG
-gcG
+txY
+txY
+txY
+txY
 gcG
 gcG
 txY
@@ -109303,15 +108312,15 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
 gcG
 gcG
 gcG
 gcG
 gcG
+txY
 gcG
-gcG
-fRl
 cOr
 gcG
 gcG
@@ -109560,19 +108569,19 @@ gcG
 gcG
 gcG
 gcG
+txY
+gcG
+gcG
+gcG
 gcG
 gcG
 gcG
 gcG
 txY
-gcG
-gcG
-gcG
-fRl
-gcG
+txY
 fRl
 txY
-gcG
+txY
 txY
 gcG
 txY
@@ -109819,14 +108828,14 @@ gcG
 gcG
 gcG
 gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
 txY
-gcG
-gcG
-gcG
-fRl
-gcG
-gcG
 fRl
 gcG
 gcG
@@ -110074,18 +109083,18 @@ gcG
 gcG
 gcG
 txY
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
+gcG
 txY
 txY
-gcG
-gcG
-gcG
-gcG
-gcG
-gcG
-fRl
-fRl
-lao
-gcG
+cOr
+lBo
+txY
 gcG
 gcG
 txY
@@ -110338,8 +109347,8 @@ gcG
 gcG
 gcG
 gcG
-fRl
-fRl
+gcG
+txY
 fRl
 fRl
 gcG
@@ -110596,7 +109605,7 @@ gcG
 gcG
 gcG
 gcG
-lao
+gcG
 gcG
 fRl
 gcG
@@ -110852,7 +109861,7 @@ gcG
 gcG
 gcG
 gcG
-gcG
+txY
 gcG
 gcG
 gcG
@@ -111106,9 +110115,9 @@ gcG
 gcG
 gcG
 gcG
+txY
 gcG
-gcG
-gcG
+txY
 gcG
 gcG
 gcG

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -105,6 +105,7 @@ also be like that but I can't be arsed to go back and change them all*/
 #define ACCESS_BIKER 		135 //general not-khan cowbikers
 #define ACCESS_SCIENCE		136 //general science access
 #define ACCESS_CLUB			137 //general heavens night access placeholder
+#define ACCESS_GUILD		138 //Adventurers Guild access
 	//The Syndicate
 #define ACCESS_SYNDICATE 150//General Syndicate Access. Includes Syndicate mechs and ruins.
 #define ACCESS_SYNDICATE_LEADER 151//Nuke Op Leader Access

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -12,6 +12,7 @@
 #define FACTION_TRIBE "Tribe"
 #define FACTION_VAULT "Vault"
 #define FACTION_FOLLOWERS "Followers"
+#define FACTION_GUILD "Guild"
 #define FACTION_KHAN "Great Khans"
 #define FACTION_BIKER "Hells Nomads"
 #define FACTION_CLUB "Heavens Night"
@@ -205,7 +206,16 @@
 #define F13PROFESSOR	(1<<4)
 #define F13LEADPROFESSOR (1<<5)
 
-#define KHAN		(1<<14)
+#define GUILD			(1<<14)
+
+#define GUILDSHOPKEEP	(1<<0)
+#define GUILDBANKER		(1<<1)
+#define GUILDMEDIC		(1<<2)
+#define GUILDBARTEND	(1<<3)
+#define GUILDLIBRARIAN	(1<<4)
+#define GUILDKNIGHT		(1<<5)
+
+#define KHAN		(1<<15)
 
 #define F13NOYAN (1<<0)
 #define F13STEWARD (1<<1)
@@ -214,12 +224,12 @@
 #define F13KIPCHAK (1<<4)
 #define F13MANGUDAI (1<<5)
 
-#define HEAVENSNIGHT		(1<<15)
+#define HEAVENSNIGHT		(1<<16)
 
 #define F13MANAGER			(1<<0)
 #define F13CLUBWORKER		(1<<1)
 
-#define TEACHER		(1<<16)
+#define TEACHER		(1<<17)
 
 #define F13TEACHER (1<<0)
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -100,6 +100,7 @@
 	var/list/ncr = list()
 	var/list/vault = list()
 	var/list/clinic = list()
+	var/list/guild = list()
 	var/list/tribe = list()
 	var/list/waster = list()
 	var/list/den = list()
@@ -148,6 +149,9 @@
 			department = 1
 		if(rank in GLOB.followers_positions)
 			clinic[name] = rank
+			department = 1
+		if(rank in GLOB.guild_positions)
+			guild[name] = rank
 			department = 1
 		if(rank in GLOB.tribal_positions)
 			tribe[name] = rank
@@ -221,6 +225,11 @@
 		dat += "<tr><th colspan=3>Nash Clinic</th></tr>"
 		for(var/name in clinic)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[clinic[name]]</td></tr>"
+			even = !even
+	if(length(guild))
+		dat += "<tr><th colspan=3>Adventurers Guild</th></tr>"
+		for(var/name in guild)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[guild[name]]</td></tr>"
 			even = !even
 	if(length(tribe))
 		dat += "<tr><th colspan=3>Sulphur-Bottom Tribe</th></tr>"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -455,12 +455,6 @@
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
 	return TRUE
 
-/obj/machinery/computer/communications/ui_interact(mob/user)
-	. = ..()
-	if (z > 6)
-		to_chat(user, "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!")
-		return
-
 	var/dat = ""
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
 		var/timeleft = SSshuttle.emergency.timeLeft()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -455,6 +455,12 @@
 	playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
 	return TRUE
 
+/obj/machinery/computer/communications/ui_interact(mob/user)
+	. = ..()
+	if (z > 47) //fuck you poojawa ~TK
+		to_chat(user, "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!")
+		return
+
 	var/dat = ""
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
 		var/timeleft = SSshuttle.emergency.timeLeft()

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -1906,7 +1906,7 @@ Mayor
 	flag = GUILDKNIGHT
 	department_flag = GUILD
 	faction = "Guild"
-	total_positions = 0
+	total_positions = 3
 	spawn_positions = 3
 	supervisors = "Generally speaking your only actual supervisor is your own judgement, but it might not be amiss to listen to the Mayor and Doctors. Assuming they're around."
 	description = "You are one of the towns Paramedics.  Your job is to prepare parties to go out and try and help those in need that can't make it to the hospital on their own. Be that shooting your way to them or seeking them out with a rescue party."
@@ -1914,7 +1914,8 @@ Mayor
 	selection_color = "#FFDDFF"
 
 	outfit = /datum/outfit/job/followers/f13followerguard
-
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
 
 	loadout_options = list(
 	/datum/outfit/loadout/thelaw,

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -769,93 +769,6 @@ Mayor
 		)
 /*--------------------------------------------------------------*/
 
-/datum/job/oasis/f13barkeep
-	title = "Barkeep"
-	flag = F13BARKEEP
-	department_flag = DEP_OASIS
-	total_positions = -1
-	spawn_positions = -1
-	supervisors = "the free market and New Boston's Laws"
-	description = "As a proprietor of Heavens Night, you are responsible for ensuring both citizens and travellers in New Bostoncan get some food, drink and rest. Speak to the farmers for fresh produce!"
-	enforces = "Heaven's Night is a private business and you can decide who is welcome there. However, you are still subject to the overarching laws of New Boston."
-	selection_color = "#dcba97"
-
-	outfit = /datum/outfit/job/den/f13barkeep
-
-	loadout_options = list(
-	/datum/outfit/loadout/rugged,
-	/datum/outfit/loadout/frontier,
-	/datum/outfit/loadout/richmantender,
-	/datum/outfit/loadout/diner)
-
-	access = list(ACCESS_BAR, ACCESS_KITCHEN)
-	minimal_access = list(ACCESS_BAR, ACCESS_KITCHEN)
-	matchmaking_allowed = list(
-		/datum/matchmaking_pref/friend = list(
-			/datum/job/oasis
-		),
-		/datum/matchmaking_pref/rival = list(
-			/datum/job/oasis
-		)
-	)
-
-
-/datum/outfit/job/den/f13barkeep
-	name = "Barkeep"
-	jobtype = /datum/job/oasis/f13barkeep
-	uniform = /obj/item/clothing/under/f13/bartenderalt
-	id = /obj/item/card/id/dogtag/town
-	ears = /obj/item/radio/headset/headset_town/commerce
-	belt = /obj/item/kit_spawner/townie/barkeep
-	shoes = /obj/item/clothing/shoes/workboots/mining
-	backpack = /obj/item/storage/backpack/satchel/leather
-	backpack_contents = list(
-		/obj/item/storage/pill_bottle/chem_tin/radx,
-		/obj/item/storage/wallet/stash/mid = 1,
-	//	/obj/item/ammo_box/shotgun/bean = 2,
-		/obj/item/book/manual/nuka_recipes = 1,
-		/obj/item/stack/f13Cash/caps/onezerozero = 1,
-		/obj/item/pda = 1,
-		/obj/item/kit_spawner/tools,
-		/obj/item/reagent_containers/food/drinks/bottle/rotgut = 1
-		)
-
-/datum/outfit/loadout/rugged
-	name = "Rugged"
-	head = /obj/item/clothing/head/helmet/f13/brahmincowboyhat
-	uniform = /obj/item/clothing/under/f13/cowboyb
-	suit = /obj/item/clothing/suit/armor/outfit/vest/cowboy
-	gloves = /obj/item/clothing/gloves/color/brown
-	shoes = /obj/item/clothing/shoes/f13/brownie
-
-/datum/outfit/loadout/frontier
-	name = "Frontier"
-	head = /obj/item/clothing/head/bowler
-	mask = /obj/item/clothing/mask/fakemoustache
-	uniform = /obj/item/clothing/under/f13/westender
-	suit = /obj/item/clothing/suit/armor/outfit/vest/bartender
-	gloves = /obj/item/clothing/gloves/fingerless
-	shoes = /obj/item/clothing/shoes/f13/fancy
-
-/datum/outfit/loadout/richmantender
-	name = "Fancy"
-	head = /obj/item/clothing/head/fedora
-	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/rank/bartender
-	suit = /obj/item/clothing/suit/toggle/lawyer/black
-	gloves = /obj/item/clothing/gloves/fingerless
-	shoes = /obj/item/clothing/shoes/f13/fancy
-	neck = /obj/item/clothing/neck/tie/black
-
-/datum/outfit/loadout/diner
-	name = "Diner"
-	glasses = /obj/item/clothing/glasses/orange
-	uniform = /obj/item/clothing/under/f13/brahminf
-	neck = /obj/item/clothing/neck/apron/chef
-	gloves = /obj/item/clothing/gloves/color/white
-	shoes = /obj/item/clothing/shoes/f13/military/ncr
-
-/*--------------------------------------------------------------*/
 /datum/job/oasis/f13settler
 	title = "Citizen"
 	flag = F13SETTLER
@@ -1215,64 +1128,7 @@ Mayor
 		)
 /*--------------------------------------------------------------*/
 
-//New BostonCurator
-
 /*
-/datum/job/oasis/nashcurator
-	title = "New Boston Librarian"
-	flag = NASHCURATOR
-	department_flag = DEP_OASIS
-	total_positions = 0
-	spawn_positions = 1
-	supervisors = "New Boston's laws"
-	description = "You are a Curator for the library of New Boston. Assist people with writing books, be a journalist, stock the shelves."
-	selection_color = "#dcba97"
-
-	outfit = /datum/outfit/job/den/nashcurator
-	access = list(ACCESS_BAR)
-	minimal_access = list(ACCESS_BAR)
-	matchmaking_allowed = list(
-		/datum/matchmaking_pref/friend = list(
-			/datum/job/oasis
-		),
-		/datum/matchmaking_pref/rival = list(
-			/datum/job/oasis
-		)
-	)
-
-/datum/outfit/job/den/nashcurator
-	name = "New Boston Librarian"
-	jobtype = /datum/job/oasis/nashcurator
-	belt = /obj/item/kit_spawner/townie
-	id = /obj/item/card/id/dogtag/town
-	uniform = /obj/item/clothing/under/f13/settler
-	shoes = /obj/item/clothing/shoes/jackboots
-	backpack = /obj/item/storage/backpack/satchel/explorer
-	r_pocket = /obj/item/flashlight/flare
-	backpack_contents = list(
-		/obj/item/storage/pill_bottle/chem_tin/radx,
-		/obj/item/storage/wallet/stash/mid = 1,
-		/obj/item/folder/white = 1,
-		/obj/item/pda = 1,
-		/obj/item/pen/fountain/captain,
-		/obj/item/kit_spawner/tools,
-		/obj/item/export_scanner,
-		/obj/item/key/displaycase,
-		)
-
-/datum/outfit/job/den/nashcurator/pre_equip(mob/living/carbon/human/H)
-	. = ..()
-	uniform = pick(
-		/obj/item/clothing/under/f13/gentlesuit,
-		/obj/item/clothing/under/f13/formal,
-		/obj/item/clothing/under/f13/spring,
-		/obj/item/clothing/under/f13/relaxedwear,
-		/obj/item/clothing/under/f13/machinist,
-		/obj/item/clothing/under/f13/brahminf,
-		/obj/item/clothing/under/f13/cowboyb,
-		/obj/item/clothing/under/f13/cowboyg,
-		/obj/item/clothing/under/f13/cowboyt)
-
 //The Quartermaster
 /datum/job/oasis/f13quartermaster
 	title = "Texarkana Quartermaster"
@@ -1370,114 +1226,7 @@ Mayor
 		return
 */
 
-//The Trade Workers
-/datum/job/oasis/f13shopkeeper
-	title = "Guild Worker"
-	flag = F13SHOPKEEPER
-	department_flag = DEP_OASIS
-	total_positions = -1
-	spawn_positions = -1
-	supervisors = "the free market."
-	description = "You are one of the many workers who live in the city of New Boston. Working with the town council you have rented out a space in the shop for you to make your living."
-	enforces = "The New Bostonstore is part of your workplace, but it is not your workplace alone. You should try work with the other trade workers to try and turn a profit."
-	selection_color = "#dcba97"
-	exp_requirements = 0
 
-	loadout_options = list(
-	/datum/outfit/loadout/energy_specialist,
-	/datum/outfit/loadout/ballistic_specialist,
-	/datum/outfit/loadout/jackofall_specialist
-	)
-
-	outfit = /datum/outfit/job/den/f13shopkeeper
-	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
-	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO)
-	matchmaking_allowed = list(
-		/datum/matchmaking_pref/friend = list(
-			/datum/job/oasis
-		),
-		/datum/matchmaking_pref/rival = list(
-			/datum/job/oasis
-		)
-	)
-
-/datum/outfit/job/den/f13shopkeeper
-	name = "Shopkeeper"
-	jobtype = /datum/job/oasis/f13shopkeeper
-	id = /obj/item/card/id/dogtag/town
-	ears = /obj/item/radio/headset/headset_town/commerce
-	belt = /obj/item/kit_spawner/townie
-	uniform = /obj/item/clothing/under/f13/roving
-	backpack = /obj/item/storage/backpack
-	satchel = /obj/item/storage/backpack/satchel
-	duffelbag = /obj/item/storage/backpack/duffelbag
-	gloves = /obj/item/clothing/gloves/fingerless
-	l_pocket = /obj/item/storage/wallet/stash/high
-	r_pocket = /obj/item/flashlight/glowstick
-	shoes = /obj/item/clothing/shoes/f13/explorer
-	backpack_contents = list(
-		/obj/item/pda = 1,
-		/obj/item/kit_spawner/tools,
-		/obj/item/storage/pill_bottle/chem_tin/radx)
-
-/datum/outfit/loadout/energy_specialist
-	name = "Energy Specialist"
-	backpack_contents = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/aer9=1,
-		/obj/item/book/granter/crafting_recipe/blueprint/lightplasmapistol=1
-	)
-
-/datum/outfit/loadout/ballistic_specialist
-	name = "Ballistic Specialist"
-	backpack_contents = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/riotshotgun=1,
-		/obj/item/book/granter/crafting_recipe/blueprint/deagle=1
-	)
-
-/datum/outfit/loadout/jackofall_specialist
-	name = "Jack-Of-All Trade"
-	backpack_contents = list(
-		/obj/item/book/granter/crafting_recipe/blueprint/aep7=1,
-		/obj/item/book/granter/crafting_recipe/blueprint/uzi=1
-	)
-
-/datum/outfit/job/den/f13shopkeeper/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/policepistol)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/policerifle)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steelbib/heavy)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/armyhelmetheavy)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalradio)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/durathread_vest)
-	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
-	ADD_TRAIT(H, TRAIT_GENERIC, src)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lever_action)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/a180)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingshotgun)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/thatgun)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/frag_shrapnel)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/explosive/shrapnelmine)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pico_manip)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_matter_bin)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedenergycell)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedmfcell)
-	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedecp)
-
-/datum/outfit/job/den/f13shopkeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
 
 
 //pilot job, bare basics rn, but we can add as needed
@@ -1686,13 +1435,124 @@ Mayor
 	)
 
 
-// Practitioner
+// Guild Adventurers
 
+//Guild Worker
+
+/datum/job/oasis/f13shopkeeper
+	title = "Guild Shopkeeper"
+	flag = GUILDSHOPKEEP
+	department_flag = GUILD
+	total_positions = -1
+	spawn_positions = -1
+	supervisors = "the free market."
+	description = "You are one of the many workers who live in the city of New Boston. Working with the town council you have rented out a space in the shop for you to make your living."
+	enforces = "The New Bostonstore is part of your workplace, but it is not your workplace alone. You should try work with the other trade workers to try and turn a profit."
+	selection_color = "#dcba97"
+	exp_requirements = 0
+
+	loadout_options = list(
+	/datum/outfit/loadout/energy_specialist,
+	/datum/outfit/loadout/ballistic_specialist,
+	/datum/outfit/loadout/jackofall_specialist
+	)
+
+	outfit = /datum/outfit/job/den/f13shopkeeper
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/friend = list(
+			/datum/job/oasis
+		),
+		/datum/matchmaking_pref/rival = list(
+			/datum/job/oasis
+		)
+	)
+
+/datum/outfit/job/den/f13shopkeeper
+	name = "Shopkeeper"
+	jobtype = /datum/job/oasis/f13shopkeeper
+	id = /obj/item/card/id/dogtag/town
+	ears = /obj/item/radio/headset/headset_town/commerce
+	belt = /obj/item/kit_spawner/townie
+	uniform = /obj/item/clothing/under/f13/roving
+	backpack = /obj/item/storage/backpack
+	satchel = /obj/item/storage/backpack/satchel
+	duffelbag = /obj/item/storage/backpack/duffelbag
+	gloves = /obj/item/clothing/gloves/fingerless
+	l_pocket = /obj/item/storage/wallet/stash/high
+	r_pocket = /obj/item/flashlight/glowstick
+	shoes = /obj/item/clothing/shoes/f13/explorer
+	backpack_contents = list(
+		/obj/item/pda = 1,
+		/obj/item/kit_spawner/tools,
+		/obj/item/storage/pill_bottle/chem_tin/radx)
+
+/datum/outfit/loadout/energy_specialist
+	name = "Energy Specialist"
+	backpack_contents = list(
+		/obj/item/book/granter/crafting_recipe/blueprint/aer9=1,
+		/obj/item/book/granter/crafting_recipe/blueprint/lightplasmapistol=1
+	)
+
+/datum/outfit/loadout/ballistic_specialist
+	name = "Ballistic Specialist"
+	backpack_contents = list(
+		/obj/item/book/granter/crafting_recipe/blueprint/riotshotgun=1,
+		/obj/item/book/granter/crafting_recipe/blueprint/deagle=1
+	)
+
+/datum/outfit/loadout/jackofall_specialist
+	name = "Jack-Of-All Trade"
+	backpack_contents = list(
+		/obj/item/book/granter/crafting_recipe/blueprint/aep7=1,
+		/obj/item/book/granter/crafting_recipe/blueprint/uzi=1
+	)
+
+/datum/outfit/job/den/f13shopkeeper/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/policepistol)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/policerifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/steelbib/heavy)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/armyhelmetheavy)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/tribalradio)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/durathread_vest)
+	ADD_TRAIT(H, TRAIT_TECHNOPHREAK, src)
+	ADD_TRAIT(H, TRAIT_GENERIC, src)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/trail_carbine)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/lever_action)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/a180)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/varmintrifle)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/huntingshotgun)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/thatgun)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/uzi)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/smg10mm)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/frag_shrapnel)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/concussion)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/explosive/shrapnelmine)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/pico_manip)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_matter_bin)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/phasic_scanning)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/super_capacitor)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/ultra_micro_laser)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedenergycell)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedmfcell)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/enhancedecp)
+
+/datum/outfit/job/den/f13shopkeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(visualsOnly)
+		return
+
+//Guild Medic
 /datum/job/oasis/f13practitioner
-	title = "Town Doctor"
-	flag = F13PRACTITIONER
-	department_flag = FOLLOWERS
-	faction = "Followers"
+	title = "Guild Medic"
+	flag = GUILDMEDIC
+	department_flag = GUILD
+	faction = "Guild"
 	total_positions = -1
 	spawn_positions = -1
 	supervisors = "Generally speaking your only actual supervisor is your own judgement. Assuming they're around."
@@ -1702,6 +1562,8 @@ Mayor
 	exp_requirements = 0
 
 	outfit = /datum/outfit/job/den/f13practitioner
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
 	matchmaking_allowed = list(
 		/datum/matchmaking_pref/friend = list(
 			/datum/job/oasis/f13practitioner,
@@ -1746,7 +1608,7 @@ Mayor
 	ADD_TRAIT(H, TRAIT_CYBERNETICIST, src)
 
 /datum/outfit/job/den/f13practitioner
-	name =	"Town Doctor"
+	name =	"Guild Medic"
 	jobtype =	/datum/job/oasis/f13practitioner
 	uniform =	/obj/item/clothing/under/f13/followers
 	id =	/obj/item/card/id/silver
@@ -1807,3 +1669,316 @@ Mayor
 		/obj/item/pda/medical = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/book/granter/trait/techno = 1,)
+
+//GUILD BANKER
+
+/datum/job/oasis/f13banker
+	title = "Guild Banker"
+	flag = GUILDBANKER
+	department_flag = GUILD
+	faction = "Guild"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "The Mayor"
+	description = "No matter the nature of society, fortune and profit are there to be made! It is up to you to make deals, distribute caps and earn interest - an easy first venture might be safekeeping possessions in the strongboxes of your vault within the First Bank of New Boston. Ensure you make a profit and retain enough capital for your day-to-day operations. You are under the governance of New Boston, but perhaps deal-making will take you into other alliances."
+	enforces = "Your bank is a private business and you are not under direct control of local governance, but are subject to their laws."
+	selection_color = "#dcba97"
+	outfit = /datum/outfit/job/den/f13banker
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+
+	loadout_options = list(
+	/datum/outfit/loadout/classy,
+	/datum/outfit/loadout/loanshark,
+	/datum/outfit/loadout/investor
+	)
+
+/datum/outfit/job/den/f13banker
+	name = "Banker"
+	jobtype = /datum/job/oasis/f13banker
+	belt = /obj/item/kit_spawner/townie/mayor
+
+	uniform = /obj/item/clothing/under/lawyer/blacksuit
+	id = /obj/item/card/id/silver
+	ears = /obj/item/radio/headset/headset_town/commerce
+	shoes = /obj/item/clothing/shoes/f13/fancy
+	backpack = /obj/item/storage/backpack/satchel/leather
+	satchel = /obj/item/storage/backpack/satchel/leather
+	backpack_contents = list(
+		/obj/item/storage/pill_bottle/chem_tin/radx,
+		/obj/item/kit_spawner/tools,
+		/obj/item/pda = 1,
+		/obj/item/storage/wallet/stash/banker = 1)
+
+/datum/outfit/loadout/classy
+	name = "Classy"
+	head = /obj/item/clothing/head/collectable/tophat
+	glasses = /obj/item/clothing/glasses/monocle
+	uniform = /obj/item/clothing/under/suit_jacket/charcoal
+	suit = /obj/item/clothing/suit/armor/outfit/jacket/banker
+	gloves = /obj/item/clothing/gloves/color/white
+	shoes = /obj/item/clothing/shoes/laceup
+	backpack_contents = list(/obj/item/cane=1,
+		///obj/item/storage/belt/shoulderholster/ranger45 =1,
+		/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+		/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+		/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass=1,
+		/obj/item/lighter/gold = 1
+		)
+
+/datum/outfit/loadout/loanshark
+	name = "Loanshark"
+	glasses = /obj/item/clothing/glasses/orange
+	mask = /obj/item/clothing/mask/cigarette/cigar
+	suit = /obj/item/clothing/suit/armor/outfit/vest
+	uniform = /obj/item/clothing/under/f13/sleazeball
+	shoes = /obj/item/clothing/shoes/sandal
+	backpack_contents = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey=1,
+		/obj/item/storage/box/matches=1,
+		///obj/item/gun/ballistic/automatic/smg/mini_uzi=1,
+		/obj/item/instrument/violin/golden = 1
+		)
+
+/datum/outfit/loadout/investor
+	name = "Investor"
+	glasses = /obj/item/clothing/glasses/sunglasses
+	suit = /obj/item/clothing/suit/toggle/lawyer/black
+	uniform = /obj/item/clothing/under/f13/bennys
+	gloves = /obj/item/clothing/gloves/fingerless
+	shoes = /obj/item/clothing/shoes/laceup
+	backpack_contents = list(/obj/item/storage/fancy/cigarettes/cigpack_bigboss=1,
+		/obj/item/storage/box/matches=1,
+		/obj/item/ingot/gold = 1,
+		///obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever = 1
+		)
+
+//Guild Librarian
+
+/datum/job/oasis/nashcurator
+	title = "Guild Librarian"
+	flag = GUILDLIBRARIAN
+	department_flag = GUILD
+	faction = "Guild"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "New Boston's laws"
+	description = "You are a Curator for the library of New Boston. Assist people with writing books, be a journalist, stock the shelves."
+	selection_color = "#dcba97"
+
+	outfit = /datum/outfit/job/den/nashcurator
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/friend = list(
+			/datum/job/oasis
+		),
+		/datum/matchmaking_pref/rival = list(
+			/datum/job/oasis
+		)
+	)
+
+/datum/outfit/job/den/nashcurator
+	name = "New Boston Librarian"
+	jobtype = /datum/job/oasis/nashcurator
+	belt = /obj/item/kit_spawner/townie
+	id = /obj/item/card/id/dogtag/town
+	uniform = /obj/item/clothing/under/f13/settler
+	shoes = /obj/item/clothing/shoes/jackboots
+	backpack = /obj/item/storage/backpack/satchel/explorer
+	r_pocket = /obj/item/flashlight/flare
+	backpack_contents = list(
+		/obj/item/storage/pill_bottle/chem_tin/radx,
+		/obj/item/storage/wallet/stash/mid = 1,
+		/obj/item/folder/white = 1,
+		/obj/item/pda = 1,
+		/obj/item/pen/fountain/captain,
+		/obj/item/kit_spawner/tools,
+		/obj/item/export_scanner,
+		/obj/item/key/displaycase,
+		)
+
+/datum/outfit/job/den/nashcurator/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	uniform = pick(
+		/obj/item/clothing/under/f13/gentlesuit,
+		/obj/item/clothing/under/f13/formal,
+		/obj/item/clothing/under/f13/spring,
+		/obj/item/clothing/under/f13/relaxedwear,
+		/obj/item/clothing/under/f13/machinist,
+		/obj/item/clothing/under/f13/brahminf,
+		/obj/item/clothing/under/f13/cowboyb,
+		/obj/item/clothing/under/f13/cowboyg,
+		/obj/item/clothing/under/f13/cowboyt)
+
+//Guild Bartender
+
+/datum/job/oasis/f13barkeep
+	title = "Guild Bartender"
+	flag = GUILDBARTEND
+	department_flag = GUILD
+	faction = "Guild"
+	total_positions = -1
+	spawn_positions = -1
+	supervisors = "the free market and New Boston's Laws"
+	description = "As a proprietor of Heavens Night, you are responsible for ensuring both citizens and travellers in New Bostoncan get some food, drink and rest. Speak to the farmers for fresh produce!"
+	enforces = "Heaven's Night is a private business and you can decide who is welcome there. However, you are still subject to the overarching laws of New Boston."
+	selection_color = "#dcba97"
+
+	outfit = /datum/outfit/job/den/f13barkeep
+
+	loadout_options = list(
+	/datum/outfit/loadout/rugged,
+	/datum/outfit/loadout/frontier,
+	/datum/outfit/loadout/richmantender,
+	/datum/outfit/loadout/diner)
+
+	access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	minimal_access = list(ACCESS_BAR, ACCESS_CARGO_BOT, ACCESS_CARGO, ACCESS_GUILD)
+	matchmaking_allowed = list(
+		/datum/matchmaking_pref/friend = list(
+			/datum/job/oasis
+		),
+		/datum/matchmaking_pref/rival = list(
+			/datum/job/oasis
+		)
+	)
+
+
+/datum/outfit/job/den/f13barkeep
+	name = "Barkeep"
+	jobtype = /datum/job/oasis/f13barkeep
+	uniform = /obj/item/clothing/under/f13/bartenderalt
+	id = /obj/item/card/id/dogtag/town
+	ears = /obj/item/radio/headset/headset_town/commerce
+	belt = /obj/item/kit_spawner/townie/barkeep
+	shoes = /obj/item/clothing/shoes/workboots/mining
+	backpack = /obj/item/storage/backpack/satchel/leather
+	backpack_contents = list(
+		/obj/item/storage/pill_bottle/chem_tin/radx,
+		/obj/item/storage/wallet/stash/mid = 1,
+	//	/obj/item/ammo_box/shotgun/bean = 2,
+		/obj/item/book/manual/nuka_recipes = 1,
+		/obj/item/stack/f13Cash/caps/onezerozero = 1,
+		/obj/item/pda = 1,
+		/obj/item/kit_spawner/tools,
+		/obj/item/reagent_containers/food/drinks/bottle/rotgut = 1
+		)
+
+/datum/outfit/loadout/rugged
+	name = "Rugged"
+	head = /obj/item/clothing/head/helmet/f13/brahmincowboyhat
+	uniform = /obj/item/clothing/under/f13/cowboyb
+	suit = /obj/item/clothing/suit/armor/outfit/vest/cowboy
+	gloves = /obj/item/clothing/gloves/color/brown
+	shoes = /obj/item/clothing/shoes/f13/brownie
+
+/datum/outfit/loadout/frontier
+	name = "Frontier"
+	head = /obj/item/clothing/head/bowler
+	mask = /obj/item/clothing/mask/fakemoustache
+	uniform = /obj/item/clothing/under/f13/westender
+	suit = /obj/item/clothing/suit/armor/outfit/vest/bartender
+	gloves = /obj/item/clothing/gloves/fingerless
+	shoes = /obj/item/clothing/shoes/f13/fancy
+
+/datum/outfit/loadout/richmantender
+	name = "Fancy"
+	head = /obj/item/clothing/head/fedora
+	glasses = /obj/item/clothing/glasses/sunglasses
+	uniform = /obj/item/clothing/under/rank/bartender
+	suit = /obj/item/clothing/suit/toggle/lawyer/black
+	gloves = /obj/item/clothing/gloves/fingerless
+	shoes = /obj/item/clothing/shoes/f13/fancy
+	neck = /obj/item/clothing/neck/tie/black
+
+/datum/outfit/loadout/diner
+	name = "Diner"
+	glasses = /obj/item/clothing/glasses/orange
+	uniform = /obj/item/clothing/under/f13/brahminf
+	neck = /obj/item/clothing/neck/apron/chef
+	gloves = /obj/item/clothing/gloves/color/white
+	shoes = /obj/item/clothing/shoes/f13/military/ncr
+
+//Guild Knight
+
+/datum/job/followers/f13followerguard
+	title = "Guild Knight"
+	flag = GUILDKNIGHT
+	department_flag = GUILD
+	faction = "Guild"
+	total_positions = 0
+	spawn_positions = 3
+	supervisors = "Generally speaking your only actual supervisor is your own judgement, but it might not be amiss to listen to the Mayor and Doctors. Assuming they're around."
+	description = "You are one of the towns Paramedics.  Your job is to prepare parties to go out and try and help those in need that can't make it to the hospital on their own. Be that shooting your way to them or seeking them out with a rescue party."
+	enforces = "Assist and provide medical services to those in need. Provide education for all those who are willing to learn."
+	selection_color = "#FFDDFF"
+
+	outfit = /datum/outfit/job/followers/f13followerguard
+
+
+	loadout_options = list(
+	/datum/outfit/loadout/thelaw,
+	/datum/outfit/loadout/thechief,
+	/datum/outfit/loadout/thedictator
+	)
+
+	access = list(ACCESS_FOLLOWER, ACCESS_MILITARY)
+	minimal_access = list(ACCESS_FOLLOWER, ACCESS_MILITARY)
+
+/datum/outfit/job/followers/f13followerguard
+	name =	"Knight"
+	jobtype =	/datum/job/followers/f13followerguard
+	belt = /obj/item/kit_spawner/follower/guard
+	id =	/obj/item/card/id/silver
+	uniform =	/obj/item/clothing/under/f13/bodyguard
+	suit =	/obj/item/clothing/suit/armor/medium/vest/bulletproof/big
+	head =	/obj/item/clothing/head/helmet/riot/vaultsec
+	glasses =	/obj/item/clothing/glasses/sunglasses
+	shoes =	/obj/item/clothing/shoes/combat
+	l_pocket =	/obj/item/storage/belt/shoulderholster
+	backpack =	/obj/item/storage/backpack/explorer
+	satchel =	/obj/item/storage/backpack/satchel/explorer
+	backpack_contents = list(
+		/obj/item/pda = 1,
+		/obj/item/storage/survivalkit/medical/follower = 1,
+		/obj/item/gun/energy/laser/complianceregulator = 1,
+		/obj/item/flashlight/seclite = 1,
+		/obj/item/storage/firstaid/ancient = 1,
+		/obj/item/stock_parts/cell/ammo/ec = 2,
+		/obj/item/storage/belt/army/followers = 1,
+		/obj/item/storage/wallet/stash/mid = 1,
+	)
+
+/datum/outfit/loadout/thelaw
+	name = "The Law Man"
+	suit = /obj/item/clothing/suit/armor/medium/duster/town/sheriff
+	head = /obj/item/clothing/head/f13/town/sheriff
+	uniform = /obj/item/clothing/under/f13/police/formal
+	neck = /obj/item/storage/belt/shoulderholster
+	r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
+	shoes = /obj/item/clothing/shoes/f13/military/plated
+
+	backpack_contents = list(
+	/obj/item/ammo_box/tube/c4570 = 3,
+	/obj/item/gun_upgrade/scope/watchman = 1
+	)
+
+/datum/outfit/loadout/thechief
+	name = "The Chief"
+	uniform = /obj/item/clothing/under/f13/police/chief
+	suit = /obj/item/clothing/suit/armor/medium/duster/town/chief
+	head = /obj/item/clothing/head/f13/town/chief
+	neck = /obj/item/storage/belt/shoulderholster/ranger45
+	shoes = /obj/item/clothing/shoes/combat
+	r_hand = /obj/item/gun/ballistic/shotgun/automatic/combat/citykiller
+	backpack_contents = list(/obj/item/ammo_box/shotgun/slug = 1,
+	/obj/item/ammo_box/shotgun/buck = 2
+	)
+
+/datum/outfit/loadout/thedictator
+	name = "The Dictator"
+	uniform = /obj/item/clothing/under/f13/police/chief
+	suit = /obj/item/clothing/suit/armor/medium/duster/town/sheriff
+	r_hand = /obj/item/gun/energy/laser/scatter
+	backpack_contents = list(/obj/item/stock_parts/cell/ammo/mfc = 1,
+	)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -328,6 +328,15 @@ GLOBAL_LIST_INIT(followers_positions, list(
 	"Nurse",
 	"Senior Scientist",
 ))
+
+GLOBAL_LIST_INIT(guild_positions, list(
+	"Guild Librarian",
+	"Guild Medic",
+	"Guild Shopkeeper",
+	"Guild Bartender",
+	"Guild Knight"
+))
+
 //Heavens Night
 GLOBAL_LIST_INIT(heavensnight_positions, list(
 	"Club Manager",
@@ -347,6 +356,7 @@ GLOBAL_LIST_INIT(position_categories, list(
 	// EXP_TYPE_KHAN = list("jobs" = khan_positions, "color" = "#006666"),
 	"New Boston" = list("jobs" = oasis_positions, "color" = "#d7b088"),
 	"Den" = list("jobs" = den_positions, "color" = "#d7b088"),
+	"Guild" = list("jobs" = guild_positions, "color" = "#d45b3d"),
 	//"Garland" = list("jobs" = gar_positions, "color" = "#d7b088"),
 	EXP_TYPE_SILICON = list("jobs" = silicon_positions, "color" = "#4a4a4a"),
 	EXP_TYPE_TRIBAL = list("jobs" = tribal_positions, "color" = "#006666"),
@@ -373,6 +383,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_OUTLAW = list("titles" = list("Outlaw","Den Mob Boss","Den Mob Enforcer","Den Doctor",)),
 	EXP_TYPE_BROTHERHOOD = list("titles" = brotherhood_positions),
 	EXP_TYPE_OASIS = list("titles" = oasis_positions ),
+	EXP_TYPE_GUILD = list("titles" = guild_positions ),
 	EXP_TYPE_LEGION = list("titles" = legion_positions),
 	EXP_TYPE_NCR = list("titles" = ncr_positions),
 	EXP_TYPE_VAULT = list("titles" = vault_positions),

--- a/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wasteanimals.dm
@@ -875,6 +875,11 @@
 	make_a_nest = /obj/effect/proc_holder/mob_common/make_nest/molerat
 	. = ..()
 
+/mob/living/simple_animal/hostile/molerat/Initialize()
+	.=..()
+	resize = 0.5
+	update_transform()
+
 /mob/living/simple_animal/hostile/gelcube
 	name = "gelatinous cube"
 	desc = "A big green radioactive cube creature, it jiggles with menacing wiggles and is making some sort of goofy face at you."


### PR DESCRIPTION
- Integrates Clinic into Guild Space
- Integrates Clinic upstairs into Guild Space
- Re-enlarges the Bank space slightly, but should make it more streamlined
- Integrates Bar into Guild Space
- Integrates Library into Guild Space
- Moves Farm to where Clinic was
- Overhauls main area of Heavens Night (not the park)
- Moves Well of Souls into the Dump (lol)
- More Green space in New Boston

Needs some things done, hopefully @PrettyPsychoForAWolf can do me some stuff today and we can roll this out this afternoon.

To do

- [x] Break Guild Worker into...
- [x] Guild Shopkeep
- [x] Guild Banker
- [x] Guild Medic
- [x] Guild Bartender
- [x] Guild Librarian
  
- [x] Unify all the Guild jobs equipment.  Same headsets, same starting gear (for the most part, obvs librarian has set gear, others may as well
- [x] Make sure all of the guild jobs share full access across the board.
- [x] Make sure they all use the Citizen gear and weapons kits