### PR TITLE
Fixes White Stove and Counters

### DIFF
--- a/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown-Upper.dmm
@@ -304,7 +304,6 @@
 "cI" = (
 /obj/structure/chair/sofa/left{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 7;
 	color = "green"
 	},
@@ -320,7 +319,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/brown/beer{
-	pixel_y = 0;
 	pixel_x = 6
 	},
 /obj/item/reagent_containers/food/drinks/bottle/brown/beer{
@@ -350,8 +348,7 @@
 	icon_state = "weapon_idle"
 	},
 /obj/structure/fence/wooden{
-	pixel_x = 16;
-	pixel_y = 0
+	pixel_x = 16
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/ashdown)
@@ -736,7 +733,6 @@
 	dir = 4
 	},
 /obj/machinery/biogenerator{
-	pixel_y = 0;
 	pixel_x = 1
 	},
 /turf/open/floor/plasteel/f13{
@@ -1133,7 +1129,6 @@
 	pixel_x = -7
 	},
 /obj/item/toy/lewd/dildo/canine{
-	pixel_y = 0;
 	pixel_x = -3
 	},
 /obj/item/toy/lewd/dildo/dragon{
@@ -1514,9 +1509,7 @@
 "lC" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22;
-	density = 0;
-	opacity = 0
+	pixel_y = 22
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -1694,12 +1687,10 @@
 "mL" = (
 /obj/machinery/mineral/wasteland_vendor/crafting,
 /obj/structure/fence/wooden{
-	pixel_x = 15;
-	pixel_y = 0
+	pixel_x = 15
 	},
 /obj/structure/fence/wooden{
-	pixel_x = -17;
-	pixel_y = 0
+	pixel_x = -17
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/ashdown)
@@ -1726,9 +1717,7 @@
 /area/f13/building/abandoned)
 "mX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/radroach{
-	max_mobs = 3
-	},
+/obj/structure/nest/radroach,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustysolid"
@@ -1876,7 +1865,6 @@
 "oq" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	icon_state = "railing_corner"
 	},
 /turf/open/floor/f13/wood,
@@ -2357,7 +2345,6 @@
 /area/f13/building)
 "rY" = (
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = 13
 	},
 /obj/structure/fence/wooden{
@@ -2373,7 +2360,6 @@
 	pixel_x = -15
 	},
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = 13
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -2596,7 +2582,6 @@
 	pixel_x = -6
 	},
 /obj/item/reagent_containers/food/drinks/bottle/brown/beer{
-	pixel_y = 0;
 	pixel_x = 6
 	},
 /turf/open/floor/f13/wood,
@@ -2644,9 +2629,7 @@
 "uc" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22;
-	density = 0;
-	opacity = 0
+	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -2785,14 +2768,6 @@
 /obj/structure/rug/carpet2,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"uU" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "uX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase,
@@ -2830,8 +2805,7 @@
 "vg" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
@@ -3263,8 +3237,7 @@
 /area/f13/wasteland)
 "yb" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building)
 "yf" = (
@@ -3321,12 +3294,10 @@
 "yu" = (
 /obj/machinery/mineral/wasteland_vendor/mining,
 /obj/structure/fence/wooden{
-	pixel_x = 15;
-	pixel_y = 0
+	pixel_x = 15
 	},
 /obj/structure/fence/wooden{
-	pixel_x = -17;
-	pixel_y = 0
+	pixel_x = -17
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/ashdown)
@@ -3443,8 +3414,7 @@
 	resistance_flags = 64
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "zl" = (
@@ -4157,8 +4127,7 @@
 "Ew" = (
 /obj/machinery/mineral/wasteland_vendor/weapons,
 /obj/structure/fence/wooden{
-	pixel_x = -18;
-	pixel_y = 0
+	pixel_x = -18
 	},
 /turf/open/indestructible/cobble,
 /area/f13/building/workshop/ashdown)
@@ -5519,7 +5488,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/fo13colored/Pink{
-	dir = 2;
 	name = "sex shop light"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -60383,10 +60351,10 @@ Hw
 EF
 zS
 qm
-uU
-uU
-uU
-uU
+jG
+jG
+jG
+jG
 Tz
 Hw
 Hw
@@ -62924,16 +62892,16 @@ Hw
 Hw
 Hw
 qm
-uU
-uU
-uU
-uU
-uU
-uU
-uU
-uU
-uU
-uU
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
+jG
 ks
 Hw
 Hw
@@ -66051,8 +66019,8 @@ wj
 wj
 wj
 wj
-uU
-uU
+jG
+jG
 Tz
 Hw
 Hw

--- a/_maps/map_files/coyote_bayou/Ashdown.dmm
+++ b/_maps/map_files/coyote_bayou/Ashdown.dmm
@@ -162,7 +162,6 @@
 	color = "#FF5555"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -1573,8 +1572,7 @@
 /obj/structure/decoration/rag{
 	icon_state = "skulls";
 	name = "human skulls";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/old,
@@ -1865,7 +1863,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -2767,7 +2764,6 @@
 "bnx" = (
 /obj/structure/fence/door,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -3135,7 +3131,6 @@
 /area/f13/building/abandoned)
 "bur" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -4042,7 +4037,6 @@
 	throw_range = 9
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -5190,12 +5184,6 @@
 /obj/structure/flora/small_bush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"cqZ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "crk" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
@@ -5332,15 +5320,6 @@
 /obj/structure/flora/twig2,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"ctY" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "cuc" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -6199,9 +6178,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cNU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "cOk" = (
@@ -6249,7 +6226,6 @@
 	},
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -18
 	},
 /turf/open/indestructible/ground/outside/desert,
@@ -7418,8 +7394,7 @@
 /area/f13/building/abandoned)
 "dmW" = (
 /obj/structure/campfire/stove{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -8845,12 +8820,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bar/ashdown)
-"dOO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "dOP" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -9664,7 +9633,6 @@
 /area/f13/wasteland)
 "ein" = (
 /turf/open/floor/f13{
-	dir = 2;
 	icon_state = "yellowsiding"
 	},
 /area/f13/building/coyote/safe/ashdown)
@@ -10734,8 +10702,7 @@
 /area/f13/wasteland)
 "eGO" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -12209,9 +12176,7 @@
 /area/f13/building/abandoned)
 "fmj" = (
 /obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/medical/ancientfirstaid{
-	pixel_y = 0
-	},
+/obj/item/storage/medical/ancientfirstaid,
 /obj/item/storage/box/ration/ranger_breakfast{
 	pixel_y = -6
 	},
@@ -12752,19 +12717,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"fyD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#FFBB77";
-	name = "the watering hole"
-	},
-/area/f13/wasteland)
 "fyV" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -14068,7 +14020,6 @@
 /area/f13/city)
 "gcF" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
@@ -14378,15 +14329,6 @@
 	dir = 2
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"giP" = (
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
 /area/f13/wasteland)
 "gjf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16214,7 +16156,6 @@
 	icon_state = "tall_grass_3"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -16858,8 +16799,7 @@
 "hpc" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/sign/poster/prewar/poster73{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar/ashdown)
@@ -17444,7 +17384,6 @@
 	},
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 18
 	},
 /turf/open/indestructible/ground/outside/desert,
@@ -19339,7 +19278,6 @@
 /obj/structure/fence,
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 18
 	},
 /obj/structure/fence{
@@ -19423,7 +19361,6 @@
 "ixo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -20139,15 +20076,6 @@
 /area/f13/building)
 "iLx" = (
 /turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland)
-"iLR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iLT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23605,8 +23533,7 @@
 	pixel_y = 9
 	},
 /obj/structure/fermenting_barrel{
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25389,8 +25316,7 @@
 "kWu" = (
 /obj/structure/flora/tallgrass7,
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -26447,8 +26373,7 @@
 "luC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
+	dir = 4
 	},
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27350,15 +27275,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
-"lQs" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "lQz" = (
 /obj/structure/flora/small_bush,
 /obj/structure/flora/grass/wasteland{
@@ -29102,7 +29018,6 @@
 /area/f13/caves)
 "mGO" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -30203,7 +30118,6 @@
 "ngX" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -30412,7 +30326,6 @@
 /area/f13/wasteland/city)
 "nkH" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -31135,9 +31048,7 @@
 	},
 /area/f13/wasteland)
 "nCB" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -31373,16 +31284,6 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
-"nHv" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city)
 "nHB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -33071,8 +32972,7 @@
 /area/f13/wasteland)
 "out" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -33488,7 +33388,6 @@
 /obj/item/storage/bag/salvagestorage,
 /obj/item/weldingtool,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/building)
@@ -33670,8 +33569,7 @@
 "oHU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -38952,15 +38850,6 @@
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned)
-"rcU" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city)
 "rcV" = (
 /obj/structure/nest/mirelurk,
 /obj/effect/turf_decal/weather/dirt{
@@ -39463,19 +39352,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet,
 /area/f13/building)
-"rqq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#FFBB77";
-	name = "the watering hole"
-	},
-/area/f13/wasteland)
 "rqv" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -38;
@@ -44588,8 +44464,7 @@
 /area/f13/building)
 "tAx" = (
 /obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
@@ -46840,13 +46715,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/blueyellow,
 /area/f13/building)
-"uvV" = (
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "uwd" = (
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
@@ -47098,9 +46966,7 @@
 /area/f13/caves)
 "uCx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "uCA" = (
@@ -47758,7 +47624,6 @@
 "uRl" = (
 /obj/machinery/autolathe,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/building)
@@ -49156,16 +49021,6 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/building)
-"vzb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	light_color = null;
-	color = "#FFBB77";
-	name = "the watering hole"
-	},
-/area/f13/wasteland)
 "vzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -49240,16 +49095,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/abandoned)
-"vBZ" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/obj/structure/spacevine,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city)
 "vCe" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -51934,7 +51779,6 @@
 /obj/structure/fence,
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -18
 	},
 /obj/structure/fence{
@@ -52550,8 +52394,7 @@
 /area/f13/wasteland)
 "xdo" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -52622,16 +52465,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/savannah,
