### PR TITLE
Reloading Hotkey Part 2

### DIFF
--- a/code/modules/keybindings/keybind/combat.dm
+++ b/code/modules/keybindings/keybind/combat.dm
@@ -140,3 +140,14 @@
 /datum/keybinding/carbon/reload_gun/down(client/user)
 	user.mob?.ReloadGun()
 	return TRUE
+
+/datum/keybinding/carbon/reload_gun_or_throw
+	hotkey_keys = list("CtrlR")
+	name = "reload_gun_or_throw"
+	full_name = "Reload or toggle throw"
+	description = "Automatically reloads the gun in your active hand, or toggles throwing mode if you don't have a gun in your active hand."
+	category = CATEGORY_COMBAT
+
+/datum/keybinding/carbon/reload_gun_or_throw/down(client/user)
+	user.mob?.ReloadGun(TRUE)
+	return TRUE

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -607,8 +607,8 @@
 
 	character.client.is_in_game = 1
 	spawn(5 MINUTES)
-		if(character.client.is_in_game)
-			character.client.is_in_game = 2
+		if(character?.client?.is_in_game)
+			character?.client?.is_in_game = 2
 
 			for(var/i in GLOB.player_list)
 				if(isliving(i))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1308,10 +1308,10 @@ ATTACHMENTS
 	if(!my_mode)
 		return fire_delay // shrug
 	. = my_mode.get_fire_delay()
-	if(CHECK_BITFIELD(gun_skill_check, AFFECTED_BY_FAST_PUMP))
+	if(CHECK_BITFIELD(gun_skill_check, AFFECTED_BY_FAST_PUMP) && user)
 		if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
 			. *= GUN_RIFLEMAN_REFIRE_DELAY_MULT
-	if(CHECK_BITFIELD(cooldown_delay_mods, GUN_AUTO_PUMPED))
+	if(CHECK_BITFIELD(cooldown_delay_mods, GUN_AUTO_PUMPED) && user)
 		if(!HAS_TRAIT(user, TRAIT_FAST_PUMP))
 			. *= GUN_AUTOPUMP_REFIRE_DELAY_MULT
 
