### PR TITLE
Deletes 90% of the world to speed up init

### DIFF
--- a/AAADevTool/AAA_DEVELOPMENT_CONFIG.dm
+++ b/AAADevTool/AAA_DEVELOPMENT_CONFIG.dm
@@ -1,0 +1,6 @@
+/// set to 1 (not TRUE) to make it only load new boston and nothing else
+#define SANIC_SPEED 1
+
+#ifdef SANIC_SPEED
+#define FORCE_MAP "_maps/pahrump-just_new_boston_only.json"  // quick and dirty exclusion of broken boxstation
+#endif

--- a/_maps/pahrump-just_new_boston_only.json
+++ b/_maps/pahrump-just_new_boston_only.json
@@ -1,0 +1,11 @@
+{
+	"map_name": "Western Texarkana",
+	"map_path": "map_files/coyote_bayou",
+	"map_file": [
+		"Newboston.dmm"
+	],
+	"station_ruin_budget":0,
+	"space_ruin_levels":0,
+	"space_empty_levels":0,
+	"minetype": "none"
+}

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -15,6 +15,7 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
+#include "AAADevTool\AAA_DEVELOPMENT_CONFIG.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"


### PR DESCRIPTION
## About The Pull Request
Adds in a define that makes only the newboston Z load.

HOW 2 USE:
Open AAADevTool/AAA_DEVELOPMENT_CONFIG.dm
Set SANIC_SPEED to 1

Done. Try not to commit this file with SANIC_SPEED set to 1, though im like 30% sure I can make TGS overwrite it. It'll be our little dirty secret =3