-/area/f13/wasteland)
-"xfL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
 /area/f13/wasteland)
 "xfU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55059,9 +54892,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ykm" = (
@@ -59921,7 +59752,7 @@ ipV
 uGR
 uGR
 ioX
-vBZ
+lTx
 iKf
 hLb
 ycK
@@ -60178,7 +60009,7 @@ eWw
 jIh
 ioX
 ioX
-rcU
+bqj
 iKf
 nng
 iKf
@@ -60435,7 +60266,7 @@ dNe
 uGR
 uGR
 ioX
-nHv
+olZ
 iKf
 hYM
 iKf
@@ -60692,7 +60523,7 @@ leo
 mXC
 xoS
 uGR
-rcU
+bqj
 iKf
 iKf
 wnL
@@ -60949,7 +60780,7 @@ nOH
 cMz
 qlm
 nKM
-rcU
+bqj
 iKf
 iKf
 mQR
@@ -61206,7 +61037,7 @@ sty
 wuc
 xoS
 ahd
-vBZ
+lTx
 iKf
 cwu
 xZC
@@ -61463,7 +61294,7 @@ iGq
 bOS
 qfF
 ahd
-vBZ
+lTx
 iKf
 iKf
 tiN
@@ -61720,7 +61551,7 @@ fmm
 bgG
 gJA
 wPk
-vBZ
+lTx
 iKf
 nng
 jza
@@ -61977,7 +61808,7 @@ xoS
 wuc
 qfF
 ahd
-vBZ
+lTx
 tiN
 tGM
 iKf
@@ -80390,7 +80221,7 @@ siv
 aFM
 bJy
 wWG
-uvV
+hyW
 iKf
 iKf
 iKf
@@ -80647,7 +80478,7 @@ gVU
 nLL
 lHJ
 wWG
-uvV
+hyW
 iKf
 iKf
 mYI
@@ -81161,7 +80992,7 @@ bFL
 fAV
 oMp
 nvX
-uvV
+hyW
 iKf
 lmY
 iKf
@@ -81402,7 +81233,7 @@ iKf
 rIj
 jqA
 lrs
-cqZ
+stW
 iKf
 bPP
 iKf
@@ -81418,7 +81249,7 @@ bxV
 sZm
 bJy
 wWG
-uvV
+hyW
 iKf
 tiN
 lmY
@@ -81659,7 +81490,7 @@ iKf
 ojJ
 lrs
 oog
-cqZ
+stW
 iKf
 qel
 vHo
@@ -81675,7 +81506,7 @@ siv
 yft
 duP
 wWG
-uvV
+hyW
 iKf
 tiN
 iKf
@@ -81916,7 +81747,7 @@ lmY
 ojJ
 gLI
 lrs
-cqZ
+stW
 iKf
 iKf
 bPP
@@ -82173,7 +82004,7 @@ iKf
 ojJ
 lrs
 kVa
-cqZ
+stW
 iKf
 iKf
 bPP
@@ -82191,7 +82022,7 @@ vEc
 trG
 edC
 gVU
-giP
+ljb
 iKf
 hYM
 iKf
@@ -82430,7 +82261,7 @@ tiN
 xzd
 bGl
 gOB
-cqZ
+stW
 iKf
 jTY
 hnD
@@ -82448,7 +82279,7 @@ fEv
 voZ
 rTL
 wNz
-xfL
+wHx
 iKf
 iKf
 hLb
@@ -82687,7 +82518,7 @@ rIj
 jqA
 wzX
 bGl
-cqZ
+stW
 jTY
 jYG
 bPP
@@ -82705,7 +82536,7 @@ vck
 voZ
 axF
 eGY
-giP
+ljb
 cwu
 iKf
 nng
@@ -82962,7 +82793,7 @@ eTN
 eTN
 iLx
 wWG
-giP
+ljb
 iKf
 hoh
 lPw
@@ -83219,7 +83050,7 @@ trV
 skh
 dbh
 wWG
-giP
+ljb
 yaf
 iKf
 iKf
@@ -83476,7 +83307,7 @@ trV
 skh
 voZ
 wWG
-giP
+ljb
 iMM
 iKf
 iKf
@@ -83990,7 +83821,7 @@ trV
 voZ
 iLx
 wWG
-xfL
+wHx
 keP
 iKf
 iKf
@@ -84231,7 +84062,7 @@ ojJ
 rpt
 gOB
 lrs
-cqZ
+stW
 bPP
 tiN
 xoD
@@ -84247,7 +84078,7 @@ iLx
 trV
 iLx
 wWG
-xfL
+wHx
 iKf
 keP
 nng
@@ -84488,7 +84319,7 @@ xzd
 gOB
 kVa
 xsx
-cqZ
+stW
 bPP
 tiN
 iKf
@@ -84504,7 +84335,7 @@ iLx
 iLx
 iLx
 wWG
-giP
+ljb
 tiN
 tiN
 tGM
@@ -84729,7 +84560,7 @@ gRn
 gRn
 gRn
 xZe
-cqZ
+stW
 rIj
 udf
 wCL
@@ -84761,7 +84592,7 @@ iLx
 iLx
 qtP
 gVU
-xfL
+wHx
 xjS
 iKf
 oFC
@@ -84986,10 +84817,10 @@ lrs
 xZe
 xZe
 uQs
-cqZ
+stW
 ojJ
 lrs
-cqZ
+stW
 rZl
 mYI
 iKf
@@ -85018,7 +84849,7 @@ maI
 qvf
 ime
 vXn
-xfL
+wHx
 vof
 uGu
 dqB
@@ -85243,10 +85074,10 @@ lrs
 xZe
 uQs
 xZe
-cqZ
+stW
 ojJ
 lrs
-cqZ
+stW
 iKf
 mYI
 mYI
@@ -85257,7 +85088,7 @@ iKf
 iKf
 ojJ
 lrs
-cqZ
+stW
 iKf
 iEr
 bPP
@@ -86271,7 +86102,7 @@ eFz
 eFz
 lFI
 agQ
-cqZ
+stW
 iKf
 iKf
 mYI
@@ -86800,7 +86631,7 @@ iKf
 ojJ
 lrs
 lrs
-cqZ
+stW
 tiN
 ycK
 bPP
@@ -87057,7 +86888,7 @@ iKf
 mBp
 uHV
 lrs
-cqZ
+stW
 tiN
 iKf
 bPP
@@ -87830,7 +87661,7 @@ iKf
 rIj
 jqA
 lrs
-cqZ
+stW
 bPP
 gMW
 gMW
@@ -89114,7 +88945,7 @@ iKf
 ojJ
 lrs
 lrs
-cqZ
+stW
 iKf
 iKf
 iKf
@@ -89371,7 +89202,7 @@ iKf
 ojJ
 lrs
 lrs
-cqZ
+stW
 iKf
 iKf
 iKf
@@ -110997,7 +110828,7 @@ yjX
 iyb
 cVr
 jiZ
-fyD
+wYV
 pDx
 iKf
 iKf
@@ -111249,13 +111080,13 @@ iKf
 rZl
 tiN
 iKf
-ctY
+nYZ
 iyb
 bPQ
 dXS
 bPQ
 bPQ
-fyD
+wYV
 fJi
 iKf
 tiN
@@ -111506,13 +111337,13 @@ iKf
 mex
 iKf
 iKf
-iLR
+izs
 cMZ
 dXS
 bPQ
 bPQ
 lyt
-vzb
+lpH
 qZY
 iKf
 iKf
@@ -111762,14 +111593,14 @@ iKf
 aCW
 tiN
 iKf
-dOO
+mGg
 iyb
 xQF
 rwY
 bPQ
 jNG
 bPQ
-vzb
+lpH
 sLP
 pkw
 wmL
@@ -112026,7 +111857,7 @@ bPQ
 bPQ
 bPQ
 bPQ
-vzb
+lpH
 qZY
 iKf
 iKf
@@ -112283,7 +112114,7 @@ bPQ
 bPQ
 bPQ
 bPQ
-rqq
+oGA
 qZY
 lmY
 tiN
@@ -112534,12 +112365,12 @@ iKf
 iKf
 iKf
 iKf
-lQs
+gPG
 aiH
 bPQ
 bPQ
 bPQ
-rqq
+oGA
 fOj
 pkw
 iKf
@@ -112792,10 +112623,10 @@ mYI
 iKf
 iKf
 iKf
-lQs
+gPG
 aiH
 rXD
-rqq
+oGA
 fOj
 iKf
 iKf

--- a/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana-Upper-2.dmm
@@ -290,8 +290,7 @@
 /area/f13/building)
 "bb" = (
 /obj/structure/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair_settler"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
@@ -396,8 +395,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -1305,7 +1303,6 @@
 "eG" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -1341,8 +1338,7 @@
 "eP" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1576,11 +1572,6 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "fF" = (
-/obj/structure/wood_counter{
-	layer = 6;
-	pixel_y = -1;
-	opacity = 1
-	},
 /obj/structure/fence/wooden{
 	dir = 4;
 	pixel_y = 9
@@ -2176,8 +2167,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/prewar/poster73{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblack,
@@ -2646,8 +2636,7 @@
 "js" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3053,8 +3042,7 @@
 "la" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/wood,
 /obj/item/canvas/nineteenXnineteen,
@@ -3133,13 +3121,11 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -3307,7 +3293,6 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -3435,7 +3420,6 @@
 /area/f13/caves)
 "mw" = (
 /obj/structure/railing{
-	color = null;
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust{
@@ -3784,7 +3768,6 @@
 "nR" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_y = 0;
 	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
@@ -3909,8 +3892,7 @@
 "oq" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22;
-	density = 0
+	pixel_y = 22
 	},
 /obj/item/flashlight/littlelamp{
 	light_on = 1;
@@ -4543,7 +4525,6 @@
 "qG" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -4629,13 +4610,11 @@
 "qX" = (
 /obj/structure/fence/wooden{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = 14;
 	density = 0
 	},
 /obj/structure/fence/wooden{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = -14;
 	density = 0
 	},
@@ -4692,7 +4671,6 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -4887,13 +4865,11 @@
 "rS" = (
 /obj/structure/fence/wooden{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = 14;
 	density = 0
 	},
 /obj/structure/fence/wooden{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = -14;
 	density = 0
 	},
@@ -5006,8 +4982,7 @@
 /area/f13/caves)
 "sn" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "so" = (
@@ -5460,8 +5435,6 @@
 /area/f13/wasteland)
 "tW" = (
 /obj/structure/chair/sofa/corp/right{
-	dir = 2;
-	pixel_y = 0;
 	color = "pink"
 	},
 /turf/open/floor/f13/wood,
@@ -5827,7 +5800,6 @@
 /area/f13/wasteland)
 "vn" = (
 /obj/structure/chair/sofa/corp/left{
-	dir = 2;
 	color = "pink"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6014,14 +5986,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"vR" = (
-/obj/structure/fence{
-	icon_state = "end";
-	pixel_x = -18;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "vT" = (
 /obj/machinery/light{
 	dir = 8
@@ -6354,7 +6318,6 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -6797,8 +6760,7 @@
 /area/f13/wasteland)
 "yE" = (
 /obj/structure/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+	dir = 8
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -6900,12 +6862,10 @@
 /area/f13/caves)
 "yY" = (
 /obj/structure/railing{
-	dir = 6;
-	layer = 4.1
+	dir = 6
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "yZ" = (
@@ -6923,7 +6883,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = 16
 	},
 /obj/structure/rug/carpet,
@@ -7074,8 +7033,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "zz" = (
@@ -7464,8 +7422,7 @@
 "AS" = (
 /obj/structure/table/wood/bar,
 /obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/item/lipstick/jade,
 /obj/item/lipstick/purple,
@@ -7475,8 +7432,7 @@
 /area/f13/building)
 "AT" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
@@ -7866,7 +7822,6 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -8005,8 +7960,7 @@
 "De" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/chair/bench{
 	dir = 8
@@ -8021,8 +7975,7 @@
 "Dh" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/chair/bench{
 	dir = 8
@@ -8490,8 +8443,7 @@
 "EP" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/open/floor/f13/wood{
 	color = "#C2B280"
@@ -9003,8 +8955,7 @@
 "GJ" = (
 /obj/structure/table/wood/bar,
 /obj/structure/mirror{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/item/lipstick,
 /obj/item/lipstick/black,
@@ -9270,8 +9221,7 @@
 /area/f13/building)
 "HJ" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9279,12 +9229,6 @@
 	color = "#779999"
 	},
 /area/f13/building)
-"HM" = (
-/obj/structure/railing/corner{
-	color = null
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "HN" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -9308,8 +9252,7 @@
 "HS" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
-	pixel_x = -46;
-	pixel_y = 0
+	pixel_x = -46
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
@@ -9374,8 +9317,7 @@
 "HZ" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9688,8 +9630,7 @@
 "Jf" = (
 /obj/structure/spacevine,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "Jh" = (
@@ -10350,8 +10291,6 @@
 /area/f13/wasteland)
 "Lz" = (
 /obj/structure/chair/sofa/corp/right{
-	dir = 2;
-	pixel_y = 0;
 	color = "pink"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10369,8 +10308,7 @@
 /area/f13/building)
 "LC" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -10393,9 +10331,7 @@
 /obj/item/toy/beach_ball{
 	pixel_x = 17
 	},
-/obj/structure/fluff/beach_umbrella{
-	pixel_y = 0
-	},
+/obj/structure/fluff/beach_umbrella,
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "LF" = (
@@ -10418,7 +10354,6 @@
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
 	color = "#A47449";
-	dir = 2;
 	footstep = "wood";
 	opacity = 1
 	},
@@ -10492,8 +10427,7 @@
 "LS" = (
 /obj/structure/table/wood/bar,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -10570,7 +10504,6 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/floor/grass,
@@ -10673,8 +10606,7 @@
 /area/f13/building)
 "MD" = (
 /obj/structure/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
@@ -10737,14 +10669,6 @@
 	color = "#11ff11"
 	},
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"MJ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "ML" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10930,7 +10854,6 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -10978,7 +10901,6 @@
 /area/f13/building)
 "Nz" = (
 /obj/structure/flora/chomp/bones/lribs1{
-	pixel_y = 0;
 	pixel_x = -10;
 	light_color = "#444466";
 	light_range = 2;
@@ -11006,13 +10928,6 @@
 	color = "#11ff11"
 	},
 /turf/open/indestructible/ground/outside/roof,
-/area/f13/wasteland)
-"NC" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2
-	},
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "ND" = (
 /obj/structure/railing,
@@ -11109,9 +11024,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "NT" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "NV" = (
@@ -11187,8 +11100,7 @@
 	color = "#A47449"
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
@@ -11202,9 +11114,7 @@
 	},
 /area/f13/wasteland)
 "Ol" = (
-/obj/item/kirbyplants{
-	pixel_y = 0
-	},
+/obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -11313,8 +11223,7 @@
 "OJ" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned)
@@ -11401,7 +11310,6 @@
 /obj/structure/flora/tree/pink_tree{
 	color = "#BBBBBB";
 	pixel_x = -46;
-	pixel_y = 0;
 	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -11436,9 +11344,7 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Pk" = (
-/obj/machinery/computer/message_monitor{
-	dir = 2
-	},
+/obj/machinery/computer/message_monitor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/monitorkey,
@@ -11455,8 +11361,7 @@
 "Pn" = (
 /obj/structure/fence{
 	icon_state = "end";
-	pixel_x = -18;
-	pixel_y = 0
+	pixel_x = -18
 	},
 /obj/structure/fence{
 	icon_state = "end";
@@ -11618,8 +11523,7 @@
 /area/f13/wasteland)
 "PI" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/wood_common{
 	color = "#888888"
@@ -11647,7 +11551,6 @@
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
 	color = "#A47449";
-	dir = 2;
 	footstep = "wood";
 	opacity = 1
 	},
@@ -12031,14 +11934,6 @@
 /obj/item/card/highbounty,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"Rn" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "Ro" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light,
@@ -12641,7 +12536,6 @@
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
 	color = "#A47449";
-	dir = 2;
 	footstep = "wood";
 	opacity = 1
 	},
@@ -12712,7 +12606,6 @@
 /area/f13/wasteland)
 "Ta" = (
 /obj/structure/railing{
-	color = null;
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt/dust{
@@ -12735,8 +12628,7 @@
 "Td" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -13183,8 +13075,7 @@
 "UB" = (
 /obj/structure/railing/corner,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "UC" = (
@@ -13515,14 +13406,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"VI" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "VJ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -13931,8 +13814,7 @@
 "XA" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/wood,
 /obj/item/chisel,
@@ -13944,8 +13826,7 @@
 	pixel_y = 9
 	},
 /obj/item/toy/crayon/spraycan{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -14507,8 +14388,7 @@
 "ZE" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17041,12 +16921,12 @@ hm
 hm
 hm
 Yw
-Rn
-Rn
+zD
+zD
 hm
-Rn
-Rn
-Rn
+zD
+zD
+zD
 JZ
 fP
 eM
@@ -17305,10 +17185,10 @@ hm
 hm
 hm
 Yw
-Rn
-Rn
-Rn
-Rn
+zD
+zD
+zD
+zD
 OI
 hm
 hm
@@ -20385,7 +20265,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 FN
 oj
 oj
@@ -20642,7 +20522,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 oj
 cB
@@ -20899,7 +20779,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 mJ
 FN
@@ -21156,7 +21036,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 oj
 LF
@@ -21413,7 +21293,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 YV
 oj
@@ -21500,11 +21380,11 @@ hm
 hm
 hm
 hm
-MJ
-MJ
-MJ
-MJ
-MJ
+EU
+EU
+EU
+EU
+EU
 hm
 hm
 hm
@@ -21650,7 +21530,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 al
 Kz
 iE
@@ -21670,7 +21550,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 oj
 SU
@@ -21907,7 +21787,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 iA
 Kz
 iE
@@ -21927,7 +21807,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 oj
 rz
@@ -22164,7 +22044,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kj
 Kz
@@ -22184,7 +22064,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 GL
 fC
@@ -22421,7 +22301,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 jl
@@ -22441,7 +22321,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 oj
 oj
 oj
@@ -22678,7 +22558,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 fn
 iE
@@ -22935,7 +22815,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 iA
 iE
 iE
@@ -23192,7 +23072,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 al
 Vr
 RX
@@ -28351,7 +28231,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 cP
 Kz
 Kz
@@ -28608,7 +28488,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -28865,7 +28745,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kj
 Kz
@@ -29122,7 +29002,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 li
 jT
 Kz
@@ -29379,7 +29259,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 OM
 Kz
 Uq
@@ -29636,7 +29516,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 al
 OM
 wl
@@ -29658,7 +29538,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 iA
 al
 Kz
@@ -29915,7 +29795,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -30172,7 +30052,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -30205,7 +30085,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 al
 HG
 OM
@@ -30429,7 +30309,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -30462,7 +30342,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 jT
 Kz
@@ -30495,7 +30375,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 iA
 al
 Kz
@@ -30686,7 +30566,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 jT
 iE
@@ -30719,7 +30599,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -30752,7 +30632,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -30943,7 +30823,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 al
 OM
@@ -30976,7 +30856,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -31009,7 +30889,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -31233,7 +31113,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 jT
 iE
@@ -31266,7 +31146,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 Kz
 Kz
@@ -31490,7 +31370,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 al
 QV
 OM
@@ -31523,7 +31403,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 jT
 iE
@@ -31780,7 +31660,7 @@ hm
 hm
 hm
 hm
-NC
+xU
 Kz
 al
 OM
@@ -45773,7 +45653,7 @@ jk
 FS
 FS
 Zm
-VI
+LW
 qs
 jk
 jk
@@ -57692,11 +57572,11 @@ Xj
 KI
 wJ
 Pn
-vR
-vR
-vR
-vR
-vR
+UZ
+UZ
+UZ
+UZ
+UZ
 hm
 hm
 hm
@@ -64821,7 +64701,7 @@ hm
 hm
 hm
 hm
-HM
+jj
 WA
 WA
 WA

--- a/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana-Upper.dmm
@@ -35,8 +35,7 @@
 "aao" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/wood_common{
@@ -68,8 +67,7 @@
 "aaL" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "aaZ" = (
@@ -420,8 +418,7 @@
 "ajQ" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/chair/bench{
 	dir = 8
@@ -596,8 +593,7 @@
 "anx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
@@ -1087,8 +1083,7 @@
 /area/f13/building/abandoned)
 "aBE" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /obj/structure/toilet_paper{
 	pixel_y = 27
@@ -1129,8 +1124,7 @@
 /area/f13/building)
 "aBT" = (
 /obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/caves)
@@ -1543,8 +1537,7 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -1638,8 +1631,7 @@
 /area/f13/building)
 "aNr" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
@@ -1895,8 +1887,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/deployable_barricade/wooden,
 /turf/open/indestructible/ground/outside/roof,
@@ -2297,8 +2288,7 @@
 /obj/structure/lattice,
 /obj/structure/spacevine,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "bgs" = (
@@ -2471,8 +2461,7 @@
 /area/f13/building)
 "blz" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3722,14 +3711,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -4216,7 +4203,6 @@
 "cdM" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4
 	},
 /turf/open/transparent/openspace,
@@ -5062,12 +5048,6 @@
 	icon_state = "common-broken3"
 	},
 /area/f13/building/abandoned)
-"cAO" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "cAQ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -5454,14 +5434,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /turf/closed/wall/f13/sunset/brick_small_dark{
@@ -5916,8 +5894,7 @@
 "dbf" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -6675,8 +6652,7 @@
 "dvJ" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "dvV" = (
@@ -7471,8 +7447,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "dOP" = (
@@ -7900,7 +7875,6 @@
 "ebn" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4
 	},
 /obj/structure/railing{
@@ -8068,8 +8042,7 @@
 "egq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "egK" = (
@@ -8487,14 +8460,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -8831,8 +8802,7 @@
 "eBi" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-12";
@@ -8919,8 +8889,7 @@
 "eEX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
@@ -8928,8 +8897,7 @@
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ff0000";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
@@ -9047,8 +9015,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "eGC" = (
@@ -9996,14 +9963,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -10039,9 +10004,7 @@
 	},
 /area/f13/wasteland)
 "ffT" = (
-/obj/structure/bed/old{
-	pixel_y = 0
-	},
+/obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/ruins)
 "fgm" = (
@@ -10230,7 +10193,6 @@
 "fkD" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4
 	},
 /obj/structure/railing{
@@ -10271,8 +10233,7 @@
 /area/f13/building/mall)
 "flr" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/ruins)
 "flw" = (
@@ -11311,14 +11272,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark{
 	color = "#AA5555"
@@ -11722,9 +11681,7 @@
 /obj/structure/bed/old{
 	pixel_y = 11
 	},
-/obj/structure/bed/old{
-	pixel_y = 0
-	},
+/obj/structure/bed/old,
 /obj/item/bedsheet{
 	pixel_y = 11
 	},
@@ -11860,8 +11817,7 @@
 /area/f13/building/mall)
 "gej" = (
 /obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
@@ -12166,7 +12122,6 @@
 	},
 /area/f13/wasteland/nash)
 "gkm" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/medicine,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12552,12 +12507,10 @@
 /area/f13/wasteland)
 "grY" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
@@ -14113,8 +14066,7 @@
 /obj/item/trash/sosjerky,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "hdw" = (
@@ -14202,7 +14154,6 @@
 	},
 /area/f13/building/mall)
 "hfH" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -14544,14 +14495,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -14826,8 +14775,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "hsz" = (
@@ -15622,14 +15570,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/coyote/fortress_brick,
 /area/f13/building)
@@ -16093,8 +16039,7 @@
 "iau" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+	dir = 8
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
@@ -16148,8 +16093,7 @@
 "icv" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/trading_machine,
 /turf/open/floor/f13/wood,
@@ -16608,12 +16552,10 @@
 /area/f13/building/massfusion)
 "ipC" = (
 /obj/structure/railing{
-	color = null;
 	dir = 9
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "ipE" = (
@@ -16944,8 +16886,7 @@
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ff0000";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
@@ -17075,8 +17016,7 @@
 "iBy" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/f13/wood,
@@ -17084,8 +17024,7 @@
 "iBz" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
@@ -17203,7 +17142,6 @@
 "iFs" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -18003,7 +17941,6 @@
 "iXV" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -18162,8 +18099,7 @@
 /area/f13/wasteland)
 "jcF" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
@@ -18587,10 +18523,6 @@
 	},
 /area/f13/building/massfusion)
 "jpy" = (
-/obj/structure/wood_counter{
-	layer = 6;
-	pixel_y = -1
-	},
 /obj/structure/fence/wooden{
 	dir = 4;
 	pixel_y = 9
@@ -18775,8 +18707,7 @@
 "jsn" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral{
 	dir = 8;
@@ -19158,8 +19089,7 @@
 "jCd" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
@@ -19255,8 +19185,7 @@
 /area/f13/building)
 "jFo" = (
 /obj/effect/turf_decal/big{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood_wide,
@@ -20651,21 +20580,6 @@
 	icon_state = "greenrustychess"
 	},
 /area/f13/building/massfusion)
-"kqL" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
-	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
-	},
-/turf/closed/wall/f13/sunset/brick_small_dark,
-/area/f13/building)
 "kqN" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13{
@@ -20848,8 +20762,7 @@
 "kvO" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -21032,7 +20945,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/protectron{
 	layer = 3;
-	max_mobs = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -21857,8 +21769,7 @@
 "kRU" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -21968,8 +21879,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -22252,17 +22162,6 @@
 /obj/machinery/light/broken,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
-"lco" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "lcv" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_y = 10
@@ -22466,12 +22365,10 @@
 /area/f13/building)
 "lgL" = (
 /obj/structure/railing{
-	color = null;
 	dir = 5
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "lgP" = (
@@ -22738,8 +22635,7 @@
 /area/f13/building/hospital)
 "loO" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
@@ -22762,8 +22658,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "lpZ" = (
@@ -24261,8 +24156,7 @@
 	},
 /obj/item/soap,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
@@ -24343,8 +24237,7 @@
 /area/f13/building/massfusion)
 "mcX" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital/clinic/nash)
@@ -24865,12 +24758,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"mup" = (
-/obj/structure/railing/corner{
-	color = null
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "muy" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/closet/crate/bin,
@@ -24930,7 +24817,6 @@
 	},
 /area/f13/building)
 "mvo" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/circuitry,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/f13{
@@ -25232,8 +25118,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "mBR" = (
@@ -25839,9 +25724,7 @@
 	pixel_x = 10;
 	pixel_y = -2
 	},
-/obj/structure/fence/wooden{
-	pixel_y = 0
-	},
+/obj/structure/fence/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -27305,8 +27188,7 @@
 /area/f13/caves)
 "nAT" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "nAW" = (
@@ -28224,8 +28106,7 @@
 "nUm" = (
 /obj/structure/lattice,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "nUs" = (
@@ -28465,8 +28346,7 @@
 /obj/item/trash/sosjerky,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "obA" = (
@@ -28710,14 +28590,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark{
 	color = "#AA5555"
@@ -28845,14 +28723,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/brick,
@@ -28960,8 +28836,7 @@
 	dir = 6
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "ooN" = (
@@ -29295,14 +29170,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -29333,7 +29206,6 @@
 	},
 /area/f13/wasteland)
 "oAZ" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29606,13 +29478,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
-"oIp" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "oIu" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -30063,8 +29928,7 @@
 "oTC" = (
 /obj/structure/nest/protectron,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
@@ -30283,14 +30147,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -31038,8 +30900,7 @@
 /area/f13/wasteland)
 "pys" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -31297,14 +31158,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/coyote/fortress_brick{
 	opacity = 0
@@ -31986,8 +31845,7 @@
 "pWv" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/fence/end/wooden{
 	density = 0;
@@ -32329,7 +32187,6 @@
 	},
 /area/f13/building/abandoned)
 "qeV" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/nuka_recipes,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -32610,8 +32467,7 @@
 "qlX" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -32918,8 +32774,7 @@
 /obj/structure/chair/sofa/corp/right{
 	color = "pink";
 	dir = 8;
-	pixel_x = 8;
-	pixel_y = 0
+	pixel_x = 8
 	},
 /turf/open/floor/carpet/black,
 /area/f13/bar/heaven)
@@ -33087,8 +32942,7 @@
 /area/f13/building/massfusion)
 "qwh" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/abandoned)
 "qwt" = (
@@ -34647,8 +34501,7 @@
 	dir = 10
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "rqa" = (
@@ -34739,14 +34592,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -35068,8 +34919,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/abandoned)
 "rAJ" = (
@@ -35260,20 +35110,17 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -35522,8 +35369,7 @@
 /area/f13/building/hospital/clinic/nash)
 "rLd" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -36012,8 +35858,7 @@
 /area/f13/bar/nash)
 "sbP" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "sbW" = (
@@ -36551,8 +36396,7 @@
 /area/f13/building/abandoned)
 "srZ" = (
 /obj/effect/turf_decal/big{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
@@ -37433,8 +37277,7 @@
 /obj/structure/chair/sofa/corp/right{
 	color = "pink";
 	dir = 8;
-	pixel_x = 8;
-	pixel_y = 0
+	pixel_x = 8
 	},
 /obj/machinery/light/small{
 	color = "#444499";
@@ -37775,8 +37618,7 @@
 "tcj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -38547,8 +38389,7 @@
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ff0000";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -39373,8 +39214,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "tPc" = (
@@ -39501,8 +39341,7 @@
 "tRd" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -39727,8 +39566,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "tWB" = (
@@ -39954,10 +39792,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building/hospital)
-"ueB" = (
-/obj/effect/temp_visual/steam,
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "ueM" = (
 /obj/structure/simple_door/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -40151,8 +39985,7 @@
 /area/f13/building/mall)
 "ulz" = (
 /obj/structure/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair_settler"
+	dir = 4
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/nash)
@@ -40286,8 +40119,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "uoi" = (
@@ -40806,14 +40638,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /turf/closed/wall/f13/sunset/brick_small_dark{
@@ -40844,8 +40674,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "uAg" = (
@@ -41184,8 +41013,7 @@
 	icon_state = "smoke";
 	name = "fog";
 	opacity = 1;
-	pixel_x = -1;
-	pixel_y = 0
+	pixel_x = -1
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -42215,8 +42043,7 @@
 "vmu" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -42434,8 +42261,7 @@
 /area/f13/building/mall)
 "vqz" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "vqD" = (
@@ -42618,8 +42444,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -42769,8 +42594,7 @@
 "vCb" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -43211,8 +43035,7 @@
 /area/f13/building/mall)
 "vMj" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/structure/railing{
 	color = "#A47449";
@@ -44888,8 +44711,7 @@
 /area/f13/building/tribal)
 "wEW" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/validball_spawner,
 /turf/open/floor/plasteel/f13{
@@ -44942,8 +44764,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
@@ -45150,7 +44971,6 @@
 	color = "#C4897D";
 	desc = "A wooden bedpost";
 	dir = 4;
-	icon = 'icons/fallout/structures/fences.dmi';
 	layer = 3;
 	name = "bedpost";
 	pixel_x = 1
@@ -45159,7 +44979,6 @@
 	color = "#C4897D";
 	desc = "A wooden bedpost";
 	dir = 8;
-	icon = 'icons/fallout/structures/fences.dmi';
 	layer = 3;
 	name = "bedpost";
 	pixel_x = -1
@@ -45301,14 +45120,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /turf/closed/wall/f13/sunset/brick_small_dark,
 /area/f13/building)
@@ -45359,8 +45176,7 @@
 /area/f13/building)
 "wUV" = (
 /obj/structure/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+	dir = 8
 	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
@@ -45463,8 +45279,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "wXH" = (
@@ -45489,14 +45304,12 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 14;
-	pixel_y = 0
+	pixel_x = 14
 	},
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = -14;
-	pixel_y = 0
+	pixel_x = -14
 	},
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -46125,8 +45938,7 @@
 	name = "power unit"
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
@@ -46660,8 +46472,7 @@
 /area/f13/caves)
 "xFS" = (
 /obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -46692,8 +46503,7 @@
 /area/f13/building/mall)
 "xGL" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/ruins,
@@ -46899,7 +46709,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
 "xMK" = (
-/obj/structure/table/reinforced/brass,
 /obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
@@ -47541,14 +47350,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/wasteland)
-"yeY" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "yfr" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -47809,13 +47610,6 @@
 	color = "#777777"
 	},
 /area/f13/wasteland)
-"ykS" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/nash)
 "ykW" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50350,7 +50144,7 @@ psj
 psj
 psj
 psj
-ykS
+bul
 ftt
 ftt
 oSN
@@ -50607,7 +50401,7 @@ veF
 veF
 vOP
 psj
-ykS
+bul
 vvS
 ftt
 vvS
@@ -50864,7 +50658,7 @@ nzO
 isp
 vtO
 psj
-ykS
+bul
 vvS
 ftt
 xIp
@@ -51121,7 +50915,7 @@ mNr
 wzU
 mNr
 psj
-ykS
+bul
 gjV
 ftt
 ftt
@@ -51378,7 +51172,7 @@ voa
 blz
 jZh
 psj
-ykS
+bul
 ftt
 qnC
 ftt
@@ -51635,7 +51429,7 @@ mLj
 xDy
 mLj
 psj
-ykS
+bul
 ftt
 cKE
 ftt
@@ -52385,12 +52179,12 @@ qnC
 qnC
 qnC
 qnC
-kqL
+pfJ
 lcB
 nCS
 mNn
 lkh
-kqL
+pfJ
 hHi
 oeP
 qnC
@@ -52646,7 +52440,7 @@ oYF
 cNi
 jzy
 mNn
-kqL
+pfJ
 cBX
 kHS
 oeP
@@ -52903,7 +52697,7 @@ rqY
 dNl
 eQo
 hlo
-kqL
+pfJ
 hHi
 qqx
 oeP
@@ -53413,7 +53207,7 @@ vlI
 hHi
 oeP
 qnC
-kqL
+pfJ
 rty
 mNn
 slU
@@ -53670,7 +53464,7 @@ fXF
 hHi
 oeP
 qnC
-kqL
+pfJ
 gPk
 mNn
 mNn
@@ -53927,7 +53721,7 @@ xPZ
 hHi
 oeP
 qnC
-kqL
+pfJ
 slU
 slU
 mNn
@@ -54640,8 +54434,8 @@ oez
 oez
 oez
 uUX
-yeY
-yeY
+sRu
+sRu
 ykM
 kCD
 dYg
@@ -55408,7 +55202,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 rrM
 knV
 mNn
@@ -55632,7 +55426,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 nSY
 nSY
@@ -55665,7 +55459,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 mNn
 mNn
@@ -55889,7 +55683,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 dTc
 jdQ
@@ -55922,7 +55716,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 mNn
 mNn
@@ -56146,7 +55940,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 mdq
@@ -56179,7 +55973,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 tPg
 eJT
@@ -56199,7 +55993,7 @@ bvw
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -56241,7 +56035,7 @@ qqU
 qnC
 qnC
 qnC
-ykS
+bul
 poH
 nEl
 ihO
@@ -56257,7 +56051,7 @@ qnC
 qnC
 qnC
 qnC
-ykS
+bul
 qDg
 cor
 cdN
@@ -56403,7 +56197,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 lbC
@@ -56456,7 +56250,7 @@ nBo
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -56498,7 +56292,7 @@ nEl
 nEl
 nEl
 wky
-ykS
+bul
 gWO
 hHi
 srZ
@@ -56660,7 +56454,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 lbC
@@ -56713,7 +56507,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -56755,7 +56549,7 @@ hHi
 hHi
 hHi
 oeP
-ykS
+bul
 gWO
 hHi
 srZ
@@ -56917,7 +56711,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 uFd
@@ -56970,7 +56764,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -57012,7 +56806,7 @@ pyX
 pyX
 lxx
 uqG
-ykS
+bul
 gWO
 hHi
 jFo
@@ -57174,7 +56968,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 dTc
 dZy
@@ -57227,7 +57021,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -57269,7 +57063,7 @@ eTm
 mNn
 uRt
 rrs
-ykS
+bul
 gWO
 hHi
 srZ
@@ -57431,7 +57225,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 nSY
 nSY
@@ -57484,7 +57278,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -57526,7 +57320,7 @@ jAx
 slU
 mNn
 rrs
-ykS
+bul
 gWO
 hHi
 hvY
@@ -57741,7 +57535,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -57783,7 +57577,7 @@ pOk
 eoY
 mNn
 rrs
-ykS
+bul
 gWO
 hHi
 hHi
@@ -57998,7 +57792,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -58255,7 +58049,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -58512,7 +58306,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -58684,7 +58478,7 @@ deZ
 srk
 srk
 oez
-cAO
+nez
 sRA
 aQp
 qLE
@@ -58941,7 +58735,7 @@ srk
 srk
 srk
 oez
-cAO
+nez
 rGU
 pAr
 rqy
@@ -59797,7 +59591,7 @@ dtb
 dtb
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -60054,7 +59848,7 @@ dtb
 dtb
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -60311,7 +60105,7 @@ dtb
 dtb
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -60568,7 +60362,7 @@ vjL
 dtb
 oez
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -60825,7 +60619,7 @@ uID
 xlB
 dtb
 oez
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -61339,7 +61133,7 @@ dtb
 dtb
 dtb
 dtb
-oIp
+tXH
 ftt
 ftt
 ftt
@@ -62109,7 +61903,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 knV
 mNn
@@ -62366,7 +62160,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 rrM
 mNn
 mNn
@@ -63416,7 +63210,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 mNn
 mNn
@@ -63673,7 +63467,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mNn
 rrM
 mNn
@@ -73789,7 +73583,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 xTf
 mLO
 iTN
@@ -74046,7 +73840,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 olD
 bUU
 nNJ
@@ -74303,7 +74097,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 tta
 giL
 din
@@ -74560,7 +74354,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 cXu
 wUV
 dXp
@@ -80310,7 +80104,7 @@ vje
 vje
 vje
 vje
-ueB
+oez
 oez
 oez
 oez
@@ -80567,8 +80361,8 @@ vje
 icJ
 aFK
 evM
-ueB
-ueB
+oez
+oez
 oez
 oez
 oez
@@ -80824,7 +80618,7 @@ icJ
 qYc
 qls
 vje
-ueB
+oez
 oez
 wYG
 wYG
@@ -87839,7 +87633,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 qCs
 qCs
 ygs
@@ -88352,7 +88146,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 kpv
 kpv
@@ -88609,7 +88403,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 msC
 qCs
 kTF
@@ -89123,7 +88917,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 jSQ
 kTF
@@ -89380,7 +89174,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 kpv
@@ -89637,7 +89431,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 mSv
 kTF
@@ -89894,7 +89688,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 vWC
 kTF
 kpv
@@ -90151,7 +89945,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 uOi
 kpv
 kTF
@@ -90408,7 +90202,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 mSv
@@ -90665,7 +90459,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 wrN
 kpv
 kTF
@@ -90922,7 +90716,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 fho
 kpv
@@ -91179,7 +90973,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 msC
 fho
 kTF
@@ -91436,7 +91230,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 uOi
 kTF
 kpv
@@ -91694,7 +91488,7 @@ oez
 oez
 oez
 oez
-lco
+tLL
 fho
 kTF
 fvt
@@ -91951,7 +91745,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 rsw
@@ -96999,7 +96793,7 @@ iUG
 mbc
 eNt
 nBq
-mup
+cVc
 nQJ
 nQJ
 nQJ

--- a/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana.dmm
+++ b/_maps/map_files/coyote_bayou/Backup Nash/Nash_and_Texarkana.dmm
@@ -9439,9 +9439,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/ruins)
 "aHg" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/ruins)
 "aHh" = (
@@ -15392,7 +15390,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /turf/open/floor/wood_common{
@@ -15406,7 +15403,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -16899,14 +16895,12 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -23068,7 +23062,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -23944,7 +23937,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -25427,7 +25419,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -26299,7 +26290,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -26787,7 +26777,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -26905,7 +26894,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -27179,8 +27167,7 @@
 /area/f13/building)
 "cKC" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
@@ -27213,8 +27200,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /obj/structure/sign/painting/library{
 	pixel_y = 35
@@ -28645,7 +28631,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -29676,9 +29661,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dph" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/ruins)
@@ -30763,7 +30746,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -31251,7 +31233,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -31712,14 +31693,12 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -33103,7 +33082,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -36309,7 +36287,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -38617,7 +38594,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -39517,7 +39493,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -40572,7 +40547,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -41004,7 +40978,6 @@
 "fSc" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4;
-	pixel_y = 0;
 	color = "pink"
 	},
 /turf/open/floor/wood_common{
@@ -42005,7 +41978,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -42603,7 +42575,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -43322,7 +43293,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -44665,7 +44635,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -45044,7 +45013,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/road{
@@ -45199,7 +45167,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/ruins,
@@ -46123,9 +46090,7 @@
 	},
 /area/f13/wasteland/city)
 "gYo" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -47857,7 +47822,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -47952,11 +47916,9 @@
 /area/f13/building/abandoned)
 "hvt" = (
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = 12
 	},
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = -13
 	},
 /turf/closed/wall/f13/wood/house,
@@ -48059,9 +48021,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_y = 15
 	},
-/obj/structure/table/wood/bar{
-	pixel_y = 0
-	},
+/obj/structure/table/wood/bar,
 /turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/bar/nash)
 "hwO" = (
@@ -48571,7 +48531,6 @@
 "hDT" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -48928,7 +48887,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -49248,7 +49206,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -52104,7 +52061,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -53026,7 +52982,6 @@
 "iAl" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -53869,7 +53824,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -54038,8 +53992,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -54165,7 +54118,6 @@
 "iMn" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -54423,7 +54375,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -55268,7 +55219,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -55772,7 +55722,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -57223,7 +57172,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /turf/open/floor/wood_common{
@@ -57957,8 +57905,7 @@
 "jHA" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
 	icon_state = "showroomfloor";
@@ -58776,7 +58723,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -59036,7 +58982,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -60047,7 +59992,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -60890,7 +60834,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -63399,7 +63342,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -64033,7 +63975,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -64478,7 +64419,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -65944,7 +65884,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -65974,7 +65913,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -67661,7 +67599,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69047,7 +68984,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -70441,7 +70377,6 @@
 "msP" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8;
-	pixel_y = 0;
 	color = "pink"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -70645,7 +70580,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -71576,7 +71510,6 @@
 /obj/machinery/light/small{
 	color = "#FF0000";
 	light_color = "#FF0000";
-	pixel_y = 0;
 	pixel_x = 14
 	},
 /obj/machinery/button/door{
@@ -73084,7 +73017,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -73292,7 +73224,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -3
 	},
 /obj/structure/chair/comfy/purple{
@@ -75334,7 +75265,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel,
@@ -77236,8 +77166,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -77879,7 +77808,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -81140,9 +81068,7 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/building/abandoned)
 "oLI" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -82824,7 +82750,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -83591,7 +83516,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -87220,7 +87144,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -87240,7 +87163,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -87335,7 +87257,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -3
 	},
 /obj/effect/decal/cleanable/dirt{
@@ -87624,7 +87545,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -89493,7 +89413,6 @@
 	pixel_y = 19
 	},
 /obj/structure/chair/sofa/left{
-	dir = 2;
 	icon_state = "sofacorner"
 	},
 /turf/open/floor/wood_common{
@@ -90879,7 +90798,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -90959,7 +90877,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -91846,7 +91763,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -92098,7 +92014,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -94523,7 +94438,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -95216,16 +95130,6 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland/city/nash/downtown)
-"rXA" = (
-/obj/structure/spacevine{
-	color = "#225522";
-	pixel_y = 0
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/closed/indestructible/riveted/boss{
-	name = "temple wall"
-	},
-/area/f13/building/tribal)
 "rXB" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -97276,7 +97180,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -97498,7 +97401,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -99595,7 +99497,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -100377,7 +100278,6 @@
 /obj/machinery/light/small{
 	color = "#FF0000";
 	light_color = "#FF0000";
-	pixel_y = 0;
 	pixel_x = 14
 	},
 /obj/structure/stairs/west{
@@ -101371,7 +101271,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -102660,7 +102559,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel,
@@ -102784,7 +102682,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -103429,7 +103326,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -103785,7 +103681,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/effect/turf_decal/weather/dirt{
@@ -103893,7 +103788,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -104094,7 +103988,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -104916,7 +104809,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -105077,7 +104969,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/road{
@@ -105807,7 +105698,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -105815,7 +105705,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -106368,8 +106257,7 @@
 /area/f13/building/hospital/clinic/nash)
 "utI" = (
 /obj/structure/railing{
-	dir = 6;
-	layer = 4.1
+	dir = 6
 	},
 /obj/item/reagent_containers/food/snacks/grown/harebell{
 	pixel_y = 22
@@ -107098,7 +106986,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -107566,7 +107453,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /turf/open/floor/wood_common{
@@ -112711,7 +112597,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -113340,7 +113225,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -113425,7 +113309,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -113937,7 +113820,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/ruins,
@@ -115841,7 +115723,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -116566,7 +116447,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -117677,7 +117557,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -117801,7 +117680,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -118351,7 +118229,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -119823,8 +119700,7 @@
 /obj/machinery/light/small{
 	color = "#FF0000";
 	light_color = "#FF0000";
-	pixel_x = -13;
-	pixel_y = 0
+	pixel_x = -13
 	},
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "heart";
@@ -120065,7 +119941,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/effect/turf_decal/weather/dirt{
@@ -120347,7 +120222,6 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -121676,7 +121550,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -123124,7 +122997,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -127950,7 +127822,7 @@ sUI
 vQI
 oYg
 vQI
-rXA
+aJx
 eKL
 dhs
 vEb
@@ -128207,7 +128079,7 @@ beL
 vQI
 xnP
 xBo
-rXA
+aJx
 eKL
 him
 byg

--- a/_maps/map_files/coyote_bayou/Backup Nash/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Backup Nash/Newboston-Upper.dmm
@@ -4097,8 +4097,7 @@
 /area/f13/village)
 "HV" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
@@ -4789,8 +4788,7 @@
 /area/f13/building)
 "Ol" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -5485,7 +5483,6 @@
 /area/f13/city)
 "TK" = (
 /obj/machinery/computer/terminal{
-	dir = 2;
 	pixel_x = 16;
 	pixel_y = 8;
 	termtag = "Business"

--- a/_maps/map_files/coyote_bayou/Backup Nash/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Backup Nash/Newboston.dmm
@@ -4520,9 +4520,7 @@
 	},
 /area/f13/building)
 "dxz" = (
-/obj/machinery/vending/engineering{
-	req_access = null
-	},
+/obj/machinery/vending/engineering,
 /turf/open/floor/plasteel/darkbrown/side{
 	dir = 1
 	},
@@ -6170,9 +6168,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eIn" = (
-/obj/machinery/vending/medical{
-	req_access = null
-	},
+/obj/machinery/vending/medical,
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "eIu" = (
@@ -13561,9 +13557,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "jTF" = (
-/obj/structure/toilet{
-	pixel_y = 0
-	},
+/obj/structure/toilet,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -15002,16 +14996,6 @@
 /obj/structure/flora/wasteplant/wild_xander,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"kXC" = (
-/obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "kXK" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
@@ -15792,9 +15776,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lxG" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 4
-	},
+/obj/structure/simple_door/metal/fence,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
@@ -22604,9 +22586,7 @@
 	},
 /area/f13/tunnel)
 "qCp" = (
-/obj/machinery/vending/medical{
-	req_access = null
-	},
+/obj/machinery/vending/medical,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -24132,9 +24112,7 @@
 	},
 /area/f13/building)
 "rKK" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 4
-	},
+/obj/structure/simple_door/metal/fence,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -29138,11 +29116,9 @@
 /area/f13/wasteland)
 "vlZ" = (
 /obj/structure/filingcabinet{
-	pixel_y = 0;
 	pixel_x = 9
 	},
 /obj/structure/filingcabinet{
-	pixel_y = 0;
 	pixel_x = -1
 	},
 /obj/machinery/light/small{
@@ -43013,7 +42989,7 @@ mec
 eSu
 yde
 bKl
-kXC
+jHN
 dpp
 lez
 dpp

--- a/_maps/map_files/coyote_bayou/Dungeons.dmm
+++ b/_maps/map_files/coyote_bayou/Dungeons.dmm
@@ -82,9 +82,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "aaG" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -204,9 +202,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "adl" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -2259,8 +2255,7 @@
 "aVD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/big{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -3657,7 +3652,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/machinery/shower{
@@ -4161,8 +4155,7 @@
 /area/f13/underground/cave/tunnelertemple/void)
 "bRj" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -4675,14 +4668,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/vault)
-"ccT" = (
-/mob/living/simple_animal/hostile/securitron/sentrybot/chew{
-	faction = list("wastebot")
-	},
-/turf/open/floor/plating/f13/inside/mountain{
-	icon_state = "mountain2"
-	},
-/area/f13/underground/cave)
 "ccZ" = (
 /obj/structure/barricade/sandbags{
 	dir = 1
@@ -5509,9 +5494,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4
-	},
+/obj/machinery/door/window/brigdoor,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
@@ -5773,9 +5756,7 @@
 	},
 /area/f13/building)
 "cCe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
@@ -6818,9 +6799,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/underground/cave/tunnelertemple)
 "cUg" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2"
@@ -10765,13 +10744,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"ewz" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ewC" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -11959,8 +11931,7 @@
 /area/f13/bunker)
 "eXm" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/wood,
 /turf/open/floor/f13/wood,
@@ -14550,9 +14521,7 @@
 	},
 /area/f13/building)
 "gcB" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
 	dir = 1
 	},
@@ -14792,7 +14761,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -15395,12 +15363,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/vault)
-"gvA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
 "gvM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16414,9 +16376,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "gSv" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -16729,7 +16689,6 @@
 /obj/machinery/button/door{
 	id = "finalbossyellow";
 	name = "shutters button";
-	pixel_y = 0;
 	light_color = "#FFFF00";
 	light_power = 40;
 	light_range = 4;
@@ -20196,9 +20155,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/vault)
 "iFy" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
 /area/f13/building)
 "iFE" = (
@@ -22674,7 +22631,6 @@
 "jMd" = (
 /obj/structure/nest/protectron{
 	layer = 3;
-	max_mobs = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -23002,8 +22958,7 @@
 /area/f13/brotherhood/operations)
 "jUZ" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/f13/building)
@@ -25464,8 +25419,7 @@
 "kXI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer1{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/structure/reagent_dispensers/barrel/explosive{
 	pixel_x = -2;
@@ -25496,7 +25450,6 @@
 "kYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
-	id_tag = null;
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -26344,8 +26297,7 @@
 /area/f13/bunker)
 "lsg" = (
 /obj/structure/chair/comfy/brown{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -27548,11 +27500,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "lVq" = (
-/obj/structure/wood_counter{
-	layer = 6;
-	pixel_y = -1;
-	opacity = 1
-	},
 /obj/structure/fence/wooden{
 	dir = 4;
 	pixel_y = 9
@@ -27609,7 +27556,6 @@
 "lVG" = (
 /obj/structure/nest/protectron{
 	layer = 3;
-	max_mobs = 2;
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -30385,7 +30331,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -31646,8 +31591,7 @@
 /area/f13/building)
 "nDp" = (
 /obj/machinery/light/broken{
-	dir = 8;
-	icon_state = "tube-broken"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -37852,9 +37796,7 @@
 /turf/open/floor/carpet/purple,
 /area/f13/brotherhood/rnd)
 "qgJ" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/structure/closet,
 /obj/effect/validball_spawner,
 /turf/open/floor/plasteel/barber{
@@ -40014,13 +39956,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"raO" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/f13/whitemarble,
-/area/f13/building)
 "raY" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Head Knight's Office";
@@ -40137,7 +40072,6 @@
 /area/f13/building)
 "rcQ" = (
 /obj/machinery/door/airlock/grunge{
-	id_tag = null;
 	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -41061,9 +40995,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4
-	},
+/obj/machinery/door/window/brigdoor,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -45767,8 +45699,7 @@
 /area/f13/brotherhood/leisure)
 "tDc" = (
 /obj/effect/turf_decal/big{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -46199,13 +46130,6 @@
 	light_color = "#ad1b1b"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/building)
-"tLf" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
-	},
-/turf/open/floor/plating/beach/water,
 /area/f13/building)
 "tLA" = (
 /obj/machinery/plantgenes,
@@ -47597,9 +47521,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/water,
 /area/f13/underground/cave/tunnelertemple/void)
 "urZ" = (
@@ -67096,7 +67018,7 @@ aoh
 cCj
 dHW
 aRZ
-ccT
+fTd
 cCj
 gHj
 tMp
@@ -96270,7 +96192,7 @@ dXJ
 xrG
 dXJ
 riK
-gvA
+dON
 qOs
 aLX
 aLX
@@ -115460,7 +115382,7 @@ ltw
 rLB
 tOZ
 tOZ
-raO
+ahI
 jsq
 erS
 rLB
@@ -116752,7 +116674,7 @@ rLB
 jfP
 ubw
 ubw
-ewz
+kIj
 ubw
 eXm
 rLB
@@ -117521,7 +117443,7 @@ cuN
 nsp
 vtf
 tdb
-tLf
+uGd
 qWX
 qWX
 uGd

--- a/_maps/map_files/coyote_bayou/Garland-City.dmm
+++ b/_maps/map_files/coyote_bayou/Garland-City.dmm
@@ -16,9 +16,7 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
 "aaC" = (
-/obj/machinery/vending/engineering{
-	req_access = null
-	},
+/obj/machinery/vending/engineering,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -486,8 +484,7 @@
 /area/f13/wasteland)
 "asX" = (
 /obj/structure/simple_door/metal/fence{
-	dir = 8;
-	icon_state = "fence"
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -828,14 +825,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"aFI" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "aGc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -916,7 +905,6 @@
 /area/f13/building)
 "aIu" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1222,9 +1210,7 @@
 	},
 /area/f13/wasteland)
 "aSd" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
@@ -1277,9 +1263,7 @@
 /area/f13/building)
 "aSS" = (
 /obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/medical/ancientfirstaid{
-	pixel_y = 0
-	},
+/obj/item/storage/medical/ancientfirstaid,
 /obj/item/storage/box/ration/ranger_breakfast{
 	pixel_y = -6
 	},
@@ -1333,7 +1317,6 @@
 /area/f13/building)
 "aTD" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /obj/machinery/light,
@@ -2404,10 +2387,7 @@
 /area/f13/wasteland)
 "bOS" = (
 /obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -2597,13 +2577,6 @@
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
-"bVN" = (
-/obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "bVX" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom0"
@@ -2667,8 +2640,7 @@
 /area/f13/building)
 "bYH" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
@@ -2719,8 +2691,7 @@
 /area/f13/building)
 "bZV" = (
 /obj/structure/nest/ghoul{
-	layer = 2.07;
-	max_mobs = 2
+	layer = 2.07
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
@@ -3233,9 +3204,7 @@
 "cuC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13/wood,
@@ -4106,10 +4075,7 @@
 /area/f13/city)
 "cWX" = (
 /obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -4253,13 +4219,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/building/coyote/safe/garland)
-"daA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8;
-	icon_state = "comfychair"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "daS" = (
 /obj/machinery/mineral/wasteland_vendor/crafting{
 	icon_state = "parts_idle"
@@ -4998,8 +4957,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -5008,9 +4966,7 @@
 "dEv" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -5030,7 +4986,6 @@
 /area/f13/building)
 "dEP" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 1
 	},
 /obj/effect/decal/remains{
@@ -5403,13 +5358,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dQB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "dQV" = (
 /obj/effect/decal/cleanable/flour,
 /obj/effect/decal/cleanable/dirt,
@@ -5658,8 +5606,7 @@
 "dZz" = (
 /obj/structure/rug/mat/welcome{
 	dir = 8;
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/open/floor/wood_wide{
 	color = "#777777"
@@ -6346,12 +6293,10 @@
 /area/f13/wasteland)
 "ezq" = (
 /obj/structure/chair/comfy/brown{
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 9;
-	icon_state = "tracks"
+	dir = 9
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -6908,15 +6853,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"eTA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "eTZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6988,8 +6924,7 @@
 "eVr" = (
 /obj/structure/table,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -7245,7 +7180,6 @@
 "fgq" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -7534,8 +7468,7 @@
 /area/f13/wasteland)
 "fqy" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/nest/gecko,
 /turf/open/floor/f13/wood,
@@ -7871,8 +7804,7 @@
 /obj/structure/rack,
 /obj/item/stock_parts/cell,
 /obj/item/stock_parts/cell{
-	icon_state = "hpcell";
-	pixel_y = 0
+	icon_state = "hpcell"
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -7949,8 +7881,7 @@
 /area/f13/building)
 "fIt" = (
 /obj/machinery/light/small/broken{
-	dir = 4;
-	icon_state = "bulb-broken"
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -8361,18 +8292,10 @@
 /area/f13/wasteland)
 "fXL" = (
 /obj/structure/rack,
-/obj/item/pen{
-	pixel_y = 0
-	},
-/obj/item/pen{
-	pixel_y = 0
-	},
-/obj/item/pen{
-	pixel_y = 0
-	},
-/obj/item/pen{
-	pixel_y = 0
-	},
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
 /obj/item/stack/cable_coil,
 /obj/item/reagent_containers/food/condiment/soymilk,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -10713,9 +10636,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hLF" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10952,14 +10873,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/building)
-"hSA" = (
-/obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "hSH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -10981,14 +10894,6 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"hTG" = (
-/obj/structure/chair{
-	icon_state = "chair";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hTH" = (
@@ -11038,13 +10943,6 @@
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/food,
 /obj/effect/spawner/lootdrop/food,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"hVB" = (
-/obj/structure/chair/comfy{
-	dir = 4;
-	icon_state = "comfychair"
-	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hVG" = (
@@ -11101,13 +10999,11 @@
 "hYq" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -11595,7 +11491,6 @@
 /obj/machinery/button/door{
 	id = "finalbossteal";
 	name = "shutters button";
-	pixel_y = 0;
 	light_color = "#00FFFF";
 	light_power = 40;
 	light_range = 4;
@@ -12076,8 +11971,7 @@
 "iBQ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -12282,7 +12176,6 @@
 /area/f13/wasteland)
 "iJQ" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -12349,9 +12242,7 @@
 	},
 /area/f13/building)
 "iMb" = (
-/obj/structure/toilet{
-	pixel_y = 0
-	},
+/obj/structure/toilet,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -12741,9 +12632,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
 "iYS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -12892,7 +12781,6 @@
 /area/f13/building)
 "jdo" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -13015,7 +12903,6 @@
 	},
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 15
 	},
 /turf/open/floor/f13{
@@ -13241,15 +13128,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"jsp" = (
-/obj/structure/chair{
-	icon_state = "chair";
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "jss" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -13276,9 +13154,7 @@
 "jsR" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -13447,9 +13323,7 @@
 /area/f13/building)
 "jzf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -13543,13 +13417,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"jET" = (
-/obj/structure/fence/corner{
-	dir = 1;
-	icon_state = "corner"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jFa" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -13662,9 +13529,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "jIx" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -13744,7 +13609,6 @@
 	},
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -18
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -14047,18 +13911,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"jWU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "jXm" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -14600,8 +14452,7 @@
 /area/f13/building)
 "koC" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -14732,7 +14583,6 @@
 /obj/structure/fence,
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 18
 	},
 /obj/structure/fence{
@@ -15044,8 +14894,7 @@
 /area/f13/building)
 "kFn" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -15161,7 +15010,6 @@
 /area/f13/wasteland)
 "kJV" = (
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindow";
 	dir = 2
 	},
 /turf/open/floor/f13{
@@ -16093,8 +15941,7 @@
 /area/f13/wasteland)
 "lqI" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6;
-	icon_state = "pipe"
+	dir = 6
 	},
 /obj/structure/spacevine{
 	name = "vines"
@@ -16315,9 +16162,7 @@
 "lAb" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -16757,9 +16602,7 @@
 /area/f13/building)
 "lQl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -17526,8 +17369,7 @@
 /area/f13/building)
 "mpL" = (
 /obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
@@ -17846,8 +17688,7 @@
 /area/f13/building)
 "myL" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/item/clothing/under/pants/f13/ghoul,
 /turf/open/floor/f13/wood,
@@ -18732,9 +18573,7 @@
 /obj/item/paper_bin{
 	pixel_y = 1
 	},
-/obj/item/pen{
-	pixel_y = 0
-	},
+/obj/item/pen,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -19203,8 +19042,7 @@
 "nxa" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -19297,8 +19135,7 @@
 /area/f13/building)
 "nzV" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -19552,7 +19389,6 @@
 /area/f13/building)
 "nHY" = (
 /obj/structure/chair/comfy{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
@@ -19575,7 +19411,6 @@
 /area/f13/city)
 "nJd" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -19592,15 +19427,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/rare,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
-"nJx" = (
-/obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
-	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -20226,15 +20052,6 @@
 /mob/living/simple_animal/hostile/wolf/cold,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
-"odW" = (
-/obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "odX" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/wmelee_middle,
@@ -20583,7 +20400,6 @@
 /obj/structure/fence,
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -18
 	},
 /obj/structure/fence{
@@ -20594,9 +20410,7 @@
 "oqn" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -21214,17 +21028,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building)
-"oMg" = (
-/obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 4;
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "oMo" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4;
@@ -21261,7 +21064,6 @@
 "oNn" = (
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 25
 	},
 /turf/open/floor/f13/wood,
@@ -21738,8 +21540,7 @@
 /area/f13/building)
 "peu" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
@@ -22038,9 +21839,7 @@
 "pmr" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -22112,15 +21911,6 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/radiation)
-"pqn" = (
-/obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "pqq" = (
 /obj/item/clothing/head/fedora,
 /obj/machinery/light{
@@ -22278,9 +22068,7 @@
 "pwV" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -22643,7 +22431,6 @@
 /area/f13/building)
 "pLk" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
@@ -23577,7 +23364,6 @@
 /area/f13/building)
 "qrQ" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -23894,8 +23680,7 @@
 /area/f13/wasteland)
 "qCl" = (
 /obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -23950,7 +23735,6 @@
 /area/f13/building)
 "qDP" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -24400,16 +24184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qYi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "qYj" = (
 /obj/structure/table,
 /turf/open/floor/f13/wood,
@@ -24728,8 +24502,7 @@
 /area/f13/building)
 "rjN" = (
 /obj/structure/chair{
-	dir = 1;
-	icon_state = "chair"
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -25493,7 +25266,6 @@
 /area/f13/wasteland)
 "rOL" = (
 /turf/open/floor/f13{
-	dir = 2;
 	icon_state = "yellowsiding"
 	},
 /area/f13/building/coyote/safe/garland)
@@ -25829,7 +25601,6 @@
 "sbj" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -25851,15 +25622,6 @@
 "sbF" = (
 /mob/living/simple_animal/hostile/wolf,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"scm" = (
-/obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
 /area/f13/building)
 "scI" = (
 /obj/structure/lattice,
@@ -26087,8 +25849,7 @@
 /area/f13/building)
 "sjM" = (
 /obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
@@ -26204,7 +25965,6 @@
 "sot" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/open/floor/f13{
@@ -26662,8 +26422,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -26983,13 +26742,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"sQp" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "sQq" = (
 /turf/closed/mineral,
 /area/f13/building)
@@ -27008,8 +26760,7 @@
 /area/f13/wasteland)
 "sRo" = (
 /obj/structure/chair/stool{
-	icon_state = "bench";
-	dir = 2
+	icon_state = "bench"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -27333,7 +27084,6 @@
 "tgQ" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/open/floor/f13{
@@ -27474,8 +27224,7 @@
 /area/f13/building)
 "tlV" = (
 /obj/structure/decoration/ruins{
-	dir = 8;
-	icon_state = "overlap"
+	dir = 8
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
@@ -27738,7 +27487,6 @@
 /area/f13/building)
 "ttW" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -27968,8 +27716,7 @@
 "tBH" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/light/small/broken{
-	dir = 4;
-	icon_state = "bulb-broken"
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -28233,13 +27980,11 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -28304,8 +28049,7 @@
 /area/f13/city)
 "tMw" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
@@ -28593,10 +28337,7 @@
 /area/f13/building)
 "tWc" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/crafts,
 /obj/machinery/light/small,
@@ -29367,7 +29108,6 @@
 /area/f13/building)
 "utW" = (
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindow";
 	dir = 2
 	},
 /turf/open/floor/plasteel/barber{
@@ -29519,7 +29259,6 @@
 /area/f13/building)
 "uCf" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 8
 	},
 /obj/effect/decal/remains/human,
@@ -29575,10 +29314,7 @@
 /area/f13/caves)
 "uEG" = (
 /obj/structure/toilet{
-	dir = 4;
-	icon_state = "toilet00";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/storage/fancy/heart_box,
 /turf/open/floor/f13{
@@ -29707,8 +29443,7 @@
 /area/f13/wasteland)
 "uJP" = (
 /obj/structure/chair/comfy/black{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/wasteland)
@@ -30164,8 +29899,7 @@
 /area/f13/wasteland)
 "uXL" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -30209,9 +29943,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vaB" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
@@ -30682,7 +30414,6 @@
 /area/f13/building)
 "vrj" = (
 /obj/structure/chair/stool{
-	dir = 2;
 	icon_state = "bench"
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -30706,13 +30437,6 @@
 	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland)
-"vsQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "vtj" = (
 /turf/open/floor/plasteel/f13{
 	dir = 4;
@@ -30733,7 +30457,6 @@
 	},
 /obj/structure/fence{
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = 18
 	},
 /turf/open/indestructible/ground/outside/desert/harsh,
@@ -31763,10 +31486,7 @@
 /area/f13/caves)
 "wgz" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/light/small,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -32068,9 +31788,7 @@
 "wqR" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -32522,8 +32240,7 @@
 /area/f13/building)
 "wIJ" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -32787,7 +32504,6 @@
 /area/f13/city)
 "wQO" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/floor/plasteel/barber{
@@ -33499,9 +33215,7 @@
 "xpx" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
-	icon_state = "sS-casing";
-	pixel_x = 0;
-	pixel_y = 0
+	icon_state = "sS-casing"
 	},
 /obj/effect/validball_spawner,
 /turf/open/floor/f13/wood,
@@ -33810,8 +33524,7 @@
 /area/f13/building)
 "xzY" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -33866,12 +33579,10 @@
 /area/f13/building)
 "xDQ" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/structure/decoration/ruins{
-	dir = 8;
-	icon_state = "overlap"
+	dir = 8
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
@@ -33885,12 +33596,10 @@
 /area/f13/building)
 "xEl" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
@@ -33921,12 +33630,6 @@
 	color = "#999999"
 	},
 /area/f13/building)
-"xFl" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "xGm" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/eyepatch,
@@ -34292,8 +33995,7 @@
 /area/f13/wasteland)
 "xUM" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building)
@@ -34418,12 +34120,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"yah" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "yai" = (
 /obj/structure/chair/bench,
 /obj/effect/decal/remains{
@@ -34480,15 +34176,6 @@
 /obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
-"ycm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "ycn" = (
 /obj/machinery/trading_machine/medical,
 /turf/open/floor/f13,
@@ -34656,18 +34343,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"yhK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland)
 "yii" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/f13/wood,
@@ -34731,7 +34406,6 @@
 "ykX" = (
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34761,7 +34435,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -35604,7 +35277,7 @@ bJQ
 aqs
 sQM
 sAL
-daA
+hiM
 ezq
 ksy
 nTR
@@ -36661,12 +36334,12 @@ bHy
 lYk
 snE
 ugt
-scm
+kFn
 bHy
 lYk
 snE
 ugt
-scm
+kFn
 bHy
 lYk
 snE
@@ -41668,7 +41341,7 @@ bHy
 njI
 lzr
 bHy
-oMg
+reu
 bIf
 jfa
 rUq
@@ -42440,7 +42113,7 @@ vmF
 vmF
 mWi
 uhp
-odW
+nzV
 jfa
 sZw
 rUq
@@ -42580,7 +42253,7 @@ vmF
 lzr
 ugt
 jin
-oMg
+reu
 ugt
 qTT
 sed
@@ -42620,7 +42293,7 @@ cON
 qTT
 gmt
 tgf
-scm
+kFn
 bHy
 mom
 viN
@@ -42692,7 +42365,7 @@ sZw
 wmg
 qNF
 ghb
-hSA
+eVD
 vmF
 iXY
 bHy
@@ -43351,7 +43024,7 @@ wzr
 lzr
 ugt
 eyP
-odW
+nzV
 ugt
 rYf
 sed
@@ -43860,7 +43533,7 @@ ugt
 ode
 uhp
 lAC
-hTG
+qtc
 wzr
 vmF
 ugt
@@ -46648,7 +46321,7 @@ rUq
 rUq
 mMG
 lQl
-jWU
+dKF
 mip
 sZw
 rUq
@@ -46905,7 +46578,7 @@ rUq
 rUq
 iYS
 iFt
-yah
+uqV
 mip
 rUq
 gEo
@@ -47159,10 +46832,10 @@ rUq
 rUq
 mMG
 rUq
-xFl
+pKh
 wXC
 uPn
-yhK
+uzJ
 tLd
 rUq
 bzO
@@ -47277,7 +46950,7 @@ eyZ
 nro
 eyZ
 eyZ
-jET
+vAx
 rUq
 rUq
 oGl
@@ -47416,9 +47089,9 @@ ibW
 cod
 gzG
 sZw
-dQB
+dgd
 hvn
-qYi
+ozt
 wcY
 rUq
 rUq
@@ -47442,7 +47115,7 @@ jfa
 hYM
 rUq
 qFx
-sQp
+kcS
 rUq
 rUq
 bHy
@@ -47534,7 +47207,7 @@ rUq
 rUq
 rUq
 rUq
-sQp
+kcS
 ycp
 doL
 oGl
@@ -47699,7 +47372,7 @@ kqO
 cnn
 rUq
 cnn
-sQp
+kcS
 rUq
 rUq
 dUC
@@ -47791,7 +47464,7 @@ rUq
 rUq
 rUq
 rUq
-sQp
+kcS
 oGl
 kFU
 sQn
@@ -47956,7 +47629,7 @@ fhj
 pYX
 mzS
 oKn
-sQp
+kcS
 rUq
 rUq
 bHy
@@ -48048,7 +47721,7 @@ rUq
 mMG
 rUq
 rUq
-sQp
+kcS
 ycp
 vou
 snE
@@ -48213,7 +47886,7 @@ cNw
 nfr
 qFx
 cnn
-sQp
+kcS
 rUq
 rUq
 eDO
@@ -48305,7 +47978,7 @@ rUq
 rUq
 rUq
 rUq
-sQp
+kcS
 ycp
 tHI
 vmF
@@ -48562,7 +48235,7 @@ rUq
 rUq
 rUq
 rUq
-aFI
+xCK
 ycp
 vmF
 vmF
@@ -48881,7 +48554,7 @@ rUq
 sZw
 mMG
 lQl
-jWU
+dKF
 tLd
 rUq
 rUq
@@ -49136,9 +48809,9 @@ rUq
 sZw
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 tLd
 rUq
 rUq
@@ -49392,10 +49065,10 @@ sZw
 rUq
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 rUq
@@ -49649,9 +49322,9 @@ rUq
 rUq
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 bzO
 rUq
@@ -51145,7 +50818,7 @@ bzO
 rUq
 mMG
 lQl
-jWU
+dKF
 tLd
 bzO
 cON
@@ -51400,9 +51073,9 @@ bzO
 bzO
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 sJt
 rUq
 cON
@@ -51656,7 +51329,7 @@ peE
 epU
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
 peE
@@ -51913,9 +51586,9 @@ peE
 sZw
 rUq
 bzO
-dQB
+dgd
 mqW
-qYi
+ozt
 bPs
 cON
 peE
@@ -52020,7 +51693,7 @@ rUq
 rUq
 mMG
 lQl
-jWU
+dKF
 tLd
 rUq
 rUq
@@ -52275,9 +51948,9 @@ rUq
 rUq
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 tLd
 rUq
 rUq
@@ -52531,10 +52204,10 @@ rUq
 rUq
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 rUq
@@ -52788,9 +52461,9 @@ rUq
 rUq
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 rUq
 rUq
@@ -53501,7 +53174,7 @@ bzO
 rUq
 mMG
 lQl
-jWU
+dKF
 tnz
 bzO
 rUq
@@ -53756,9 +53429,9 @@ oGl
 rUq
 bzO
 bzO
-ycm
+ejs
 iFt
-yah
+uqV
 tnz
 bzO
 rUq
@@ -54012,10 +53685,10 @@ oGl
 kKq
 sZw
 bzO
-vsQ
+wMO
 wXC
 dhA
-eTA
+bYq
 tnz
 rUq
 bzO
@@ -54271,7 +53944,7 @@ rUq
 bzO
 jzf
 mqW
-qYi
+ozt
 wcY
 bzO
 rUq
@@ -54512,7 +54185,7 @@ euF
 ran
 juh
 oGl
-jsp
+wRP
 taP
 upk
 juh
@@ -55284,7 +54957,7 @@ xtg
 npw
 sIH
 fNY
-jsp
+wRP
 taP
 sIH
 taP
@@ -56667,9 +56340,9 @@ rUq
 rUq
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 tLd
 rUq
 sZw
@@ -56923,10 +56596,10 @@ rUq
 rUq
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 sZw
@@ -57180,9 +56853,9 @@ rUq
 rUq
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 rUq
 rUq
@@ -60308,7 +59981,7 @@ rUq
 rUq
 mMG
 lQl
-jWU
+dKF
 tLd
 rUq
 rUq
@@ -60563,7 +60236,7 @@ rUq
 rUq
 rUq
 rUq
-ycm
+ejs
 iFt
 nOw
 tLd
@@ -60819,10 +60492,10 @@ rUq
 kWY
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 rUq
@@ -61076,9 +60749,9 @@ kWY
 kWY
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 rUq
 rUq
@@ -65628,7 +65301,7 @@ iTD
 iTD
 jfa
 njI
-bVN
+hqf
 rqX
 jfa
 jfa
@@ -79138,7 +78811,7 @@ kTa
 rUq
 mMG
 lQl
-jWU
+dKF
 tLd
 via
 rUq
@@ -79393,9 +79066,9 @@ eyA
 eyA
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 tLd
 rUq
 rUq
@@ -79649,10 +79322,10 @@ rUq
 rUq
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 eCo
@@ -79906,9 +79579,9 @@ rUq
 rUq
 nOw
 nOw
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 rUq
 rUq
@@ -84707,7 +84380,7 @@ iTD
 iTD
 iTD
 iTD
-qYi
+ozt
 tYe
 iTD
 iTD
@@ -89170,7 +88843,7 @@ euF
 juh
 juh
 oGl
-nJx
+wRP
 xiB
 aUy
 pcW
@@ -89942,7 +89615,7 @@ nvI
 lUv
 oGl
 fNY
-nJx
+wRP
 juh
 oGl
 uPg
@@ -90090,7 +89763,7 @@ iTD
 iTD
 rjU
 oKI
-pqn
+fdi
 bHy
 snE
 snE
@@ -92045,7 +91718,7 @@ rUq
 rUq
 mMG
 lQl
-jWU
+dKF
 mip
 rUq
 rUq
@@ -92143,7 +91816,7 @@ iTD
 iTD
 iTD
 gmt
-pqn
+fdi
 kFn
 bHy
 oNn
@@ -92300,9 +91973,9 @@ rUq
 rUq
 rUq
 iNW
-ycm
+ejs
 iFt
-yah
+uqV
 mip
 rUq
 rUq
@@ -92556,10 +92229,10 @@ xDq
 rUq
 kWY
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 rUq
 nOw
@@ -92813,9 +92486,9 @@ xDq
 rUq
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 wcY
 cod
 rUq
@@ -93947,7 +93620,7 @@ iTD
 ugt
 edq
 ifO
-hVB
+nHY
 mcw
 vmF
 koC
@@ -95870,7 +95543,7 @@ rUq
 rUq
 mMG
 lQl
-jWU
+dKF
 tLd
 rUq
 sZw
@@ -96125,9 +95798,9 @@ sZw
 rUq
 rUq
 rUq
-ycm
+ejs
 iFt
-yah
+uqV
 tLd
 rUq
 rUq
@@ -96381,10 +96054,10 @@ rUq
 sZw
 rUq
 rUq
-xFl
+pKh
 wXC
 dhA
-eTA
+bYq
 tLd
 sZw
 rUq
@@ -96638,9 +96311,9 @@ rUq
 dEE
 rUq
 rUq
-dQB
+dgd
 mqW
-qYi
+ozt
 sSv
 sZw
 rUq

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper-2.dmm
@@ -1479,7 +1479,6 @@
 "fh" = (
 /obj/effect/fake_stairs/east,
 /obj/structure/railing{
-	dir = 2;
 	color = "Grey"
 	},
 /obj/machinery/light{
@@ -1982,21 +1981,6 @@
 	light_color = "#BAF8FF"
 	},
 /area/f13/caves)
-"gx" = (
-/obj/structure/wood_counter{
-	color = "#251A17";
-	layer = 2
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/turf/open/floor/f13{
-	color = "#d9c4b9";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/building)
 "gA" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13{
@@ -2021,11 +2005,6 @@
 /obj/item/lipstick/black,
 /obj/structure/mirror{
 	pixel_x = 24
-	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	layer = 2;
-	dir = 4
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -2486,8 +2465,7 @@
 "iE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
@@ -2682,10 +2660,6 @@
 "jA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common_food,
-/obj/structure/wood_counter/bend{
-	layer = 2;
-	dir = 8
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -3565,19 +3539,6 @@
 	color = "#6D6D6D"
 	},
 /area/f13/wasteland)
-"mY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common_food,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 1
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
 "mZ" = (
 /obj/structure/railing{
 	dir = 8;
@@ -4275,10 +4236,6 @@
 	layer = 2.5;
 	alpha = 1
 	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	layer = 2
-	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -4513,11 +4470,6 @@
 "qy" = (
 /obj/machinery/microwave/stove{
 	pixel_x = 18
-	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 1;
-	pixel_x = -10
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -5164,11 +5116,6 @@
 "sT" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 1
-	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	dir = 1;
-	layer = 2
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -5943,11 +5890,6 @@
 /obj/item/lipstick,
 /obj/structure/mirror{
 	pixel_x = 24
-	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	layer = 2;
-	dir = 4
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -7778,10 +7720,6 @@
 /area/f13/building)
 "CJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -9004,11 +8942,6 @@
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1
 	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	dir = 1;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -9759,10 +9692,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/wood_counter{
-	color = "#251A17";
-	layer = 2
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -11655,11 +11584,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/drinkingglasses,
-/obj/structure/wood_counter{
-	color = "#251A17";
-	dir = 1;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -13016,10 +12940,6 @@
 /area/f13/caves)
 "UK" = (
 /obj/machinery/light,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 1
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -13315,10 +13235,6 @@
 /area/f13/wasteland)
 "VI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter/bend{
-	dir = 1;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -14544,9 +14460,6 @@
 /area/f13/building)
 "ZK" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 19;
 	layer = 1.9
@@ -49091,7 +49004,7 @@ Zo
 Zo
 NO
 QU
-gx
+pB
 OL
 ox
 IU
@@ -59902,7 +59815,7 @@ RD
 Zo
 ZK
 ll
-mY
+jA
 Zo
 jk
 jk

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana-Upper.dmm
@@ -57,8 +57,7 @@
 "aaL" = (
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "aaZ" = (
@@ -427,8 +426,7 @@
 "anx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
@@ -1838,8 +1836,7 @@
 /obj/structure/lattice,
 /obj/structure/spacevine,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "bgu" = (
@@ -3816,12 +3813,6 @@
 	icon_state = "common-broken3"
 	},
 /area/f13/building/abandoned)
-"cAO" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "cAQ" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -5106,8 +5097,7 @@
 "dvJ" = (
 /obj/structure/railing,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "dvV" = (
@@ -5835,8 +5825,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "dOP" = (
@@ -6362,8 +6351,7 @@
 "egq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "egJ" = (
@@ -7066,8 +7054,7 @@
 "eEX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
@@ -7137,8 +7124,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "eGJ" = (
@@ -7307,7 +7293,6 @@
 /area/f13/wasteland)
 "eLR" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 2;
 	color = "#413527"
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -7813,9 +7798,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "ffT" = (
-/obj/structure/bed/old{
-	pixel_y = 0
-	},
+/obj/structure/bed/old,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/ruins)
 "fgm" = (
@@ -8009,8 +7992,7 @@
 /area/f13/building/mall)
 "flr" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/ruins)
 "flw" = (
@@ -8135,8 +8117,7 @@
 "fpm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -8883,8 +8864,7 @@
 	},
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
@@ -9224,9 +9204,7 @@
 /obj/structure/bed/old{
 	pixel_y = 11
 	},
-/obj/structure/bed/old{
-	pixel_y = 0
-	},
+/obj/structure/bed/old,
 /obj/item/bedsheet{
 	pixel_y = 11
 	},
@@ -9420,7 +9398,6 @@
 /area/f13/wasteland)
 "gfQ" = (
 /obj/structure/railing{
-	dir = 2;
 	color = "Grey"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -10003,12 +9980,10 @@
 /area/f13/wasteland)
 "grY" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
@@ -11135,10 +11110,6 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/wasteland)
 "hdf" = (
-/obj/structure/wood_counter/bend{
-	layer = 2;
-	dir = 8
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -11153,8 +11124,7 @@
 /obj/item/trash/sosjerky,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "hdw" = (
@@ -11661,8 +11631,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "hsz" = (
@@ -11840,10 +11809,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 8
 	},
 /obj/machinery/processor/chopping_block{
 	pixel_y = 8
@@ -13081,12 +13046,10 @@
 /area/f13/building/massfusion)
 "ipC" = (
 /obj/structure/railing{
-	color = null;
 	dir = 9
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "ipE" = (
@@ -13336,8 +13299,7 @@
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ff0000";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
@@ -13454,9 +13416,6 @@
 /obj/structure/sink/greyscale{
 	pixel_y = 38
 	},
-/obj/structure/wood_counter{
-	pixel_y = 18
-	},
 /obj/structure/towel_rack{
 	pixel_x = -30;
 	pixel_y = 20
@@ -13474,8 +13433,7 @@
 "iBz" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
@@ -13509,10 +13467,6 @@
 "iDM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 1
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -14444,8 +14398,7 @@
 /area/f13/wasteland)
 "jcF" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrusty"
@@ -15316,8 +15269,7 @@
 "jCd" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/massfusion)
@@ -16667,8 +16619,7 @@
 "kvO" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -16794,7 +16745,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/protectron{
 	layer = 3;
-	max_mobs = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -17688,8 +17638,7 @@
 "kRU" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -17995,10 +17944,6 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -18025,8 +17970,7 @@
 /area/f13/building/hospital)
 "lco" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/structure/railing{
 	color = "#A47449";
@@ -18201,12 +18145,10 @@
 /area/f13/building)
 "lgL" = (
 /obj/structure/railing{
-	color = null;
 	dir = 5
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "lhy" = (
@@ -18369,8 +18311,7 @@
 /area/f13/building/hospital)
 "loO" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
@@ -18393,8 +18334,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "lpZ" = (
@@ -19435,7 +19375,6 @@
 	color = "grey"
 	},
 /obj/structure/railing{
-	dir = 2;
 	color = "Grey"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -19600,8 +19539,7 @@
 	},
 /obj/item/soap,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "greenrustychess"
@@ -20160,12 +20098,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"mup" = (
-/obj/structure/railing/corner{
-	color = null
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "muJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/sandbags,
@@ -20467,8 +20399,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "mBR" = (
@@ -20949,9 +20880,7 @@
 	pixel_x = 10;
 	pixel_y = -2
 	},
-/obj/structure/fence/wooden{
-	pixel_y = 0
-	},
+/obj/structure/fence/wooden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -21080,10 +21009,6 @@
 	alpha = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 1
-	},
 /obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -21732,10 +21657,6 @@
 	layer = 2.5;
 	alpha = 1
 	},
-/obj/structure/wood_counter/bend{
-	dir = 1;
-	layer = 2
-	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
 	icon_state = "darkrusty";
@@ -22236,8 +22157,7 @@
 /area/f13/wasteland)
 "nAl" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -22249,8 +22169,7 @@
 /area/f13/caves)
 "nAT" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "nBq" = (
@@ -22947,8 +22866,7 @@
 "nUm" = (
 /obj/structure/lattice,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "nUs" = (
@@ -23178,8 +23096,7 @@
 /obj/item/trash/sosjerky,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "obA" = (
@@ -23578,8 +23495,7 @@
 	dir = 6
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "ooN" = (
@@ -24067,9 +23983,6 @@
 "oFf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/obj/structure/wood_counter{
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -24121,13 +24034,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/caves)
-"oIp" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 2
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "oIu" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -24424,10 +24330,6 @@
 /area/f13/wasteland)
 "oQq" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -24451,7 +24353,6 @@
 "oQZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/billboard/den{
-	desc = "A sprayed metal sheet that says \"The Den \".";
 	pixel_y = 17
 	},
 /turf/open/floor/wood_common{
@@ -24568,8 +24469,7 @@
 "oTC" = (
 /obj/structure/nest/protectron,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
@@ -25099,10 +24999,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
 	},
 /obj/structure/window{
 	dir = 4
@@ -26438,10 +26334,6 @@
 "qgG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 8
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -26659,8 +26551,7 @@
 "qlX" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -26786,9 +26677,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/reagentgrinder{
 	pixel_y = 7
-	},
-/obj/structure/wood_counter{
-	layer = 2
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -27056,8 +26944,7 @@
 /area/f13/building/massfusion)
 "qwh" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/abandoned)
 "qwH" = (
@@ -27371,9 +27258,6 @@
 /area/f13/building/massfusion)
 "qLq" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2
-	},
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
@@ -28010,21 +27894,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"rhW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/obj/structure/wood_counter/bend{
-	layer = 2
-	},
-/turf/open/floor/f13{
-	color = "#d9c4b9";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/building)
 "rhY" = (
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -28340,8 +28209,7 @@
 	dir = 10
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/mall)
 "rqa" = (
@@ -28652,8 +28520,7 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/abandoned)
 "rAJ" = (
@@ -28943,8 +28810,7 @@
 /area/f13/building)
 "rLd" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -29361,8 +29227,7 @@
 /area/f13/wasteland)
 "sbP" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "sbW" = (
@@ -30539,8 +30404,7 @@
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ff0000";
-	pixel_x = -10;
-	pixel_y = 0
+	pixel_x = -10
 	},
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/indestructible/ground/outside/roof,
@@ -30597,10 +30461,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -31470,9 +31330,6 @@
 /area/f13/building)
 "tyE" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -32040,8 +31897,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "tPc" = (
@@ -32136,8 +31992,7 @@
 "tRd" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -32321,8 +32176,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "tWB" = (
@@ -32394,9 +32248,6 @@
 "tZo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/chem_dispenser/drinks,
-/obj/structure/wood_counter{
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -32749,8 +32600,7 @@
 /obj/item/trash/candy,
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/hospital)
 "uoc" = (
@@ -32859,9 +32709,6 @@
 /area/f13/wasteland)
 "uqW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	pixel_y = 18
-	},
 /obj/structure/mirror/alt{
 	pixel_y = 34
 	},
@@ -33069,8 +32916,7 @@
 /obj/machinery/mineral/wasteland_vendor/badammo,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
@@ -33179,8 +33025,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "uAg" = (
@@ -33824,9 +33669,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/greyscale{
 	pixel_y = 38
-	},
-/obj/structure/wood_counter{
-	pixel_y = 18
 	},
 /turf/open/floor/f13{
 	color = "#d9c4b9";
@@ -34514,8 +34356,7 @@
 /area/f13/building/mall)
 "vqz" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "vqF" = (
@@ -34644,8 +34485,7 @@
 "vwe" = (
 /obj/structure/rack/shelf_metal,
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -34668,8 +34508,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -34794,8 +34633,7 @@
 "vCb" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -35109,8 +34947,7 @@
 /area/f13/building/mall)
 "vMj" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 2
+	color = "#A47449"
 	},
 /obj/structure/railing{
 	color = "#A47449";
@@ -35416,10 +35253,6 @@
 /obj/machinery/reagentgrinder,
 /obj/structure/window{
 	dir = 4
-	},
-/obj/structure/wood_counter/bend{
-	layer = 2;
-	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "redrustyfull"
@@ -36504,8 +36337,7 @@
 /area/f13/building/hospital)
 "wEW" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/validball_spawner,
 /turf/open/floor/plasteel/f13{
@@ -36703,10 +36535,6 @@
 "wOp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/glass/rag,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -36743,7 +36571,6 @@
 	color = "#C4897D";
 	desc = "A wooden bedpost";
 	dir = 4;
-	icon = 'icons/fallout/structures/fences.dmi';
 	layer = 3;
 	name = "bedpost";
 	pixel_x = 1
@@ -36752,7 +36579,6 @@
 	color = "#C4897D";
 	desc = "A wooden bedpost";
 	dir = 8;
-	icon = 'icons/fallout/structures/fences.dmi';
 	layer = 3;
 	name = "bedpost";
 	pixel_x = -1
@@ -36910,8 +36736,7 @@
 /area/f13/building)
 "wUV" = (
 /obj/structure/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_settler"
+	dir = 8
 	},
 /turf/open/floor/wood_wide,
 /area/f13/building)
@@ -36992,8 +36817,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "wXJ" = (
@@ -37005,7 +36829,6 @@
 	color = "grey"
 	},
 /obj/structure/railing{
-	dir = 2;
 	color = "Grey"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37533,8 +37356,7 @@
 	name = "power unit"
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building/massfusion)
@@ -37778,7 +37600,6 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 2;
 	color = "Grey"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -38032,8 +37853,7 @@
 /area/f13/caves)
 "xFS" = (
 /obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -38055,8 +37875,7 @@
 /area/f13/building/mall)
 "xGL" = (
 /obj/effect/decal/cleanable/blood/tracks{
-	dir = 4;
-	icon_state = "tracks"
+	dir = 4
 	},
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/ruins,
@@ -38144,10 +37963,6 @@
 /area/f13/wasteland)
 "xKv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	dir = 4
-	},
 /obj/item/clothing/mask/cigarette/cigar{
 	pixel_y = -3;
 	pixel_x = 4
@@ -46760,7 +46575,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 nSY
 nSY
@@ -47017,7 +46832,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 dTc
 jdQ
@@ -47274,7 +47089,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 mdq
@@ -47531,7 +47346,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 lbC
@@ -47788,7 +47603,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 lbC
@@ -48045,7 +47860,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 vbL
 uFd
@@ -48302,7 +48117,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 dTc
 dZy
@@ -48559,7 +48374,7 @@ oez
 oez
 oez
 oez
-cAO
+nez
 nSY
 nSY
 nSY
@@ -49812,7 +49627,7 @@ deZ
 srk
 srk
 oez
-cAO
+nez
 sRA
 aQp
 qLE
@@ -50069,7 +49884,7 @@ srk
 srk
 srk
 oez
-cAO
+nez
 rGU
 pAr
 rqy
@@ -64917,7 +64732,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 xTf
 mLO
 iTN
@@ -65174,7 +64989,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 olD
 bUU
 nNJ
@@ -65431,7 +65246,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 tta
 giL
 din
@@ -65688,7 +65503,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 cXu
 wUV
 dXp
@@ -72446,7 +72261,7 @@ iRb
 iRb
 iRb
 gIL
-rhW
+oQq
 laA
 qgG
 aFC
@@ -78967,7 +78782,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 qCs
 qCs
 ygs
@@ -79480,7 +79295,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 kpv
 kpv
@@ -79737,7 +79552,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 msC
 qCs
 kTF
@@ -80251,7 +80066,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 jSQ
 kTF
@@ -80508,7 +80323,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 kpv
@@ -80765,7 +80580,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 mSv
 kTF
@@ -81022,7 +80837,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 vWC
 kTF
 kpv
@@ -81279,7 +81094,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 uOi
 kpv
 kTF
@@ -81536,7 +81351,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 mSv
@@ -81793,7 +81608,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 wrN
 kpv
 kTF
@@ -82050,7 +81865,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 mdw
 fho
 kpv
@@ -82307,7 +82122,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 msC
 fho
 kTF
@@ -82564,7 +82379,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 uOi
 kTF
 kpv
@@ -83079,7 +82894,7 @@ oez
 oez
 oez
 oez
-oIp
+tXH
 kTF
 kTF
 rsw
@@ -88127,7 +87942,7 @@ iUG
 mbc
 eNt
 nBq
-mup
+cVc
 nQJ
 nQJ
 nQJ

--- a/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
+++ b/_maps/map_files/coyote_bayou/Nash_and_Texarkana.dmm
@@ -470,7 +470,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -982,7 +981,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -2249,7 +2247,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -4759,7 +4756,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -5084,7 +5080,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -6482,7 +6477,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -8802,7 +8796,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -8878,9 +8871,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/ruins)
 "aHg" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/ruins)
 "aHh" = (
@@ -13385,7 +13376,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -13563,7 +13553,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -13952,7 +13941,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -14207,7 +14195,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -14391,7 +14378,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -15512,14 +15498,12 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -15657,7 +15641,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -15767,7 +15750,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -18383,7 +18365,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -19118,7 +19099,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -20412,7 +20392,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -20770,7 +20749,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -21108,7 +21086,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -21122,7 +21099,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -22722,7 +22698,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -23470,7 +23445,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -23883,7 +23857,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -23956,7 +23929,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -24176,8 +24148,7 @@
 /area/f13/building)
 "cKC" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
@@ -24212,7 +24183,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -24561,7 +24531,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -25161,7 +25130,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -25187,7 +25155,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -25489,7 +25456,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -25844,9 +25810,7 @@
 /area/f13/wasteland)
 "dhn" = (
 /obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/medical/ancientfirstaid{
-	pixel_y = 0
-	},
+/obj/item/storage/medical/ancientfirstaid,
 /obj/item/storage/box/ration/ranger_breakfast{
 	pixel_y = -6
 	},
@@ -26377,9 +26341,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dph" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/ruins)
@@ -27023,7 +26985,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -27095,7 +27056,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -27237,7 +27197,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -27294,7 +27253,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -27325,7 +27283,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -27584,7 +27541,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -27637,7 +27593,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -28856,7 +28811,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -28896,7 +28850,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -29141,7 +29094,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -29244,7 +29196,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -29866,7 +29817,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -30275,7 +30225,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -30595,7 +30544,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -30760,7 +30708,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -30861,7 +30808,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -31125,7 +31071,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -31497,7 +31442,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -33855,7 +33799,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -34004,7 +33947,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -34451,7 +34393,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -34599,7 +34540,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -34964,7 +34904,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -35477,7 +35416,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -36482,7 +36420,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -37150,7 +37087,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -37749,7 +37685,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -38706,7 +38641,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -38890,7 +38824,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -39236,7 +39169,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/road{
@@ -39374,7 +39306,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/ruins,
@@ -40134,9 +40065,7 @@
 	},
 /area/f13/wasteland/city)
 "gYo" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -40482,7 +40411,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -41547,7 +41475,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -41630,11 +41557,9 @@
 /area/f13/building/abandoned)
 "hvt" = (
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = 12
 	},
 /obj/structure/fence/wooden{
-	pixel_y = 0;
 	pixel_x = -13
 	},
 /turf/closed/wall/f13/wood/house,
@@ -41739,7 +41664,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -41858,7 +41782,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -42723,7 +42646,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -42853,7 +42775,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -43027,7 +42948,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -43167,7 +43087,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -43309,7 +43228,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -44394,7 +44312,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -45148,7 +45065,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -45227,7 +45143,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -45508,7 +45423,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -46687,7 +46601,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -46777,7 +46690,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -46850,8 +46762,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -47469,7 +47380,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -47753,7 +47663,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -47917,7 +47826,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -48147,7 +48055,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -48548,7 +48455,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -50037,7 +49943,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -50389,7 +50294,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -50763,7 +50667,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -50974,7 +50877,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -51555,7 +51457,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -51849,7 +51750,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -52132,7 +52032,6 @@
 /area/f13/wasteland/massfusion/entrance)
 "kkD" = (
 /turf/open/floor/f13{
-	dir = 2;
 	icon_state = "yellowsiding"
 	},
 /area/f13/building/coyote/safe/nash)
@@ -52599,7 +52498,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -54778,7 +54676,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -54820,7 +54717,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -55014,7 +54910,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -55258,7 +55153,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -55315,7 +55209,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -55370,7 +55263,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -55725,7 +55617,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56908,7 +56799,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/inside/dirt,
@@ -57342,7 +57232,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -58022,7 +57911,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -58325,7 +58213,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -58475,7 +58362,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -59092,7 +58978,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -59114,7 +58999,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -59456,7 +59340,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -60476,7 +60359,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -60535,7 +60417,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -60868,7 +60749,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -60893,7 +60773,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -61561,7 +61440,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -62408,7 +62286,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -62610,7 +62487,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -63633,7 +63509,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -64076,7 +63951,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -64877,7 +64751,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel,
@@ -65006,7 +64879,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -65071,7 +64943,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -65988,7 +65859,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -66020,7 +65890,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -66092,7 +65961,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -66183,7 +66051,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -66561,8 +66428,7 @@
 	density = 0;
 	dir = 1;
 	layer = 3.6;
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain0"
@@ -67087,7 +66953,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -67415,7 +67280,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -67521,7 +67385,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -68367,7 +68230,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -68749,7 +68611,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69159,7 +69020,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69205,7 +69065,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69334,7 +69193,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69664,7 +69522,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -69897,9 +69754,7 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/building/abandoned)
 "oLI" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -70510,7 +70365,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -70598,7 +70452,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -71257,7 +71110,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -71390,7 +71242,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -71452,7 +71303,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -72077,7 +71927,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -73532,7 +73381,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -74252,7 +74100,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -74588,7 +74435,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -74606,7 +74452,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -75038,7 +74883,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/item/trash,
@@ -75058,7 +74902,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -75287,7 +75130,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -75555,7 +75397,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -77265,7 +77106,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -77664,7 +77504,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -77761,7 +77600,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -78154,7 +77992,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -78234,7 +78071,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -78689,7 +78525,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -79185,7 +79020,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -79448,7 +79282,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -79897,7 +79730,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -80027,7 +79859,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -81243,7 +81074,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -82310,7 +82140,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -83430,7 +83259,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -83615,7 +83443,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -85262,7 +85089,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -85301,7 +85127,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -85518,7 +85343,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -86170,7 +85994,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -86243,7 +86066,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -86733,7 +86555,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -87486,7 +87307,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -87650,7 +87470,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -87874,7 +87693,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel,
@@ -87999,7 +87817,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -88018,7 +87835,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -88312,7 +88128,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -88852,7 +88667,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/effect/turf_decal/weather/dirt{
@@ -88954,7 +88768,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -89151,7 +88964,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -89856,7 +89668,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -89872,7 +89683,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -89999,7 +89809,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/road{
@@ -90641,7 +90450,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -90649,7 +90457,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -90900,7 +90707,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -91285,7 +91091,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -92327,7 +92132,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -92541,7 +92345,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -92711,7 +92514,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -93511,7 +93313,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -93522,7 +93323,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -95531,7 +95331,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -95859,7 +95658,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -96009,7 +95807,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -96360,7 +96157,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -96440,7 +96236,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water{
@@ -97182,7 +96977,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -97409,7 +97203,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -97478,7 +97271,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/ruins,
@@ -97860,7 +97652,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -98493,7 +98284,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -98512,7 +98302,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -99199,7 +98988,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -99303,7 +99091,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -99586,7 +99373,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/gravel{
@@ -99771,7 +99557,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -100194,7 +99979,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -100454,7 +100238,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -100548,7 +100331,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -101076,7 +100858,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -101368,7 +101149,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -101528,7 +101308,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -102218,7 +101997,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -102233,7 +102011,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -102603,7 +102380,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/effect/turf_decal/weather/dirt{
@@ -102889,7 +102665,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -103832,7 +103607,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -104056,7 +103830,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -104098,7 +103871,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -104924,7 +104696,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},
@@ -105106,7 +104877,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "fog";
-	pixel_y = 0;
 	pixel_x = -1;
 	opacity = 1
 	},

--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -517,10 +517,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/obj/structure/craft_counter{
-	dir = 4;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -584,10 +580,6 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bY" = (
-/obj/structure/craft_counter/bend{
-	dir = 4;
-	layer = 2
-	},
 /obj/item/kitchen/rollingpin,
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -1784,7 +1776,6 @@
 "eU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1;
-	pixel_y = 0;
 	pixel_x = 21
 	},
 /obj/structure/simple_door/house{
@@ -2949,10 +2940,6 @@
 	},
 /area/f13/building)
 "hP" = (
-/obj/structure/wood_counter{
-	layer = 6;
-	pixel_y = -1
-	},
 /obj/structure/fence/wooden{
 	dir = 4;
 	pixel_y = 9
@@ -3691,15 +3678,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"kb" = (
-/obj/machinery/light/small{
-	light_color = "#884444";
-	dir = 2
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/bar/heaven)
 "kc" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/f13{
@@ -5154,10 +5132,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/obj/structure/craft_counter{
-	dir = 4;
-	layer = 2
-	},
 /obj/item/kitchen/knife/butcher,
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -5830,10 +5804,6 @@
 /area/f13/building)
 "pH" = (
 /obj/item/kitchen/knife,
-/obj/structure/craft_counter{
-	dir = 4;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -5912,9 +5882,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/craft_counter{
-	layer = 2
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
@@ -6943,9 +6910,6 @@
 	},
 /area/f13/tribe)
 "sP" = (
-/obj/structure/craft_counter{
-	layer = 2
-	},
 /obj/item/pestle{
 	pixel_y = 6;
 	pixel_x = -14
@@ -7520,10 +7484,6 @@
 	},
 /obj/item/reagent_containers/pill/antivenom,
 /obj/item/reagent_containers/pill/antivenom,
-/obj/structure/craft_counter/bend{
-	dir = 4;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -7699,9 +7659,6 @@
 /area/f13/caves)
 "uL" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
-/obj/structure/craft_counter{
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -7846,9 +7803,7 @@
 "vd" = (
 /obj/structure/nightstand/small{
 	pixel_x = 2;
-	pixel_y = 22;
-	density = 0;
-	opacity = 0
+	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -8103,9 +8058,6 @@
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
-	},
-/obj/structure/craft_counter{
-	layer = 2
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
@@ -11465,10 +11417,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "EK" = (
-/obj/structure/craft_counter/bend{
-	dir = 8;
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -13496,9 +13444,6 @@
 	pixel_x = 7;
 	pixel_y = 10
 	},
-/obj/structure/craft_counter{
-	layer = 2
-	},
 /obj/structure/table/wood{
 	layer = 2.5;
 	alpha = 1
@@ -13712,10 +13657,6 @@
 "KD" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
-	},
-/obj/structure/craft_counter{
-	dir = 4;
-	layer = 2
 	},
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -14034,15 +13975,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 2;
 	pixel_y = 32
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Ly" = (
-/obj/structure/craft_counter{
-	layer = 2
-	},
 /obj/item/pestle,
 /obj/structure/table/wood{
 	layer = 2.5;
@@ -15709,19 +15646,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"PQ" = (
-/obj/structure/craft_counter{
-	dir = 4;
-	layer = 2
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/building/tribal)
 "PR" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -17050,18 +16974,6 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
-"TB" = (
-/obj/structure/craft_counter{
-	layer = 2
-	},
-/obj/structure/table/wood{
-	layer = 2.5;
-	alpha = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/building/tribal)
 "TD" = (
 /obj/structure/chair/sofa/right{
 	color = "#800000";
@@ -17839,7 +17751,6 @@
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5;
-	pixel_y = 0;
 	pixel_x = -32
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -24327,7 +24238,7 @@ HU
 HU
 HU
 HU
-TB
+EK
 CE
 Ar
 UG
@@ -25610,7 +25521,7 @@ la
 nk
 Vy
 Ey
-PQ
+EK
 KD
 EK
 rz
@@ -45162,7 +45073,7 @@ WX
 Hy
 eG
 ot
-kb
+CF
 tj
 tN
 tN

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -2677,7 +2677,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = 2
 	},
 /turf/open/floor/wood_common{
@@ -3760,9 +3759,7 @@
 	},
 /area/f13/building)
 "ceh" = (
-/obj/machinery/mineral/wasteland_vendor/ammo{
-	pixel_y = 0
-	},
+/obj/machinery/mineral/wasteland_vendor/ammo,
 /obj/machinery/light{
 	light_color = "#e8eaff";
 	dir = 1;
@@ -10900,10 +10897,6 @@
 /area/f13/wasteland)
 "fKF" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wood_counter{
-	layer = 2;
-	pixel_y = 3
-	},
 /obj/structure/sink{
 	pixel_y = 20;
 	layer = 1.9
@@ -13527,12 +13520,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"hel" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "hep" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/curtain,
@@ -17218,9 +17205,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	name = "stepping stones";
 	color = "#bfbfbf"
@@ -25808,9 +25793,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "nyL" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -38747,9 +38730,7 @@
 	},
 /area/f13/building)
 "ujm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/ruins{
 	name = "stepping stones";
 	color = "#bfbfbf"
@@ -40140,9 +40121,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "uYT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -45122,9 +45101,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
 	pixel_y = 15
 	},
-/obj/structure/table/wood/bar{
-	pixel_y = 0
-	},
+/obj/structure/table/wood/bar,
 /turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/wasteland/city/newboston/bar)
 "xGw" = (
@@ -76021,7 +75998,7 @@ vMp
 vMp
 dGj
 yde
-hel
+vJk
 kMK
 yde
 ogc
@@ -76278,7 +76255,7 @@ cZU
 cZU
 dGj
 yde
-hel
+vJk
 rGC
 yde
 yde
@@ -76535,7 +76512,7 @@ qBj
 qBj
 xgZ
 yde
-hel
+vJk
 dqa
 dlN
 xZc
@@ -76792,7 +76769,7 @@ dGj
 xgZ
 fKN
 yde
-hel
+vJk
 iYx
 gje
 pll
@@ -77049,7 +77026,7 @@ jtS
 jtS
 bBH
 yde
-hel
+vJk
 rGC
 gje
 pll
@@ -77306,7 +77283,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-hel
+vJk
 rGC
 gje
 tZu
@@ -77563,7 +77540,7 @@ yde
 yde
 yde
 yde
-hel
+vJk
 rGC
 gje
 syK
@@ -78591,7 +78568,7 @@ uIt
 bKo
 ptC
 uQa
-hel
+vJk
 rGC
 cyi
 mrr
@@ -78848,7 +78825,7 @@ yde
 yde
 yde
 yde
-hel
+vJk
 rGC
 gje
 xZc

--- a/_maps/map_files/coyote_bayou/Redwater-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Redwater-Upper.dmm
@@ -15,8 +15,7 @@
 /area/f13/building/firetower)
 "bk" = (
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "bq" = (
@@ -50,8 +49,7 @@
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "cd" = (
@@ -93,8 +91,7 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 1;
-	icon_state = "railing_corner";
-	pixel_y = 0
+	icon_state = "railing_corner"
 	},
 /obj/structure/railing{
 	color = "#A47449";
@@ -103,8 +100,7 @@
 	pixel_x = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "cZ" = (
@@ -151,12 +147,10 @@
 /obj/structure/railing{
 	dir = 1;
 	icon_state = "railing_corner";
-	pixel_y = 0;
 	pixel_x = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "dV" = (
@@ -188,14 +182,11 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "eQ" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crossborderroundmid"
 	},
@@ -237,8 +228,7 @@
 	color = "#363636"
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "fL" = (
@@ -422,13 +412,11 @@
 "mR" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	icon_state = "railing_corner";
 	pixel_x = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "nj" = (
@@ -458,8 +446,7 @@
 "oj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "oo" = (
@@ -501,7 +488,6 @@
 "oN" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/structure/railing{
-	dir = 2;
 	icon_state = "railing_corner";
 	pixel_y = 2
 	},
@@ -526,20 +512,17 @@
 	light_color = "#f4e3b0"
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "pL" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 1;
-	icon_state = "railing_corner";
-	pixel_y = 0
+	icon_state = "railing_corner"
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "pM" = (
@@ -605,8 +588,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "ro" = (
@@ -782,14 +764,11 @@
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/firetower)
 "vb" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
 	},
@@ -844,9 +823,7 @@
 	},
 /area/f13/wasteland)
 "xA" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
 	},
@@ -899,9 +876,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland)
 "yI" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/structure/car/rubbish3,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crossborderroundmid"
@@ -930,8 +905,7 @@
 	pixel_x = 1
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "zj" = (
@@ -1013,8 +987,7 @@
 "Aw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "AF" = (
@@ -1087,9 +1060,7 @@
 /turf/open/floor/carpet,
 /area/f13/building/firetower)
 "BU" = (
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/closed/wall/f13/wood,
 /area/f13/village/overpass_village)
 "Cg" = (
@@ -1193,8 +1164,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/firetower)
 "FF" = (
@@ -1207,8 +1177,7 @@
 	dir = 4
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/building/firetower)
 "FL" = (
@@ -1717,8 +1686,7 @@
 	dir = 8
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "Tc" = (
@@ -1907,8 +1875,7 @@
 	pixel_y = 2
 	},
 /turf/open/transparent/openspace{
-	name = "air";
-	sunlight_state = 1
+	name = "air"
 	},
 /area/f13/wasteland)
 "Zc" = (

--- a/_maps/map_files/coyote_bayou/Redwater.dmm
+++ b/_maps/map_files/coyote_bayou/Redwater.dmm
@@ -59,9 +59,7 @@
 /area/f13/building)
 "abp" = (
 /obj/effect/decal/remains/human,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "acc" = (
@@ -213,9 +211,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal)
 "afI" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -610,9 +606,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -639,16 +633,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
-"aob" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "aof" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -725,8 +709,7 @@
 /area/f13/building)
 "apB" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
@@ -845,9 +828,7 @@
 /obj/structure/stone_tile/block{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "arS" = (
@@ -936,9 +917,7 @@
 /area/f13/wasteland/redwater)
 "asO" = (
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
@@ -1863,9 +1842,7 @@
 /turf/open/water,
 /area/f13/building)
 "aMC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/redwater)
 "aMP" = (
@@ -2005,9 +1982,7 @@
 /area/f13/wasteland/redwater)
 "aOL" = (
 /obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -2327,13 +2302,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
-"aVh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/town)
 "aVq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -2385,8 +2353,7 @@
 /area/f13/wasteland/redwater)
 "aWd" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
@@ -2560,12 +2527,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/town)
-"aZE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "aZI" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -3016,9 +2977,7 @@
 	icon_state = "crossborderroundmid";
 	name = "Upwards Road"
 	},
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crossborderroundmid"
 	},
@@ -3032,9 +2991,7 @@
 "bho" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -3601,9 +3558,7 @@
 /turf/open/floor/grass,
 /area/f13/wasteland/redwater)
 "brg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -3705,12 +3660,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned)
-"bsw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/town)
 "bsF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4180,7 +4129,6 @@
 	dir = 9
 	},
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /obj/structure/flora/rock/pile/largejungle,
@@ -4228,9 +4176,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4254,9 +4200,7 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "bAP" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "darkrustysolid"
@@ -4373,13 +4317,6 @@
 	},
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
-"bCX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "bDc" = (
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
@@ -4429,15 +4366,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/redwater)
-"bDQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "bDT" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 3;
@@ -4911,9 +4839,7 @@
 /area/f13/building)
 "bMc" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -4951,13 +4877,6 @@
 /obj/effect/validball_spawner,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"bMK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
 "bMM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -5157,8 +5076,7 @@
 "bPT" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -5199,8 +5117,7 @@
 /obj/structure/car/rubbish3,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -5378,13 +5295,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/building/abandoned)
-"bVz" = (
-/obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "bVV" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -5553,8 +5463,7 @@
 /area/f13/building)
 "bZo" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/structure/spacevine{
 	name = "vines"
@@ -5775,9 +5684,7 @@
 	icon_state = "tall_grass_6"
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "ccM" = (
@@ -7295,9 +7202,7 @@
 /area/f13/wasteland/redwater)
 "cAY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -7637,13 +7542,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building/abandoned)
-"cHG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "cHR" = (
 /obj/structure/simple_door/house{
 	icon_state = "roomopening"
@@ -7696,9 +7594,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -7878,9 +7774,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
@@ -8293,9 +8187,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
@@ -8315,9 +8207,7 @@
 /area/f13/building)
 "cUj" = (
 /obj/structure/fence,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "cUk" = (
@@ -8965,18 +8855,8 @@
 /obj/effect/validball_spawner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
-"deJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water{
-	desc = "Deep, poorly filtered gardening water.";
-	name = "stagnant water"
-	},
-/area/f13/wasteland/redwater)
 "deU" = (
 /obj/structure/nest/ghoul{
-	max_mobs = 2;
 	radius = 5
 	},
 /turf/open/floor/wood_common,
@@ -9176,9 +9056,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -9425,8 +9303,7 @@
 "dnC" = (
 /obj/structure/rack,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "bar"
@@ -9495,9 +9372,7 @@
 /turf/open/floor/grass,
 /area/f13/wasteland/redwater)
 "doR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/tallgrass9,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -9553,13 +9428,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"dpG" = (
-/obj/machinery/light/small/broken{
-	dir = 4;
-	icon_state = "bulb-broken"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dpJ" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -10074,9 +9942,7 @@
 /area/f13/building/abandoned)
 "dAd" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
@@ -10093,9 +9959,7 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/town)
 "dAz" = (
-/obj/structure/lamp_post/doubles/bent{
-	dir = 2
-	},
+/obj/structure/lamp_post/doubles/bent,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
 	},
@@ -10545,8 +10409,7 @@
 /area/f13/wasteland/redwater)
 "dHC" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
@@ -10700,7 +10563,6 @@
 	dir = 1
 	},
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /obj/structure/flora/rock/pile/largejungle,
@@ -10979,8 +10841,7 @@
 "dRU" = (
 /obj/structure/table,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -11301,9 +11162,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "dWY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -11321,15 +11180,11 @@
 /area/f13/wasteland/redwater)
 "dXh" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "dXl" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -11540,9 +11395,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "eaY" = (
@@ -12671,9 +12524,7 @@
 /area/f13/wasteland/redwater)
 "evv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -13104,8 +12955,7 @@
 /area/f13/building)
 "eDW" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13145,13 +12995,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
-"eEt" = (
-/obj/structure/fence/corner{
-	dir = 8;
-	icon_state = "corner"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "eEM" = (
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13{
@@ -13237,9 +13080,7 @@
 /turf/open/floor/f13,
 /area/f13/city)
 "eFP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -14076,9 +13917,7 @@
 	},
 /area/f13/building)
 "eUx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14145,9 +13984,7 @@
 "eVt" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/cloth/thirty,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -14156,15 +13993,6 @@
 "eVv" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/redwater)
-"eVB" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "eVP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14326,9 +14154,7 @@
 /area/f13/wasteland/redwater)
 "eXK" = (
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "eXP" = (
@@ -14789,9 +14615,7 @@
 /area/f13/building)
 "fgp" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "fgv" = (
@@ -15000,8 +14824,7 @@
 "fjH" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain0"
@@ -15259,9 +15082,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
 "foz" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
 	pixel_x = -6
@@ -15383,8 +15204,7 @@
 /area/f13/caves)
 "fqX" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -15450,9 +15270,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "fsR" = (
@@ -15674,13 +15492,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/town)
-"fxc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "fxn" = (
 /obj/machinery/light/broken{
 	dir = 4;
@@ -15831,8 +15642,7 @@
 /area/f13/building)
 "fAh" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6;
-	icon_state = "pipe"
+	dir = 6
 	},
 /obj/structure/spacevine{
 	name = "vines"
@@ -16315,9 +16125,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -16488,9 +16296,7 @@
 /area/f13/city)
 "fMo" = (
 /obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/redwater)
@@ -16849,7 +16655,6 @@
 	dir = 8
 	},
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -16888,9 +16693,7 @@
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "fVR" = (
@@ -17237,9 +17040,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
 "gbO" = (
@@ -17772,9 +17573,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/punji_sticks,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18273,9 +18072,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "guz" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/town)
@@ -18296,15 +18093,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"guQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "guS" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5";
@@ -19554,9 +19342,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -19894,16 +19680,6 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building)
-"gXc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "gXo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19931,8 +19707,7 @@
 /area/f13/building/abandoned)
 "gXT" = (
 /obj/structure/chair/comfy/black{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland)
@@ -20090,9 +19865,7 @@
 	},
 /area/f13/building)
 "hbe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
 	},
@@ -20332,9 +20105,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
@@ -20602,7 +20373,6 @@
 "hjT" = (
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -20830,12 +20600,6 @@
 	},
 /turf/closed/wall/rust,
 /area/f13/building)
-"hnM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
 "hnP" = (
 /obj/structure/table/reinforced{
 	color = "#3c2c21"
@@ -21063,16 +20827,8 @@
 "hqL" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar)
-"hqS" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland/redwater)
 "hqX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -21092,9 +20848,7 @@
 "hrf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/wasteland/redwater)
 "hrm" = (
@@ -21363,15 +21117,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
-"hxB" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "hxV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -21455,9 +21200,7 @@
 "hyY" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -21738,9 +21481,7 @@
 	door_type = "fence_wood";
 	icon_state = "fence_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21751,9 +21492,7 @@
 /area/f13/wasteland/redwater)
 "hEj" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21910,7 +21649,6 @@
 /area/f13/building)
 "hHB" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22645,15 +22383,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
-"hVU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/town)
 "hWm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -22725,9 +22454,7 @@
 	},
 /area/f13/wasteland/redwater)
 "hXc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -22742,9 +22469,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -23161,9 +22886,7 @@
 /turf/open/floor/wood_common,
 /area/f13/bar)
 "ido" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#6D6D6D"
@@ -23287,9 +23010,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
@@ -23318,8 +23039,7 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 13;
-	pixel_y = 0
+	pixel_x = 13
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -23611,9 +23331,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -23936,9 +23654,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
@@ -24069,8 +23785,7 @@
 "iuG" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -24796,7 +24511,6 @@
 "iEY" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/redwater)
@@ -25443,9 +25157,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "iPw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -26087,13 +25799,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
-"jaH" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
 "jaQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -26214,9 +25919,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "jcw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
@@ -26485,9 +26188,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "jif" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 4;
 	pixel_y = 13
@@ -26645,9 +26346,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "jkW" = (
@@ -26828,7 +26527,6 @@
 "jnB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -27388,8 +27086,7 @@
 "jwI" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /mob/living/simple_animal/hostile/gecko/tribal/warrior,
 /turf/open/indestructible/ground/outside/gravel,
@@ -27515,9 +27212,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal/cave)
 "jzp" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/outside/gravel,
@@ -27999,13 +27694,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"jJr" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "jJA" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/turf_decal/weather/dirt{
@@ -28085,9 +27773,7 @@
 /area/f13/building)
 "jKs" = (
 /obj/structure/stone_tile/slab,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
 	footstep = "dirt";
@@ -28345,9 +28031,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "jQA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -28366,8 +28050,7 @@
 /area/f13/building)
 "jQM" = (
 /obj/structure/fence{
-	dir = 1;
-	icon_state = "straight"
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -28460,15 +28143,6 @@
 /obj/structure/debris/v2,
 /turf/closed/wall/mineral/concrete/blastproof,
 /area/f13/building/abandoned)
-"jSU" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "jTi" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -28557,12 +28231,8 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/redwater)
 "jUT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/town)
 "jVf" = (
@@ -28985,9 +28655,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/redwater)
 "kdR" = (
@@ -29048,9 +28716,7 @@
 	},
 /area/f13/building)
 "keE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/machinery/light/small{
 	color = "#FF0000";
 	dir = 1;
@@ -29165,12 +28831,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"khw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "khF" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
@@ -29295,9 +28955,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
@@ -29326,9 +28984,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
@@ -29431,9 +29087,7 @@
 	},
 /area/f13/wasteland/redwater)
 "kmK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -29764,9 +29418,7 @@
 /area/f13/wasteland/town)
 "ktd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -29808,9 +29460,7 @@
 /area/f13/building)
 "kua" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -30317,9 +29967,7 @@
 	dir = 2;
 	icon_state = "housewindowbroken"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/curtain{
 	color = "#845f58";
 	layer = 5
@@ -30745,7 +30393,6 @@
 /obj/machinery/computer/terminal{
 	dir = 4;
 	doc_content_1 = "This document seems to be trying to tell you how you should format slave documentation.  It mentions to include their name and collar number/id, and if you sell one write out a proper 'writ of sale' to the new owner.  Or maybe you can't read, and this is just a pretty screen.  I'm not your dad.";
-	doc_content_2 = "";
 	doc_title_1 = "Slave Capture Blank Doc";
 	pixel_x = 4;
 	pixel_y = 5
@@ -31154,9 +30801,7 @@
 "kUZ" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fernybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "kVa" = (
@@ -31273,9 +30918,7 @@
 	},
 /area/f13/building/tribal)
 "kXg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -31616,9 +31259,7 @@
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -31812,15 +31453,6 @@
 	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
-"lgq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -32051,9 +31683,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
@@ -32061,16 +31691,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
-"ljr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "ljx" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/structure/closet/crate/bin,
@@ -32127,9 +31747,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "lkq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
 	randomizer_kind = "high level mobs";
@@ -32140,9 +31758,7 @@
 "lkz" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
-	icon_state = "sS-casing";
-	pixel_x = 0;
-	pixel_y = 0
+	icon_state = "sS-casing"
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
@@ -32461,9 +32077,7 @@
 /area/f13/building)
 "lqD" = (
 /obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/redwater)
 "lqE" = (
@@ -32575,9 +32189,7 @@
 	},
 /area/f13/building/abandoned)
 "lsw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
@@ -32585,9 +32197,7 @@
 "lsy" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "lsB" = (
@@ -33044,8 +32654,7 @@
 /area/f13/building)
 "lAF" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -33185,9 +32794,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -33732,9 +33339,7 @@
 /area/f13/building)
 "lOp" = (
 /obj/effect/spawner/lootdrop/trash,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/town)
@@ -34058,9 +33663,7 @@
 /area/f13/wasteland/redwater)
 "lTn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
@@ -34441,9 +34044,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -35027,15 +34628,6 @@
 	},
 /turf/closed/indestructible/rock,
 /area/f13/building)
-"mkG" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "mlh" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -35197,7 +34789,6 @@
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/water,
@@ -35430,15 +35021,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"mrr" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "mrs" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -35593,9 +35175,7 @@
 	},
 /area/f13/building/abandoned)
 "mvv" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -35615,16 +35195,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
-"mvJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#B7ABAB";
-	footstep = "dirt";
-	name = "rocky dirt"
-	},
-/area/f13/wasteland/redwater)
 "mwe" = (
 /obj/structure/flora/grass/wasteland,
 /obj/effect/decal/waste{
@@ -35757,16 +35327,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building/abandoned)
-"myY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "mzb" = (
 /obj/structure/junk/small/bed,
 /obj/structure/curtain{
@@ -36358,15 +35918,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
-"mJQ" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water/running,
-/area/f13/wasteland/redwater)
 "mJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -36824,8 +36375,7 @@
 "mTe" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -37428,10 +36978,8 @@
 /area/f13/building/abandoned)
 "nhX" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 4;
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -37806,7 +37354,6 @@
 /area/f13/wasteland/town)
 "noO" = (
 /turf/open/floor/f13{
-	dir = 2;
 	icon_state = "yellowsiding"
 	},
 /area/f13/building/coyote/safe/redwater)
@@ -37874,9 +37421,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
@@ -37917,9 +37462,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "nqZ" = (
@@ -38659,9 +38202,7 @@
 /area/f13/bar)
 "nFA" = (
 /obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/medical/ancientfirstaid{
-	pixel_y = 0
-	},
+/obj/item/storage/medical/ancientfirstaid,
 /obj/item/storage/box/ration/ranger_breakfast{
 	pixel_y = -6
 	},
@@ -38721,7 +38262,6 @@
 /area/f13/building)
 "nHV" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -39496,9 +39036,7 @@
 /turf/open/floor/carpet/red,
 /area/f13/bar)
 "nVn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/car/rubbish2{
 	icon_state = "car_rubish3";
@@ -39760,13 +39298,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
-"nZD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
 "nZT" = (
 /obj/structure/decoration/rag{
 	layer = 4.3
@@ -40618,18 +40149,14 @@
 "oqg" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oqy" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -41581,7 +41108,6 @@
 	icon_state = "bush3"
 	},
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/desert,
@@ -41611,13 +41137,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/building)
-"oHb" = (
-/obj/structure/fence/corner{
-	dir = 1;
-	icon_state = "corner"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "oHu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo11"
@@ -42053,9 +41572,7 @@
 /obj/structure/stone_tile/block{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "oPM" = (
@@ -42253,9 +41770,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/rock/jungle,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -42391,9 +41906,7 @@
 "oWI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -42498,9 +42011,7 @@
 /area/f13/wasteland/redwater)
 "oXQ" = (
 /obj/structure/table/wood/settler,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "oYf" = (
@@ -42844,9 +42355,7 @@
 /area/f13/building)
 "pfl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -42924,9 +42433,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/town)
 "pgv" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -42943,9 +42450,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "pgZ" = (
@@ -43323,9 +42828,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building/tribal)
 "pps" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -43714,7 +43217,6 @@
 /area/f13/building)
 "pwa" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -43874,15 +43376,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/redwater)
-"pzP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "pzT" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /obj/effect/spawner/lootdrop/f13/seedspawner,
@@ -44160,9 +43653,7 @@
 /turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/building/abandoned)
 "pFu" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_wide,
 /area/f13/wasteland/redwater)
 "pFL" = (
@@ -44566,12 +44057,6 @@
 /obj/item/clothing/glasses/f13/biker,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"pNw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water/running,
-/area/f13/wasteland/redwater)
 "pNA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/nest/randomized{
@@ -45357,8 +44842,7 @@
 /area/f13/building)
 "qdF" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine{
@@ -45771,8 +45255,7 @@
 /area/f13/wasteland/redwater)
 "qls" = (
 /obj/structure/chair{
-	dir = 4;
-	icon_state = "chair"
+	dir = 4
 	},
 /obj/item/clothing/under/pants/f13/ghoul,
 /turf/open/floor/f13/wood,
@@ -45890,17 +45373,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"qoq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
-	pixel_x = -11;
-	pixel_y = 11
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "qov" = (
 /obj/structure/flora/grass/coyote/nine,
 /obj/structure/flora/grass/wasteland,
@@ -45952,9 +45424,7 @@
 /area/f13/building)
 "qoX" = (
 /obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "qoZ" = (
@@ -46009,8 +45479,7 @@
 	color = "#363636"
 	},
 /obj/structure/nest/ghoul{
-	layer = 2.07;
-	max_mobs = 2
+	layer = 2.07
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -47067,13 +46536,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building/abandoned)
-"qKt" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "qKv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -47321,9 +46783,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "qOd" = (
@@ -47665,7 +47125,6 @@
 /area/f13/building)
 "qTI" = (
 /obj/structure/toilet{
-	icon_state = "toilet00";
 	dir = 8
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -47751,8 +47210,7 @@
 /area/f13/building)
 "qUO" = (
 /obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet00"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -47910,9 +47368,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "qXN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -48151,9 +47607,7 @@
 "raI" = (
 /obj/structure/flora/stump,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "raK" = (
@@ -48488,16 +47942,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"rgQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "rhd" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48508,9 +47952,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
@@ -48549,9 +47991,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
@@ -48644,13 +48084,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"rjf" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "rjx" = (
 /obj/structure/fence/wooden,
 /turf/open/floor/f13/wood,
@@ -48828,9 +48261,7 @@
 	},
 /area/f13/building/abandoned)
 "rmg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -48839,9 +48270,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "rmi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
@@ -48861,9 +48290,7 @@
 	pixel_x = -2;
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -48960,12 +48387,6 @@
 	smooth = 1
 	},
 /area/f13/building)
-"roc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/redwater)
 "rok" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -49169,9 +48590,7 @@
 /obj/machinery/light/sign/kebab_sign{
 	pixel_x = -18
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "rrF" = (
@@ -49474,9 +48893,7 @@
 /area/f13/building/abandoned)
 "rws" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "rww" = (
@@ -49585,9 +49002,7 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "ryO" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -49648,9 +49063,7 @@
 	icon_state = "crossborderroundmid";
 	name = "Upwards Road"
 	},
-/obj/structure/railing{
-	layer = 4.1
-	},
+/obj/structure/railing,
 /obj/structure/stairs/west,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "crossborderroundmid"
@@ -49923,20 +49336,10 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
-"rDo" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "rDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -50004,9 +49407,7 @@
 /area/f13/wasteland/redwater)
 "rEJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
@@ -50469,9 +49870,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
@@ -50578,9 +49977,7 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
 "rPK" = (
-/obj/structure/nest/protectron{
-	max_mobs = 2
-	},
+/obj/structure/nest/protectron,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "bluechess2"
@@ -50797,9 +50194,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -50970,9 +50365,7 @@
 /area/f13/building)
 "rWe" = (
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "rWf" = (
@@ -51156,9 +50549,7 @@
 /turf/open/floor/wood_common,
 /area/f13/building/tribal)
 "rYR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -51282,9 +50673,7 @@
 /area/f13/building)
 "sbB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -51326,9 +50715,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "sbV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
 	randomizer_kind = "high level mobs";
@@ -51360,9 +50747,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt,
@@ -51711,9 +51096,7 @@
 "shi" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/metal/fifty,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -51770,13 +51153,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/redwater)
-"siV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/town)
 "siW" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -52122,9 +51498,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
 "sov" = (
@@ -52209,9 +51583,7 @@
 "sqj" = (
 /obj/structure/simple_door/dirtyglass,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -52399,8 +51771,7 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 13;
-	pixel_y = 0
+	pixel_x = 13
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal)
@@ -52614,9 +51985,7 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "sxM" = (
@@ -52751,9 +52120,7 @@
 /area/f13/building/abandoned)
 "sAj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
 "sAs" = (
@@ -52801,8 +52168,7 @@
 "sBE" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/tribal/cave)
@@ -53029,7 +52395,6 @@
 /area/f13/building)
 "sGa" = (
 /obj/structure/chair{
-	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/floor/plasteel/barber{
@@ -53144,9 +52509,7 @@
 	},
 /area/f13/building)
 "sIc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/gravel,
@@ -54040,8 +53403,7 @@
 /obj/structure/fence/wooden{
 	density = 0;
 	dir = 1;
-	pixel_x = 13;
-	pixel_y = 0
+	pixel_x = 13
 	},
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#B7ABAB";
@@ -54123,7 +53485,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 1;
-	icon_state = "sink";
 	pixel_y = 16
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -54132,9 +53493,7 @@
 	},
 /area/f13/building)
 "tbU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -54153,9 +53512,7 @@
 	dir = 4;
 	icon_state = "post_wood"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt{
@@ -54209,9 +53566,7 @@
 /area/f13/bar)
 "tdr" = (
 /obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -54220,8 +53575,7 @@
 "tdt" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/light/small/broken{
-	dir = 4;
-	icon_state = "bulb-broken"
+	dir = 4
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -54533,8 +53887,7 @@
 /area/f13/building)
 "tjW" = (
 /obj/structure/fence/corner{
-	dir = 8;
-	icon_state = "corner"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -55042,13 +54395,6 @@
 /obj/structure/punji_sticks,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
-"ttp" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "ttx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -55204,9 +54550,7 @@
 /area/f13/building)
 "twg" = (
 /obj/structure/fence,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
@@ -55513,9 +54857,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
 	layer = 5;
@@ -55600,9 +54942,7 @@
 /area/f13/building)
 "tCg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "tCv" = (
@@ -55952,9 +55292,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "tIw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -56207,15 +55545,6 @@
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"tNZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gib3-old"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "tOd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -56349,9 +55678,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -56690,9 +56017,7 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building/abandoned)
 "tXr" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -56734,9 +56059,7 @@
 /area/f13/building)
 "tXU" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "tXZ" = (
@@ -56856,9 +56179,7 @@
 /area/f13/wasteland/redwater)
 "tZK" = (
 /obj/structure/flora/rock/pile/largejungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
@@ -56898,9 +56219,7 @@
 /area/f13/wasteland/redwater)
 "tZX" = (
 /obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -57103,15 +56422,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/building)
-"ucC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/waste{
-	icon_state = "goo11"
-	},
-/turf/open/indestructible/ground/outside/water/running,
-/area/f13/wasteland/redwater)
 "ucF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -57639,8 +56949,7 @@
 "ulG" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /mob/living/simple_animal/hostile/gecko/tribal,
 /turf/open/indestructible/ground/outside/gravel,
@@ -57802,8 +57111,7 @@
 /area/f13/building)
 "uoB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -58022,9 +57330,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
 	},
