### PR TITLE
Makes the chameleon clothing craftable

### DIFF
--- a/arfsuits.dm
+++ b/arfsuits.dm
@@ -220,12 +220,12 @@
 	icon = 'icons/fallout/clothing/armored_power.dmi'
 	var/requires_training = FALSE
 
-/obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness
+/* /obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness
 	name = "secondary gear harness"
 	desc = "A collection of practically invisible straps useful for holding items. And that's about it."
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_TINY */ //Replaced by chameleon harness
 
 /obj/item/clothing/suit/armor/outfit/vest/utility/logisticsofficer //same as his beret
 	name = "logistics officer utility vest"
@@ -5266,7 +5266,7 @@
 
 // Magic armors - bizarre stats, don't fit into normal categories? Probably will need tweaking down the line.
 
-/obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor
+/obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor
 	name = "talisman of protection"
 	desc = "A talisman made of magically charged titanium and set with a gleaming fragment of gold. This will protect the wearer from all attacks equally, but the enchantment prevents the wearing of proper armor."
 	w_class = WEIGHT_CLASS_TINY
@@ -5277,7 +5277,7 @@
 	armor = list("linemelee" = 0, "linebullet" = 0, "linelaser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 10, "damage_threshold" = 10)
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 
-/obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor/hazard
+/obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor/hazard
 	name = "talisman of cleansing"
 	desc = "A talisman made of magically charged titanium and set with a humming shard of plasma. This will protect the wearer from hazards like radiation and acid, but offers no protection from more mundane threats."
 	icon_state = "hazardamulet"

--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -349,3 +349,11 @@
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC
 
+/datum/crafting_recipe/sand
+	name = "Crush rocks"
+	result = /obj/item/stack/ore/glass/three
+	reqs = list(/obj/item/ammo_casing/caseless/rocks = 3)
+	time = 15
+	subcategory = CAT_MISCELLANEOUS
+	category = CAT_MISC
+

--- a/code/datums/components/crafting/recipes/recipes_assemblies.dm
+++ b/code/datums/components/crafting/recipes/recipes_assemblies.dm
@@ -352,7 +352,7 @@
 /datum/crafting_recipe/sand
 	name = "Crush rocks"
 	result = /obj/item/stack/ore/glass/three
-	reqs = list(/obj/item/ammo_casing/caseless/rocks = 3)
+	reqs = list(/obj/item/ammo_casing/caseless/rock = 3)
 	time = 15
 	subcategory = CAT_MISCELLANEOUS
 	category = CAT_MISC

--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -483,7 +483,7 @@
 /datum/crafting_recipe/well
 	name = "Water Well"
 	result = /obj/structure/sink/well
-	reqs = list(/obj/item/stack/sheet/metal = 20, /obj/item/stack/sheet/mineral/wood = 20, /obj/item/stack/sheet/mineral/sandstone = 5, /obj/item/weaponcrafting/string = 5, /obj/item/reagent_containers/glass/bucket =1)
+	reqs = list(/obj/item/ammo_casing/caseless/rock = 8, /obj/item/stack/sheet/mineral/wood = 15, /obj/item/ammo_casing/caseless/brick = 8, /obj/item/reagent_containers/glass/bucket =1)
 	tools = list(TOOL_SHOVEL)
 	time = 100
 	subcategory = CAT_MISCELLANEOUS

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -774,7 +774,7 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_GENCLOTHES
 
-/datum/crafting_recipe/tailor/chameleon_mask
+/*/datum/crafting_recipe/tailor/chameleon_mask
 	name = "Chameleon Mask"
 	result = /obj/item/clothing/mask/chameleon
 	reqs = list(/obj/item/clothing/mask/breath,
@@ -783,7 +783,7 @@
 	tools = list(TOOL_WORKBENCH)
 	time = 15
 	category = CAT_CLOTHING
-	subcategory = CAT_GENCLOTHES
+	subcategory = CAT_GENCLOTHES*/
 
 /datum/crafting_recipe/tailor/ncruniform
 	name = "NCR Uniform"

--- a/code/datums/components/crafting/recipes/recipes_tribal.dm
+++ b/code/datums/components/crafting/recipes/recipes_tribal.dm
@@ -478,7 +478,7 @@
 // Amulet of Protection (Tier 1.5 armor, 10 DT/Wound prot)
 /datum/crafting_recipe/magic/armoramulet
 	name = "Amulet of Protection"
-	result = /obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor
+	result = /obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor
 	time = 10
 	reqs = list(/obj/item/stack/sheet/leather = 2,
 				/obj/item/stack/sheet/mineral/titanium = 1,
@@ -488,7 +488,7 @@
 // Amulet of Hazard Protection (Tier 1? armor, 75 enviro prot + 50 plasma prot)
 /datum/crafting_recipe/magic/radamulet
 	name = "Amulet of Cleansing"
-	result = /obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor/hazard
+	result = /obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor/hazard
 	time = 10
 	reqs = list(/obj/item/stack/sheet/leather = 2,
 				/obj/item/stack/sheet/mineral/titanium = 1,

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1109,7 +1109,7 @@ GLOBAL_LIST_EMPTY(cult_contraband)
 /datum/objective/collector/New()
 	..()
 	if(!GLOB.traitor_contraband.len)//Only need to fill the list when it's needed.
-		GLOB.traitor_contraband = list(/obj/item/card/emag/empty,/obj/item/clothing/glasses/phantomthief,/obj/item/clothing/gloves/chameleon/broken)
+		GLOB.traitor_contraband = list(/obj/item/card/emag/empty,/obj/item/clothing/glasses/phantomthief,/*/obj/item/clothing/gloves/chameleon/broken*/) //I dont know if this is actually important or not
 	if(!GLOB.cult_contraband.len)
 		GLOB.cult_contraband = list(/obj/item/shuttle_curse,/obj/item/cult_shift)
 

--- a/code/game/objects/items/stacks/crafting.dm
+++ b/code/game/objects/items/stacks/crafting.dm
@@ -87,6 +87,9 @@ GLOBAL_LIST_INIT(metalparts_recipes, list(\
 
 GLOBAL_LIST_INIT(electronicparts_recipes, list(\
 	new/datum/stack_recipe("ion arrowhead", /obj/item/stack/arrowhead/ion, 1, 1, 1 SECONDS),\
+	new/datum/stack_recipe("chameleon mask", /obj/item/clothing/mask/chameleon, 5, 1, 1 SECONDS),\
+	new/datum/stack_recipe("chameleon glasses", /obj/item/clothing/glasses/chameleon, 5, 1, 1 SECONDS),\
+
 	))
 
 /obj/item/stack/crafting/electronicparts/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -337,7 +337,11 @@ GLOBAL_LIST_INIT(leatherstrips_recipes, list (
 	new/datum/stack_recipe("slave labor outfit", /obj/item/clothing/suit/armor/outfit/slavelabor, 2, time = 50), 
 	new/datum/stack_recipe("jabroni outfit", /obj/item/clothing/under/jabroni, 4, time = 80),
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2, time = 40), 
-	new/datum/stack_recipe("pet collar", /obj/item/clothing/neck/petcollar, 2, time = 40)
+	new/datum/stack_recipe("pet collar", /obj/item/clothing/neck/petcollar, 2, time = 40),
+	new/datum/stack_recipe("secondary gear harness", /obj/item/clothing/suit/chameleon/harness/second_gear_harness, 4, time = 40), //From here on, this is all so people can have their snowflake loadout drip incase it gets burnt in a fire or w\e
+	new/datum/stack_recipe("light harness", /obj/item/clothing/suit/chameleon/harness, 6, time = 40), 
+	new/datum/stack_recipe("medium harness", /obj/item/clothing/suit/chameleon/harness/medium, 10, time = 40),
+	new/datum/stack_recipe("heavy harness", /obj/item/clothing/suit/chameleon/harness/heavy, 12, time = 40),
 ))
 
 /obj/item/stack/sheet/leatherstrips/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -413,7 +413,12 @@ GLOBAL_LIST_INIT(bamboo_recipes, list ( \
 // Cloth
 
 GLOBAL_LIST_INIT(cloth_recipes, list ( \
-	new/datum/stack_recipe("backpack", /obj/item/storage/backpack, 4), \
+	new/datum/stack_recipe("custom backpack", /obj/item/storage/backpack/chameleon, 4), \
+	new/datum/stack_recipe("custom jumpsuit", /obj/item/clothing/under/chameleon, 5), \
+	new/datum/stack_recipe("custom gloves", /obj/item/clothing/gloves/chameleon, 5), \
+	new/datum/stack_recipe("custom shoes", /obj/item/clothing/shoes/chameleon, 5), \
+	new/datum/stack_recipe("custom neck cloak", /obj/item/clothing/neck/cloak/chameleon, 5), \
+	new/datum/stack_recipe("custom hat", /obj/item/clothing/head/chameleon, 5), \
 	new/datum/stack_recipe("duffel bag", /obj/item/storage/backpack/duffelbag, 6), \
 	null, \
 	new/datum/stack_recipe("produce bag", /obj/item/storage/bag/plants, 4), \

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -356,6 +356,16 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/suit/chameleon)
 	armor = 0
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 	stiffness = 0
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/clothing/suit/chameleon/harness/second_gear_harness
+	name = "secondary gear harness"
+	desc = "A collection of practically invisible straps useful for holding items. And that's about it."
+	icon_state = "gear_harness"
+	item_state = "gear_harness"
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/four
+	armor = ARMOR_VALUE_CLOTHES
+	armor_tier_desc = ARMOR_CLOTHING_DESC
 
 /obj/item/clothing/suit/chameleon/harness
 	name = "light harness"
@@ -378,6 +388,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/suit/chameleon)
 	armor_tokens = list(ARMOR_MODIFIER_UP_BULLET_T1, ARMOR_MODIFIER_UP_MELEE_T1, ARMOR_MODIFIER_UP_LASER_T1, ARMOR_MODIFIER_UP_ENERGY_T1, ARMOR_MODIFIER_UP_ENV_T1, ARMOR_MODIFIER_UP_BOMB_T1)
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 	stiffness = LIGHT_STIFFNESS
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/suit/chameleon/harness/medium
 	name = "medium harness"
@@ -427,7 +438,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/glasses/chameleon)
 	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/glasses/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/glasses/chameleon/emp_act(severity)
+/*/obj/item/clothing/glasses/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -435,7 +446,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/glasses/chameleon)
 
 /obj/item/clothing/glasses/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon)
 	desc = "These gloves will protect the wearer from electric shock."
@@ -459,7 +470,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon/insulated)
 	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/gloves, /obj/item/clothing/gloves/color, /obj/item/clothing/gloves/changeling), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/gloves/chameleon/emp_act(severity)
+/*/obj/item/clothing/gloves/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -467,7 +478,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon/insulated)
 
 /obj/item/clothing/gloves/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/head/chameleon)
 	name = "grey cap"
@@ -537,7 +548,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/mask/chameleon)
 	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/mask/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/mask/chameleon/emp_act(severity)
+/*/obj/item/clothing/mask/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -545,7 +556,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/mask/chameleon)
 
 /obj/item/clothing/mask/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 /obj/item/clothing/mask/chameleon/attack_self(mob/user)
 	voice_change = !voice_change
@@ -588,11 +599,11 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon)
 	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/shoes/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/shoes/chameleon/emp_act(severity)
+/*/obj/item/clothing/shoes/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	chameleon_action.emp_randomise()
+	chameleon_action.emp_randomise()*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon/noslip)
 	name = "black shoes"
@@ -600,9 +611,9 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon/noslip)
 	desc = "A pair of black shoes."
 	clothing_flags = NOSLIP
 
