### PR TITLE
Cutlet Equality

### DIFF
--- a/code/modules/fallout/obj/food_and_drinks/food.dm
+++ b/code/modules/fallout/obj/food_and_drinks/food.dm
@@ -204,7 +204,7 @@
 	tastes = list("rotting flesh" = 3)
 	filling_color = "#7c1104" //Dark Red
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/ghoul
-	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain
 	foodtype = RAW | MEAT | GROSS
 
 /obj/item/reagent_containers/food/snacks/meat/slab/human/centaur
@@ -218,7 +218,7 @@
 	tastes = list("abomination" = 2, "mutatated flesh" = 1)
 	filling_color = "#7c1104"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/centaur
-	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain
 	foodtype = RAW | MEAT | GROSS
 
 //WASTELAND STEAKS


### PR DESCRIPTION
## About The Pull Request
Adds cutlet variations for all the wasteland meats, so now you can whack your friends with deathclaw sausages.

Tried to keep the cutlet subtypes thematically correct with their existing meat slabs, so they're mostly just standard cutlets, but the geckos use the chicken cutlets and the rats and deathclaws use the bear cutlets, since the rats use the bear steak sprite and deathclaws just seem pretty bear-y to me. Shouldn't have any effect on the actual meat itself beyond looks since the cutlets inherit all their info from the parent slabs.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added cutlets for all the wasteland meats.
:cl:
