### PR TITLE
BOTANY BROS WE ARE SO BACK

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -13372,6 +13372,10 @@
 "gvH" = (
 /turf/open/floor/carpet/purple,
 /area/f13/building/abandoned)
+"gvN" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "gvS" = (
 /obj/structure/barricade/wooden,
 /obj/structure/spacevine,
@@ -48179,10 +48183,8 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "wTs" = (
 /obj/structure/rack/shelf_wood,
-/obj/item/circuitboard/machine/hydroponics/automagic,
-/obj/item/circuitboard/machine/hydroponics/automagic{
-	pixel_y = -7
-	},
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -100648,7 +100650,7 @@ tot
 tot
 tot
 nyL
-gIL
+gvN
 dAy
 jgL
 jgL

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -35,7 +35,7 @@
 
 /obj/machinery/hydroponics/Initialize()
 	//Here lies "nutrilevel", killed by ArcaneMusic 20??-2019. Finally, we strive for a better future. Please use "reagents" instead
-	create_reagents(20)
+	create_reagents(100)
 	reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 100) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
 	. = ..()
 	LAZYREMOVE(GLOB.machines, src)
@@ -49,7 +49,7 @@
 	icon_state = "hydrotray3"
 
 /obj/machinery/hydroponics/constructable/RefreshParts()
-	return
+	reagents.maximum_volume = 100
 	/* 
 	var/tmp_capacity = 0
 	for (var/obj/item/stock_parts/matter_bin/M in component_parts)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/645091e0-079c-43f5-b843-e8c98e4e9631)
Finally fixes the damn trays not having a max of 100, total and max are not actually the same, which max is what was altered during the previous time of parts actually working on trays. Now instead of defaulting to 20 it will properly stay stuck at 100, with a bonus of 100 nutrient roundstart. Also removes bugged trays from NB, and adds the vendor closer to the ORM that fenny forgor. Unsure if the drain is still horrid, but maybe it will be better now, perhaps a botanist thread on the discord can help with keeping track of times, for now everyone gets to keep rushing gaia.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/4ce20db6-733d-4fa9-b6e4-559d6b4cb55e)


## Changelog
fix: reagents.max_volume null refrence
add: mining vendor next to the orm like a sane person
fix: building south of NB no longer spawns bugged circ boards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
