### PR TITLE
Allow the pacifist flower to be in the loadout

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -97,8 +97,8 @@ Slimecrossing Armor
 		new /obj/structure/light_prism(get_turf(owner), glasses.glasses_color)
 
 /obj/item/clothing/head/peaceflower
-	name = "heroine bud"
-	desc = "An extremely addictive flower, full of peace magic."
+	name = "entrancing bud"
+	desc = "An extremely addictive flower, full of peace magic. This rare flower is not often seen due to its entrancing pacifying effects when worn."
 	icon = 'icons/obj/slimecrossing.dmi'
 	icon_state = "peaceflower"
 	item_state = "peaceflower"

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -1300,6 +1300,11 @@
 	path = /obj/item/reagent_containers/food/snacks/grown/harebell
 	subcategory = LOADOUT_SUBCATEGORY_HEAD_GENERAL
 
+/datum/gear/head/peaceflower
+	name = "peaceflower"
+	path = /obj/item/clothing/head/peaceflower //This is a xenobiology product that makes the wearer a pacifist, and unable to take off the flower without help, looks very pretty tho.
+	subcategory = LOADOUT_SUBCATEGORY_HEAD_GENERAL
+
 /datum/gear/head/sunflower
 	name = "sun flower"
 	path = /obj/item/grown/sunflower


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Allows the pacifist flower to be added to the loadout. It looks very pretty, unlike actual flowers, it cannot be grown or turned into seeds, its just a hat that makes you a pacifist. Despite the code, you can remove it by click dragging to your hand.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
