### PR TITLE
Fixes Arlem

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/captainarlem.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/captainarlem.dm
@@ -35,9 +35,7 @@
 	deathmessage = span_colossus("chokes on their own blood, gurgling out 'You're coming with me, mutie' as they activate their self destruct!")
 	deathsound = 'sound/effects/gravhit.ogg'
 	del_on_death = FALSE
-	loot = list(/obj/effect/spawner/lootdrop/f13/rare)
-	loot_drop_amount = 15
-	loot_amount_random = TRUE
+	loot = list(/obj/item/keycard/library)
 
 
 /mob/living/simple_animal/hostile/megafauna/captainarlem/BiologicalLife(seconds, times_fired)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Ahem. one, the keycard is for the enclave PA Arlem guards. two; ARLEM MAKES A HARD-DEL EXPLOSION ON DEATH, this removes any loot spawned unless it is indestructable.
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/0c0b0bbd-baa7-47e4-96d3-256fc67cb1a9)
(test not needed, revert of a small section of pr 4771)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
fix: Arlem now drops the golden key again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
