### PR TITLE
Adds crafty and tinkerer traits, and standardizes mob buckling

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -629,6 +629,18 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 		H.mind.learned_recipes -= GLOB.pa_repair
 		H.mind.learned_recipes -= GLOB.armored_hazard_suit
 
+/datum/quirk/crafty
+	name = "Crafty"
+	desc = "You are able to craft without the necessities provided by a traditional workbench."
+	value = 1
+	category = "Lifepath Quirks"
+	mechanics = "You do not need a workbench or alchemy table when crafting."
+	human_only = FALSE
+/datum/quirk/crafty/on_spawn()
+	var/mob/living/H = quirk_holder
+	new /obj/machinery/workbench(H)
+	new /obj/machinery/chem_master/primitive(H)
+
 /datum/quirk/gunsmith
 	name = "Weaponsmith - Basic"
 	desc = "You know how to make various weapons, protective vests, gun mods, and can now forge weapons at an anvil. The list is too large to try and put here."

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -632,7 +632,7 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 /datum/quirk/crafty
 	name = "Crafty"
 	desc = "You are able to craft without the necessities provided by a traditional workbench."
-	value = 1
+	value = 25
 	category = "Lifepath Quirks"
 	mechanics = "You do not need a workbench or alchemy table when crafting."
 	human_only = FALSE
@@ -2711,6 +2711,48 @@ GLOBAL_LIST_INIT(weapons_of_texarkana, list(
 	if(!QDELETED(H))
 		REMOVE_TRAIT(H, TRAIT_NIGHT_VISION, "Dark Vision - Minor")
 		REMOVE_TRAIT(H, TRAIT_SOFT_YARDS, "Mobility - Wasteland Wanderer")
+
+/datum/quirk/package/tinkerer
+	name = "Tinker-er"
+	desc = "You are able to craft without a traditional workbench, as well as craft more and gain more from salvage"
+	value = 85
+	category = "Quirk Packages"
+	mechanics = "You don't need a workbench or alchemy table when crafting, get more recipes, and gain 1-3 more from salvaging"
+	human_only = FALSE
+	conflicts = list(
+		/datum/quirk/tribal,
+		/datum/quirk/dumb,
+		/datum/quirk/luddite,
+		/datum/quirk/primitive,
+		/datum/quirk/technophreak,
+		/datum/quirk/crafty
+		)
+	mob_trait = TRAIT_TECHNOPHREAK
+
+/datum/quirk/package/tinkerer/on_spawn()
+	var/mob/living/H = quirk_holder
+	new /obj/machinery/workbench(H)
+	new /obj/machinery/chem_master/primitive(H)
+
+/datum/quirk/package/tinkerer/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	// I made the quirks add the same recipes as the trait books. Feel free to nerf this
+	if(!H.mind.learned_recipes)
+		H.mind.learned_recipes = list()
+	H.mind.learned_recipes |= GLOB.tier_three_parts
+	H.mind.learned_recipes |= GLOB.energyweapon_cell_crafting
+	H.mind.learned_recipes |= GLOB.energyweapon_crafting
+	H.mind.learned_recipes |= GLOB.pa_repair
+	H.mind.learned_recipes |= GLOB.armored_hazard_suit
+
+/datum/quirk/package/tinkerer/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		H.mind.learned_recipes -= GLOB.tier_three_parts
+		H.mind.learned_recipes -= GLOB.energyweapon_cell_crafting
+		H.mind.learned_recipes -= GLOB.energyweapon_crafting
+		H.mind.learned_recipes -= GLOB.pa_repair
+		H.mind.learned_recipes -= GLOB.armored_hazard_suit
 
 /datum/quirk/package/generalmedicalpractitioner
 	name = "General Medical Practitioner"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1399,13 +1399,13 @@ GLOBAL_VAR_INIT(crotch_call_cooldown, 0)
 				if(target.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
 					target.visible_message(span_warning("[target] can't hang onto [src]!"))
 					return
-				if(dna.features["taur"] != "None" || IsFeral())  //if the mount is a taur, then everyone needs -1 hands to piggback ride.
+				/*if(dna.features["taur"] != "None" || IsFeral())  //if the mount is a taur, then everyone needs -1 hands to piggback ride.
 					if(istype(get_item_by_slot(SLOT_WEAR_SUIT), /obj/item/clothing/suit/armor/taursaddle) || (locate(/obj/item/clothing/suit/armor/taursaddle) in src))  //if the mount is wearing a saddle, then there's no need to use hands at all
 						buckle_mob(target, TRUE, TRUE, FALSE, 0, 0, FALSE)
 					else
-						buckle_mob(target, TRUE, TRUE, FALSE, 0, 1, FALSE)
+						buckle_mob(target, TRUE, TRUE, FALSE, 0, 1, FALSE)*/
 				else
-					buckle_mob(target, TRUE, TRUE, FALSE, 1, 2, FALSE)
+					buckle_mob(target, TRUE, TRUE, FALSE, 0, 1, FALSE)
 		else
 			visible_message(span_warning("[target] fails to climb onto [src]!"))
 	else


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
This is just a fancy way of saying that I added a trait that shoves a workbench/alchemy table up your ass and comments out all the code that gives ferals/taurs an advantage on buckling over other people, now you can carry your bottoms on your back without having to be a pokemon and still use your guns
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
