### PR TITLE
Reload Gun Hotkey

### DIFF
--- a/code/_onclick/hud/screen_objects/character_actions.dm
+++ b/code/_onclick/hud/screen_objects/character_actions.dm
@@ -87,11 +87,11 @@
 				H.emote("tend")
 
 			I = H.get_active_held_item()
-			I.melee_attack_chain(H, H, params)
+			I?.melee_attack_chain(H, H, params)
 
 		else if(istype(I, /obj/item/hand_item/healable/))
 			I = H.get_active_held_item()
-			I.melee_attack_chain(H, H, params)
+			I?.melee_attack_chain(H, H, params)
 
 /atom/movable/screen/aooc_hud_button
 	name = "AOOC"

--- a/code/modules/keybindings/keybind/combat.dm
+++ b/code/modules/keybindings/keybind/combat.dm
@@ -129,3 +129,14 @@
 			return
 	murderer.ClickOn(victim, params)
 	return
+
+/datum/keybinding/carbon/reload_gun
+	hotkey_keys = list("ShiftR")
+	name = "reload_gun"
+	full_name = "Reload gun"
+	description = "Automatically reloads the gun in your active hand."
+	category = CATEGORY_COMBAT
+
+/datum/keybinding/carbon/reload_gun/down(client/user)
+	user.mob?.ReloadGun()
+	return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -463,7 +463,7 @@
 // we clearly want the revolver to be re-sheathed in the previous location.
 // If anything is broken, or not working properly, contact me or fix it -leonzrygin
 //<--
-/mob/verb/quick_equip()
+/mob/verb/quick_equip(obj/item/I)
 	set name = "quick-equip"
 	set hidden = 1
 
@@ -471,7 +471,8 @@
 		return
 
 	var/obj/item/storage
-	var/obj/item/I = get_active_held_item()
+	if(!isitem(I))
+		I = get_active_held_item()
 
 	//obj/item/melee/onehanded
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -186,6 +186,11 @@ ATTACHMENTS
 	/// Cooldown between times the gun will tell you it shot, 0.5 seconds cus its not super duper important
 	COOLDOWN_DECLARE(shoot_message_antispam)
 
+	/// Is the player currently reloading this gun?
+	var/reloading = FALSE
+	/// This is the base reload speed, which is modified by things like the size of the magazine in use.
+	var/reloading_time = 1 SECONDS
+
 /obj/item/gun/Initialize()
 	recoil_tag = SSrecoil.give_recoil_tag(init_recoil)
 	if(!recoil_tag)
@@ -520,9 +525,9 @@ ATTACHMENTS
 
 /obj/item/gun/proc/on_cooldown(mob/user)
 	if (automatic == 0)
-		return busy_action || firing || ((last_fire + get_fire_delay(user)) > world.time)
+		return reloading || busy_action || firing || ((last_fire + get_fire_delay(user)) > world.time)
 	if (automatic == 1)
