### PR TITLE
Shadow wizard money gang (buffs wands and adjusts staffs)

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -235,7 +235,7 @@
 	recharge_rate = 10 SECONDS // With delimbing disabled this is much less dangerous than it used to be.
 	slowdown = 1
 	fire_sound = 'sound/magic/fireball.ogg'
-	ammo_type = /obj/item/ammo_casing/magic/fireball // 40 to 90 bomb + knockdown + always blinds a square around the impact point + bonus dmg vs mobs
+	ammo_type = /obj/item/projectile/magic/aoe/fireball/lowpower
 
 
 /****************/
@@ -324,8 +324,8 @@
 	name = "acid spray"
 	icon_state = "toxin"
 	damage = 12
-	damage_low = 5
-	damage_high = 20
+	damage_low = 15
+	damage_high = 55
 	damage_type = BURN
 	flag = "laser"
 

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -260,8 +260,8 @@
 	name = "weak arcane bolt"
 	icon_state = "arcane_barrage"
 	damage = 15
-	damage_low = 10
-	damage_high = 30
+	damage_low = 15
+	damage_high = 34
 	damage_type = BURN
 	flag = "laser"
 


### PR DESCRIPTION
legalize nuclear bombs

Wands changed to a concept of low mag cap with quickish recharge.  Thusly high burst damage but poor sustain.

Staffs buffed to not be dogshit, oh and I fixed the low power fireball staff.  It was accidently using the actual fireball not the lower power one 😩 

https://www.youtube.com/watch?v=Tq1Kl1luIjA

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
