### PR TITLE
Makes experienced builders atleast 6900% more powerful

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/misc.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/misc.dm
@@ -39,7 +39,7 @@
 	name = "brick launcher chamber"
 	ammo_type = /obj/item/ammo_casing/caseless/brick
 	caliber = list(CALIBER_BRICK)
-	max_ammo = 1
+	max_ammo = 3
 	can_change_caliber = FALSE
 
 // BETA STUFF // Obsolete


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
The brick launcher can (supposedly) hold 3 bricks instead of 1, each brick is about 60 damage, compared to many other options, I think this is balanced and make it a weapon instead of a gimmick
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
