### PR TITLE
Bazonger fix

### DIFF
--- a/code/modules/arousal/genitals_sprite_accessories.dm
+++ b/code/modules/arousal/genitals_sprite_accessories.dm
@@ -151,7 +151,7 @@
 	icon_state = "udders"
 	name = "Udders"
 
-/datum/sprite_accessory/breasts/pair_round
+/datum/sprite_accessory/breasts/pairround
 	icon_state = "pairround"
 	name = "Pair(round)"
 

--- a/code/modules/arousal/organs/breasts.dm
+++ b/code/modules/arousal/organs/breasts.dm
@@ -77,6 +77,8 @@ GLOBAL_LIST_INIT(massive_breast_descriptors, list(
 			out["BitName"] = "A set of udders."
 		if("pair")
 			out["BitName"] = "A pair of breasts."
+		if("pairround")
+			out["BitName"] = "A pair of breasts."
 		else
 			out["BitName"] = "A [shape]-set of breasts."
 	out["BitSize"] = "They are a [uppertext(size)]-cup."
@@ -91,6 +93,8 @@ GLOBAL_LIST_INIT(massive_breast_descriptors, list(
 	var/lowershape = lowertext(shape)
 	switch(lowershape)
 		if("pair")
+			desc = "You see a pair of breasts."
+		if("pairround")
 			desc = "You see a pair of breasts."
 		if("quad")
 			desc = "You see two pairs of breast, one just under the other."


### PR DESCRIPTION
## About The Pull Request
Fixes the description for the new "Pair(round)" breast shape to display the same description for a regular pair of breasts rather than "exotic"

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: breast descriptions for new breast shape
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
