### PR TITLE
possibly fixes typing sounds not saving

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1224,7 +1224,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	features_override["hair_color_2"]	= sanitize_hexcolor(features_override["hair_color_2"], 6, FALSE, default = COLOR_ALMOST_BLACK)
 	features_override["hair_style_2"]	= sanitize_inlist(features_override["hair_style_2"], GLOB.hair_styles_list, "Bald")
-
+	
+	if(!LAZYLEN(GLOB.typing_sounds))
+		SStypinginit.populate_typing_list()//This list is initialized late, so if a savefile is saved during initialization (they almost always are), they might lose their sound selection. Manually populate it early, in that case.
 	features_speech["typing_indicator_sound"]				= sanitize_inlist(features_speech["typing_indicator_sound"], GLOB.typing_sounds, "Default")//
 	features_speech["typing_indicator_sound_play"]			= sanitize_inlist(features_speech["typing_indicator_sound_play"], GLOB.play_methods, "No Sound")
 	features_speech["typing_indicator_speed"]				= sanitize_inlist(features_speech["typing_indicator_speed"], GLOB.typing_indicator_speeds, "Speed: Average (2)")

--- a/modular_coyote/code/modules/say/typing_sounds.dm
+++ b/modular_coyote/code/modules/say/typing_sounds.dm
@@ -10,6 +10,12 @@ SUBSYSTEM_DEF(typinginit)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/typinginit/Initialize()
+	if(!LAZYLEN(GLOB.typing_sounds))
+		populate_typing_list()
+
+	. = ..()
+
+/datum/controller/subsystem/typinginit/proc/populate_typing_list()
 	var/list/typingPaths = typesof(/datum/typing_sound)
 	
 	var/datum/typing_sound/currentSound = null
@@ -18,7 +24,6 @@ SUBSYSTEM_DEF(typinginit)
 		currentSound.AddToList()
 		currentSound = null
 
-	. = ..()
 
 // The new sound files!
 // name 					The unique key, CASE SENSITIVE, cannot be duplicates.


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
The list of viable typing sounds was often not populated before players were opening and saving their character saves, so it was being sanitized and returned to "Default" when the list was found to be empty.


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