@@ -58393,7 +57699,6 @@
 /area/f13/building)
 "uAR" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/open/floor/f13{
@@ -58452,15 +57757,12 @@
 	color = "#363636"
 	},
 /obj/structure/nest/ghoul{
-	max_mobs = 2;
 	radius = 5
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "uCj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -58475,9 +57777,7 @@
 	},
 /area/f13/building)
 "uCq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -59133,13 +58433,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
-"uOK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "uPd" = (
 /obj/structure/chair/left{
 	dir = 4
@@ -59571,8 +58864,7 @@
 /area/f13/building)
 "uXk" = (
 /obj/structure/fence{
-	dir = 8;
-	icon_state = "straight"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59623,9 +58915,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
@@ -60265,9 +59555,7 @@
 /area/f13/wasteland/redwater)
 "vji" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -61241,13 +60529,6 @@
 	name = "rocky dirt"
 	},
 /area/f13/building)
-"vBK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/validball_spawner,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
 "vBP" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/pile/largejungle{
@@ -61786,9 +61067,7 @@
 "vKN" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 10;
-	pixel_y = 0
+	pixel_x = 10
 	},
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -61881,9 +61160,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "vMz" = (
@@ -62466,9 +61743,7 @@
 	},
 /area/f13/building/abandoned)
 "vXF" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
