### PR TITLE
Adds the private flashing text span for later use

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -71,6 +71,7 @@
 #define span_his_grace(str) ("<span class='his_grace'>" + str + "</span>")
 #define span_holoparasite(str) ("<span class='holoparasite'>" + str + "</span>")
 #define span_hypnophrase(str) ("<span class='hypnophrase'>" + str + "</span>")
+#define span_private(str) ("<span class='private'>" + str + "</span>")
 
 #define span_icon(str) ("<span class='icon'>" + str + "</span>")
 #define span_inathneq(str) ("<span class='inathneq'>" + str + "</span>")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1213,5 +1213,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	[span_warning("span_warning")]\n\
 	[span_yell("span_yell")]\n\
 	[span_yellowteamradio("span_yellowteamradio")]\n\
+	[span_private("span_private")]\n\
 	")
 

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1019,6 +1019,31 @@ em {
   }
 }
 
+.private	{
+  color: #00BB80;
+  font-weight: bold;
+  animation: private 3000ms;
+  animation-direction: linear;
+}
+
+@keyframes private {
+	0% {
+    color: #006734;
+  }
+	10% {
+    color: #00FF00;
+  }
+	20% {
+    color: #006734;
+  }
+	30% {
+    color: #00FF00;
+  }
+	100% {
+    color: #00BB80;
+  }
+}
+
 .phobia {
   color: #dd0000;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1102,6 +1102,31 @@ h1.alert, h2.alert {
   }
 }
 
+.private	{
+  color: #00BB80;
+  font-weight: bold;
+  animation: private 3000ms;
+  animation-direction: linear;
+}
+
+@keyframes private {
+	0% {
+    color: #006734;
+  }
+	10% {
+    color: #00FF00;
+  }
+	20% {
+    color: #006734;
+  }
+	30% {
+    color: #00FF00;
+  }
+	100% {
+    color: #00BB80;
+  }
+}
+
 .icon {
   height: 1em;
   width: auto;


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Adds in a flashing colorful text thats ment to be used in a private player to player DM system in the future. This flashes the message 2 times, and then becomes a solid singular color, intended to be eye catching, but not straining to read, as the animation is done in about 1 second
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