-		return busy_action || firing
+		return reloading || busy_action || firing
 
 /*
  * So here is the list of proc calls that happen when you fire a gun:
@@ -1634,6 +1639,20 @@ GLOBAL_LIST_INIT(gun_yeet_words, list(
 	new /obj/item/gun/ballistic/automatic/shotgun/pancor(src)
 	new /obj/item/ammo_box/magazine/d12g/buck(src)
 	new /obj/item/ammo_box/magazine/d12g/buck(src)
+
+//Reload hotkey stuff
+/obj/item/gun/proc/MagReload(mob/user)
+	return FALSE
+
+/mob/proc/ReloadGun()
+	return FALSE
+
+/mob/living/carbon/human/ReloadGun()
+	var/I = get_active_held_item()
+	if(!istype(I, /obj/item/gun))
+		return FALSE
+	var/obj/item/gun/G = I
+	return G.MagReload(src)
 
 ///////////////////
 //GUNCODE ARCHIVE//

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 	var/handedness = GUN_EJECTOR_RIGHT
 	var/cock_sound = "gun_slide_lock"
 	fire_sound = null //null tells the gun to draw from the casing instead of the gun for sound
+
 /obj/item/gun/ballistic/Initialize()
 	. = ..()
 	if(spawnwithmagazine)
@@ -408,3 +409,51 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 			if(GUN_EJECTOR_ANY)
 				return turn(user.dir, pick(0, -90, 90, 180))
 	return angle2dir_cardinal(rand(0,360)) // something fucked up, just send a direction
+
+/obj/item/gun/ballistic/MagReload(mob/user)
+	if(istype(mag_type, /obj/item/ammo_box/magazine/internal) || !ishuman(user))//Miniguns and stuff
+		return FALSE
+	if(on_cooldown() || !user.has_direct_access_to(src, STORAGE_VIEW_DEPTH))
+		to_chat(user, span_notice("You can't reload [src] right now!"))
+		return FALSE
+	//typecast the user as a human
+	var/mob/living/carbon/human/H = user
+
+	//Wait a second or two so we can't spam reload too quickly. Also if this runtimes then the gun will never be reloadable again with this proc so rip
+	busy_action = TRUE
+	playsound(get_turf(H), "rustle", rand(50,100), 1, SOUND_DISTANCE(7))
+	H.visible_message(span_notice("[H] starts reloading \the [src]..."), span_notice("You start looking for a magazine to reload \the [src] with..."), span_notice("You hear the clinking of metal..."))
+	if(!do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE))
+		busy_action = FALSE
+		return FALSE
+
+	//First, search for compatible magazines in some predictable locations. Let's not search every item on them to save compute time.
+	var/list/validmags = list()
+	var/list/yourstuff = H?.contents + H?.belt?.contents + H?.back?.contents + H?.wear_suit?.contents + H?.shoes?.contents + H?.head?.contents + H?.l_store?.contents + H?.r_store?.contents + H?.s_store?.contents
+
+	for(var/obj/item/ammo_box/magazine/M in yourstuff)
+		var/rounds = LAZYLEN(M.stored_ammo)
+		if(rounds > 0 && is_magazine_allowed(M))//valid mags have ammo and are allowed to be inserted into your gun
+			validmags[M] = rounds
+	yourstuff = null
+
+	//Then, try to insert the one with the most ammo in it.
+	if(LAZYLEN(validmags))
+		sortTim(validmags, /proc/cmp_numeric_dsc, TRUE)//Sort them by most filled to least filled.
+		for(var/obj/item/ammo_box/magazine/M in validmags)
+			var/obj/magloc = isobj(M.loc) ? M.loc : null
+			if(isgun(magloc))// Don't swap magazines with two guns.
+				continue
+			var/obj/oldmag = isobj(magazine) ? magazine : null
+			if(H.has_direct_access_to(M, STORAGE_VIEW_DEPTH) && attackby(M, user))//Actually reload the gun
+				if(magloc && oldmag)
+					if(!magloc.attackby(oldmag, user))// Try to put your old mag in the new one's place
+						H.quick_equip(oldmag)// If that fails, quick equip it.
+				break//If we loaded a new mag successfully, stop
+	else
+		to_chat(H, span_alert("You couldn't find any filled magazines that fit \the [src]!"))
+		busy_action = FALSE
+		return FALSE
+
+	busy_action = FALSE
+	return TRUE

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -411,7 +411,7 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 	return angle2dir_cardinal(rand(0,360)) // something fucked up, just send a direction
 
 /obj/item/gun/ballistic/MagReload(mob/user)
-	if(istype(mag_type, /obj/item/ammo_box/magazine/internal) || !ishuman(user))//Miniguns and stuff
+	if((magazine && istype(magazine, /obj/item/ammo_box/magazine/internal)) || !ishuman(user))//Miniguns and shotguns and bolt actions and not magazine guns
 		return FALSE
 	if(on_cooldown() || !user.has_direct_access_to(src, STORAGE_VIEW_DEPTH))
 		to_chat(user, span_notice("You can't reload [src] right now!"))


### PR DESCRIPTION
Press 1 button to reload the gun in your active hand, assuming it uses external magazines. Can be adapted later to work with toploaders/shotguns/energy weapons/etc. It will search 1 layer deep into any pockets, bags, rigs, armor, shoes, helmets, etc that you might be wearing. Has trouble with magazines that are stored in your pockets and stuff but aren't in another item.

Takes 1 second to reload by default, but it can be altered on a gun-by-gun basis with a single variable. A variable on magazines would be a good idea too, but that can come later if we feel we need it for balance.

When you use it, it will replace the magazine that you pulled out with the empty one you just ejected if possible. Otherwise, it's ejected to the floor.