### PR TITLE
Berserker overhaul / Rising bass added.

### DIFF
--- a/code/datums/martial/berserker.dm
+++ b/code/datums/martial/berserker.dm
@@ -38,19 +38,19 @@
 					span_userdanger("[A] [atk_verb]s you!"), null, null, A)
 	to_chat(A, span_danger("You [atk_verb] [D]!"))
 	if(prob(10))
-		crit_damage += (damage * 2)
+		crit_damage += (damage * 2.5)
 		playsound(get_turf(D), 'sound/weapons/bite.ogg', 50, TRUE, -1)
 		D.visible_message(span_warning("[D] staggers as they're slammed in the stomach"), span_userdanger("You are struck with incredible precision by [A]!"))
 		log_combat(A, D, "critcal hard punched (Berserker)")//log it here because a critical can swing for 40 force and it's important for the sake of how hard they hit
 	else
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 		log_combat(A, D, "hard punched punched (Berserker)")//so as to not double up on logging
-	D.apply_damage(damage * 1.3 + crit_damage, BRUTE, affecting, armor_block, wound_bonus = CANT_WOUND)
+	D.apply_damage(damage * 2 + crit_damage, BRUTE, affecting, armor_block, wound_bonus = CANT_WOUND)
 	return TRUE
 
 ///Shouldercheck: Harm Harm Harm combo, throws people seven tiles backwards
 /datum/martial_art/berserker/proc/shoulderCheck(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/damage = (damage_roll(A,D) + 3)
+	var/damage = (damage_roll(A,D) * 1.5)
 	var/obj/item/bodypart/affecting = D.get_bodypart(BODY_ZONE_CHEST)
 	var/armor_block = D.run_armor_check(affecting, "melee")
 	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
@@ -96,8 +96,8 @@
 		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 		D.emote("scream")
 		D.dropItemToGround(D.get_active_held_item())
-		D.apply_damage(10, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
-		D.apply_damage(20, STAMINA, pick(A.zone_selected))
+		D.apply_damage(20, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+		D.apply_damage(35, STAMINA, pick(A.zone_selected))
 		to_chat(A, span_danger("You wrench [D]'s wrist!"))
 		log_combat(A, D, "wrist wrenched (Berserker)")
 
@@ -146,6 +146,7 @@
 	ADD_TRAIT(H, TRAIT_AUTO_CATCH_ITEM, TRAIT_BERSERKER)
 	ADD_TRAIT(H, TRAIT_BERSERKER, TRAIT_BERSERKER)
 	ADD_TRAIT(H, TRAIT_MARTIAL_A, TRAIT_BERSERKER)
+	ADD_TRAIT(H, TRAIT_NOSLIPALL, TRAIT_BERSERKER)
 	H.physiology.stamina_mod *= 0.3 //more stamina
 	H.physiology.stun_mod *= 0.3 //better stun resistance
 
@@ -158,6 +159,7 @@
 	REMOVE_TRAIT(H, TRAIT_BERSERKER, BERSERKER_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_AUTO_CATCH_ITEM, TRAIT_BERSERKER)
 	REMOVE_TRAIT(H, TRAIT_MARTIAL_A, TRAIT_BERSERKER)
+	REMOVE_TRAIT(H, TRAIT_NOSLIPALL, TRAIT_BERSERKER)
 	H.physiology.stamina_mod = initial(H.physiology.stamina_mod)
 	H.physiology.stun_mod = initial(H.physiology.stun_mod)
 
@@ -171,5 +173,5 @@
 	to_chat(usr, "<span class='notice'>Gutpunch</span>: Harm Harm. Deal additional damage every second punch, with a chance for even more damage!")
 	to_chat(usr, "<span class='notice'>Shoulder Check</span>: Harm Disarm. Launch people brutally across rooms, and away from you.")
 	to_chat(usr, span_notice("<span class='notice'>Wrist Wrench</span>: Disarm Disarm. Grab and painfully wrench someone's wrist, disarming them and dealing minor brute and stamina damage."))
-	to_chat(usr, span_notice("In addition, your body is better conditioned, giving you further stamina and increased stun resistance."))
+	to_chat(usr, span_notice("In addition, your body is better conditioned, giving you further stamina and increased stun resistance, you also are able to have a better footing and will no longer slip."))
 	//to_chat(usr, "<span class='notice'>Chokeslam</span>: Harm  Grab. Chokeslam to the floor. Against prone targets, deal additional stamina damage and disarm them.")

--- a/code/modules/supplykit/supplykit_items/supplykit_magic.dm
+++ b/code/modules/supplykit/supplykit_items/supplykit_magic.dm
@@ -76,7 +76,7 @@
 
 /datum/supplykit_item/magic/berseker
 	name = "Berserker's Rights"
-	desc = "A ritual scroll granting the reader aggressive and brutal unarmed combos, improved stamina, enhanced reflexes for catching incoming objects, and a loss of ability in operating firearms."
+	desc = "A ritual scroll granting the reader aggressive and brutal unarmed combos, improved stamina, better footing, enhanced reflexes for catching incoming objects, and a loss of ability in operating firearms."
 	item = /obj/item/book/granter/martial/berserker
 	cost = 40
 
@@ -88,7 +88,7 @@
 
 /datum/supplykit_item/magic/sleepingcarp
 	name = "Sleeping Carp Scroll"
-	desc = "A ritual scroll granting the reader the ability to deflect bullets with an open hand, at the cost of stamina, improved resistance to incoming stamina damage and stuns, and an aversion to drugs and firearms."
+	desc = "A ritual scroll granting the reader the ability to deflect bullets with an open hand, at the cost of stamina and increased damage taken, improved resistance to incoming stamina damage and stuns, and an aversion to drugs."
 	item = /obj/item/book/granter/martial/carp
 	cost = 40
 
@@ -97,3 +97,9 @@
 	desc = "A flower that when worn heals you and feeds you for large amounts, but makes you a pacifist. Its behavior can be altered with shift+ctrl click. You can click it to reduce your radiation too!"
 	item = /obj/item/clothing/head/peaceflower
 	cost = 15
+
+/datum/supplykit_item/magic/bass
+	name = "Rising Bass"
+	desc = "A ritual scroll granting the reader the ability to passively dodge bullets and perform many potent defensive moves, at the cost of ranged weaponry and drugs."
+	item = /obj/item/book/granter/martial/carp
+	cost = 40


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Hehehe ohoho funny unarmed changes - 
TLDR with the advent of melee becoming stronger under recent changes, and the ability for backstabbing, as well as sleeping carp now being compatible with guns, i made this PR to give unarmed some more well defined roles in the form of offense with berserker and  and defense  with rising bass.

Changes - Berserker has some damage increases that are below the original ones, but still equivalent to what a melee weapon would get with backstabs when the correct combos are performed, it also received a no slip trait to really encourage the aggressive nature, as the oil that seems to be everywhere on the floor really punishes melee players when they're aggressive.

Rising bass was now added to the round start supply kit, as a more defensive focused alternative to berserker, lacking any direct simple damage boosts but instead offering projectile dodges and some extra defensive moves that work on players and mobs alike, it still retains the no drugs / no guns trait unlike carp.

## Pre-Merge Checklist
- [ Y] You tested this on a local server.
- [ Y] This code did not runtime during testing.
- [ Y] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
