### PR TITLE
Increases bag sizes

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -278,7 +278,9 @@
 /obj/item/reagent_containers/food/snacks/meat/rawbacon,
 /obj/item/reagent_containers/food/snacks/grown/meatwheat,
 /obj/item/reagent_containers/food/snacks/grown/meatwheat,
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/freezer{
+	anchored = 1
+	},
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 15
@@ -5115,7 +5117,9 @@
 	dir = 8;
 	light_color = "#d8b1b1"
 	},
-/obj/structure/closet/fridge,
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -28762,7 +28766,9 @@
 	},
 /area/f13/building)
 "qlE" = (
-/obj/structure/closet/fridge,
+/obj/structure/closet/fridge{
+	anchored = 1
+	},
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/milk,
 /obj/item/reagent_containers/food/condiment/milk,

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -669,7 +669,8 @@ GLOBAL_LIST_INIT(storage_produce_bag_can_hold, typecacheof(list(
 	/obj/item/stack/sheet/leather,
 	/obj/item/stack/sheet/sinew,
 	/obj/item/stack/sheet/bone,
-	/obj/item/fishy
+	/obj/item/fishy,
+	/obj/item/disk/plantgene
 	)))
 
 GLOBAL_LIST_INIT(storage_salvage_storage_bag_can_hold, typecacheof(list(
@@ -833,14 +834,14 @@ GLOBAL_LIST_INIT(storage_tray_can_hold, typecacheof(list(
 #define STORAGE_BAG_MAX_TOTAL_SPACE STORAGE_BAG_MAX_ITEMS * STORAGE_BAG_MAX_SIZE
 
 /// How many items fit in a salvage bag
-#define STORAGE_SALVAGE_BAG_MAX_ITEMS 32
+#define STORAGE_SALVAGE_BAG_MAX_ITEMS 50
 /// How big a thing can fit in a bag thing
 #define STORAGE_SALVAGE_BAG_MAX_SIZE WEIGHT_CLASS_NORMAL
 /// How much volume fits in a bag thing
 #define STORAGE_SALVAGE_BAG_MAX_TOTAL_SPACE STORAGE_SALVAGE_BAG_MAX_ITEMS * STORAGE_SALVAGE_BAG_MAX_ITEMS
 
 /// How many items total fit in a trash bag thing
-#define STORAGE_TRASH_BAG_MAX_ITEMS STORAGE_BAG_MAX_ITEMS * 2 //28
+#define STORAGE_TRASH_BAG_MAX_ITEMS 50
 /// How big a thing can fit in a trash bag thing
 #define STORAGE_TRASH_BAG_MAX_SIZE WEIGHT_CLASS_SMALL
 /// How much volume fits in a trash bag thing


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Changes the size of trash, botany, and salvage bags to 50 instead of 38 and 34 respectively
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/95d2894a-84bc-4bc6-836f-0455535a19a6)
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/abe2cc48-cf7a-4084-8840-6bf571e1e698)

This also allows plant disks to be moved with produce bags, and fixes the fridges my dumbass forgot to anchor in my last kitchen PR (oopsies)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: bags store 50 items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
