### PR TITLE
Removes vestigial lead

### DIFF
--- a/_maps/map_files/Pahrump-Sunset - Backup/RedRiver.dmm
+++ b/_maps/map_files/Pahrump-Sunset - Backup/RedRiver.dmm
@@ -8595,7 +8595,6 @@
 	},
 /area/f13/building)
 "eTF" = (
-/obj/item/stack/ore/lead,
 /turf/open/water,
 /area/f13/building/abandoned)
 "eUh" = (
@@ -11882,7 +11881,7 @@
 	},
 /area/f13/wasteland)
 "gPz" = (
-/obj/item/stack/sheet/lead/twenty,
+/obj/item/stack/sheet/metal/twenty,
 /obj/structure/closet/crate,
 /turf/open/floor/plating/rust,
 /area/f13/building)

--- a/_maps/map_files/Pahrump-Sunset - Backup/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset - Backup/RockSprings.dmm
@@ -41300,7 +41300,7 @@
 /area/f13/bar)
 "ubb" = (
 /obj/structure/closet/crate/large,
-/obj/item/stack/sheet/lead/five,
+/obj/item/stack/sheet/metal/five,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ube" = (

--- a/_maps/map_files/coyote_bayou/Ashdown.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown.dmm
@@ -11257,7 +11257,6 @@
 	},
 /area/f13/wasteland/city)
 "eTF" = (
-/obj/item/stack/ore/lead,
 /turf/open/water,
 /area/f13/building/abandoned)
 "eTN" = (

--- a/_maps/map_files/coyote_bayou/Redwater.dmm
+++ b/_maps/map_files/coyote_bayou/Redwater.dmm
@@ -56847,7 +56847,7 @@
 /area/f13/bar)
 "ubb" = (
 /obj/structure/closet/crate/large,
-/obj/item/stack/sheet/lead/five,
+/obj/item/stack/sheet/metal/five,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "ube" = (

--- a/code/datums/components/artifacts.dm
+++ b/code/datums/components/artifacts.dm
@@ -2392,8 +2392,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = INV_SLOTBIT_ID | INV_SLOTBIT_BELT | INV_SLOTBIT_BACK | INV_SLOTBIT_POCKET | INV_SLOTBIT_BACKPACK | INV_SLOTBIT_SUITSTORE
 	foldable = FALSE
-	custom_materials = list(/datum/material/lead = MINERAL_MATERIAL_AMOUNT)
-	grind_results = list(/datum/reagent/lead = 20)
+	custom_materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT)
+	grind_results = list(/datum/reagent/iron = 20)
 	component_type = /datum/component/storage/concrete/box/artifact
 
 /obj/item/storage/box/artifactcontainer/ComponentInitialize()
@@ -2477,7 +2477,7 @@
 	custom_materials = list(
 		/datum/material/plasma = MINERAL_MATERIAL_AMOUNT * 0.5,
 		/datum/material/titanium = MINERAL_MATERIAL_AMOUNT * 0.5,
-		/datum/material/lead = MINERAL_MATERIAL_AMOUNT * 0.5
+		/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 0.5
 		)
 	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
 

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -65,8 +65,7 @@ handles linking back and forth.
 		/datum/material/uranium,
 		/datum/material/titanium,
 		/datum/material/bluespace,
-		/datum/material/plastic,
-		/datum/material/lead,
+		/datum/material/plastic
 		)
 
 	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, allowed_types=/obj/item/stack, _after_insert = after_insert)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -8,14 +8,6 @@
 	sheet_type = /obj/item/stack/sheet/metal
 	value_per_unit = 0.0025
 
-/datum/material/lead
-	name = "lead"
-	desc = "Common lead ore often found in sedimentary and igneous layers of the crust."
-	color = "#878687"
-	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
-	sheet_type = /obj/item/stack/sheet/lead
-	value_per_unit = 0.0025
-
 ///Breaks extremely easily but is transparent.
 /datum/material/glass
 	name = "glass"

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -2747,7 +2747,6 @@ there should be very few of these spawns on the whole map. finding one should be
 		/obj/item/stack/ore/bluespace_crystal = 1,
 		/obj/item/stack/ore/glass = 2,
 		/obj/item/stack/ore/iron = 2,
-		/obj/item/stack/ore/lead = 1,
 		/obj/item/stack/ore/titanium = 2)
 
 /obj/effect/spawner/lootdrop/f13/bounty

--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -1197,7 +1197,6 @@
 		/obj/item/stack/sheet/mineral/silver/twentyfive = 1,
 		/obj/item/stack/sheet/bronze/thirty = 1,
 		/obj/item/stack/rods/scaffold/ten = 1,
