### PR TITLE
Tweak Zero's Custom Kits

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -1903,31 +1903,13 @@
 // Z
 
 /datum/gear/donator/kits/zeronetalpha
-	name = "DocBot115"
+	name = "Glowstick Kit"
 	path = /obj/item/storage/box/large/custom_kit/zeronetalpha
-	ckeywhitelist = list("zeronetalpha")
+	ckeywhitelist = list("zeronetalpha, zeronettwo")
 
 /obj/item/storage/box/large/custom_kit/zeronetalpha/PopulateContents()
+	new /obj/item/cartridge/resize
 	new /obj/item/gun/energy/laser/pistol(src)
-	new /obj/item/storage/belt/shoulderholster(src)
-	new /obj/item/clothing/head/beret/med(src)
-	new /obj/item/clothing/suit/toggle/labcoat/emt/highvis(src)
-	new /obj/item/clothing/under/pants/black(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/stealthboy(src)
-	new /obj/item/gun/ballistic/automatic/x9/toy(src)
-
-/datum/gear/donator/kits/zeronetalpha2
-	name = "EIEIO"
-	path = /obj/item/storage/box/large/custom_kit/zeronetalpha2
-	ckeywhitelist = list("zeronetalpha")
-
-/obj/item/storage/box/large/custom_kit/zeronetalpha2/PopulateContents()
-	new /obj/item/clothing/gloves/evening/black(src)
-	new /obj/item/clothing/shoes/wraps(src)
-	new /obj/item/clothing/suit/jacket/leather/overcoat(src)
-	new /obj/item/clothing/under/dress/blacktango(src)
-	new /obj/item/clothing/head/beret(src)
 	new /obj/item/gun/energy/laser/pistol(src)
 	new /obj/item/stock_parts/cell/ammo/ec(src)
 	new /obj/item/stock_parts/cell/ammo/ec(src)


### PR DESCRIPTION
## About The Pull Request
Condensed the two kits into one, removed clothes and Stealth Boy from both and added a resize cartridge (thx Andy!)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added ZeroNetTwo as a valid Ckey to ZeroNetAlpha's kit.
add: Added a resize cartridge to ZeroNetAlpha's kit.
del: Removed custom kit clothes, Foam force X9, and Stealthboy from ZeroNetAlpha's Kits.
tweak: Condensed ZeroNetAlpha's Kits into one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
