### PR TITLE
Solves toxinlover-ism

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1342,7 +1342,7 @@
 	M.adjustBruteLoss(-5*REM, FALSE, include_roboparts = TRUE) //A ton of healing - this is a 50 telecrystal investment.
 	M.adjustFireLoss(-5*REM, FALSE, include_roboparts = TRUE)
 	M.adjustOxyLoss(-15 * effect_mult, FALSE)
-	M.adjustToxLoss(-5*REM, FALSE)
+	M.adjustToxLoss(-5*REM, TRUE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
 	M.adjustCloneLoss(-3*REM, FALSE)
 	M.adjustStaminaLoss(-25*REM,FALSE)
@@ -1364,7 +1364,7 @@
 	M.adjustBruteLoss(-2*REM, FALSE, include_roboparts = TRUE)
 	M.adjustFireLoss(-2*REM, FALSE, include_roboparts = TRUE)
 	M.adjustOxyLoss(-5*REM, FALSE)
-	M.adjustToxLoss(-2*REM, FALSE)
+	M.adjustToxLoss(-2*REM, TRUE)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5*REM)
 	M.adjustCloneLoss(-1.25*REM, FALSE)
 	M.adjustStaminaLoss(-4*REM,FALSE)


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
makes nanites safe for toxinlovers, 1: Rare as fuck chem to get 2: it is buried under a long series of dead forums, but nukie chems are balanced strange as fuck. One of these balances was for when xenobio was actually decent, given xenobio is fucked here, and not exclusive for the toxinlover trait this balance does not work anymore.

Logically nanites that can cure your fucking dna should also ya know... not be stupid enough to kill you with toxins.

Devils advocate incoming; Magic users do still exist and can easily outpace the rate for toxinhaters, this just serves to add a small bit of extra option to act as a stepping stool to a ladder. 
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
Entirely untested gem, because it is 1 var being changed and it builds fine
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: IM SLIME STIMMINNGGG!!!!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