-		/obj/item/stack/sheet/lead/ten = 1,
 	)
 
 /obj/effect/spawner/lootdrop/f13/rare_mats

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -138,8 +138,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		/datum/material/plastic = (MINERAL_MATERIAL_AMOUNT * 1),
 		/datum/material/bronze = (MINERAL_MATERIAL_AMOUNT * 1),
 		/datum/material/plasma = (MINERAL_MATERIAL_AMOUNT * 0.5),
-		/datum/material/titanium = (MINERAL_MATERIAL_AMOUNT * 0.5),
-		/datum/material/lead = (MINERAL_MATERIAL_AMOUNT * 0.5)
+		/datum/material/titanium = (MINERAL_MATERIAL_AMOUNT * 0.5)
 		)
 	max_amount = 100
 	resistance_flags = FIRE_PROOF | LAVA_PROOF

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -173,43 +173,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 
 /obj/item/stack/sheet/metal/five
 	amount = 5
-
-GLOBAL_LIST_INIT(lead_recipes, list ( \
-	new/datum/stack_recipe("anomalous artifact exclusion cube", /obj/item/storage/box/artifactcontainer, 1, time = 10),
-	))
-
-/obj/item/stack/sheet/lead
-	name = "lead"
-	desc = "Sheets made out of lead."
-	singular_name = "lead sheet"
-	icon_state = "sheet-lead"
-	item_state = "sheet-lead"
-	custom_materials = list(/datum/material/lead=MINERAL_MATERIAL_AMOUNT)
-	throwforce = 10
-	flags_1 = CONDUCT_1
-	resistance_flags = FIRE_PROOF
-	merge_type = /obj/item/stack/sheet/lead
-	grind_results = list(/datum/reagent/lead = 20)
-	point_value = 2
-	//tableVariant = /obj/structure/table
-	material_type = /datum/material/lead
-
-/obj/item/stack/sheet/lead/fifty
-	amount = 50
-
-/obj/item/stack/sheet/lead/twenty
-	amount = 20
-
-/obj/item/stack/sheet/lead/ten
-	amount = 10
-
-/obj/item/stack/sheet/lead/five
-	amount = 5
-
-/obj/item/stack/sheet/lead/get_main_recipes()
-	. = ..()
-	. += GLOB.lead_recipes
-
 /obj/item/stack/sheet/metal/cyborg
 	custom_materials = null
 	is_cyborg = 1
@@ -1103,7 +1066,7 @@ GLOBAL_LIST_INIT(prewar_recipes, list ( \
 	custom_materials = list(
 		/datum/material/plasma = MINERAL_MATERIAL_AMOUNT * 0.5,
 		/datum/material/titanium = MINERAL_MATERIAL_AMOUNT * 0.5,
-		/datum/material/lead = MINERAL_MATERIAL_AMOUNT * 0.5
+		/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 0.5
 		)
 	throwforce = 10
 	flags_1 = CONDUCT_1

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -4,8 +4,7 @@ GLOBAL_LIST_INIT(ore_probability, list(/obj/item/stack/ore/uranium = 50,
 									   /obj/item/stack/ore/silver = 50,
 									   /obj/item/stack/ore/gold = 50,
 									   /obj/item/stack/ore/diamond = 25,
-									   /obj/item/stack/ore/titanium = 75,
-									   /obj/item/stack/ore/lead = 80))
+									   /obj/item/stack/ore/titanium = 75))
 
 /obj/structure/spawner/ice_moon
 	name = "cave entrance"

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -246,7 +246,7 @@
 	mineralChance = 15
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/lead = 30, /turf/closed/mineral/limestone = 20,
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/limestone = 20,
 		/*/turf/closed/mineral/gibtonite = 2, *//turf/closed/mineral/bscrystal = 1, /turf/closed/mineral/strange = 30) //indestructable chance moved to child, /underground
 
 /turf/closed/mineral/random/low_chance_desert
@@ -255,13 +255,13 @@
 	mineralChance = 6
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/lead = 30, /turf/closed/mineral/limestone = 20,
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/limestone = 20,
 		/*/turf/closed/mineral/gibtonite = 2, *//turf/closed/mineral/bscrystal = 1, /turf/closed/mineral/strange = 4) //indestructable chance moved to child, /underground
 
 /turf/closed/mineral/random/low_chance/underground
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/lead = 30, /turf/closed/mineral/limestone = 20,
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40, /turf/closed/mineral/limestone = 20,
 		/*/turf/closed/mineral/gibtonite = 2, *//turf/closed/mineral/bscrystal = 1, /turf/closed/mineral/indestructible = 50) //fortuna edit, indestructible rocks added to chance list
 
 /turf/closed/mineral/random/low_chance/earth_like
@@ -370,12 +370,6 @@
 		/turf/closed/mineral/iron/ice/icemoon = 95)
 
 
