### PR TITLE
Fixes and adjusts the TG Blasters for fun and balance (Good to go if it passes checks)

### DIFF
--- a/code/game/objects/effects/spawners/masterlootdrop.dm
+++ b/code/game/objects/effects/spawners/masterlootdrop.dm
@@ -537,10 +537,10 @@
 		/obj/item/gun/energy/laser/scatter/laserbuss = 5,           //213 2
 		/obj/item/gun/energy/laser/auto = 10,                       //200 60
 		/obj/item/gun/energy/laser/cranklasergun/tg/rifle/heavy = 10,             //80  24 internal cell
-		/obj/item/gun/energy/laser/cranklasergun/tg/rifle/auto = 10,              //200 60 internal cell
 		/obj/item/gun/energy/laser/rcw = 10,                        //190 50
 		/obj/item/gun/energy/laser/badlands = 10,                   //167 16
 		/obj/item/gun/energy/laser/auto/twin = 10,                  //37.5 30 DPS tool says it's low but I think it struggles with burst fire. Similar in power to tesla autoshock
+		/obj/item/gun/energy/laser/scatter/nonlethal = 100,					//132(276) 20 insane for pve wtf, nonlethal damage only so it's here
 
 		//sidearms
 		/obj/item/gun/energy/laser/plasma/pistol/eve = 8,           //150 10 plasma
@@ -560,13 +560,13 @@
 /obj/effect/spawner/lootdrop/f13/very_rare_energy
 	name = "very rare energy"
 	loot = list(
-		/obj/item/gun/energy/laser/cranklasergun/tg/particlecannon = 300,	//133 5 while the DPS is low it has ABSURD burst damage (also it needs the DPS tool run again to get the bane DPS)
-		/obj/item/gun/energy/laser/scatter/nonlethal = 100,					//132(276) 20 insane for pve wtf
-		/obj/item/gun/energy/laser/auto/oasis = 400,						//266 50 low damage per shot, deals plasma damage
-		/obj/item/gun/energy/kinetic_accelerator/crossbow/large = 500,		//200 1 self charge, EMP immune
-		/obj/item/gun/energy/laser/plasma/pistol/alien = 99,				//225 4
-		/obj/item/gun/medbeam/magic = 400,									//000 inf medbeam
-		/obj/item/minigunpack = 1,											//??? 200 Note: the laser gatling actually isn't working with the DPS tool, but it's 15 damage at 600 RPM. Once in a blue moon this will make someone's day.
+		/obj/item/gun/energy/laser/tg/particlecannon = 5,					//133 (~300) 5, have to use a Weapon Recharger
+		/obj/item/gun/energy/laser/auto/oasis = 10,							//266 50 low damage per shot, deals plasma damage
+		/obj/item/gun/energy/laser/cranklasergun/tg/rifle/auto = 10,		//200 60 internal cell
+		/obj/item/gun/energy/kinetic_accelerator/crossbow/large = 50,		//200 1 self charge, EMP immune
+		/obj/item/gun/energy/laser/plasma/pistol/alien = 10,				//225 4
+		/obj/item/gun/medbeam/magic = 10,									//000 inf medbeam
+		/obj/item/minigunpack = 5,											//??? 200 Note: the laser gatling actually isn't working with the DPS tool, but it's 15 damage at 600 RPM. Once in a blue moon this will make someone's day.
 	)
 
 ///////////////////////////

--- a/code/modules/cargo/exports/misc_export.dm
+++ b/code/modules/cargo/exports/misc_export.dm
@@ -266,7 +266,7 @@
 		/obj/item/gun/ballistic/fatman,
 		/obj/item/gun/ballistic/rifle/hunting/paciencia,
 		/obj/item/gun/ballistic/revolver/shotpistol/flair_gun,
-		/obj/item/gun/energy/laser/cranklasergun/tg/particlecannon,
+		/obj/item/gun/energy/laser/tg/particlecannon,
 		/obj/item/gun/energy/laser/xcomufolaser,
 		/obj/item/gun/energy/laser/LaserAK,
 	)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -1280,7 +1280,7 @@ Phased out for /obj/item/projectile/beam/laser/cranklasergun/tg */
  * Unique
  * * * * * */
 
-/*/obj/item/gun/energy/laser/tg/particlecannon
+/obj/item/gun/energy/laser/tg/particlecannon
 	name = "particle cannon"
 	desc = "The Trident Gammaworks 'Yamato' particle cannon was designed to be mounted on light armor for use against hard targets, ranging from vehicles to buildings. And some madman has disconnected this one and modified it to be portable. Without an engine to supply its immense power requirements, the capacitors can only handle five shots before needing to recharge -- but sometimes, that's all you need."
 	icon_state = "lassniper"
@@ -1289,10 +1289,10 @@ Phased out for /obj/item/projectile/beam/laser/cranklasergun/tg */
 	w_class = WEIGHT_CLASS_BULKY
 	can_flashlight = 0
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/tg/particle)
-	init_recoil = LASER_RIFLE_RECOIL(2, 3)
+	init_recoil = LASER_RIFLE_RECOIL(3, 5) // Bad handling means it's not as good right as you find it, but basically any modding solves this problem.
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slower
-	)*/
+	)
 
 /* * * * * *
  * TG Not-Calico

--- a/code/modules/projectiles/guns/energy/laser_crank.dm
+++ b/code/modules/projectiles/guns/energy/laser_crank.dm
@@ -222,7 +222,25 @@
 /obj/item/projectile/beam/laser/cranklasergun/overcharge/revolver_man
 	damage = 30
 
-// Start of TG lasers
+/* * * * * * *
+ * TG Lasers *
+ * * * * * * */
+
+/* * * * * * * * * * *
+ * Classic TG blasters
+ * Almost always projectile, rarely hitscan
+ * Can't remove cell, charge in Weapon Rechargers, can crank to charge at the cost of stamina
+ * Very ammo efficient
+ * Ranges from Spawn tier to actual good loot:tm:
+ * * * * * * * * * * */
+
+// CRANK GUN KEY
+// crank_power = X | The amount of power restored per crank
+// crank_stamina_cost = X | The amount of stamina used per crank; stamina crit is at 130 damage.
+// cranking_time = X SECONDS | The amount of time needed per crank. If you don't have "SECONDS" it'll default to ticks.
+
+
+// Improvised Laser: craftable and the most efficient but bad capacity.
 /obj/item/gun/energy/laser/cranklasergun/tg
 	name = "improvised laser"
 	desc = "Hanging out of a gutted weapon's frame are a series of wires and capacitors. This improvised carbine hums ominously as you examine it. It... Probably won't explode when you pull the trigger, at least?"
@@ -237,13 +255,11 @@
 	shaded_charge = 1
 	can_charge = 1
 	can_scope = TRUE
-	crank_power = 1250 // Laser rebalance. Cranking weapons gives you alot of power
-	crank_stamina_cost = 50 // But also cost more stamina than before
-	cranking_time = 4 // And require a little more time
+	crank_power = 1250 // 4 cranks
+	crank_stamina_cost = 32 // 1/4th stamina
+	cranking_time = 2.5 SECONDS
 	trigger_guard = TRIGGER_GUARD_NORMAL
 	max_upgrades = 6
-	cranking_time = 1.2 SECONDS
-	crank_stamina_cost = 10
 	crank_sound = list(
 		'sound/effects/dynamo_crank/dynamo_crank_mb1.ogg',
 		'sound/effects/dynamo_crank/dynamo_crank_mb2.ogg',
@@ -258,19 +274,17 @@
 		/datum/firemode/automatic/rpm100
 	)
 
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg  //basically a single shot charge
+/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg
 	name = "integrated single charge cell"
 	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
 	icon = 'icons/fallout/objects/powercells.dmi'
 	icon_state = "mfc-full"
 	maxcharge = 5000
 
-
 /obj/item/ammo_casing/energy/cranklasergun/tg
 	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
-	e_cost = 250 // 5 shots per crank
+	e_cost = 250 // 20 shots
 	select_name = "kill"
-
 
 /obj/item/projectile/beam/laser/cranklasergun/tg
 	name = "blaster bolt"
@@ -286,249 +300,49 @@
 	eyeblur = 2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
-	ricochets_max = 50	//Honk!
+	ricochets_max = 3
 	ricochet_chance = 0
 	is_reflectable = TRUE
 	recoil = BULLET_RECOIL_LASER
 
-// THE TG CARBINE
-
+// TG Carbine: Starter tier primary weapon. Best handling between the Repeating Blaster and Shock Autoblaster, fits in certain holsters or a bag.
 /obj/item/gun/energy/laser/cranklasergun/tg/carbine
 	name = "laser carbine"
 	desc = "A somewhat compact laser carbine that's capable of being put in larger holsters. Manufactured by Trident Gammaworks, this model of rifle was marketed before the collapse for hunting and sport shooting."
 	icon_state = "lascarbine"
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/carbine
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg)
+	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/carbine)
 	can_flashlight = 1
 	flight_x_offset = 15
 	flight_y_offset = 10
 	crank_sound = list(
 		'sound/effects/dynamo_crank/dynamo_crank.mp3',
 	)
-	crank_power = 1333 // 6 cranks till full
-	crank_stamina_cost = 50 // But also cost more stamina than before
-	cranking_time = 4 // And require a little more time
-	init_recoil = LASER_CARBINE_RECOIL(1, 0.8)
+	crank_power = 1000 // 5 cranks
+	crank_stamina_cost = 32 // 1/4th stamina
+	cranking_time = 4 SECONDS // slightly slower
+	init_recoil = LASER_CARBINE_RECOIL(1, 0.6)
 
 /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/carbine
 	name = "integrated single charge cell"
 	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
 	icon = 'icons/fallout/objects/powercells.dmi'
 	icon_state = "mfc-full"
-	maxcharge = 7000 // 35 shots
-
+	maxcharge = 5000
 
 /obj/item/ammo_casing/energy/cranklasergun/tg/carbine
-	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
-	e_cost = 200 // 7.5 shots per crank
-	select_name = "kill"
-// TG CARBINE END
+	e_cost = 200 // 25 shots
 
-// TG PISTOL
-/obj/item/gun/energy/laser/cranklasergun/tg/pistol
-	name = "miniture laser pistol"
-	desc = "An ultracompact version of the Trident Gammaworks laser carbine, this gun is small enough to fit in a pocket or pouch. While it retains most of the carbine's power, its battery is less efficient due to the size."
-	icon_state = "laspistol"
-	item_state = "laser"
-	w_class = WEIGHT_CLASS_SMALL
-	damage_multiplier = GUN_LESS_DAMAGE_T1
-	cranking_time = 3 SECONDS
-	crank_stamina_cost = 30
-	crank_power = 2500
-	crank_sound = list(
-		'sound/effects/dynamo_crank/dynamo_crank.mp3',
-	)
-	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/pistol
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/pistol)
-	init_recoil = LASER_HANDGUN_RECOIL(1, 1)
-
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/pistol
-	name = "integrated single charge cell"
-	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
-	icon = 'icons/fallout/objects/powercells.dmi'
-	icon_state = "mfc-full"
-	maxcharge = 10000 // So it can be put into a portable recharger
-
-/obj/item/ammo_casing/energy/cranklasergun/tg/pistol
-	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg/pistol
-	e_cost = 500
-	select_name = "kill"
-
-/obj/item/projectile/beam/laser/cranklasergun/tg/pistol
-	name = "weakened blaster bolt"
-	damage = 20
-	damage_list = list("15" = 25, "20" = 25, "25" = 25, "30" = 25)
-// TG PISTOL END
-
-// TG RIFLE
-/obj/item/gun/energy/laser/cranklasergun/tg/rifle
-	name = "laser rifle"
-	desc = "The Mark II laser rifle, produced by Trident Gammaworks, was the golden standard of energy weapons pre-collapse, but it rapidly lost popularity with the introduction of the Wattz 2000 and AER-9 rifles."
-	icon_state = "lasrifle"
-	weapon_weight = GUN_TWO_HAND_ONLY
-	w_class = WEIGHT_CLASS_BULKY
-	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle)
-	crank_power = 1500 // 7 cranks until full
-	crank_stamina_cost = 45 // 3 stamina bars
-	cranking_time = 4 SECONDS// And require a little more time
-	can_flashlight = 1
-	crank_sound = list(
-		'sound/effects/dynamo_crank/dynamo_crank.mp3',
-	)
-	flight_x_offset = 20
-	flight_y_offset = 10
-	init_recoil = LASER_RIFLE_RECOIL(1, 1)
-	init_firemodes = list(
-		/datum/firemode/burst/two,
-		/datum/firemode/semi_auto/fast,
-		/datum/firemode/automatic/rpm75
-	)
-
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle
-	name = "integrated single charge cell"
-	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
-	icon = 'icons/fallout/objects/powercells.dmi'
-	icon_state = "mfc-full"
-	maxcharge = 10000 // 50 shots
-
-/obj/item/ammo_casing/energy/cranklasergun/tg/rifle
-	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
-	e_cost = 200 // 7.5 shots per crank
-	select_name = "kill"
-// TG RIFLE END
-
-// TG HEAVY RIFLE
-/obj/item/gun/energy/laser/cranklasergun/tg/rifle/heavy
-	name = "heavy laser rifle"
-	desc = "Originally designed as a man portable anti-tank weapon, nowadays this massive rifle is mostly used to fry Super Mutants and bandits in Power Armor."
-	icon_state = "lascannon"
-	weapon_weight = GUN_TWO_HAND_ONLY
-	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/heavy
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/heavy)
-	crank_power = 1000 // 10 cranks until full
-	crank_stamina_cost = 50 // 4 stamina bars
-	cranking_time = 6 SECONDS // And require a little more time
-	crank_sound = list(
-		'sound/weapons/laserPump.ogg',
-	)
-	init_recoil = LASER_RIFLE_RECOIL(2, 1)
-	init_firemodes = list(
-		/datum/firemode/semi_auto/slower,
-		/datum/firemode/automatic/rpm40
-	)
-
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/heavy
-	name = "integrated single charge cell"
-	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
-	icon = 'icons/fallout/objects/powercells.dmi'
-	icon_state = "mfc-full"
-	maxcharge = 9800 // 65 shots per charge
-
-/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/heavy
-	projectile_type = /obj/item/projectile/beam/cranklasergun/tg/rifle/heavy
-	e_cost = 150 // 6.5 shots per crank
-	fire_sound = 'sound/weapons/pulse.ogg'
-	select_name = "kill"
-
-/obj/item/projectile/beam/cranklasergun/tg/rifle/heavy
-	name = "intense blaster bolt"
-	damage = 60
-	damage_list = list("55" = 25, "60" = 25, "65" = 25, "70" = 25)
-	wound_bonus = 40 // nasty, but it's still a laser.
-	recoil = BULLET_RECOIL_PLASMA
-// TG HEAVY RIFLE END
-
-// TG SMG
-/obj/item/gun/energy/laser/cranklasergun/tg/rifle/auto
-	name = "tactical laser rifle"
-	desc = "Despite the introduction of interchangeable power cells for energy weapons, the Mark IV autolaser remained in use with SWAT and National Guard units due its incredibly efficient laser projection system."
-	icon_state = "taclaser"
-	item_state = "p90"
-	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/auto
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/auto)
-	crank_power = 1000 // 10 cranks until full
-	crank_stamina_cost = 45 // 4 stamina bars
-	cranking_time = 6 // And require a little more time
-	crank_sound = list(
-		'sound/weapons/laserPump.ogg',
-	)
-	init_recoil = AUTOCARBINE_RECOIL(1, 1)
-	init_firemodes = list(
-		/datum/firemode/automatic/rpm200,
-		/datum/firemode/burst/three/fast,
-		/datum/firemode/semi_auto/fast
-	)
-
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/auto
-	name = "integrated single charge cell"
-	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
-	icon = 'icons/fallout/objects/powercells.dmi'
-	icon_state = "mfc-full"
-	maxcharge = 10000 // 100 shots per charge
-
-/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/auto
-	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
-	e_cost = 100 // 10 shots per crank
-	select_name = "kill"
-
-// TG PARTY CANNON
-/obj/item/gun/energy/laser/cranklasergun/tg/particlecannon
-	name = "particle cannon"
-	desc = "The Trident Gammaworks 'Yamato' particle cannon was designed to be mounted on light armor for use against hard targets, ranging from vehicles to buildings. And some madman has disconnected this one and modified it to be portable. Without an engine to supply its immense power requirements, the capacitors can only handle five shots before needing to recharge -- but sometimes, that's all you need."
-	icon_state = "lassniper"
-	item_state = "esniper"
-	weapon_weight = GUN_TWO_HAND_ONLY
-	w_class = WEIGHT_CLASS_BULKY
-	cranking_time = 3 SECONDS // Pretty reasonable.
-	crank_stamina_cost = 40 // Takes 160 stamina for one charge
-	crank_power = 500
-	crank_sound = list(
-		'sound/weapons/laserPumpEmpty.ogg',
-	)
-	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/particalcannon
-	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/particalcannon)
-	init_recoil = LASER_RIFLE_RECOIL(2, 3)
-	init_firemodes = list(
-		/datum/firemode/semi_auto/slower,
-	)
-
-/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/particalcannon
-	name = "integrated single charge cell"
-	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
-	icon = 'icons/fallout/objects/powercells.dmi'
-	icon_state = "mfc-full"
-	maxcharge = 10000 // Holds 5 shots
-
-/obj/item/ammo_casing/energy/cranklasergun/tg/particalcannon
-	projectile_type = /obj/item/projectile/beam/cranklasergun/tg/particalcannon
-	e_cost = 2000
-	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	select_name = "kill"
-
-/obj/item/projectile/beam/cranklasergun/tg/particalcannon
-	name = "hyper-velocity particle beam"
-	icon_state = "emitter"
-	damage = 100 // With no -HP traits, any light armor saves you and EVERYONE is armored; you get 5 shots and can't reload in the field
-	damage_list = list("90" = 25, "100" = 25, "115" = 25, "130" = 24, "1000" = 1) //fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you fuck you ~TK
-	wound_bonus = 60 // nasty, but it's still a laser
-	supereffective_damage = 100 // lowered from 150 because you can charge it now
-	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "yaoguai")
-	hitscan = TRUE
-	tracer_type = /obj/effect/projectile/tracer/xray
-	muzzle_type = /obj/effect/projectile/muzzle/xray
-	impact_type = /obj/effect/projectile/impact/xray
-
-// TG Repeating Blaster
+// TG Repeating Blaster: Spawn tier swarm killer. Easier to charge, but doesn't scale well.
 /obj/item/gun/energy/laser/cranklasergun/tg/spamlaser
 	name = "repeating blaster"
 	desc = "The odd design of the Trident Gammaworks M950 repeating blaster allows for an extremely high number of shots, but the weapon's power is rather low in turn. Before the end of the world, it was marketed as an anti-varmint weapon. Turns out, it's still largely used as one after the end."
 	icon_state = "spamlaser"
 	weapon_weight = GUN_TWO_HAND_ONLY
 	w_class = WEIGHT_CLASS_BULKY