-/obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
+/*/obj/item/clothing/shoes/chameleon/noslip/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/backpack/chameleon)
 	name = "backpack"
@@ -615,7 +626,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/backpack/chameleon)
 	chameleon_action.chameleon_name = "Backpack"
 	chameleon_action.initialize_disguises()
 
-/obj/item/storage/backpack/chameleon/emp_act(severity)
+/*/obj/item/storage/backpack/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -623,7 +634,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/backpack/chameleon)
 
 /obj/item/storage/backpack/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/belt/chameleon)
 	name = "toolbelt"
@@ -643,7 +654,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/belt/chameleon)
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.silent = TRUE
 
-/obj/item/storage/belt/chameleon/emp_act(severity)
+/*/obj/item/storage/belt/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -651,7 +662,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/belt/chameleon)
 
 /obj/item/storage/belt/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/radio/headset/chameleon)
 	name = "radio headset"
@@ -728,8 +739,8 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/neck/cloak/chameleon)
 	chameleon_action.chameleon_name = "Cloak"
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/neck/cloak/chameleon/emp_act(severity)
+/*/obj/item/clothing/neck/cloak/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	chameleon_action.emp_randomise()
+	chameleon_action.emp_randomise()*/

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -498,7 +498,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/head/chameleon)
 	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/head/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
