### PR TITLE
Guild radio fix

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -228,8 +228,8 @@
 #define MODE_HOLOPAD "holopad"
 
 #define MODE_CHANGELING "changeling"
-#define MODE_KEY_CHANGELING "g"
-#define MODE_TOKEN_CHANGELING ":g"
+#define MODE_KEY_CHANGELING "a"
+#define MODE_TOKEN_CHANGELING ":a"
 
 #define MODE_VOCALCORDS "cords"
 #define MODE_KEY_VOCALCORDS "x"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -201,7 +201,7 @@
 	channels = list(RADIO_CHANNEL_TOWN = 1, RADIO_CHANNEL_TOWN_COMMERCE = 1)
 
 /obj/item/encryptionkey/headset_town/guild
-	name = "New Boston commercial guild encryption key"
+	name = "New Boston guild encryption key"
 	desc = "An encryption key for a radio headset.\
 		\nTo access the Nash channel, use :f.\
 		\nTo access the Nash guild channel, use :g"


### PR DESCRIPTION
## About The Pull Request
redefines the "changeling" mode keys so that it's no longer conflicting with the guild key, letting the radio now work.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: guild radio key and changeling mode key conflict
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