-	cranking_time = 3 SECONDS // Pretty reasonable.
-	crank_stamina_cost = 35 // Gets 3 cranks per stamina bar
-	crank_power = 500
+	cranking_time = 4 SECONDS
+	crank_stamina_cost = 25 // 1/5th stamina
+	crank_power = 500 // 10 cranks
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/spamlaser
 	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/spamlaser)
 	init_recoil = AUTOCARBINE_RECOIL(1, 1)
@@ -542,30 +356,29 @@
 	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
 	icon = 'icons/fallout/objects/powercells.dmi'
 	icon_state = "mfc-full"
-	maxcharge = 5000 // takes about 10 cranks to fill
+	maxcharge = 5000
 
 /obj/item/ammo_casing/energy/cranklasergun/tg/spamlaser
 	projectile_type = /obj/item/projectile/beam/cranklasergun/tg/spamlaser
-	e_cost = 40 //Gets 12 shots per charge
+	e_cost = 41.5 // 120 shots
 	fire_sound = 'sound/weapons/taser2.ogg'
-	select_name = "kill"
 
-/obj/item/projectile/beam/cranklasergun/tg/spamlaser //ultra weak but spammy, duh
-	name = "blaster bolt"
+/obj/item/projectile/beam/cranklasergun/tg/spamlaser //ultra weak but spammy
+	name = "ultralight blaster bolt"
 	damage = 10
 	damage_list = list("8" = 20, "10" = 60, "15" = 15, "30" = 5)