-/obj/item/clothing/head/chameleon/emp_act(severity)
+/*/obj/item/clothing/head/chameleon/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
@@ -506,7 +506,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/head/chameleon)
 
 /obj/item/clothing/head/chameleon/broken/Initialize()
 	. = ..()
-	chameleon_action.emp_randomise(INFINITY)
+	chameleon_action.emp_randomise(INFINITY)*/
 
 /obj/item/clothing/head/chameleon/drone
 	// The camohat, I mean, holographic hat projection, is part of the

--- a/code/modules/clothing/suits/arfsuits.dm
+++ b/code/modules/clothing/suits/arfsuits.dm
@@ -5263,7 +5263,7 @@
 
 // Magic armors - bizarre stats, don't fit into normal categories? Probably will need tweaking down the line.
 
-/obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor
+/obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor
 	name = "talisman of protection"
 	desc = "A talisman made of magically charged titanium and set with a gleaming fragment of gold. This will protect the wearer from all attacks equally, but the enchantment prevents the wearing of proper armor."
 	w_class = WEIGHT_CLASS_TINY
@@ -5274,7 +5274,7 @@
 	armor = list("linemelee" = 0, "linebullet" = 0, "linelaser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 10, "damage_threshold" = 10)
 	armor_tier_desc = ARMOR_CLOTHING_LIGHT
 
-/obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness/magicarmor/hazard
+/obj/item/clothing/suit/armor/outfit/vest/utility/magicarmor/hazard
 	name = "talisman of cleansing"
 	desc = "A talisman made of magically charged titanium and set with a humming shard of plasma. This will protect the wearer from hazards like radiation and acid, but offers no protection from more mundane threats."
 	icon_state = "hazardamulet"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -81,6 +81,7 @@
 	custom_materials = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/metal
 	merge_type = /obj/item/stack/ore/iron
+
 /obj/item/stack/ore/glass
 	name = "sand pile"
 	icon_state = "Glass ore"
@@ -92,6 +93,9 @@
 	w_class = WEIGHT_CLASS_TINY
 	merge_type = /obj/item/stack/ore/glass
 	grind_results = list(/datum/reagent/silicon = 20,)
+
+/obj/item/stack/ore/glass/three
+	amount = 3
 
 GLOBAL_LIST_INIT(sand_recipes, list(\
 	new/datum/stack_recipe("sandstone", /obj/item/stack/sheet/mineral/sandstone, 1, 1, 50),\

--- a/modular_citadel/code/modules/client/loadout/glasses.dm
+++ b/modular_citadel/code/modules/client/loadout/glasses.dm
@@ -23,6 +23,11 @@
 	name = "Large sunglasses"
 	path = /obj/item/clothing/glasses/sunglasses/big
 
+/datum/gear/glasses/chameleon
+	name = "chameleon glasses"
+	path = /obj/item/clothing/glasses/chameleon
+	cost = 0
+
 /datum/gear/glasses/biker
 	name = "biker goggles"
 	path = /obj/item/clothing/glasses/f13/biker

--- a/modular_citadel/code/modules/client/loadout/gloves.dm
+++ b/modular_citadel/code/modules/client/loadout/gloves.dm
@@ -15,6 +15,11 @@
 	name = "grey gloves"
 	path = /obj/item/clothing/gloves/color/grey
 
+/datum/gear/gloves/chameleon
+	name = "chameleon gloves"
+	/obj/item/clothing/gloves/chameleon
+	cost = 0
+
 /datum/gear/gloves/brown
 	name = "brown gloves"
 	path = /obj/item/clothing/gloves/color/brown

--- a/modular_citadel/code/modules/client/loadout/gloves.dm
+++ b/modular_citadel/code/modules/client/loadout/gloves.dm
@@ -17,7 +17,7 @@
 
 /datum/gear/gloves/chameleon
 	name = "chameleon gloves"
-	/obj/item/clothing/gloves/chameleon
+	path = /obj/item/clothing/gloves/chameleon
 	cost = 0
 
 /datum/gear/gloves/brown

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -8,6 +8,11 @@
 	name = "ballcap"
 	path = /obj/item/clothing/head/soft/mime
 
+/datum/gear/head/chameleon
+	name = "chameleon hat"
+	/obj/item/clothing/head/chameleon
+	cost = 0
+
 /datum/gear/head/beanie
 	name = "beanie"
 	path = /obj/item/clothing/head/beanie

--- a/modular_citadel/code/modules/client/loadout/head.dm
+++ b/modular_citadel/code/modules/client/loadout/head.dm
@@ -10,7 +10,7 @@
 
 /datum/gear/head/chameleon
 	name = "chameleon hat"
-	/obj/item/clothing/head/chameleon
+	path = /obj/item/clothing/head/chameleon
 	cost = 0
 
 /datum/gear/head/beanie

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -71,7 +71,7 @@
 	name= "gas mask"
 	path = /obj/item/clothing/mask/gas
 
-/datum/gear/mask/gasmask
+/datum/gear/mask/gasmask/chameleon
 	name = "voice changing mask"
 	path = /obj/item/clothing/mask/chameleon
 	cost = 1

--- a/modular_citadel/code/modules/client/loadout/neck.dm
+++ b/modular_citadel/code/modules/client/loadout/neck.dm
@@ -70,6 +70,12 @@
 	name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
 
+/datum/gear/neck/chameleon
+	name = "chameleon neckpiece"
+	subcategory = LOADOUT_SUBCATEGORY_NECK_GENERAL
+	path = /obj/item/clothing/neck/cloak/chameleon
+	cost = 0
+
 /datum/gear/neck/blacktie
 	name = "black tie"
 	subcategory = LOADOUT_SUBCATEGORY_NECK_GENERAL

--- a/modular_citadel/code/modules/client/loadout/shoes.dm
+++ b/modular_citadel/code/modules/client/loadout/shoes.dm
@@ -34,6 +34,11 @@
 	name = "sandals"
 	path = /obj/item/clothing/shoes/sandal
 
+/datum/gear/shoes/chameleon
+	name = "chameleon shoes"
+	path = /obj/item/clothing/shoes/chameleon
+	cost = 0
+
 /datum/gear/shoes/blackshoes
 	name = "black shoes"
 	path = /obj/item/clothing/shoes/sneakers/black

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -35,7 +35,7 @@
 
 /datum/gear/suit/suit_gear_harness
 	name = "secondary gear harness"
-	path = /obj/item/clothing/suit/armor/outfit/vest/utility/gear_harness
+	path = /obj/item/clothing/suit/chameleon/harness/second_gear_harness
 	cost = 0
 
 /datum/gear/suit/suit_gear_harness/drip

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -43,7 +43,6 @@
 	path = /obj/item/clothing/suit/chameleon/dripharness
 	cost = 1
 
-
 /datum/gear/suit/suit_gear_harness/light
 	name = "light harness"
 	path = /obj/item/clothing/suit/chameleon/harness

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -525,6 +525,12 @@
 	path = /obj/item/clothing/under/misc/gear_harness
 	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_GENERAL
 
+/datum/gear/uniform/chameleon
+	name = "chameleon outfit"
+	path = /obj/item/clothing/under/chameleon
+	subcategory = LOADOUT_SUBCATEGORY_UNIFORM_GENERAL
+	cost = 0
+
 /datum/gear/uniform/navy
 	name = "navy jumpsuit"
 	path = /obj/item/clothing/under/f13/navy


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Makes chameleon clothing craftable to replace peoples unobtainable loadout items in the event they step on a mald mine or get set on fire while in crit + makes them selectable in the loadout for free

Makes the well crafting recipe not nearly as bad as it was. You can carry around like, 5 metal parts and 5 metal and make a sink literally anywhere, it doesnt need an entire towns assistance to make a small well. Now it just takes time + wood in various forms, instead of requiring the ever elusive sand.

Makes sand less elusive by letting people craft 3 at a time by bashing rocks together. Side effects include monkey glass production industry and crafting soil literally anywhere and adding fun to the game
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