@@ -62494,13 +61769,6 @@
 "vYa" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/redwater)
-"vYb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "vYd" = (
 /obj/structure/flora/grass/wasteland,
@@ -62619,9 +61887,7 @@
 /obj/machinery/light/sign/kebab{
 	pixel_x = -15
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/wood_common,
 /area/f13/building)
 "wbg" = (
@@ -62630,15 +61896,6 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
-/area/f13/wasteland/redwater)
-"wbo" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "wbH" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62859,7 +62116,6 @@
 /area/f13/building)
 "wfY" = (
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -63177,20 +62433,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"wlU" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/town)
 "wmb" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/structure/reagent_dispensers/barrel/three{
 	pixel_x = -13
@@ -63959,17 +63205,13 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/redwater)
 "wzp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
 	},
@@ -64600,9 +63842,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4";
 	layer = 5;
@@ -65163,9 +64403,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
@@ -65894,9 +65132,7 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/redwater)
 "xkl" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib3-old"
@@ -65917,9 +65153,7 @@
 /area/f13/wasteland/redwater)
 "xkZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
 "xla" = (
@@ -66354,8 +65588,7 @@
 "xrq" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -66372,7 +65605,6 @@
 /area/f13/building)
 "xrO" = (
 /obj/structure/window/fulltile/house{
-	icon_state = "housewindow";
 	dir = 2
 	},
 /turf/open/floor/plasteel/barber{
@@ -66518,13 +65750,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"xuy" = (
-/obj/structure/flora/grass/jungle,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/redwater)
 "xuE" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/structure/flora/rock/pile/largejungle,
@@ -66598,7 +65823,6 @@
 "xvM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/nest/mirelurk{
-	max_mobs = 2;
 	spawn_time = 20
 	},
 /turf/open/indestructible/ground/outside/dirt,
@@ -67011,9 +66235,7 @@
 	pixel_x = -2;
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
@@ -67139,7 +66361,6 @@
 "xFe" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /turf/open/floor/f13{
@@ -68265,9 +67486,7 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -68406,9 +67625,7 @@
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland/redwater)
 "yeH" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "yeL" = (
@@ -68550,9 +67767,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/outside/dirt{
 	color = "#9c9c9c"
@@ -71144,7 +70359,7 @@ ddX
 bkw
 eZm
 rzE
-hnM
+tuP
 oRi
 xAc
 pzx
@@ -71684,7 +70899,7 @@ oas
 oas
 flv
 wid
-hnM
+tuP
 wRg
 bDc
 klZ
@@ -71941,7 +71156,7 @@ ucQ
 jqt
 wRg
 xrQ
-hnM
+tuP
 wRg
 vCc
 hEn
@@ -72172,7 +71387,7 @@ ddX
 bkw
 eZm
 rzE
-hnM
+tuP
 mOj
 uEV
 vnE
@@ -72183,7 +71398,7 @@ tRd
 bRw
 eff
 eff
-pNw
+wFx
 flv
 lsD
 dmL
@@ -72198,7 +71413,7 @@ fTy
 aKX
 oVp
 ldL
-hnM
+tuP
 okM
 rGG
 hEn
@@ -72953,7 +72168,7 @@ tRd
 xsw
 eff
 eff
-ucC
+mLD
 jJe
 aqK
 flv
@@ -73210,7 +72425,7 @@ tRd
 bRw
 eff
 eff
-ucC
+mLD
 dKh
 xCF
 mHP
@@ -73226,7 +72441,7 @@ bDc
 bDc
 flv
 cyx
-hnM
+tuP
 wRg
 oas
 oiW
@@ -73467,7 +72682,7 @@ tRd
 bRw
 pVN
 wcz
-ucC
+mLD
 dmL
 kvS
 mHP
@@ -73483,7 +72698,7 @@ okM
 okM
 flv
 ldL
-hnM
+tuP
 tTJ
 oas
 oas
@@ -73724,7 +72939,7 @@ tRd
 bRw
 eff
 jtn
-pNw
+wFx
 set
 jle
 xOk
@@ -73847,7 +73062,7 @@ yie
 ddZ
 ddZ
 sfW
-hqS
+gzS
 bFR
 cxN
 lPs
@@ -73981,7 +73196,7 @@ tRd
 fLw
 jtn
 eff
-pNw
+wFx
 dKh
 flv
 flv
@@ -73997,7 +73212,7 @@ aCs
 hLL
 dmL
 xrQ
-hnM
+tuP
 qSA
 dKh
 rzU
@@ -74238,7 +73453,7 @@ tRd
 bRw
 eff
 eff
-mJQ
+uNC
 dKh
 xCF
 xOk
@@ -74254,7 +73469,7 @@ tPi
 jJn
 set
 kuO
-hnM
+tuP
 bJs
 dmL
 jJn
@@ -74495,7 +73710,7 @@ tRd
 oLz
 eff
 eff
-pNw
+wFx
 dmL
 pGr
 xOk
@@ -74752,7 +73967,7 @@ ngS
 bRw
 yja
 jtn
-pNw
+wFx
 set
 fTP
 xOk
@@ -75517,7 +74732,7 @@ jAi
 mem
 okM
 rIf
-aZE
+cxN
 xsw
 eff
 eff
@@ -75539,7 +74754,7 @@ joB
 lCU
 hzN
 wid
-hnM
+tuP
 pJb
 flv
 gMV
@@ -75774,7 +74989,7 @@ quS
 nLY
 okM
 eVe
-aZE
+cxN
 bRw
 eff
 eff
@@ -76031,7 +75246,7 @@ aWq
 hVI
 okM
 kZZ
-aZE
+cxN
 bRw
 eff
 eff
@@ -77059,7 +76274,7 @@ aCi
 vyW
 okM
 mJw
-aZE
+cxN
 bRw
 eff
 eff
@@ -77829,7 +77044,7 @@ tTb
 qrC
 xoJ
 uiq
-guQ
+wWC
 bRw
 eff
 eff
@@ -78860,7 +78075,7 @@ eff
 eff
 anw
 eff
-pNw
+wFx
 rIf
 bFR
 tRM
@@ -78870,7 +78085,7 @@ eff
 eff
 eff
 eff
-pNw
+wFx
 wWC
 smj
 flv
@@ -79117,17 +78332,17 @@ jtn
 eff
 eff
 eff
-pNw
+wFx
 eVe
 bFR
 jyD
-aZE
+cxN
 bRw
 eff
 eff
 eff
 xLw
-pNw
+wFx
 kbL
 bfU
 xrQ
@@ -79374,11 +78589,11 @@ jtn
 eff
 eff
 xLw
-pNw
+wFx
 eVe
 bFR
 bFR
-mkG
+vbX
 bRw
 eff
 jtn
@@ -79631,7 +78846,7 @@ eff
 eff
 eff
 eff
-pNw
+wFx
 wQj
 tRM
 bFR
@@ -81245,7 +80460,7 @@ yie
 lQC
 hds
 sfW
-hqS
+gzS
 bFR
 geA
 xAZ
@@ -81445,7 +80660,7 @@ dKh
 set
 xrQ
 flv
-hnM
+tuP
 flv
 bYy
 dmL
@@ -81502,7 +80717,7 @@ qIh
 feS
 lQC
 sfW
-hqS
+gzS
 fHN
 nWj
 rTx
@@ -81702,7 +80917,7 @@ tCV
 dKh
 xrQ
 vYa
-hnM
+tuP
 flv
 tWE
 ycf
@@ -81719,7 +80934,7 @@ sDQ
 vQA
 hKV
 qnc
-pNw
+wFx
 tRd
 qnn
 "}
@@ -81959,7 +81174,7 @@ ycf
 pRj
 xrQ
 flv
-hnM
+tuP
 cTN
 xOk
 xOk
@@ -82473,7 +81688,7 @@ dKh
 set
 xrQ
 flv
-hnM
+tuP
 pNG
 bYy
 dmL
@@ -82987,10 +82202,10 @@ ete
 vYa
 ete
 flv
-hnM
+tuP
 enS
 nIF
-aZE
+cxN
 bYy
 bYy
 pRj
@@ -83247,7 +82462,7 @@ flv
 vOh
 lGx
 eVe
-tNZ
+iEq
 bYy
 xCF
 ung
@@ -83502,9 +82717,9 @@ vDs
 smj
 flv
 flv
-hnM
+tuP
 kbL
-qoq
+gyy
 dmL
 hzu
 xOk
@@ -83761,7 +82976,7 @@ xrQ
 ugP
 ete
 lGx
-lgq
+pJC
 flv
 xOk
 xOk
@@ -84017,7 +83232,7 @@ jcw
 smj
 flv
 ete
-hnM
+tuP
 oUs
 flv
 flv
@@ -84274,7 +83489,7 @@ oas
 emR
 xrQ
 vYa
-hnM
+tuP
 hCd
 oeT
 tOg
@@ -84350,7 +83565,7 @@ uVV
 otE
 aXu
 bFR
-aZE
+cxN
 iHH
 rss
 xrQ
@@ -84531,12 +83746,12 @@ hRS
 afI
 xrQ
 ete
-hnM
+tuP
 kbL
 udY
 kuO
 flv
-hnM
+tuP
 rez
 eWl
 eWl
@@ -85042,7 +84257,7 @@ oas
 oas
 acA
 cOe
-mvJ
+faI
 xrQ
 ete
 flv
@@ -85051,7 +84266,7 @@ flv
 flv
 ugP
 ete
-hnM
+tuP
 bhB
 vkz
 rGG
@@ -85122,7 +84337,7 @@ oBP
 fHN
 rCo
 bFR
-aZE
+cxN
 kwK
 smj
 ecv
@@ -85379,7 +84594,7 @@ bFR
 fHN
 rCo
 bFR
-aZE
+cxN
 cGv
 vru
 wuH
@@ -85559,12 +84774,12 @@ tkK
 tOg
 flv
 flv
-hnM
+tuP
 qbu
 oeT
 xrQ
 flv
-hnM
+tuP
 jrm
 okM
 eWl
@@ -85636,7 +84851,7 @@ fHN
 fHN
 rCo
 bFR
-aZE
+cxN
 cBl
 vXY
 iyU
@@ -85893,7 +85108,7 @@ fHN
 bFR
 fHN
 fHN
-fxc
+vdM
 iLM
 xrQ
 tfq
@@ -86074,7 +85289,7 @@ flv
 kIO
 flv
 qgJ
-guQ
+wWC
 flv
 flv
 rYP
@@ -86150,7 +85365,7 @@ bFR
 oiu
 bFR
 bFR
-fxc
+vdM
 fkG
 xrQ
 flv
@@ -86329,9 +85544,9 @@ ecv
 ecv
 flv
 ete
-hnM
+tuP
 cgC
-aZE
+cxN
 flv
 flv
 xOk
@@ -86407,7 +85622,7 @@ bFR
 fHN
 fHN
 bFR
-aZE
+cxN
 fkG
 xrQ
 ecv
@@ -86586,9 +85801,9 @@ rIf
 uwK
 xrQ
 ete
-hnM
+tuP
 eVe
-bCX
+iQA
 dmL
 xOk
 xOk
@@ -86664,9 +85879,9 @@ fHN
 bFR
 bFR
 wgx
-aZE
+cxN
 gxR
-eVB
+lFo
 oSQ
 xrQ
 tuP
@@ -86833,19 +86048,19 @@ tRd
 tRd
 tRd
 eVe
-aZE
+cxN
 dKh
 tWE
 xOk
 beY
 flv
 lza
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
-aZE
+cxN
 vbs
 tWE
 ycf
@@ -86921,9 +86136,9 @@ bFR
 bFR
 bFR
 bFR
-rgQ
+uAL
 fkG
-eVB
+lFo
 cap
 xrQ
 tuP
@@ -87090,19 +86305,19 @@ eWw
 eWw
 tRd
 wQj
-aZE
+cxN
 dmL
 cZi
 xOk
 iWy
 dmL
 kZZ
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
-aZE
+cxN
 dmL
 xOk
 xOk
@@ -87178,7 +86393,7 @@ bFR
 fHN
 fwy
 fHN
-jSU
+nTd
 fkG
 xrQ
 tfq
@@ -87354,12 +86569,12 @@ jJn
 gtd
 set
 eVe
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
-qoq
+gyy
 vbs
 eTX
 tcR
@@ -87435,7 +86650,7 @@ fHN
 bFR
 bFR
 bFR
-aZE
+cxN
 pDJ
 xrQ
 flv
@@ -87614,7 +86829,7 @@ qjn
 eWb
 xrQ
 flv
-hnM
+tuP
 rHM
 udY
 bYy
@@ -87692,7 +86907,7 @@ bFR
 bFR
 wgx
 bFR
-aZE
+cxN
 pDJ
 smj
 flv
@@ -87949,7 +87164,7 @@ aXu
 bFR
 wgx
 bFR
-aZE
+cxN
 etm
 emR
 xrQ
@@ -88206,7 +87421,7 @@ wgx
 aXu
 aXu
 bFR
-jSU
+nTd
 ous
 wIf
 xrQ
@@ -88463,7 +87678,7 @@ wgx
 bFR
 aXu
 wgx
-aZE
+cxN
 ous
 nyD
 xrQ
@@ -88703,7 +87918,7 @@ fHN
 gqQ
 nsy
 nbV
-bVz
+xWj
 aXu
 aXu
 bFR
@@ -88720,7 +87935,7 @@ bFR
 bFR
 aXu
 bFR
-aZE
+cxN
 rkF
 tOg
 tuP
@@ -88960,7 +88175,7 @@ bFR
 fHN
 hDE
 sxO
-bVz
+xWj
 fHN
 aXu
 aXu
@@ -88977,7 +88192,7 @@ bFR
 wgx
 qSZ
 bFR
-aZE
+cxN
 tqb
 xrQ
 flv
@@ -89217,7 +88432,7 @@ bFR
 fHN
 wMr
 jJI
-bVz
+xWj
 fHN
 fHN
 bFR
@@ -89474,7 +88689,7 @@ bFR
 vmU
 bFR
 eWW
-bVz
+xWj
 fHN
 fHN
 bFR
@@ -89748,7 +88963,7 @@ bFR
 aXu
 bFR
 bFR
-xuy
+ssK
 fkG
 xrQ
 flv
@@ -89988,7 +89203,7 @@ fHN
 qkO
 eTx
 bFR
-bVz
+xWj
 bFR
 bFR
 cxN
@@ -90005,7 +89220,7 @@ bRu
 bFR
 uVV
 bFR
-aZE
+cxN
 cBl
 ine
 tuP
@@ -90245,7 +89460,7 @@ wlg
 fHN
 bFR
 bFR
-bVz
+xWj
 bFR
 bFR
 cxN
@@ -90262,7 +89477,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 cBl
 xrQ
 flv
@@ -90519,7 +89734,7 @@ fyB
 bFR
 bFR
 bFR
-jSU
+nTd
 cBl
 smj
 flv
@@ -90776,7 +89991,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 tFS
 emR
 xrQ
@@ -90952,7 +90167,7 @@ bFR
 wgx
 bFR
 dXe
-aZE
+cxN
 tOg
 wlw
 rIf
@@ -91033,7 +90248,7 @@ aXu
 bFR
 bFR
 bFR
-aZE
+cxN
 ous
 cBl
 smj
@@ -91209,8 +90424,8 @@ wgx
 bFR
 bFR
 cog
-aZE
-eVB
+cxN
+lFo
 rIf
 cFc
 oiu
@@ -91290,7 +90505,7 @@ aXu
 bFR
 wgx
 bFR
-aZE
+cxN
 ous
 uNA
 jER
@@ -91468,7 +90683,7 @@ bFR
 bFR
 jif
 rNJ
-lgq
+pJC
 nqN
 dDK
 bFR
@@ -91547,7 +90762,7 @@ aXu
 bFR
 nQD
 bFR
-aZE
+cxN
 tFS
 ydM
 onx
@@ -91804,7 +91019,7 @@ bFR
 wgx
 bFR
 bFR
-aZE
+cxN
 tFS
 qPL
 tOg
@@ -91980,7 +91195,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 kdG
 tOg
 qgJ
@@ -92061,7 +91276,7 @@ aXu
 bFR
 bFR
 bFR
-aZE
+cxN
 iLM
 tOg
 flv
@@ -92318,10 +91533,10 @@ aXu
 bFR
 bFR
 bFR
-aZE
+cxN
 kwK
 xrQ
-hnM
+tuP
 wRi
 cCn
 fkG
@@ -92575,7 +91790,7 @@ bFR
 fHN
 mfy
 fHN
-aZE
+cxN
 cBl
 smj
 flv
@@ -92753,7 +91968,7 @@ bFR
 bFR
 foz
 vMu
-guQ
+wWC
 nqN
 qNF
 bFR
@@ -92832,10 +92047,10 @@ uVV
 boe
 fHN
 bFR
-aZE
+cxN
 hoy
 xmt
-hnM
+tuP
 bMZ
 klu
 hka
@@ -93011,7 +92226,7 @@ bBV
 bFR
 otE
 eIj
-eVB
+lFo
 kbL
 bFR
 bFR
@@ -93089,10 +92304,10 @@ bFR
 fHN
 bFR
 bFR
-fxc
+vdM
 tOQ
 tOg
-hnM
+tuP
 gLq
 vXY
 tqb
@@ -93351,7 +92566,7 @@ cez
 xrQ
 flv
 tfq
-hnM
+tuP
 jJC
 bFR
 bFR
@@ -96396,7 +95611,7 @@ mJV
 mJV
 anz
 mJV
-eEt
+wGp
 bWy
 bWy
 bWy
@@ -96419,7 +95634,7 @@ iLG
 twg
 gIx
 gll
-nZD
+sYp
 quW
 iLG
 weR
@@ -96543,7 +95758,7 @@ bFR
 bFR
 bFR
 caE
-aZE
+cxN
 tOg
 tfq
 tfq
@@ -96640,7 +95855,7 @@ eYA
 iye
 bFR
 kKT
-aZE
+cxN
 vXY
 clM
 tsv
@@ -96673,7 +95888,7 @@ dDu
 bFR
 fHN
 mdg
-qKt
+xXL
 gIx
 gll
 lTn
@@ -96800,7 +96015,7 @@ pDr
 bFR
 fzA
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -96816,7 +96031,7 @@ rzF
 xrQ
 flv
 mnf
-hnM
+tuP
 vTW
 shN
 shN
@@ -96930,10 +96145,10 @@ chf
 bFR
 fHN
 fHN
-qKt
+xXL
 gIx
 flv
-hnM
+tuP
 eVe
 fHN
 fHN
@@ -97057,7 +96272,7 @@ caE
 bFR
 caE
 bFR
-aZE
+cxN
 xrQ
 flv
 wnU
@@ -97067,13 +96282,13 @@ flv
 flv
 flv
 flv
-hnM
+tuP
 hMQ
 qLn
 xrQ
 flv
 flv
-hnM
+tuP
 fPH
 fPH
 sFY
@@ -97187,10 +96402,10 @@ qZD
 bFR
 nNW
 fHN
-qKt
+xXL
 gIx
 mpX
-hnM
+tuP
 eVe
 bFR
 wgx
@@ -97314,7 +96529,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -97330,7 +96545,7 @@ tfq
 flv
 flv
 flv
-hnM
+tuP
 fPH
 yhx
 yhx
@@ -97447,7 +96662,7 @@ vDi
 sbB
 gIx
 gll
-hnM
+tuP
 eVe
 wgx
 bFR
@@ -97571,7 +96786,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 dgi
 flv
@@ -97587,7 +96802,7 @@ flv
 flv
 flv
 rkx
-hnM
+tuP
 fPH
 yhx
 css
@@ -97701,10 +96916,10 @@ chf
 bFR
 fHN
 fHN
-qKt
+xXL
 gIx
 flv
-hnM
+tuP
 phF
 bFR
 bFR
@@ -97828,7 +97043,7 @@ pDr
 pDr
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -97844,7 +97059,7 @@ flv
 flv
 flv
 flv
-hnM
+tuP
 fPH
 yhx
 yhx
@@ -97958,10 +97173,10 @@ chf
 fHN
 fHN
 fHN
-qKt
+xXL
 gIx
 flv
-nZD
+sYp
 bxL
 flP
 fHN
@@ -98085,7 +97300,7 @@ bFR
 bFR
 bRu
 bRu
-aZE
+cxN
 xrQ
 flv
 flv
@@ -98094,14 +97309,14 @@ tuP
 iHH
 wcu
 wcu
-deJ
+ngp
 xrQ
 flv
 flv
 flv
 flv
 ntD
-hnM
+tuP
 fPH
 yhx
 dEt
@@ -98215,7 +97430,7 @@ qZD
 bFR
 fHN
 fHN
-aob
+jHK
 cOq
 gll
 vji
@@ -98342,7 +97557,7 @@ oiR
 bRu
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -98358,7 +97573,7 @@ flv
 flv
 flv
 flv
-hnM
+tuP
 fPH
 kRH
 irc
@@ -98471,10 +97686,10 @@ bZo
 chf
 bFR
 fHN
-qKt
+xXL
 stn
 gll
-bMK
+tWj
 tYf
 avE
 aXu
@@ -98599,7 +97814,7 @@ caE
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -98615,7 +97830,7 @@ flv
 flv
 flv
 flv
-hnM
+tuP
 fPH
 jZb
 ksH
@@ -98731,7 +97946,7 @@ nNW
 eUx
 gIx
 gll
-bMK
+tWj
 wbS
 bFR
 bFR
@@ -98856,7 +98071,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -98866,13 +98081,13 @@ tuP
 oLp
 otE
 pDr
-vYb
+jbu
 xrQ
 flv
 flv
 flv
 dyR
-hnM
+tuP
 tfn
 yhx
 yhx
@@ -98988,7 +98203,7 @@ fHN
 kua
 gIx
 gll
-hnM
+tuP
 muY
 bFR
 bFR
@@ -99113,23 +98328,23 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 xMR
 xrQ
 flv
 lGx
 eVe
 bFR
-mkG
+vbX
 xrQ
 flv
 flv
 flv
 flv
-hnM
+tuP
 sFY
 yhx
 gdt
@@ -99223,7 +98438,7 @@ fHN
 bFR
 fHN
 qZD
-bVz
+xWj
 qgS
 dzx
 rtH
@@ -99245,7 +98460,7 @@ mdg
 kua
 cOq
 qQf
-hnM
+tuP
 eVe
 bFR
 aXu
@@ -99293,7 +98508,7 @@ mJV
 wWm
 mJV
 mJV
-oHb
+dYP
 bFR
 bFR
 sHq
@@ -99370,7 +98585,7 @@ bFR
 caE
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -99380,13 +98595,13 @@ flv
 qgJ
 eVe
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
 ecv
 flv
-hnM
+tuP
 sFY
 ayu
 gok
@@ -99480,7 +98695,7 @@ bFR
 bFR
 bFR
 chf
-bVz
+xWj
 gpk
 mid
 sti
@@ -99495,14 +98710,14 @@ pdN
 alI
 wKQ
 xLx
-bVz
+xWj
 qZD
 bFR
 fHN
-qKt
+xXL
 xrQ
 flv
-hnM
+tuP
 eVe
 fzA
 bFR
@@ -99550,7 +98765,7 @@ bFR
 bFR
 bFR
 bFR
-rjf
+vLD
 axx
 hsM
 sHq
@@ -99627,7 +98842,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -99640,10 +98855,10 @@ caE
 eIj
 smj
 flv
-hnM
+tuP
 lUW
 xrQ
-hnM
+tuP
 sFY
 gUf
 qXg
@@ -99759,7 +98974,7 @@ juE
 sbB
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -99807,7 +99022,7 @@ bFR
 bFR
 bFR
 bFR
-rjf
+vLD
 sHq
 thG
 jaV
@@ -99884,7 +99099,7 @@ nJM
 fHN
 bFR
 bFR
-aZE
+cxN
 xrQ
 pOL
 flv
@@ -99897,10 +99112,10 @@ eWb
 fah
 dYZ
 xrQ
-hnM
+tuP
 eQW
 xrQ
-hnM
+tuP
 sFY
 yhx
 yhx
@@ -100013,10 +99228,10 @@ ePZ
 chf
 bFR
 juE
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -100064,7 +99279,7 @@ bFR
 fHN
 bFR
 bFR
-rjf
+vLD
 axx
 gWB
 sVg
@@ -100141,7 +99356,7 @@ bzz
 hfs
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -100157,7 +99372,7 @@ xrQ
 flv
 tfq
 flv
-hnM
+tuP
 fPH
 fPH
 fPH
@@ -100270,10 +99485,10 @@ ePZ
 chf
 bFR
 bFR
-fxc
+vdM
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -100321,7 +99536,7 @@ bFR
 bFR
 bFR
 bFR
-rjf
+vLD
 axx
 qwv
 jXi
@@ -100398,7 +99613,7 @@ fhX
 qpw
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -100414,7 +99629,7 @@ flv
 flv
 flv
 rgw
-hnM
+tuP
 bFR
 bFR
 bFR
@@ -100527,10 +99742,10 @@ iQt
 chf
 bFR
 bFR
-aZE
+cxN
 xrQ
 gll
-hnM
+tuP
 eVe
 bFR
 aXu
@@ -100578,7 +99793,7 @@ bFR
 bFR
 bFR
 bFR
-rDo
+jJf
 axx
 jXi
 jXi
@@ -100655,7 +99870,7 @@ fhX
 yij
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 sRT
@@ -100671,7 +99886,7 @@ flv
 flv
 flv
 oMR
-hnM
+tuP
 bFR
 bFR
 bFR
@@ -100784,10 +99999,10 @@ mVP
 chf
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 aXu
@@ -100912,7 +100127,7 @@ fhX
 gbb
 bFR
 bFR
-aZE
+cxN
 smj
 ecv
 ecv
@@ -101041,10 +100256,10 @@ wFM
 chf
 bFR
 bFR
-aZE
+cxN
 uKq
 gll
-hnM
+tuP
 nDe
 bFR
 aXu
@@ -101178,7 +100393,7 @@ clI
 dUe
 xrQ
 flv
-hnM
+tuP
 sHq
 sHq
 sHq
@@ -101298,10 +100513,10 @@ iQt
 chf
 bFR
 fHN
-fxc
+vdM
 xrQ
 gll
-hnM
+tuP
 eVe
 fWo
 oBP
@@ -101555,10 +100770,10 @@ tss
 chf
 bFR
 mdg
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 oBP
@@ -101812,7 +101027,7 @@ tss
 chf
 nNW
 vDi
-aob
+jHK
 xrQ
 flv
 pfl
@@ -101949,7 +101164,7 @@ rWJ
 dUe
 xrQ
 flv
-hnM
+tuP
 eZa
 qoZ
 uwa
@@ -102038,7 +101253,7 @@ isQ
 xAc
 lhQ
 xrQ
-hnM
+tuP
 mGC
 xAc
 isQ
@@ -102068,10 +101283,10 @@ dLj
 tss
 qZD
 nNW
-qKt
+xXL
 stn
 flv
-hnM
+tuP
 jtt
 bFR
 bFR
@@ -102206,7 +101421,7 @@ gXp
 hfU
 xrQ
 flv
-hnM
+tuP
 kdd
 iQI
 iZa
@@ -102325,10 +101540,10 @@ nQM
 tss
 chf
 fHN
-qKt
+xXL
 gIx
 flv
-hnM
+tuP
 eVe
 fHN
 bFR
@@ -102463,7 +101678,7 @@ dOn
 hfU
 xrQ
 hiG
-hnM
+tuP
 gAw
 rWf
 vbN
@@ -102582,10 +101797,10 @@ qUU
 qUU
 vhF
 bFR
-aob
+jHK
 gIx
 flv
-hnM
+tuP
 eVe
 fHN
 bFR
@@ -102720,7 +101935,7 @@ qKm
 hfU
 xrQ
 flv
-hnM
+tuP
 eZa
 gAM
 uwa
@@ -102809,7 +102024,7 @@ awz
 otE
 rAo
 xrQ
-hnM
+tuP
 iuK
 otE
 awz
@@ -102838,7 +102053,7 @@ caE
 bFR
 fHN
 bFR
-aZE
+cxN
 kcU
 gll
 flv
@@ -102977,7 +102192,7 @@ peV
 hfU
 trx
 flv
-hnM
+tuP
 prj
 kKW
 lIn
@@ -103095,10 +102310,10 @@ bFR
 bFR
 caE
 bFR
-aZE
+cxN
 gIx
 gll
-bMK
+tWj
 xJW
 bFR
 bFR
@@ -103234,7 +102449,7 @@ dUe
 dUe
 xrQ
 flv
-hnM
+tuP
 eZa
 hyK
 cnm
@@ -103352,10 +102567,10 @@ bFR
 bFR
 caE
 fHN
-aZE
+cxN
 gIx
 gll
-hnM
+tuP
 eVe
 bFR
 jaQ
@@ -103609,10 +102824,10 @@ bFR
 fHN
 bFR
 bFR
-jJr
+vvn
 gIx
 gll
-hnM
+tuP
 eVe
 wgx
 sNS
@@ -103866,10 +103081,10 @@ fHN
 bFR
 bFR
 bFR
-aZE
+cxN
 gIx
 gll
-hnM
+tuP
 eVe
 wgx
 ims
@@ -104123,10 +103338,10 @@ bFR
 bFR
 bFR
 mdg
-aZE
+cxN
 gIx
 gll
-hnM
+tuP
 pqB
 jHu
 fHN
@@ -104380,10 +103595,10 @@ bFR
 caE
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 jwG
 bFR
 hOp
@@ -104523,7 +103738,7 @@ flv
 flv
 flv
 flv
-hnM
+tuP
 cVT
 tTW
 dDY
@@ -104637,10 +103852,10 @@ bFR
 fHN
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 caE
@@ -104894,10 +104109,10 @@ jHu
 bFR
 bFR
 fHN
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -104984,7 +104199,7 @@ tLG
 bWu
 koN
 iRe
-hnM
+tuP
 eVe
 cxN
 bRw
@@ -105037,7 +104252,7 @@ qgJ
 etX
 rTO
 ueh
-hnM
+tuP
 sHq
 mNp
 jFW
@@ -105151,10 +104366,10 @@ qig
 caE
 fHN
 nNW
-fxc
+vdM
 mqN
 gll
-bMK
+tWj
 eVe
 bFR
 aXu
@@ -105241,7 +104456,7 @@ aaL
 jOw
 olG
 hYP
-hnM
+tuP
 wSW
 cxN
 mXw
@@ -105294,7 +104509,7 @@ kDz
 mPu
 mBJ
 xrQ
-hnM
+tuP
 vBR
 hbG
 aeT
@@ -105411,7 +104626,7 @@ bFR
 tZX
 xrQ
 flv
-hnM
+tuP
 hfQ
 bFR
 aXu
@@ -105498,7 +104713,7 @@ jlH
 pvp
 acz
 jXx
-hnM
+tuP
 snj
 cxN
 bRw
@@ -105542,7 +104757,7 @@ jTo
 kDz
 trx
 tuP
-lgq
+pJC
 wFH
 nWt
 nxT
@@ -105551,7 +104766,7 @@ kZF
 nWt
 seW
 xrQ
-jaH
+gBr
 sHq
 hUE
 cfF
@@ -105664,11 +104879,11 @@ fHN
 bFR
 bFR
 bFR
-aZE
+cxN
 oXy
 flv
 flv
-hnM
+tuP
 pqB
 bFR
 bFR
@@ -105755,7 +104970,7 @@ bWu
 rCy
 aUv
 uYW
-hnM
+tuP
 sts
 vvn
 bRw
@@ -105799,7 +105014,7 @@ jTo
 kDz
 xrQ
 tuP
-lgq
+pJC
 xhI
 bMc
 ygk
@@ -105808,7 +105023,7 @@ gbN
 lCH
 jFP
 xrQ
-hnM
+tuP
 sHq
 eZa
 eZa
@@ -105921,7 +105136,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 flv
@@ -106012,7 +105227,7 @@ aUv
 nfi
 aUv
 jXx
-hnM
+tuP
 gNp
 vVU
 bRw
@@ -106056,7 +105271,7 @@ jTo
 hLo
 xrQ
 tuP
-lgq
+pJC
 jFP
 bMc
 vEK
@@ -106065,7 +105280,7 @@ sAj
 lCH
 xhI
 xrQ
-hnM
+tuP
 iqN
 xwz
 ciX
@@ -106178,7 +105393,7 @@ fHN
 fHN
 fHN
 bFR
-wbo
+xAZ
 kuO
 flv
 eXK
@@ -106313,7 +105528,7 @@ jTo
 kDz
 xrQ
 tuP
-lgq
+pJC
 deB
 fJG
 ygk
@@ -106322,8 +105537,8 @@ gbN
 djX
 deB
 xrQ
-hnM
-lgq
+tuP
+pJC
 uYv
 oMD
 hos
@@ -106434,7 +105649,7 @@ bFR
 bFR
 bFR
 mdg
-aZE
+cxN
 oXy
 ete
 flv
@@ -106570,7 +105785,7 @@ jTo
 kDz
 xrQ
 tuP
-lgq
+pJC
 wFH
 bMc
 qYg
@@ -106579,8 +105794,8 @@ soq
 lCH
 mGy
 xrQ
-hnM
-lgq
+tuP
+pJC
 oKt
 uYv
 oMD
@@ -106691,10 +105906,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 xJW
 jHu
 bFR
@@ -106827,7 +106042,7 @@ giN
 iIf
 xrQ
 gBr
-lgq
+pJC
 xhI
 bMc
 ygk
@@ -106836,8 +106051,8 @@ gbN
 lCH
 wFH
 xrQ
-hnM
-lgq
+tuP
+pJC
 xwz
 eYh
 fGQ
@@ -106948,10 +106163,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 ete
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -107084,7 +106299,7 @@ oIu
 kDz
 nWu
 tuP
-lgq
+pJC
 jFP
 sZf
 sov
@@ -107093,8 +106308,8 @@ uOq
 sZf
 xhI
 pou
-hnM
-lgq
+tuP
+pJC
 xwz
 dQM
 auB
@@ -107205,10 +106420,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 eVe
 cKN
 oBP
@@ -107341,7 +106556,7 @@ jTo
 kDz
 xrQ
 tuP
-lgq
+pJC
 mBJ
 kDz
 mBJ
@@ -107350,8 +106565,8 @@ kDz
 mBJ
 mBJ
 xrQ
-hnM
-lgq
+tuP
+pJC
 fWn
 tTW
 jFW
@@ -107462,10 +106677,10 @@ bBV
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 hfQ
 jHu
 bFR
@@ -107607,7 +106822,7 @@ tfq
 dxu
 cAM
 xrQ
-hnM
+tuP
 fsN
 xwz
 oUJ
@@ -107719,7 +106934,7 @@ bBV
 bBV
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
 cAY
@@ -107861,11 +107076,11 @@ xrQ
 qJE
 flv
 flv
-hnM
+tuP
 vsX
 xrQ
-hnM
-lgq
+tuP
+pJC
 umV
 wZQ
 jFW
@@ -107976,7 +107191,7 @@ bFR
 bFR
 bFR
 bFR
-tNZ
+iEq
 xrQ
 flv
 flv
@@ -108121,7 +107336,7 @@ flv
 flv
 tfq
 flv
-hnM
+tuP
 vsX
 axx
 dZj
@@ -108233,11 +107448,11 @@ bFR
 bFR
 lRa
 bFR
-aZE
+cxN
 slv
 flv
 flv
-hnM
+tuP
 eVe
 caE
 sNS
@@ -108494,7 +107709,7 @@ bFR
 asO
 uKq
 gll
-hnM
+tuP
 hfs
 bFR
 bFR
@@ -109009,7 +108224,7 @@ mQK
 qyb
 kaP
 flv
-hnM
+tuP
 vls
 bFR
 bFR
@@ -109260,13 +108475,13 @@ bFR
 nQD
 bFR
 bFR
-aZE
+cxN
 sRx
 fOk
 eHm
 xtr
 sPt
-hnM
+tuP
 vls
 bFR
 bFR
@@ -109517,7 +108732,7 @@ nQD
 nQD
 bFR
 bFR
-aZE
+cxN
 gme
 imm
 hrf
@@ -109774,13 +108989,13 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 gme
 fNf
 hrf
 gIx
 caR
-hnM
+tuP
 dDK
 bFR
 bFR
@@ -110031,13 +109246,13 @@ bFR
 bFR
 bFR
 mdg
-aZE
+cxN
 gme
 imm
 hrf
 xtr
 flv
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -110288,7 +109503,7 @@ bFR
 bBV
 bFR
 bFR
-aZE
+cxN
 hYB
 ojG
 qqZ
@@ -110551,7 +109766,7 @@ nBB
 sFM
 lKN
 flv
-hnM
+tuP
 eVe
 fHN
 bFR
@@ -110804,7 +110019,7 @@ bFR
 bBV
 bFR
 rFi
-aZE
+cxN
 xrQ
 flv
 flv
@@ -111321,7 +110536,7 @@ bFR
 ybo
 mwx
 lKN
-hnM
+tuP
 eVe
 bFR
 mBb
@@ -111578,7 +110793,7 @@ bFR
 ybo
 mwx
 lKN
-hnM
+tuP
 eVe
 bFR
 bFR
@@ -111809,7 +111024,7 @@ jHu
 bFR
 bFR
 bFR
-aZE
+cxN
 lPs
 swo
 bFR
@@ -112325,7 +111540,7 @@ bFR
 sNS
 bFR
 bFR
-aZE
+cxN
 xfA
 hcy
 fhX
@@ -112582,7 +111797,7 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 oAe
 iQw
 fhX
@@ -112855,7 +112070,7 @@ fhX
 fhX
 wej
 wej
-roc
+jFE
 oFY
 rtN
 rtN
@@ -114166,7 +113381,7 @@ mjd
 uQk
 soJ
 kdc
-hxB
+ljA
 mby
 iZH
 jXx
@@ -114423,7 +113638,7 @@ wHv
 kdc
 kVa
 kVa
-uOK
+add
 ttW
 dCV
 cpi
@@ -114937,7 +114152,7 @@ ygd
 iPX
 gss
 kVa
-uOK
+add
 iHo
 bHW
 kSL
@@ -115451,7 +114666,7 @@ sFl
 soJ
 gss
 cky
-uOK
+add
 oHS
 vNH
 kSi
@@ -115708,7 +114923,7 @@ sFl
 hOs
 hOs
 kdc
-bDQ
+oVE
 iZH
 bSp
 lth
@@ -116225,7 +115440,7 @@ sQt
 hOs
 srs
 kdc
-cHG
+dOE
 put
 gpH
 imi
@@ -118752,7 +117967,7 @@ cxN
 tKy
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -119009,7 +118224,7 @@ tzL
 gDG
 fhX
 iQw
-roc
+jFE
 bPw
 bPw
 pUh
@@ -119047,7 +118262,7 @@ vKK
 cTR
 xRY
 sjl
-bsw
+gEY
 tBm
 daR
 qiW
@@ -119266,7 +118481,7 @@ bFR
 oIO
 wHR
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -119304,7 +118519,7 @@ vaI
 cTR
 jGL
 icx
-bsw
+gEY
 kog
 sma
 xcL
@@ -119523,7 +118738,7 @@ bFR
 eIj
 wHR
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -119561,7 +118776,7 @@ vKK
 rhg
 jGL
 icx
-bsw
+gEY
 kkE
 uaP
 ewF
@@ -120037,7 +119252,7 @@ oTL
 fhX
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -120074,7 +119289,7 @@ iGf
 vaI
 rhg
 jGL
-bsw
+gEY
 tBm
 jlb
 lkP
@@ -120294,7 +119509,7 @@ fhX
 fhX
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -120329,7 +119544,7 @@ nDt
 brO
 xbR
 vKK
-gXc
+jws
 gEA
 jzp
 uiR
@@ -120551,7 +119766,7 @@ fhX
 fhX
 kGs
 kGs
-roc
+jFE
 bPw
 bPw
 pUh
@@ -120588,7 +119803,7 @@ gtF
 dmr
 tQT
 gEA
-aVh
+jMu
 fEJ
 hmO
 xcL
@@ -120808,7 +120023,7 @@ qen
 fhX
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -120843,9 +120058,9 @@ lbH
 kMH
 qQP
 dTE
-gXc
+jws
 gEA
-aVh
+jMu
 kkE
 qIw
 aZs
@@ -121065,7 +120280,7 @@ qen
 fhX
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 pUh
@@ -121357,7 +120572,7 @@ agZ
 mOe
 lLh
 hwI
-gXc
+jws
 gEA
 blF
 qpE
@@ -121724,7 +120939,7 @@ jXi
 jXi
 jXi
 jXi
-dpG
+oBr
 jXi
 jXi
 jXx
@@ -122385,7 +121600,7 @@ rDd
 jIj
 fpA
 jMB
-gXc
+jws
 jGL
 vDS
 bbr
@@ -122645,7 +121860,7 @@ csb
 kkT
 jGL
 icx
-bsw
+gEY
 hju
 esI
 lcR
@@ -123159,7 +122374,7 @@ lda
 fWE
 dBH
 icx
-bsw
+gEY
 kRx
 eEl
 gsb
@@ -123416,7 +122631,7 @@ qhD
 jBm
 sYB
 erO
-bsw
+gEY
 jXx
 mOW
 mOW
@@ -123673,7 +122888,7 @@ blF
 djz
 bGf
 icx
-bsw
+gEY
 wkj
 wCP
 kcm
@@ -123890,14 +123105,14 @@ eIj
 wHR
 fhX
 iQw
-roc
+jFE
 gtT
 sLt
 wYd
 wYd
 wUf
 xpI
-ttp
+mXh
 lBr
 lBr
 oMs
@@ -124147,14 +123362,14 @@ jsO
 eRh
 fhX
 fhX
-roc
+jFE
 gtT
 fww
 wYd
 xfE
 wUf
 mPa
-ttp
+mXh
 xLF
 wkI
 tCb
@@ -124404,7 +123619,7 @@ rnJ
 fhX
 fhX
 fhX
-roc
+jFE
 gtT
 ozX
 wYd
@@ -124590,7 +123805,7 @@ wyn
 sui
 sui
 flv
-hnM
+tuP
 ycp
 kgf
 gtK
@@ -124844,10 +124059,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 ycp
 pmK
 dqs
@@ -124917,7 +124132,7 @@ cxN
 vDW
 fhX
 kGs
-roc
+jFE
 bPw
 bPw
 bPw
@@ -124955,7 +124170,7 @@ fQZ
 xfh
 gEA
 blF
-aVh
+jMu
 bvv
 kdc
 pNF
@@ -125101,10 +124316,10 @@ bFR
 bFR
 cOz
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 jZt
 ppe
 ppe
@@ -125174,7 +124389,7 @@ bFR
 iwt
 wHR
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -125212,7 +124427,7 @@ cya
 jXx
 jGL
 icx
-bsw
+gEY
 uew
 kdc
 tGI
@@ -125358,10 +124573,10 @@ nBR
 nBR
 bFR
 cOz
-aZE
+cxN
 xrQ
 vOh
-hnM
+tuP
 ycp
 pmK
 pmK
@@ -125428,10 +124643,10 @@ bFR
 bFR
 bFR
 bFR
-jSU
+nTd
 nbN
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -125469,7 +124684,7 @@ wyH
 etM
 jGL
 icx
-bsw
+gEY
 uew
 ibP
 ibP
@@ -125615,10 +124830,10 @@ jHu
 bFR
 bFR
 bFR
-aZE
+cxN
 xrQ
 flv
-hnM
+tuP
 vKe
 bAy
 gtK
@@ -125685,10 +124900,10 @@ bFR
 bFR
 bFR
 bBV
-aZE
+cxN
 wHR
 nGu
-roc
+jFE
 bPw
 bPw
 bPw
@@ -125872,10 +125087,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 smj
 ecv
-hnM
+tuP
 sui
 ycp
 vKe
@@ -125942,10 +125157,10 @@ bFR
 bFR
 bFR
 bFR
-aZE
+cxN
 xNv
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -125983,8 +125198,8 @@ hll
 cCU
 jGL
 icx
-hVU
-ljr
+tOq
+ckS
 dUt
 wZm
 fZC
@@ -126137,7 +125352,7 @@ sMC
 jwy
 arL
 xrQ
-hnM
+tuP
 gvG
 sui
 vKe
@@ -126202,7 +125417,7 @@ bBV
 bFR
 oIO
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -126240,7 +125455,7 @@ hll
 rvS
 jGL
 vDS
-siV
+efp
 tXr
 hRg
 mKp
@@ -126388,13 +125603,13 @@ lMm
 dmH
 qti
 bFR
-aZE
+cxN
 uCq
-guQ
+wWC
 jwy
 utu
 xrQ
-hnM
+tuP
 utu
 xrQ
 flv
@@ -126459,7 +125674,7 @@ bFR
 bFR
 vdM
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -126497,7 +125712,7 @@ suA
 uth
 jGL
 vDS
-siV
+efp
 rmg
 gdu
 miV
@@ -126645,13 +125860,13 @@ esu
 sui
 gXb
 bFR
-aZE
+cxN
 uCq
 rez
 jwy
 bLf
 xrQ
-vBK
+mgw
 dOo
 xrQ
 flv
@@ -126716,7 +125931,7 @@ bFR
 bBV
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -126754,7 +125969,7 @@ jFW
 dRj
 jGL
 vDS
-siV
+efp
 tXr
 bXx
 vQK
@@ -126902,7 +126117,7 @@ mFf
 aDA
 pNe
 bFR
-aZE
+cxN
 xrQ
 hxy
 don
@@ -126911,7 +126126,7 @@ flv
 flv
 hxy
 flv
-hnM
+tuP
 gvG
 sui
 cey
@@ -126973,7 +126188,7 @@ bFR
 sPC
 gTZ
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -127011,7 +126226,7 @@ ycS
 iuF
 jGL
 vDS
-siV
+efp
 dXl
 mby
 mrv
@@ -127159,7 +126374,7 @@ iSK
 mFf
 quB
 bFR
-aZE
+cxN
 uCq
 sMC
 jwy
@@ -127168,7 +126383,7 @@ xrQ
 qgJ
 jGg
 smj
-hnM
+tuP
 utu
 sui
 sui
@@ -127425,7 +126640,7 @@ lFo
 iip
 dkx
 jOS
-eVB
+lFo
 utu
 osE
 eVe
@@ -127496,7 +126711,7 @@ bPw
 iAd
 aGw
 mjd
-khw
+pUv
 wUM
 hUO
 gND
@@ -127675,14 +126890,14 @@ jhT
 bFR
 rWe
 uCq
-guQ
+wWC
 jwy
 utu
 lFo
 rRd
 dkx
 jQA
-eVB
+lFo
 ygN
 osE
 eVe
@@ -127746,14 +126961,14 @@ xXL
 wHR
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
 hWm
 tUp
 mjd
-khw
+pUv
 oAn
 fht
 nxD
@@ -127782,7 +126997,7 @@ jXx
 xRY
 qoN
 vDS
-siV
+efp
 tXr
 hMH
 bdV
@@ -127930,16 +127145,16 @@ sui
 sui
 aVx
 bFR
-aZE
+cxN
 uCq
-guQ
+wWC
 jwy
 nqy
 lFo
 eaY
 bhO
 iby
-eVB
+lFo
 utu
 osE
 tZJ
@@ -128039,8 +127254,8 @@ yjb
 oZu
 vDS
 vDS
-bsw
-wlU
+gEY
+uOJ
 jnl
 eTu
 fyN
@@ -128187,7 +127402,7 @@ bFR
 bFR
 ljo
 ljo
-aZE
+cxN
 uCq
 rez
 jwy
@@ -128196,7 +127411,7 @@ xrQ
 lGx
 kpv
 tOg
-hnM
+tuP
 utu
 osE
 eVe
@@ -128259,7 +127474,7 @@ fHN
 uNV
 qfO
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -128267,7 +127482,7 @@ bPw
 jub
 kVa
 tOW
-mrr
+kHt
 rlC
 hqB
 nxD
@@ -128296,7 +127511,7 @@ bsb
 xsa
 sst
 lue
-bsw
+gEY
 eVt
 fEr
 uXL
@@ -128453,7 +127668,7 @@ vOh
 flv
 hxy
 vOh
-hnM
+tuP
 nqy
 osE
 eVe
@@ -128516,7 +127731,7 @@ fHN
 jHK
 wHR
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -128553,7 +127768,7 @@ klb
 eCQ
 vDS
 vDS
-bsw
+gEY
 shi
 gjL
 eTu
@@ -128707,10 +127922,10 @@ oeT
 jwy
 arL
 xrQ
-hnM
+tuP
 ojD
 xrQ
-hnM
+tuP
 utu
 osE
 eVe
@@ -128773,7 +127988,7 @@ cnw
 rwa
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -128810,7 +128025,7 @@ dHK
 prI
 oZu
 vDS
-hVU
+tOq
 uYm
 bSp
 eTu
@@ -128960,14 +128175,14 @@ nBR
 uVV
 sbr
 bFR
-aZE
+cxN
 jwy
 utu
 xrQ
-hnM
+tuP
 utu
 xrQ
-hnM
+tuP
 utu
 osE
 eVe
@@ -129030,7 +128245,7 @@ xXL
 acQ
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -129217,14 +128432,14 @@ bFR
 nBR
 bFR
 jHu
-aZE
+cxN
 jwy
 lwa
 xrQ
-hnM
+tuP
 lwa
 xrQ
-hnM
+tuP
 dOo
 osE
 eVe
@@ -129287,7 +128502,7 @@ cxN
 xMY
 fhX
 fhX
-roc
+jFE
 bPw
 bPw
 bPw
@@ -129474,7 +128689,7 @@ bFR
 nBR
 bFR
 fbo
-aZE
+cxN
 ncR
 jfM
 rIe
@@ -129813,7 +129028,7 @@ lBr
 dOU
 xLF
 joN
-myY
+baf
 fkD
 fnr
 nxD
@@ -130058,7 +129273,7 @@ bFR
 tHg
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -130070,7 +129285,7 @@ lBr
 dOU
 xLF
 sjN
-khw
+pUv
 jjC
 tow
 weC
@@ -130315,7 +129530,7 @@ bFR
 rFi
 eqj
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -130583,7 +129798,7 @@ osA
 cKr
 cCU
 avo
-ttp
+mXh
 cYj
 mGj
 wkj
@@ -130829,7 +130044,7 @@ bFR
 bFR
 eqj
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -130840,7 +130055,7 @@ soS
 gVk
 dmh
 mhQ
-ttp
+mXh
 cYj
 cTw
 xAV
@@ -131097,7 +130312,7 @@ cot
 xcD
 cCU
 ouL
-ttp
+mXh
 qNa
 sgb
 ewH
@@ -131344,7 +130559,7 @@ bFR
 cxN
 wHR
 fhX
-roc
+jFE
 bPw
 bPw
 jXx
@@ -131354,7 +130569,7 @@ fuv
 slG
 eWX
 cYj
-myY
+baf
 xrP
 sOx
 ewH
@@ -131611,7 +130826,7 @@ mby
 mLa
 cWv
 bSp
-pzP
+bkQ
 jXx
 qnQ
 cya
@@ -131857,7 +131072,7 @@ bFR
 bFR
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -131868,7 +131083,7 @@ bje
 dLA
 djD
 dmh
-myY
+baf
 cYj
 uuE
 jpy
@@ -132114,7 +131329,7 @@ bFR
 bFR
 cxN
 fLM
-roc
+jFE
 bPw
 bPw
 bPw
@@ -132371,7 +131586,7 @@ bFR
 bFR
 cxN
 fLM
-roc
+jFE
 bPw
 bPw
 bPw
@@ -132628,7 +131843,7 @@ bFR
 trR
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -132885,7 +132100,7 @@ bFR
 bFR
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -133142,7 +132357,7 @@ bFR
 bFR
 cxN
 wHR
-roc
+jFE
 bPw
 bPw
 bPw
@@ -133399,7 +132614,7 @@ tRd
 bFR
 cxN
 fLM
-roc
+jFE
 bPw
 bPw
 bPw
@@ -133656,7 +132871,7 @@ tRd
 tRd
 cxN
 fLM
-roc
+jFE
 bPw
 bPw
 bPw

--- a/_maps/map_files/coyote_bayou/Texarkana_underground.dmm
+++ b/_maps/map_files/coyote_bayou/Texarkana_underground.dmm
@@ -1209,7 +1209,6 @@
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8;
-	pixel_y = 0;
 	pixel_x = -3
 	},
 /turf/open/floor/f13{
@@ -1785,9 +1784,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bpP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt/bigdirtturf,
 /area/f13/caves)
 "bpQ" = (
@@ -2411,7 +2408,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -6955,9 +6951,7 @@
 	},
 /area/f13/building)
 "dno" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/glitter/blue,
 /turf/open/indestructible/ground/outside/dirt/bigdirtturf,
 /area/f13/caves)