-	recoil = BULLET_RECOIL_HEAVY_LASER
+	recoil = BULLET_RECOIL_LASER
 
-// TG Electro Autoblaster
+// TG Electro Autoblaster: Heavier version of the Repeating Blaster. Hitscan, does more damage, but less capacity/recharge.
 /obj/item/gun/energy/laser/cranklasergun/tg/spamlaser/shock
 	name = "shock autoblaster"
 	desc = "The T30 Repeater was an experiment by Trident Gammaworks to exploit tesla technology. It saw limited commercial success even though the technology was deemed to have great potential."
 	icon_state = "teslaser"
 	weapon_weight = GUN_TWO_HAND_ONLY
 	w_class = WEIGHT_CLASS_BULKY
-	cranking_time = 3 SECONDS // Pretty reasonable.
-	crank_stamina_cost = 35 // Gets 3 cranks per stamina bar
-	crank_power = 500 // Basically is just the repeating blaster again
+	cranking_time = 4 SECONDS
+	crank_stamina_cost = 25 // 1/5th stamina
+	crank_power = 500 // 10 cranks
 	crank_sound = list(
 		'sound/weapons/laserPump.ogg',
 	)
@@ -579,9 +392,8 @@
 
 /obj/item/ammo_casing/energy/cranklasergun/tg/spamlaser/shocker
 	projectile_type = /obj/item/projectile/beam/cranklasergun/tg/spamlaser/shocker
-	e_cost = 83 // 6 shots per charge
+	e_cost = 100 // 50 shots
 	fire_sound = 'sound/weapons/taser.ogg'
-	select_name = "kill"
 
 /obj/item/projectile/beam/cranklasergun/tg/spamlaser/shocker //stronger spammy zaps
 	name = "electrobolt"
@@ -601,3 +413,145 @@
 	impact_light_intensity = 8
 	impact_light_range = 3.75
 	impact_light_color_override = LIGHT_COLOR_BLUE
