### PR TITLE
Moves the ORM to science

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -1089,6 +1089,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
+"cK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "cL" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2073,6 +2083,17 @@
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
+"fc" = (
+/obj/structure/rack/shelf_metal/modern,
+/obj/item/storage/belt/xenoarch/full{
+	pixel_y = -4
+	},
+/obj/item/storage/belt/xenoarch/full,
+/obj/item/storage/belt/xenoarch/full{
+	pixel_y = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fd" = (
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
@@ -2373,6 +2394,14 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/building)
+"fN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "fO" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common{
@@ -2637,6 +2666,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
+"gl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/caves)
 "gm" = (
 /obj/effect/decal/cleanable/glass{
@@ -3039,6 +3078,20 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
+"hp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ore_box,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "hq" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -4547,6 +4600,17 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
+"kC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "kD" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
@@ -5470,6 +5534,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
+"mF" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mG" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/purple,
@@ -7055,6 +7123,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/wasteland/city/newboston/house/cabin_three)
+"qw" = (
+/obj/structure/rack/shelf_metal/modern,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/pickaxe/drill,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qy" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -7882,6 +7956,17 @@
 	color = "#779999"
 	},
 /area/f13/building)
+"sG" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "sH" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -8300,6 +8385,18 @@
 "tD" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
+"tE" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "tF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -8644,6 +8741,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building)
+"uv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "uw" = (
 /obj/structure/railing{
 	dir = 6
@@ -11265,6 +11373,15 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"Bb" = (
+/obj/machinery/mineral/ore_redemption,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "Bc" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -13412,6 +13529,20 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
+"FY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ore_box,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "FZ" = (
 /obj/structure/fermenting_barrel{
 	anchored = 1
@@ -14028,6 +14159,16 @@
 /obj/item/bedsheet/doublesheetbrown,
 /turf/open/floor/carpet/black,
 /area/f13/wasteland/city/newboston/house/cabin_five)
+"Ht" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "Hv" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -14263,6 +14404,19 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
+"HV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "HW" = (
 /obj/structure/decoration/rag,
 /obj/structure/fence/wooden{
@@ -15976,6 +16130,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland/city/newboston/outdoors)
+"Mh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "Mi" = (
 /obj/structure/rack,
 /turf/open/floor/carpet/black,
@@ -16289,6 +16453,17 @@
 /obj/structure/decoration/vent,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
+"MW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "MY" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16583,6 +16758,17 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"Ns" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "Nu" = (
 /obj/structure/sign/poster/contraband/robust_softdrinks,
 /obj/effect/decal/cleanable/dirt,
@@ -18433,6 +18619,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
+/area/f13/caves)
+"RA" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/caves)
 "RB" = (
 /obj/structure/table,
@@ -20768,6 +20963,16 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/wasteland/city/newboston/house/cabin_one)
+"WU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "WV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -21098,6 +21303,19 @@
 	light_range = 2
 	},
 /area/f13/wasteland)
