### PR TITLE
Fixing toxins hunger processing on mechs

### DIFF
--- a/modular_coyote/code/creature_species.dm
+++ b/modular_coyote/code/creature_species.dm
@@ -1196,7 +1196,7 @@
 	icon_dead_suffix = "_dead"
 	icon_rest_suffix = ""
 	species_traits = list(FERAL,NOZOMBIE,NO_UNDERWEAR,MUTCOLORS,NOTRANSSTING,EYECOLOR,ROBOTIC_LIMBS,NO_DNA_COPY,NOEYES,LIPS,)
-	inherent_traits = list(TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_NO_PROCESS_FOOD,TRAIT_RADIMMUNE,TRAIT_NOBREATH,TRAIT_CLONEIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_MUTATION_STASIS,)
+	inherent_traits = list(TRAIT_NODISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_NO_PROCESS_FOOD,TRAIT_RADIMMUNE,TRAIT_NOBREATH,TRAIT_CLONEIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_MUTATION_STASIS,)
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID|MOB_BEAST|MOB_SYNTH
 	//Just robo looking parts.
 	mutant_heart = /obj/item/organ/heart/ipc
@@ -1220,6 +1220,7 @@
 	damage_overlay_type = null
 	exotic_bloodtype = "S"
 	exotic_blood_color = BLOOD_COLOR_OIL
+	species_type = "robotic" // It was just missing this little thing, I found it in ipc.dm. Hopefully this stops mechs from bleeding/getting wounds
 
 /datum/species/adapted/handle_mutations_and_radiation(mob/living/carbon/human/H)
 	return TRUE

--- a/modular_coyote/code/creature_species.dm
+++ b/modular_coyote/code/creature_species.dm
@@ -1224,7 +1224,7 @@
 /datum/species/adapted/handle_mutations_and_radiation(mob/living/carbon/human/H)
 	return TRUE
 
-/datum/species/adapted(mob/living/carbon/human/H)
+/datum/species/adapted/spec_life(mob/living/carbon/human/H)
 	if(H.nutrition < NUTRITION_LEVEL_FED)
 		H.nutrition = NUTRITION_LEVEL_FED
 	if(H.nutrition > NUTRITION_LEVEL_FED)

--- a/modular_coyote/code/creature_species.dm
+++ b/modular_coyote/code/creature_species.dm
@@ -1195,8 +1195,8 @@
 	gib_types = list(/obj/effect/gibspawner/ipc, /obj/effect/gibspawner/ipc/bodypartless)
 	icon_dead_suffix = "_dead"
 	icon_rest_suffix = ""
-	species_traits = list(FERAL,NOZOMBIE,NO_UNDERWEAR,MUTCOLORS,NOTRANSSTING,EYECOLOR,ROBOTIC_LIMBS,NO_DNA_COPY,NOEYES,CAN_SCAR,LIPS,)
-	inherent_traits = list(TRAIT_NODISMEMBER,TRAIT_NOLIMBDISABLE,TRAIT_NOHUNGER,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_CLONEIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_MUTATION_STASIS,TRAIT_NO_PROCESS_FOOD,)
+	species_traits = list(FERAL,NOZOMBIE,NO_UNDERWEAR,MUTCOLORS,NOTRANSSTING,EYECOLOR,ROBOTIC_LIMBS,NO_DNA_COPY,NOEYES,LIPS,)
+	inherent_traits = list(TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_NO_PROCESS_FOOD,TRAIT_RADIMMUNE,TRAIT_NOBREATH,TRAIT_CLONEIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_MUTATION_STASIS,)
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID|MOB_BEAST|MOB_SYNTH
 	//Just robo looking parts.
 	mutant_heart = /obj/item/organ/heart/ipc
@@ -1218,10 +1218,21 @@
 	allowed_limb_ids = list("mammal","aquatic","avian", "human", "shadekin")
 	rotate_on_lying = TRUE
 	damage_overlay_type = null
-	tail_type = "mam_tail"
-	wagging_type = "mam_waggingtail"
 	exotic_bloodtype = "S"
 	exotic_blood_color = BLOOD_COLOR_OIL
+
+/datum/species/adapted/handle_mutations_and_radiation(mob/living/carbon/human/H)
+	return TRUE
+
+/datum/species/adapted(mob/living/carbon/human/H)
+	if(H.nutrition < NUTRITION_LEVEL_FED)
+		H.nutrition = NUTRITION_LEVEL_FED
+	if(H.nutrition > NUTRITION_LEVEL_FED)
+		H.nutrition = NUTRITION_LEVEL_FED
+	if(H.losebreath != 0)
+		H.losebreath = 0 // just in case
+	if(H.toxloss)
+		H.adjustToxLoss(-H.toxloss)
 
 /datum/species/adapted/thicktron_standard
 	name = "Adapted Assaultron"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This should fix toxins processing and hunger on mechs. The reason why I added easy dismember instead of nodismember is that I don't think its possible to dismember people regardless of the traits, and I wanted to make it as close as possible to synthliz.dm so that sleep healing hopefully works on mechs. 
!! I cannot test these changes, because my test server really hates the adapted species, and they do not appear regardless of what I do !!
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