-
-/turf/closed/mineral/lead
-	mineralType = /obj/item/stack/ore/lead
-	spreadChance = 20
-	spread = 1
-	scan_state = "rock_Lead"
 
 /turf/closed/mineral/limestone
 	mineralType = /obj/item/stack/sheet/mineral/limestone
@@ -521,13 +515,6 @@
 	turf_type = /turf/open/floor/plating/asteroid/snow/ice/icemoon
 	baseturfs = /turf/open/floor/plating/asteroid/snow/ice/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
-
-/turf/closed/mineral/lead
-	mineralType = /obj/item/stack/ore/lead
-	spreadChance = 5
-	spread = 1
-	scan_state = "rock_Lead"
-
 /turf/closed/mineral/silver
 	mineralType = /obj/item/stack/ore/silver
 	spreadChance = 5

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -17,7 +17,7 @@
 	var/ore_pickup_rate = 15
 	var/ore_multiplier = 1
 	var/point_upgrade = 1
-	var/list/ore_values = list(/datum/material/glass = 1, /datum/material/iron = 1, /datum/material/plasma = 15, /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/lead = 3)
+	var/list/ore_values = list(/datum/material/glass = 1, /datum/material/iron = 1, /datum/material/plasma = 15, /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50)
 	var/message_sent = FALSE
 	var/list/ore_buffer = list()
 	var/datum/techweb/stored_research

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -81,17 +81,6 @@
 	custom_materials = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/metal
 	merge_type = /obj/item/stack/ore/iron
-
-/obj/item/stack/ore/lead
-	name = "lead ore"
-	icon_state = "lead ore"
-	item_state = "lead ore"
-	singular_name = "lead ore chunk"
-	points = 3
-	custom_materials = list(/datum/material/lead=MINERAL_MATERIAL_AMOUNT)
-	refined_type = /obj/item/stack/sheet/lead
-	merge_type = /obj/item/stack/ore/lead
-
 /obj/item/stack/ore/glass
 	name = "sand pile"
 	icon_state = "Glass ore"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1247,18 +1247,6 @@
 		reac_volume = min((reac_volume / 10), G.amount)
 		new/obj/item/stack/medical/gauze/adv(get_turf(G), reac_volume)
 		G.use(reac_volume)
-
-/datum/reagent/lead
-	name = "Lead"
-	description = "Pure lead is a metal."
-	reagent_state = SOLID
-	taste_description = "lead"
-	pH = 6
-	overdose_threshold = 30
-	color = "#c2391d"
-	material = /datum/material/lead
-	ghoulfriendly = TRUE
-
 /datum/reagent/iron
 	name = "Iron"
 	description = "Pure iron is a metal."

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -235,16 +235,6 @@
 	build_path = /obj/item/stack/rods
 	category = list("initial","Construction")
 	maxstack = 50
-
-/datum/design/lead
-	name = "Lead"
-	id = "lead"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/lead = 2000)
-	build_path = /obj/item/stack/sheet/lead
-	category = list("initial","Construction")
-	maxstack = 50
-
 /datum/design/titanium
 	name = "Titanium"
 	id = "titanium"

--- a/code/modules/research/designs/smelting_designs.dm
+++ b/code/modules/research/designs/smelting_designs.dm
@@ -71,10 +71,10 @@
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/prewaralloy
-	name = "Pre-war alloy (Lead + Titanium + Plasma)"
+	name = "Pre-war alloy (Iron + Titanium + Plasma)"
 	id = "prewaralloy"
 	build_type = SMELTER | PROTOLATHE
-	materials = list(/datum/material/plasma = MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/lead = MINERAL_MATERIAL_AMOUNT * 0.5)
+	materials = list(/datum/material/plasma = MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/titanium = MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/iron = MINERAL_MATERIAL_AMOUNT * 0.5)
 	build_path = /obj/item/stack/sheet/prewar
 	category = list("initial", "Stock Parts")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Removes the material and reagent known as 'lead'(leadacetate is unaffected as it is actually not lead). Unlike other materials that are properly interspersed throughout the proto and autolathe fab list, lead is entirely useless due to being a vestigial material no longer in use. Even for the alloy recipe(changed to iron) it doesn't work due to some unknown bug, and lead cannot be put back into the ORM. ATM lead just serves to be an annoyance with no real purpose outside of the niche use of what anomalous cubes are pathed from and reducing mining yields by roughly 10% or so(im not doing the full math im sick of stats). However they have been changed to instead default metal (will never actually happen due to them only being made by players, and metal already existing). 

Private server testing shows alloy can be crafted, as well as anomaly boxes, with no clear runtimes either. (iron and gold pictured alongside alloy made in the ORM, the protolathe also works)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/aeb73305-dc27-4ffc-9425-dbef036e5fd5)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
del: All lead paths and mentions
balance: Alloy now requires iron instead of lead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
