### PR TITLE
Adjusts wands, also justifies toxinlover negative traits cost

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -281,8 +281,8 @@
 	desc = "Someone's gone and tied a lump of gold to the end of a metal rod before wiring a battery up to it. Somehow, this allows the 'wand' to channel a lesser variant of the Sparks spell."
 	icon_state = "improvshock"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/sparks/weak
-	max_charges = 4
-	recharge_rate = 2 SECONDS
+	max_charges = 3
+	recharge_rate = 1 SECONDS // It used to fire 3 shots, this just makes it a bit like how it was before
 	init_firemodes = list(
 		/datum/firemode/automatic/rpm300
 	)
@@ -304,7 +304,6 @@
 	desc = "A golden rod sits securely in a handle of runed wood. Attuned to this wand is the most iconic of mage spells: Magic Missile. It's a simple spell for more practical practitioners."
 	icon_state = "magicmissile"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/magicmissile/average
-	added_spread = 50
 	max_charges = 2
 	recharge_rate = 6 SECONDS
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -250,11 +250,17 @@
 	desc = "An extremely basic wand carved from bone, and topped with a roughly hewn crystal. Good for begginers, and handling vermin, but not much else."
 	icon_state = "missilewand"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/magicmissile/weak
-	max_charges = 3
-	recharge_rate = 2 SECONDS
+	max_charges = 1
+	recharge_rate = 6 SECONDS
+	init_firemodes = list(
+		/datum/firemode/semi_auto/faster
+	)
+
 
 /obj/item/ammo_casing/magic/kelpmagic/magicmissile/weak
 	projectile_type = /obj/item/projectile/magic/kelpmagic/magicmissile/weak
+	pellets = 6 //I've fucked with this for 4 hours straight, there is no variable that lets you make shotgun spread, variation does nothing, add_spread does nothing
+// Dont be like me, Don't try to make this a shotgun with a spread degree higher than 1 degree, you simply cant
 
 /obj/item/projectile/magic/kelpmagic/magicmissile/weak
 	name = "weak arcane bolt"
@@ -275,13 +281,14 @@
 	desc = "Someone's gone and tied a lump of gold to the end of a metal rod before wiring a battery up to it. Somehow, this allows the 'wand' to channel a lesser variant of the Sparks spell."
 	icon_state = "improvshock"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/sparks/weak
-	max_charges = 3
+	max_charges = 4
 	recharge_rate = 2 SECONDS
+	init_firemodes = list(
+		/datum/firemode/automatic/rpm300
+	)
 
 /obj/item/ammo_casing/magic/kelpmagic/sparks/weak
 	projectile_type = /obj/item/projectile/magic/kelpmagic/sparks/weak
-	pellets = 3
-	variance = 100
 
 /obj/item/projectile/magic/kelpmagic/sparks/weak
 	supereffective_damage = null
@@ -297,11 +304,16 @@
 	desc = "A golden rod sits securely in a handle of runed wood. Attuned to this wand is the most iconic of mage spells: Magic Missile. It's a simple spell for more practical practitioners."
 	icon_state = "magicmissile"
 	ammo_type = /obj/item/ammo_casing/magic/kelpmagic/magicmissile/average
-	max_charges = 6
-	recharge_rate = 2 SECONDS
+	added_spread = 50
+	max_charges = 2
+	recharge_rate = 6 SECONDS
+	init_firemodes = list(
+	/datum/firemode/semi_auto/faster
+	)
 
 /obj/item/ammo_casing/magic/kelpmagic/magicmissile/average
 	projectile_type = /obj/item/projectile/magic/kelpmagic/magicmissile/average
+	pellets = 6
 
 /obj/item/projectile/magic/kelpmagic/magicmissile/average
 	name = "arcane bolt"
@@ -327,8 +339,7 @@
 	max_charges = 4
 	recharge_rate = 2 SECONDS
 	init_firemodes = list(
-		/datum/firemode/automatic/rpm150,
-		/datum/firemode/semi_auto/faster
+		/datum/firemode/automatic/rpm300
 	)
 
 /obj/item/ammo_casing/magic/kelpmagic/sparks

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -566,7 +566,7 @@
 		M.adjustBruteLoss(-3, include_roboparts = TRUE) //HEALS
 		M.adjustOxyLoss(-10)
 		M.adjustFireLoss(-1, include_roboparts = TRUE)
-		M.adjustToxLoss(-1, TRUE, TRUE) //heals TOXINLOVERs
+		M.adjustToxLoss(-1, TRUE, FALSE) //heals TOXINLOVERs
 		M.adjustCloneLoss(-5)
 		M.adjustStaminaLoss(-10)
 		return
@@ -588,7 +588,7 @@
 		M.adjustBruteLoss(-1, include_roboparts = TRUE) //HEALS
 		M.adjustOxyLoss(-10)
 		M.adjustFireLoss(-3, include_roboparts = TRUE)
-		M.adjustToxLoss(-1, TRUE, TRUE) //heals TOXINLOVERs
+		M.adjustToxLoss(-1, TRUE, FALSE) //heals TOXINLOVERs
 		M.adjustCloneLoss(-5)
 		M.adjustStaminaLoss(-10)
 		return
@@ -610,7 +610,7 @@
 		M.adjustBruteLoss(-1, include_roboparts = TRUE) //HEALS
 		M.adjustOxyLoss(-50)
 		M.adjustFireLoss(-1, include_roboparts = TRUE)
-		M.adjustToxLoss(-5, TRUE, TRUE) //heals TOXINLOVERs
+		M.adjustToxLoss(-5, TRUE, FALSE) //heals TOXINLOVERs
 		M.adjustCloneLoss(-25)
 		M.adjustStaminaLoss(-50)
 		return
@@ -633,7 +633,7 @@
 		M.adjustBruteLoss(-15, include_roboparts = TRUE) //HEALS
 		M.adjustOxyLoss(-20)
 		M.adjustFireLoss(-15, include_roboparts = TRUE) // Effective on robots and people with prosthetics now
-		M.adjustToxLoss(-20, TRUE, TRUE) //heals TOXINLOVERs (It should actually do that now)
+		M.adjustToxLoss(-20, TRUE, FALSE) //heals TOXINLOVERs (It should actually do that now)
 		M.adjustCloneLoss(-5)
 		M.adjustStaminaLoss(-10)
 		return


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Made shotgun be the magic missiles gimmick, instead of just the improvised spark wands gimmick. For the absolute life of me, this code CANNOT have a shotgun with an initial spread higher than 1 degree, I've beat my head into a wall for 4 hours messing with added_spread, variation, distro, all that, nothing worked, my head broke, not the wall

Magic wands just shoot 6 projectiles and have long recharge times now, being a shotgun is their gimmick. The improv spark wand was changed to be an anti-trash wand that SHOULD be less capable of fighting mobs mid-tier or above now, but has the fastest recharge in the came, if the least capacity
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
