### PR TITLE
redo of previous grinder PR

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -10322,10 +10322,6 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fdm" = (
-/obj/machinery/mineral/equipment_vendor{
-	pixel_y = 14;
-	density = 0
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder - E"
 	},
@@ -11909,6 +11905,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "fRB" = (
@@ -35076,6 +35073,10 @@
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/workshop/nash)
+"rdY" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "reb" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
@@ -99357,7 +99358,7 @@ tot
 tot
 tot
 tot
-tPQ
+rdY
 gIL
 tPQ
 gIL


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
literially just https://github.com/ARF-SS13/coyote-bayou/pull/4790 but with the mining reward vendor also being moved next to it's counterpart next to the new ORM location.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->
entirely untested, it is 1 move and 1 add.
## Changelog
add: hydroponics grinder that was forgotten about
tweak: Reward vendor moved to ORM
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
