### PR TITLE
RnD Telescopic Riot Shield design fix

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -458,7 +458,7 @@
 	id = "tele_shield"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 4000, /datum/material/silver = 300, /datum/material/titanium = 200)
-	build_path = /obj/item/shield/riot
+	build_path = /obj/item/shield/riot/tele
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 


### PR DESCRIPTION
Makes /obj/item/shield/riot for the tele shield be /obj/item/shield/riot/tele. It was giving a regular ol riot shield instead of the telescopic one.