### PR TITLE
Saddle Storage Fixes

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -269,3 +269,10 @@
 	. = ..()
 	can_hold = GLOB.ammobelt_allowed
 	can_hold |= GLOB.gunbelt_allowed
+
+/// Saddle-bags
+/datum/component/storage/concrete/pockets/saddlebag
+	max_items = STORAGE_BELT_HOLSTER_MAX_ITEMS
+	max_w_class = STORAGE_BELT_HOLSTER_MAX_SIZE
+	max_combined_w_class = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE
+	max_volume = STORAGE_BELT_HOLSTER_MAX_TOTAL_SPACE

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -2100,7 +2100,7 @@
 	icon_state = "taursaddle"
 	item_state = "taursaddle"
 	mutantrace_variation = STYLE_ALL_TAURIC
-	pocket_storage_component_path = /datum/component/storage/concrete/pockets/armor
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/saddlebag
 ////////////////////////////////////////////////////////////////
 
 /obj/item/clothing/suit/armor/taursaddle/light
@@ -2116,7 +2116,6 @@
 	strip_delay = 10
 	equip_delay_other = 10
 	max_integrity = 100
-	pocket_storage_component_path = null
 	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_LIGHT
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
@@ -2136,7 +2135,6 @@
 	strip_delay = 30
 	equip_delay_other = 50
 	max_integrity = 200
-	pocket_storage_component_path = null
 	slowdown = ARMOR_SLOWDOWN_MEDIUM * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_MEDIUM
 	armor_tier_desc = ARMOR_CLOTHING_MEDIUM
@@ -2152,7 +2150,6 @@
 	strip_delay = 50
 	equip_delay_other = 50
 	max_integrity = 300
-	pocket_storage_component_path = null
 	slowdown = ARMOR_SLOWDOWN_HEAVY * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor = ARMOR_VALUE_HEAVY
 	armor_tier_desc = ARMOR_CLOTHING_HEAVY


### PR DESCRIPTION
## About The Pull Request
Saddles can now actually hold items. They can hold about as much as a belt, which feels fitting for saddlebags.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: a new pocket type for "saddlebags"
tweak: gave all taur-saddles the new "saddlebag" pocket type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
