### PR TITLE
Improves the nullrod and makes it choosable, also buffs the acid staff

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -366,6 +366,8 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	name = "god hand"
 	desc = "This hand of yours glows with an awesome power!"
+	force = 45
+	force_wielded = 65 //It replaces an entire hand
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/sear.ogg'
@@ -545,6 +547,8 @@
 	item_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
+	force = 55
+	force_wielded = 65 //It replaces an entire hand
 	item_flags = ABSTRACT
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = SHARP_EDGED
@@ -566,8 +570,8 @@
 	name = "monk's staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass mutants.."
 	w_class = WEIGHT_CLASS_BULKY
-	force_wielded = 30 // Slightly better than the null rod with much better block chance.
-	force_unwielded = 20
+	force_wielded = 45 // Slightly better than the null rod with much better block chance.
+	force_unwielded = 35
 	block_chance = 40
 	attack_speed = CLICK_CD_MELEE * 0.85 // Everybody was kung fu fighting!
 	slot_flags = INV_SLOTBIT_BACK
@@ -702,13 +706,14 @@
 		span_info("You kneel[M == user ? null : " next to [M]"] and begin a prayer to [deity_name]."))
 
 	praying = TRUE
-	if(do_after(user, 20, target = M))
+	if(do_after(user, 100, target = M)) //I made their time to cast about 5x longer, which isnt much still.
 		M.reagents?.add_reagent(/datum/reagent/water/holywater, 5)
+		M.reagents?.add_reagent(/datum/reagent/medicine/radaway, 5) //I would also add some wound healing personally, but I think this is good enough
 		to_chat(M, span_notice("[user]'s prayer to [deity_name] has eased your pain!"))
-		M.adjustToxLoss(-5, TRUE, TRUE)
-		M.adjustOxyLoss(-5)
-		M.adjustBruteLoss(-5)
-		M.adjustFireLoss(-5)
+		M.adjustToxLoss(-20, TRUE, TRUE)
+		M.adjustOxyLoss(-20)
+		M.adjustBruteLoss(-20, include_roboparts = TRUE) // I made robots able to benifit from this
+		M.adjustFireLoss(-20, include_roboparts = TRUE) //I quadrupled their healing
 		praying = FALSE
 	else
 		to_chat(user, span_notice("Your prayer to [deity_name] was interrupted."))

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -310,7 +310,7 @@
 	icon_state = "acidstaff"
 	fire_sound = 'sound/f13npc/centaur/spit.ogg'
 	max_charges = 60 // This puts it in the same rough ballpark as the tesla autoshock, but projectile
-	recharge_rate = 6 SECONDS
+	recharge_rate = 4 SECONDS //The acid staff is now a minigun for magic users, with worse damage
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/acidspray
 	init_firemodes = list(
 		/datum/firemode/automatic/rpm150,
@@ -325,7 +325,9 @@
 	icon_state = "toxin"
 	damage = 12
 	damage_low = 15
-	damage_high = 55
+	damage_high = 50 //Reduced the damage slightly, because now it has supereffective
 	damage_type = BURN
 	flag = "laser"
+	supereffective_damage = 5 //This should make it deal 5 damage regardless of armor
+	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
 

--- a/code/modules/supplykit/supplykit_items/supplykit_magic.dm
+++ b/code/modules/supplykit/supplykit_items/supplykit_magic.dm
@@ -15,6 +15,11 @@
 	restricted_roles = list() //for restricting by job type
 	*/
 
+/datum/supplykit_item/magic/nullrod
+	name = "Nullrod"
+	desc = "A nullrod, can also be turned into other powerful holy weapons. Like a blocking blue staff, or healing prayer bead"
+	item = /obj/item/nullrod
+	cost = 40
 
 /datum/supplykit_item/magic/shockwand
 	name = "Improvised Rod of Sparks"


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
The acid staff now has super-effective, meaning it will always deal atleast more than 5 damage to the target, also you basically cant run out of charge with it, it recharges almost as fast as you use it, should now be a super sustainable weapon for wizards, instead of having to use 3 shots to kill a rat.
Also, the nullrod is now selectable, I buffed the prayer beads to be better than just normal tending, tested alongside methods that boost your progress bars, like the utility hunting horn, I think its in a good balanced spot right now, It doesnt nullify other healing items but it does supplement if you have them. (Its brute/burn healing is about double the effectiveness of normal tending, works on robots, and applies minor blood regen, and good radiation healing)
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