@@ -1641,18 +1641,31 @@ GLOBAL_LIST_INIT(gun_yeet_words, list(
 	new /obj/item/ammo_box/magazine/d12g/buck(src)
 
 //Reload hotkey stuff
-/obj/item/gun/proc/MagReload(mob/user)
+/obj/item/gun/proc/Reload(mob/user)
 	return FALSE
 
 /mob/proc/ReloadGun()
 	return FALSE
 
-/mob/living/carbon/human/ReloadGun()
+/mob/living/carbon/human/ReloadGun(throw_if_no_gun_in_active_hand)
 	var/I = get_active_held_item()
-	if(!istype(I, /obj/item/gun))
+	var/obj/item/gun/G
+	if(istype(I, /obj/item/gun))
+		G = I
+	if(throw_if_no_gun_in_active_hand && isnull(G))
+		src.toggle_throw_mode()
+		return TRUE
+	var/I2 = get_inactive_held_item()
+	var/obj/item/gun/G2
+	if(istype(I2, /obj/item/gun))
+		G2 = I2
+	if(!G && !G2)
+		to_chat(src, span_warning("You aren't holding a gun you can reload!"))
 		return FALSE
-	var/obj/item/gun/G = I
-	return G.MagReload(src)
+	G?.Reload(src)
+	if(get_inactive_held_item() == G2)//recheck this again because it might have changed since we reloaded the active hand gun.
+		G2?.Reload(src)
+	return TRUE
 
 ///////////////////
 //GUNCODE ARCHIVE//

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 
 /// Pump if click with empty thing
 /obj/item/gun/ballistic/shoot_with_empty_chamber(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)
-	if(!casing_ejector && chambered && HAS_TRAIT(user, TRAIT_FAST_PUMP))
+	if(!casing_ejector && chambered && HAS_TRAIT(user, TRAIT_FAST_PUMP) && !istype(magazine, /obj/item/ammo_box/magazine/internal/cylinder))
 		pump(user, TRUE)
 	else
 		..()
@@ -410,12 +410,23 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 				return turn(user.dir, pick(0, -90, 90, 180))
 	return angle2dir_cardinal(rand(0,360)) // something fucked up, just send a direction
 
-/obj/item/gun/ballistic/MagReload(mob/user)
-	if((magazine && istype(magazine, /obj/item/ammo_box/magazine/internal)) || !ishuman(user))//Miniguns and shotguns and bolt actions and not magazine guns
+/obj/item/gun/ballistic/Reload(mob/user)
+	if(!ishuman(user))
 		return FALSE
-	if(on_cooldown() || !user.has_direct_access_to(src, STORAGE_VIEW_DEPTH))
-		to_chat(user, span_notice("You can't reload [src] right now!"))
+	if(on_cooldown(user) || !user.has_direct_access_to(src, STORAGE_VIEW_DEPTH))
+		to_chat(user, span_notice("You can't reload \the [src] right now!"))
 		return FALSE
+	//Shotguns, bolt action rifles, etc.
+	if(magazine?.fixed_mag)
+		return InternalReload(user)
+	//External magazine weapons
+	else
+		return MagReload(user)
+
+/*
+* Reloads an internal magazine of a weapon with boxes of ammo in your inventory or loose rounds. Unsafe, call Reload() instead.
+*/
+/obj/item/gun/ballistic/proc/InternalReload(mob/user)
 	//typecast the user as a human
 	var/mob/living/carbon/human/H = user
 
@@ -427,10 +438,100 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 		busy_action = FALSE
 		return FALSE
 
-	//First, search for compatible magazines in some predictable locations. Let's not search every item on them to save compute time.
-	var/list/validmags = list()
-	var/list/yourstuff = H?.contents + H?.belt?.contents + H?.back?.contents + H?.wear_suit?.contents + H?.shoes?.contents + H?.head?.contents + H?.l_store?.contents + H?.r_store?.contents + H?.s_store?.contents
+	var/isrevolver = FALSE
+	if(istype(src, /obj/item/gun/ballistic/revolver) || istype(magazine, /obj/item/ammo_box/magazine/internal/cylinder))//Pull any loose shells out, first.
+		var/obj/item/gun/ballistic/revolver/R = src
+		isrevolver = TRUE
+		R.eject_shells(H, TRUE)
+	else if((chambered && !chambered?.BB) || (!chambered && LAZYLEN(magazine?.stored_ammo)))//Eject any empty shells from the chamber
+		attack_self(H)
 
+	var/list/validboxes = list()
+	var/boxedrounds = 0 //If we don't have enough boxed rounds, look for loose rounds as well
+	var/list/validcasings = list()
+	var/list/yourstuff = H?.contents + H?.belt?.contents + H?.back?.contents + H?.wear_suit?.contents + H?.shoes?.contents + H?.head?.contents + H?.l_store?.contents + H?.r_store?.contents + H?.s_store?.contents + H?.wear_neck?.contents
+	//find compatible boxes of ammo
+	for(var/obj/item/ammo_box/B in yourstuff)
+		var/rounds = LAZYLEN(B.stored_ammo)
+		if(rounds > 0 && B.caliber?[1] == magazine.caliber?[1] && !isgun(B.loc))
+			boxedrounds += rounds
+			validboxes += B
+			validboxes[B] = rounds
+	//find loose rounds if there aren't enough boxed rounds to fill the magazine
+	if(LAZYLEN(validboxes) == 0 || boxedrounds < (magazine.max_ammo - magazine.ammo_count()))
+		for(var/obj/item/ammo_casing/AC in yourstuff)
+			if(AC.BB && (AC.caliber in magazine?.caliber) && !isgun(AC.loc))//Not spent, correct caliber
+				if(AC.loc in validboxes)//don't count these twice
+					continue
+				validcasings += AC
+
+	if(LAZYLEN(validboxes) || LAZYLEN(validcasings))
+		if(LAZYLEN(validboxes) && magazine.ammo_count() < magazine.max_ammo)
+			sortTim(validboxes, /proc/cmp_numeric_asc, TRUE)//Sort them by least to most filled so we empty the least filled ones first.
+			for(var/obj/item/ammo_box/B in validboxes)
+				if(isnull(B) || QDELETED(B))
+					continue
+				//reload from this ammo box multiple times if our magazine doesn't get filled in one go or we need to chamber a round and then fill up.
+				if(!magazine?.multiload)//internal magazines that don't load multiple rounds at once
+					var/numroundstoload = clamp((magazine.max_ammo - magazine.ammo_count()), 1, LAZYLEN(B.stored_ammo))
+					for(var/i = 1; i <= numroundstoload; i++)
+						if(do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE) && H.has_direct_access_to(B, STORAGE_VIEW_DEPTH) && attackby(B, user))
+							continue
+						else
+							break
+				else// magazines that accept multiple rounds at once
+					if(do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE) && H.has_direct_access_to(B, STORAGE_VIEW_DEPTH) && attackby(B, user))
+						if(!isrevolver && ((chambered && !chambered?.BB) || !chambered))//spent round or an empty chamber
+							attack_self(H)//rack the bolt
+							//Insert another round to top us off since we just chambered a round
+							if(LAZYLEN(B.stored_ammo) && do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE) && magazine.ammo_count() < magazine.max_ammo && LAZYLEN(B.stored_ammo))
+								attackby(B, user)
+						var/newammo = LAZYLEN(B.stored_ammo)
+						if(newammo == 0)
+							validboxes -= B
+						else
+							validboxes[B] = newammo //update this box's ammo count
+							sortTim(validboxes, /proc/cmp_numeric_asc, TRUE)			
+				if(LAZYLEN(magazine.stored_ammo) < magazine.max_ammo)
+					continue
+				else
+					break
+		if(LAZYLEN(validcasings) && magazine.ammo_count() < magazine.max_ammo)
+			for(var/obj/item/ammo_casing/AC in validcasings)
+				if(isnull(AC) || QDELETED(AC) || !AC.BB)
+					continue
+				if(do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE) && H.has_direct_access_to(AC, STORAGE_VIEW_DEPTH) && attackby(AC, user))
+					validcasings -= AC
+					if(!isrevolver && ((chambered && !chambered?.BB) || !chambered))//spent round or an empty chamber
+						attack_self(H)//rack the bolt
+				if(magazine.ammo_count() < magazine.max_ammo)
+					continue
+				else
+					break
+	else
+		to_chat(H, span_alert("You couldn't find any ammunition that fits into \the [src]!"))
+
+	busy_action = FALSE
+	return TRUE
+
+/// Reloads a magazine into a gun that uses external magazines. Unsafe, call Reload() instead.
+/obj/item/gun/ballistic/proc/MagReload(mob/user)
+	if(!mag_type)
+		return FALSE
+	//typecast the user as a human
+	var/mob/living/carbon/human/H = user
+
+	//Wait a second or two so we can't spam reload too quickly. Also if this runtimes then the gun will never be reloadable again with this proc so rip
+	busy_action = TRUE
+	playsound(get_turf(H), "rustle", rand(50,100), 1, SOUND_DISTANCE(7))
+	H.visible_message(span_notice("[H] starts reloading \the [src]..."), span_notice("You start looking for some ammunition to reload \the [src] with..."), span_notice("You hear the clinking of metal..."))
+	if(!do_after(H, reloading_time, TRUE, src, TRUE, allow_movement = TRUE, stay_close = TRUE, public_progbar = TRUE))
+		busy_action = FALSE
+		return FALSE
+
+	//First, search for compatible magazines in some predictable locations. Let's not search every item on them to save compute time. Skips organs and other weird stuff by doing it this way.
+	var/list/validmags = list()
+	var/list/yourstuff = H?.contents + H?.belt?.contents + H?.back?.contents + H?.wear_suit?.contents + H?.shoes?.contents + H?.head?.contents + H?.l_store?.contents + H?.r_store?.contents + H?.s_store?.contents + H?.wear_neck?.contents
 	for(var/obj/item/ammo_box/magazine/M in yourstuff)
 		var/rounds = LAZYLEN(M.stored_ammo)
 		if(rounds > 0 && is_magazine_allowed(M))//valid mags have ammo and are allowed to be inserted into your gun

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -16,10 +16,9 @@
 		/datum/firemode/semi_auto
 	)
 	handedness = GUN_EJECTOR_ANY
