### PR TITLE
Adjusts Mob Nest Frequency

### DIFF
--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -186,9 +186,6 @@ GLOBAL_LIST_INIT(tree_plant_list, list(
 	/obj/structure/flora/tree/oak_five = 5,
 	/obj/structure/flora/tree/med_pine = 7,
 	/obj/structure/flora/tree/med_pine_dead = 7,
-	/obj/structure/nest/gecko = 2,
-	/obj/structure/nest/radroach = 2,
-	/obj/structure/nest/molerat = 2,
 	/obj/structure/flora/chomp/bones/lrock = 7,
 	/obj/structure/flora/chomp/bones/lrock1 = 7,
 	/obj/structure/flora/chomp/bones/lrock2 = 7,
@@ -473,10 +470,10 @@ GLOBAL_LIST_INIT(nest_spawn_list, list(
 	))
 
 GLOBAL_LIST_INIT(junk_type_weighted, list(
-	"dust" = 92,
-	"trash" = 3,
-	"salvage" = 3,
-	"nest" = 2
+	"dust" = 89,
+	"trash" = 5,
+	"salvage" = 5,
+	"nest" = 1
 ))
 
 /turf/open/indestructible/ground/outside/dirthole

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -7,6 +7,7 @@
 	var/unique_pet = FALSE // if the mob can be renamed
 	var/obj/item/clothing/neck/petcollar/pcollar
 	var/collar_type //if the mob has collar sprites, define them.
+	density = 0
 
 /mob/living/simple_animal/pet/handle_atom_del(atom/A)
 	if(A == pcollar)

--- a/modular_coyote/code/modules/turf_changes/PlantGrass.dm
+++ b/modular_coyote/code/modules/turf_changes/PlantGrass.dm
@@ -2,69 +2,83 @@
 // I'm going to grab you by the antlers and stick every point of it up your ass
 
 // pascal deez nuts
-/turf/open/proc/plantGrass(Plantforce = FALSE)
-	if(!prob(RAND_PLANT_CHANCE))
-		return FALSE
-	if(locate(/obj/structure/flora) in src)
+/turf/open/proc/spawnRandThing()
+	if(locate(/mob) in src)
 		return FALSE
 	if((locate(/obj/structure) in src))
 		return FALSE
 	if((locate(/obj/machinery) in src))
 		return FALSE
-	var/atom/movable/randPlant
-	var/floratype = greeble ? greeble : pickweight(GLOB.plant_type_weighted)
-	if(greeble == "junklist")
-		floratype = pickweight(GLOB.junk_type_weighted)
-	switch(floratype)
-		if("medicinal")
-			randPlant = pickweight(GLOB.medicinal_plant_list)
-		if("tree")
-			randPlant = pickweight(GLOB.tree_plant_list)
-		if("grass")
-			randPlant = pickweight(GLOB.grass_plant_list)
-		if("salvage")
-			randPlant = pickweight(GLOB.salvage_spawn_list)
-		if("nest")
-			randPlant = pickweight(GLOB.nest_spawn_list)
-		if("dust")
-			randPlant = pickweight(GLOB.dust_spawn_list)
+
+	var/thingtype
+	if(spawnPlants && prob(RAND_PLANT_CHANCE))
+		thingtype = "plant"
+	else if(spawnHiddenStashes && prob(HIDDEN_STASH_CHANCE))
+		thingtype = "stash"
+	else if(greeble)
+		var/area/A = get_area(src)
+		if(!A.safe_town)
+			if(islist(greeble))
+				thingtype = pickweight(greeble)
+			else
+				thingtype = greeble
+		greeble = null //clear this var up since it's never used again
+	if(!thingtype)
+		return FALSE
+	if(thingtype == "junklist")
+		thingtype = pickweight(GLOB.junk_type_weighted)		
+	var/atom/movable/randThing
+	switch(thingtype)
+		if("plant")
+			thingtype = pickweight(GLOB.plant_type_weighted)
+			switch(thingtype)
+				if("medicinal")
+					randThing = pickweight(GLOB.medicinal_plant_list)
+				if("tree")
+					randThing = pickweight(GLOB.tree_plant_list)
+				if("grass")
+					randThing = pickweight(GLOB.grass_plant_list)
+		if("stash")
+			return StashCheck(skip_roll = TRUE, skip_checks = TRUE)
 		if("trash")
-			randPlant = pickweight(GLOB.trash_spawn_list)
+			randThing = pickweight(GLOB.trash_spawn_list)
+		if("dust")
+			randThing = pickweight(GLOB.dust_spawn_list)
+		if("salvage")
+			randThing = pickweight(GLOB.salvage_spawn_list)
+		if("nest")
+			randThing = pickweight(GLOB.nest_spawn_list)
 		if("wreckage_and_nests")
 			var/list/nestnwreck = GLOB.nest_spawn_list
 			nestnwreck |= GLOB.salvage_spawn_list
-			randPlant = pickweight(nestnwreck)
-	if(randPlant)
-		new randPlant(src)
+			randThing = pickweight(nestnwreck)
+	if(randThing)
+		new randThing(src)
 		return TRUE
 
 ///Rolls to spawn a hidden stash on this turf
-/turf/open/proc/StashCheck()
-	if(!prob(HIDDEN_STASH_CHANCE))
+/turf/open/proc/StashCheck(skip_roll = FALSE, skip_checks = FALSE)
+	if(!skip_roll && !prob(HIDDEN_STASH_CHANCE))
 		return FALSE
-	if((locate(/obj/structure) in src))
-		return FALSE
-	if((locate(/obj/machinery) in src))
-		return FALSE
-	
+	if(!skip_checks)
+		if((locate(/obj/structure) in src))
+			return FALSE
+		if((locate(/obj/machinery) in src))
+			return FALSE
+		if((locate(/mob/living) in src))
+			return FALSE
 	new /obj/structure/lootable/hidden_stash(src)
 	return TRUE
 
 /turf/open/
 	var/spawnPlants = FALSE
 	var/spawnHiddenStashes = FALSE
+	/// Type of random stuff to spawn on a turf. Supports weighted lists.
 	var/greeble
 
 /turf/open/Initialize(mapload)
-	if(mapload && (spawnPlants || greeble) && !is_reserved_level(z))
-		if(greeble)
-			var/area/here = loc
-			if(!here.safe_town)
-				plantGrass()
-		else
-			plantGrass()
-	if(mapload && spawnHiddenStashes && !is_reserved_level(z))
-		StashCheck()
+	if(mapload && !is_reserved_level(z) && (spawnPlants || greeble || spawnHiddenStashes))
+		spawnRandThing()
 	. = ..()
 
 /turf/open/ChangeTurf(path, new_baseturf, flags)
@@ -72,26 +86,36 @@
 		qdel(turfPlant)
 	. =  ..()
 
+#define OUTSIDE_JUNK_DISTRIBUTION list("nests" = 1, "salvage" = 2, "trash" = 2, "nothing" = 95)
+
 /turf/open/indestructible/ground/outside/dirt
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
 
 /turf/open/indestructible/ground/outside/savannah
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
 
 /turf/open/indestructible/ground/outside/dirt_s
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
 
 /turf/open/indestructible/ground/outside/grass_s
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
 
 /turf/open/indestructible/ground/outside/desert
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
 
 /turf/open/floor/plating/f13/outside/desert
 	spawnPlants = TRUE
 	spawnHiddenStashes = TRUE
+	greeble = OUTSIDE_JUNK_DISTRIBUTION
+
+#undef OUTSIDE_JUNK_DISTRIBUTION


### PR DESCRIPTION
should be about half as many nests on roads, but more other stuffs

fixed nests spawning anywhere that trees could, instead they are bundled with other junk and non-plants and will spawn anywhere plants didn't so long as it's not in a safe zone