@@ -7937,9 +7931,7 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/tunnel)
 "dXc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/glitter/blue,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
@@ -9856,7 +9848,6 @@
 "fro" = (
 /obj/structure/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair_settler";
 	pixel_x = -8
 	},
 /turf/open/floor/f13{
@@ -13427,7 +13418,6 @@
 /area/f13/caves)
 "hWG" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
 	pixel_y = -1
 	},
 /turf/open/floor/f13/wood{
@@ -14224,7 +14214,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -17261,7 +17250,6 @@
 "kzs" = (
 /obj/structure/chair/wood{
 	dir = 8;
-	icon_state = "wooden_chair_settler";
 	pixel_x = -8
 	},
 /turf/open/floor/f13/wood{
@@ -18287,7 +18275,6 @@
 	},
 /obj/machinery/porta_turret/syndicate/vehicle_turret{
 	desc = "A Rob-Co turret, pristene and sleek. Its robotic eyes pass over authorized individuals...onto you.";
-	faction = list("Syndicate");
 	lethal_projectile = /obj/item/projectile/bullet/a308/improvised/simple;
 	lethal_projectile_sound = 'sound/f13weapons/auto5.ogg';
 	name = "Containment Turret";
@@ -19968,7 +19955,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/machinery/light{
@@ -20511,7 +20497,6 @@
 "mDH" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -22704,7 +22689,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /turf/open/indestructible/ground/outside/water,
@@ -24710,9 +24694,7 @@
 "pvh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/brushwood,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 2
-	},
+/obj/effect/turf_decal/weather/dirt,
 /obj/effect/decal/cleanable/glitter/blue,
 /turf/open/indestructible/ground/outside/dirt/bigdirtturf,
 /area/f13/caves)
@@ -24892,7 +24874,6 @@
 "pAe" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -26723,7 +26704,6 @@
 "qFR" = (
 /obj/structure/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair_settler";
 	pixel_x = -8
 	},
 /obj/machinery/light/small{
@@ -28951,7 +28931,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -29225,7 +29204,6 @@
 "srU" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -31952,7 +31930,6 @@
 "ulg" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 2;
 	layer = 4;
 	pixel_y = -2
 	},
@@ -32354,7 +32331,6 @@
 	icon = 'icons/effects/effects.dmi';
 	icon_state = "smoke";
 	name = "steam";
-	pixel_y = 0;
 	pixel_x = 19
 	},
 /obj/structure/spacevine{
@@ -33098,7 +33074,6 @@
 "vcW" = (
 /obj/structure/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair_settler";
 	pixel_x = -8
 	},
 /turf/open/indestructible/ground/inside/mountain,
@@ -36037,7 +36012,6 @@
 /area/f13/caves)
 "xfk" = (
 /obj/structure/chair/wood{
-	icon_state = "wooden_chair_settler";
 	dir = 1
 	},
 /turf/open/floor/f13{

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -876,3 +876,52 @@
 /obj/structure/rack/large/shelf_rust
 	desc = "An extra-large heavy-duty shelf. This could store a lot of things."
 	icon_state = "metal_shelf_rust"
+
+//From Mojave sun, credit to them for the sprite
+/obj/structure/table/wood_counter
+	name = "Wooden Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "wood_counter"
+
+/obj/structure/table/wood_counter/bend
+	name = "Wooden Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "wood_counter_bend"
+
+/obj/structure/table/wood_counter/intersect
+	name = "Wooden Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "wood_counter_intersect"
+
+/obj/structure/table/wood_counter/cross
+	name = "Wooden Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "wood_counter_cross"
+
+/obj/structure/table/craft_counter
+	name = "Crafted Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "craft_counter"
+
+/obj/structure/table/craft_counter/bend
+	name = "Crafted Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "craft_counter_bend"
+
+/obj/structure/table/craft_counter/intersect
+	name = "Crafted Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "craft_counter_intersect"
+
+/obj/structure/table/craft_counter/cross
+	name = "Crafted Counter"
+	desc = "Count your wood? Or is it wood your count.."
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
+	icon_state = "craft_counter_cross"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -883,6 +883,7 @@
 	desc = "Count your wood? Or is it wood your count.."
 	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
 	icon_state = "wood_counter"
+	smooth = SMOOTH_FALSE
 
 /obj/structure/table/wood_counter/bend
 	name = "Wooden Counter"
@@ -907,6 +908,7 @@
 	desc = "Count your wood? Or is it wood your count.."
 	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
 	icon_state = "craft_counter"
+	smooth = SMOOTH_FALSE
 
 /obj/structure/table/craft_counter/bend
 	name = "Crafted Counter"

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -398,6 +398,20 @@
 	desc = "A nice white stove for cooking."
 	icon_state = "white_stove"
 
+/obj/machinery/microwave/white_stove/update_icon_state()
+	if(broken)
+		icon_state = "white_stove"
+	else if(dirty_anim_playing)
+		icon_state = "white_stove"
+	else if(dirty == 100)
+		icon_state = "white_stove"
+	else if(operating)
+		icon_state = "white_stove_on"
+	else if(panel_open)
+		icon_state = "white_stove"
+	else
+		icon_state = "white_stove"
+
 /obj/machinery/microwave/gas_stove
 	name = "gas stove"
 	desc = "A nice white gas stove for cooking."

--- a/modular_coyote/code/objects.dm
+++ b/modular_coyote/code/objects.dm
@@ -1268,6 +1268,7 @@
 	icon_state = "nightstand_alt"
 
 //From Mojave sun, credit to them for the sprite
+/*
 /obj/structure/wood_counter
 	name = "Wooden Counter"
 	desc = "Count your wood? Or is it wood your count.."
@@ -1315,7 +1316,7 @@
 	desc = "Count your wood? Or is it wood your count.."
 	icon = 'modular_coyote/icons/objects/miscellaneous.dmi'
 	icon_state = "craft_counter_cross"
-
+*/
 /obj/structure/toilet_paper
 	name = "Toilet Paper Holder"
 	desc = "Look before you shit! I mean, sit!"


### PR DESCRIPTION
## About The Pull Request
Fixes the White Stove Microwave so it doesn't break upon interacting with.
Makes Wooden Counters and Crafted Counters actual tables.
None of them are craftable. Yet.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