+"XM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "XN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/barricade/wooden/strong{
@@ -21448,6 +21666,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"YG" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/caves)
 "YI" = (
 /obj/structure/chair/metal{
 	dir = 1
@@ -21710,6 +21939,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
+"Zq" = (
+/obj/machinery/mineral/wasteland_vendor/mining,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Zr" = (
 /obj/item/warpaint_bowl{
 	pixel_y = 8
@@ -59217,9 +59450,9 @@ Yj
 Yj
 Yj
 Yj
-tN
-tN
-tN
+Ws
+Ws
+Ws
 Ws
 Ws
 Ws
@@ -59474,10 +59707,10 @@ IQ
 IQ
 IQ
 GU
-tN
-tN
-tN
-nb
+dK
+dK
+dK
+dK
 dK
 dK
 dK
@@ -59731,7 +59964,7 @@ UW
 sD
 IQ
 GU
-GU
+qF
 GU
 GU
 JD
@@ -61013,7 +61246,7 @@ IQ
 zE
 zE
 IQ
-qF
+Zq
 qF
 qF
 qF
@@ -61270,7 +61503,7 @@ IQ
 zE
 di
 IQ
-qF
+mF
 qF
 qF
 qF
@@ -62046,7 +62279,7 @@ qF
 qF
 qF
 qF
-qF
+qw
 GU
 GU
 tN
@@ -62299,11 +62532,11 @@ zE
 IQ
 qF
 qF
+Ht
+sG
+Mh
 qF
-qF
-qF
-qF
-qF
+fc
 GU
 GU
 tN
@@ -62555,12 +62788,12 @@ Th
 Br
 Gi
 qF
-qF
-qF
-qF
-qF
-qF
-qF
+uv
+kC
+hp
+XM
+Mh
+qw
 GU
 GU
 tN
@@ -62812,11 +63045,11 @@ mi
 zE
 IQ
 NS
-qF
-qF
-qF
-qF
-GU
+tE
+fN
+Bb
+WU
+RA
 us
 GU
 GU
@@ -63069,11 +63302,11 @@ in
 zE
 IQ
 GU
-GU
-qF
-qF
-qF
-GU
+MW
+HV
+FY
+Ns
+gl
 GU
 GU
 GU
@@ -63326,11 +63559,11 @@ BW
 zE
 IQ
 GU
-us
 qF
+cK
+YG
+gl
 qF
-qF
-GU
 GU
 GU
 GU

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -864,19 +864,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"asM" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "asN" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -3706,16 +3693,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"cdp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "cdu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4876,16 +4853,6 @@
 	color = "#888888"
 	},
 /area/f13/wasteland/city/newboston/library)
-"cIx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "cIE" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -5338,16 +5305,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/building/trader)
-"cXa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "cXg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -10033,16 +9990,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fFF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "fFG" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11162,20 +11109,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
-"gpC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "gpE" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -11363,10 +11296,6 @@
 "gvH" = (
 /turf/open/floor/carpet/purple,
 /area/f13/building/abandoned)
-"gvN" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
 "gvU" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -11471,19 +11400,6 @@
 "gyr" = (
 /turf/closed/wall/f13/wood,
 /area/f13/wasteland/city/newboston/bar)
-"gyP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "gza" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -17711,12 +17627,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"jVa" = (
-/obj/structure/rack/shelf_metal/modern,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/pickaxe/drill,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "jVf" = (
 /obj/structure/bookcase,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -21048,17 +20958,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"lGN" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "lGP" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
@@ -22741,17 +22640,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"mEG" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "mES" = (
 /obj/item/trash/can,
 /obj/effect/decal/cleanable/dirt,
@@ -24183,11 +24071,6 @@
 	dir = 4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
-"nyL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/wasteland_vendor/mining,
-/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "nyQ" = (
 /obj/structure/stone_tile/block,
@@ -26761,15 +26644,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"oYQ" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "oYV" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -26808,19 +26682,6 @@
 	color = "#bfbfbf"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"paf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "pag" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -32267,14 +32128,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"rZL" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "rZR" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -32651,18 +32504,6 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
-"sjU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
 /area/f13/caves)
 "skN" = (
 /turf/closed/wall/f13/coyote/oldwood,
@@ -34024,17 +33865,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
-"sYr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "sYA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -36332,17 +36162,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"upN" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "uqo" = (
 /obj/structure/anvil/obtainable/basic,
 /obj/effect/decal/cleanable/dirt,
@@ -38653,17 +38472,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vCJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "vDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38718,15 +38526,6 @@
 /obj/item/chair,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"vGz" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "vGJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
@@ -39218,20 +39017,6 @@
 	name = "tile"
 	},
 /area/f13/building)
-"vUM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "vVb" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -39269,18 +39054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vXj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "vXl" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -40646,20 +40419,6 @@
 /obj/item/stack/sheet/bone,
 /obj/item/stack/sheet/animalhide/human,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"wOQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
 /area/f13/caves)
 "wOS" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -42934,17 +42693,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"xWf" = (
-/obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/belt/xenoarch/full{
-	pixel_y = -4
-	},
-/obj/item/storage/belt/xenoarch/full,
-/obj/item/storage/belt/xenoarch/full{
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "xWp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
@@ -92485,7 +92233,7 @@ tot
 tot
 tot
 tot
-gvN
+gIL
 gIL
 tPQ
 gIL
@@ -92742,7 +92490,7 @@ tot
 tot
 tot
 tot
-nyL
+mlN
 gIL
 gIL
 tPQ
@@ -93254,11 +93002,11 @@ tot
 tot
 tot
 lQh
-koY
-vCJ
-mEG
-sYr
-mlN
+lQh
+lQh
+lQh
+lQh
+dfD
 mlN
 bSs
 mlN
@@ -93511,11 +93259,11 @@ tot
 tot
 lQh
 lQh
-vXj
-sjU
-wOQ
-vUM
-cIx
+lQh
+lQh
+lQh
+lQh
+lQh
 lQh
 rJU
 tot
@@ -93768,14 +93516,14 @@ tot
 tot
 lQh
 lQh
-asM
-rZL
-vGz
-fFF
-oYQ
 lQh
 lQh
-jVa
+lQh
+lQh
+lQh
+lQh
+lQh
+lQh
 tot
 tot
 tPQ
@@ -94025,14 +93773,14 @@ lQh
 lQh
 lQh
 lQh
-paf
-gyP
-gpC
-upN
-cXa
 lQh
 lQh
-xWf
+lQh
+lQh
+lQh
+lQh
+lQh
+lQh
 hRl
 hRl
 tot
@@ -94283,13 +94031,13 @@ lQh
 lQh
 lQh
 lQh
-cdp
-lGN
-cXa
 lQh
 lQh
 lQh
-jVa
+lQh
+lQh
+lQh
+lQh
 tot
 hRl
 hRl


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Moves the ORM, mining stuff, and xenoarch stuff to be next to science like how it was for nash and early new boston. Having to trudge through the RNG nightmare of nests every single time a mining trip has to be ran is frankly a slog, however the main issue arises from new players not knowing *where* the ORM is, with this one being readily visible from the second story it is an easy fix. The ORM is also basically only used by science as it is a vital part of the job, and making it more tedious with no real reason just serves to be annoying. Playing devils advocate of wastelanders wanting to mine for their own materials though, a small walkway has also been made to allow access from 2nd story NB on the west side. (or just use the numerous other ORM's if you want to operate elsewhere. 

This also changes the sci circ printer to be department-less since that is also how things have been for a while, and since reclaimers are also medical, this allows them to print medical supplies.
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/e062ad10-b87d-403e-ab68-deac32c7f34f)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/f9eb8c6c-044d-44ec-a71f-029571d379be)
TLDR, QoL ORM movement to upper NB and no circuit printer restriction (technically you can already just remake another printer in like 6 seconds, this just saves time)
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing. (few runtimes related to 'out of bounds' nowhere near where I made edits, may want to double check because otherwise everything appeared fine)
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->
Testing shows the areas seem fine, but SANIC mode may have caused the unknown runtimes, a mapper more versed in this kind of stuff may benefit from giving it a lookover.
## Changelog
tweak: Mining is now in NB instead of the mountains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