-
-
 	var/select = 0 //doesn't do anything?
 	equipsound = 'sound/f13weapons/equipsounds/pistolequip.ogg'
+	reloading_time = 0.5 SECONDS
 
 /obj/item/gun/ballistic/revolver/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -35,6 +35,7 @@
 	spawnwithmagazine = TRUE
 	fire_sound = 'sound/f13weapons/shotgun.ogg'
 	cock_sound = 'sound/weapons/shotgunpump.ogg'
+	reloading_time = 0.5 SECONDS
 
 /* /obj/item/gun/ballistic/rifle/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -33,6 +33,7 @@
 	init_firemodes = list(
 		/datum/firemode/semi_auto/slower
 	)
+	reloading_time = 0.5 SECONDS
 
 /* /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value


### PR DESCRIPTION
- Added another hotkey which will reload if your active hand has a gun in it, or toggle your throw mode otherwise.
- Reloading now works with bolt action rifles, shotguns, and revolvers. ( doesn't work with the widowmaker shotgun for some reason but you'll never notice that because nobody uses it :] )
- When you use the reload hotkey with these weapons it will try to load from any ammo boxes, stripper clips, or magazines you have, but will fall back to loading single bullets/shells if necessary. Will continue to loop through the reloading process until your weapon is full or there's no more ammo left.
- Fixed the search algorithm so it will correctly check your accessory slot for magazines, boxes, and bullets.
- You can now akimbo reload if you're wielding two guns
- Fixed odd behavior with revolvers and the bolt racking quirk
- :exclamation:Reloading a magazine from your raw pocket/belt slot is still slightly buggy; beware of dropped magazines.