+
+// TG Miniture Pistol: Spawn tier shitty pistol. Meant for you to have 4+ on you at a time, but has a secret use as a battery in a portable charger.
+/obj/item/gun/energy/laser/cranklasergun/tg/pistol
+	name = "miniture laser pistol"
+	desc = "An ultracompact version of the Trident Gammaworks laser carbine, this gun is small enough to fit in a pocket or pouch. While it retains most of the carbine's power, its battery is less efficient due to the size."
+	icon_state = "laspistol"
+	item_state = "laser"
+	w_class = WEIGHT_CLASS_SMALL
+	damage_multiplier = GUN_LESS_DAMAGE_T1
+	cranking_time = 1 SECONDS // It's kinda shit so...
+	crank_stamina_cost = 25 // 1/4th-ish stamina
+	crank_power = 2000 // 5 cranks
+	crank_sound = list(
+		'sound/effects/dynamo_crank/dynamo_crank.mp3',
+	)
+	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/pistol
+	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/pistol)
+	init_recoil = LASER_HANDGUN_RECOIL(1, 1)
+
+/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/pistol
+	name = "integrated single charge cell"
+	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
+	icon = 'icons/fallout/objects/powercells.dmi'
+	icon_state = "mfc-full"
+	maxcharge = 10000 // So it can be put into a portable recharger
+
+/obj/item/ammo_casing/energy/cranklasergun/tg/pistol
+	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg/pistol
+	e_cost = 500 // 20 shots
+
+/obj/item/projectile/beam/laser/cranklasergun/tg/pistol
+	name = "weakened blaster bolt"
+	damage = 20
+	damage_list = list("15" = 25, "20" = 25, "25" = 25, "30" = 25)
+
+// TG Laser Rifle: Basically just a better Carbine. More DPS, more capacity.
+/obj/item/gun/energy/laser/cranklasergun/tg/rifle
+	name = "laser rifle"
+	desc = "The Mark II laser rifle, produced by Trident Gammaworks, was the golden standard of energy weapons pre-collapse, but it rapidly lost popularity with the introduction of the Wattz 2000 and AER-9 rifles."
+	icon_state = "lasrifle"
+	weapon_weight = GUN_TWO_HAND_ONLY
+	w_class = WEIGHT_CLASS_BULKY
+	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle
+	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle)
+	crank_power = 1000 // 5 cranks
+	crank_stamina_cost = 32 // 1/4th stamina
+	cranking_time = 4 SECONDS // slightly slower, same as carbine
+	can_flashlight = 1
+	crank_sound = list(
+		'sound/effects/dynamo_crank/dynamo_crank.mp3',
+	)
+	flight_x_offset = 20
+	flight_y_offset = 10
+	init_recoil = LASER_RIFLE_RECOIL(1, 1)
+	init_firemodes = list(
+		/datum/firemode/burst/two,
+		/datum/firemode/semi_auto/fast,
+		/datum/firemode/automatic/rpm75
+	)
+
+/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle
+	name = "integrated single charge cell"
+	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
+	icon = 'icons/fallout/objects/powercells.dmi'
+	icon_state = "mfc-full"
+	maxcharge = 5000
+
+/obj/item/ammo_casing/energy/cranklasergun/tg/rifle
+	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
+	e_cost = 100 // 50 shots
+
+// TG Heavy Laser Rifle: Upgrade to the Mk. II laser rifle, sidegrade to the taclaser. High power, medium capacity
+/obj/item/gun/energy/laser/cranklasergun/tg/rifle/heavy
+	name = "heavy laser rifle"
+	desc = "Originally designed as a man portable anti-vehicle weapon, nowadays this massive rifle is mostly used to fry bandits in Power Armor and Super Mutants."
+	icon_state = "lascannon"
+	weapon_weight = GUN_TWO_HAND_ONLY
+	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/heavy
+	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/heavy)
+	crank_power = 1250 // 4 cranks until full
+	crank_stamina_cost = 32 // 1/4th stamina
+	cranking_time = 6 SECONDS // Little slower, but it's stronger
+	crank_sound = list(
+		'sound/weapons/laserPump.ogg',
+	)
+	init_recoil = LASER_RIFLE_RECOIL(2, 1)
+	init_firemodes = list(
+		/datum/firemode/semi_auto/slower,
+		/datum/firemode/automatic/rpm40
+	)
+
+/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/heavy
+	name = "integrated single charge cell"
+	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
+	icon = 'icons/fallout/objects/powercells.dmi'
+	icon_state = "mfc-full"
+	maxcharge = 5000
+
+/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/heavy
+	projectile_type = /obj/item/projectile/beam/cranklasergun/tg/rifle/heavy
+	e_cost = 250 // 20 shots
+	fire_sound = 'sound/weapons/pulse.ogg'
+
+/obj/item/projectile/beam/cranklasergun/tg/rifle/heavy
+	name = "intense blaster bolt"
+	damage = 60
+	damage_list = list("55" = 10, "60" = 50, "65" = 10, "70" = 25, "100" = 5) // This thing is stupid hard to balance so let's give it a hell of a crit and consistent damage
+	wound_bonus = 40 // nasty, but it's still a laser.
+	recoil = BULLET_RECOIL_HEAVY_LASER
+
+// TG Taclaser: Basically a laser P90. Better base stats than the Mk. II rifle, but it charges quicker. KEEP IN MIND JET EXISTS, THIS CAN GET VERY SILLY VERY FAST.
+/obj/item/gun/energy/laser/cranklasergun/tg/rifle/auto
+	name = "tactical laser rifle"
+	desc = "Despite the introduction of interchangeable power cells for energy weapons, the Mark IV autolaser remained in use with SWAT and National Guard units due its incredibly efficient laser projection system."
+	icon_state = "taclaser"
+	item_state = "p90"
+	cell_type = /obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/auto
+	ammo_type = list(/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/auto)
+	crank_power = 1000 // 5 cranks until full
+	crank_stamina_cost = 30 // 1/4th-ish stamina
+	cranking_time = 2 SECONDS // Speedy!
+	crank_sound = list(
+		'sound/weapons/laserPump.ogg',
+	)
+	init_recoil = AUTOCARBINE_RECOIL(1, 1)
+	init_firemodes = list(
+		/datum/firemode/automatic/rpm200,
+		/datum/firemode/burst/three/fast,
+		/datum/firemode/semi_auto/fast
+	)
+
+/obj/item/stock_parts/cell/ammo/mfc/cranklasergun/tg/rifle/auto
+	name = "integrated single charge cell"
+	desc = "An integrated single charge cell, typically used as fast discharge power bank for energy weapons."
+	icon = 'icons/fallout/objects/powercells.dmi'
+	icon_state = "mfc-full"
+	maxcharge = 5000
+
+/obj/item/ammo_casing/energy/cranklasergun/tg/rifle/auto
+	projectile_type = /obj/item/projectile/beam/laser/cranklasergun/tg
+	e_cost = 100 // 50 shots
+	select_name = "kill"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1023,7 +1023,7 @@
 	name = "blaster bolt"
 	damage = 10
 	damage_list = list("7" = 10, "8" = 10, "10" = 75, "15" = 5)
