### PR TITLE
(MERGE) Finally fixed

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -829,7 +829,7 @@
 //7.62x51, .30-06
 /obj/item/ammo_box/a3006box
 	name = "ammo box (.30-06)"
-	icon = 'icons/obj/ammo.dmi'
+	icon = 'icons/fallout/objects/guns/ammo.dmi'
 	icon_state = "box30"
 	multiple_sprites = 2
 	caliber = list(CALIBER_3006)


### PR DESCRIPTION
Turns out, a change from a year ago swapped the icon .dmi location from icons/fallout/objects/guns/ammo.dmi to just /obj/ammo.dmi . This will fix it,  nya.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