-	recoil = BULLET_RECOIL_HEAVY_LASER
+	recoil = BULLET_RECOIL_PLASMA
 
 //Laser AK projectiles
 /obj/item/projectile/beam/laser/tg/kalashheavy


### PR DESCRIPTION
## About The Pull Request
Title, basically.

Also tried to give each of the TG blasters a unique role. We'll see how that goes, eh?

Scraplaser: Shitty T0 weapon, but decent crankability
TG Minipistol: T0.5, shitty pistol that you're meant to have 4+ of at any time. Easy enough to crank and has a hidden use in the portable recharger.
TG Carbine: T1, almost a straight upgrade to the scraplaser. "Beats" the Repeating Blaster/Shocker in the sense you can carry two Carbines, or more if you use a bag
TG Autoblaster: T1, easy to crank anti-rodent gun. The best of the T1 weapons in terms of scaling.
TG Shocker: T1, hitscan and hits a little harder than the AB. The best T1 on its own and out of the box. Best used and discarded for pretty much any upgrade but still viable to upgrade.

TG Laser Rifle: T2, basically just an upgraded Carbine. More cap, more DPS, same crank stats.
TG Heavy Laser Rifle: T3, trades capacity and RoF for sheer power. Has brutal high roll and crit damage, and scales VERY well with mods.
TG Taclaser: T3, basically a straight upgrade to the Laser Rifle as it charges faster and easier and has better RoF.  On paper it's better than the HLR but practically loses out due to armor. Becomes T3.5 to maybe full T4 if you use stamina regen drugs.

TG Particle Rifle: T4, nuke. It kills basically anything stupid fast but you need to bring it back to a Weapon Recharger. Amazing if you find in a dungeon, but also works as a second primary to help burn down dangerous mobs and bosses. Also insanely strong if a dungeon has a nearby Weapon Recharger, or one is built inside.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:

- Gives each of the TG blasters a distinct role as well as just generally fixing their stats and some related bugs
- Adjusts and fixes masterloot regarding eguns
- Reverts the Particle Rifle to its non-crankable state, but also gives it back the bonus damage
- Fixes the Particle Rifle's recoil and poor handling being meaningless. Now you can actually miss, especially with the bad aim trait. Basically any 2h recoil mod fixes this, however
- Tries to make the Heavy Laser Rifle actually compete with the Taclaser. Unfortunately, the Taclaser still wins if you use drugs, but they should be more even otherwise

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
