### PR TITLE
Replace "New Boston" with "The Den"

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston-Upper.dmm
@@ -1,23 +1,52 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/room/dirty,
 /obj/item/lock_bolt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
 "ac" = (
-/obj/structure/flora/tree/cherryblossom{
-	plane = -2
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_x = 6
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "ad" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/structure/sink/greyscale{
+	pixel_y = 20;
+	pixel_x = 8
+	},
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = 14;
+	pixel_x = -8
+	},
+/obj/structure/toilet_paper{
+	pixel_x = -25;
+	pixel_y = 14
+	},
+/obj/structure/mirror{
+	pixel_x = 7;
+	pixel_y = 34
+	},
+/obj/structure/closet/locker/medcabinet{
+	pixel_y = 31;
+	pixel_x = -9
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "ae" = (
-/turf/closed/indestructible/vaultdoor,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#E74AE2";
+	color = "#C000FF";
+	dir = 8
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "af" = (
 /obj/structure/bed{
 	pixel_y = 10
@@ -28,14 +57,6 @@
 	},
 /obj/item/bedsheet/blue,
 /turf/open/floor/carpet/cyan,
-/area/f13/building)
-"ag" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
 /area/f13/building)
 "ai" = (
 /obj/machinery/computer/arcade{
@@ -85,22 +106,15 @@
 	},
 /area/f13/building)
 "aq" = (
-/obj/structure/railing{
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/spacevine{
-	pixel_y = -24;
-	plane = -1
+/obj/effect/turf_decal/weather/splineplain,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 1
 	},
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -1
-	},
-/obj/item/chair/stool{
-	icon_state = "bar"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "ar" = (
 /obj/structure/rack,
 /obj/item/cane,
@@ -109,7 +123,7 @@
 	},
 /area/f13/building)
 "as" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -146,8 +160,13 @@
 	},
 /area/f13/building)
 "ax" = (
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "ay" = (
 /obj/structure/chair/bench{
 	dir = 8
@@ -159,7 +178,7 @@
 "az" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aB" = (
@@ -172,29 +191,19 @@
 /area/f13/building)
 "aC" = (
 /obj/structure/decoration/rag,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine{
 	name = "vines"
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
-"aD" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "aE" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -213,8 +222,19 @@
 	},
 /area/f13/tribe)
 "aH" = (
-/turf/closed/wall/mineral/brick,
-/area/f13/wasteland/city/newboston/house)
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
+	},
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "aI" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt,
@@ -243,12 +263,14 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "aL" = (
-/obj/structure/bed/mattress,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -2
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -16
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "aM" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -261,10 +283,9 @@
 	},
 /area/f13/building/tribal)
 "aN" = (
-/obj/structure/table/booth,
-/obj/item/reagent_containers/food/snacks/meat/steak/radroach_meat,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/ore_box,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aO" = (
 /obj/structure/railing{
 	dir = 1
@@ -285,31 +306,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"aR" = (
-/obj/structure/chair/sofa/right{
-	color = "#475340"
-	},
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
-"aS" = (
-/obj/structure/bed/roller/bedroll{
-	name = "tree shaded bedroll";
-	color = "#555555"
-	},
-/obj/item/flashlight/flashdark{
-	light_on = 1;
-	dark_light_range = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
-/obj/structure/flora/tree/oak_two{
-	density = 0;
-	plane = -1;
-	pixel_x = -18;
-	pixel_y = 17
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "aV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/f13{
@@ -324,27 +320,20 @@
 /turf/open/transparent/openspace,
 /area/f13/tribe)
 "aY" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"aZ" = (
-/obj/machinery/computer/arcade/orion_trail{
-	icon_screen = "library";
-	icon_state = "oldcomp";
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/reagent_dispensers/watertank/high{
+	icon = 'icons/fallout/farming/farming_structures.dmi';
+	icon_state = "rainwater_tank"
 	},
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 9
 	},
-/turf/open/floor/carpet/arcade,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "ba" = (
 /obj/structure/campfire/wallfire{
 	color = "#645A55"
@@ -365,13 +354,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"bd" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "be" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5;
@@ -383,8 +365,8 @@
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "bg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/fireplace,
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -393,17 +375,22 @@
 "bh" = (
 /obj/structure/simple_door/house,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkrusty";
-	color = "grey"
+/obj/item/soap/deluxe,
+/obj/machinery/shower{
+	dir = 1
 	},
-/area/f13/building)
-"bi" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/structure/curtain{
+	color = "#845f58";
+	open = 0
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "bar"
+	},
+/area/f13/wasteland)
 "bj" = (
 /obj/structure/stone_tile/block{
 	dir = 1;
@@ -419,7 +406,7 @@
 /turf/open/indestructible,
 /area/f13/tcoms)
 "bl" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -463,24 +450,10 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"bp" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/building)
-"bq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "bs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "bt" = (
@@ -495,27 +468,24 @@
 	pixel_x = -8;
 	dir = 1
 	},
-/obj/structure/toilet_paper{
-	pixel_x = -25;
-	pixel_y = -4
+/obj/effect/decal/cleanable/glitter/pink{
+	layer = 3;
+	plane = -4
 	},
-/obj/structure/mirror{
-	pixel_y = -30;
-	pixel_x = 7
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/structure/closet/locker/medcabinet{
-	pixel_y = -34;
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkrusty";
-	color = "grey"
-	},
-/area/f13/building)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland)
 "bu" = (
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#E74AE2";
+	color = "#C000FF";
+	dir = 4
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "bv" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/carpet/black,
@@ -539,13 +509,11 @@
 /turf/open/indestructible/ground/outside/dirt/light,
 /area/f13/wasteland)
 "bx" = (
-/obj/structure/railing{
+/obj/structure/simple_door/room/dirty,
+/obj/item/lock_bolt{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/wasteland)
 "by" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -569,37 +537,29 @@
 	},
 /area/f13/building/tribal)
 "bB" = (
-/obj/structure/barricade/bars{
-	color = "#A47449"
-	},
-/obj/structure/window/fulltile/ruins,
 /obj/structure/railing{
 	color = "#A47449";
-	plane = -6
+	dir = 1
 	},
-/obj/structure/curtain/directional/north{
-	color = "#4B724F"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 5;
+	plane = -4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
 "bC" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/closet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"bD" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/tree/oak_five{
-	plane = -1;
-	density = 0;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "bF" = (
 /obj/structure/junk/small/bed2,
 /turf/open/floor/f13{
@@ -607,13 +567,12 @@
 	},
 /area/f13/building)
 "bH" = (
-/obj/structure/sign/poster/prewar/poster61{
-	pixel_x = 32
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 1
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetrd,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "bI" = (
 /obj/structure/spacevine{
 	color = "#225522"
@@ -623,15 +582,18 @@
 	},
 /area/f13/building/tribal)
 "bJ" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 2;
+	pixel_x = -12
 	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
 /area/f13/building)
 "bK" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2{
 	plane = -4;
 	icon_state = "cobweb1"
@@ -652,16 +614,34 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bM" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 9;
+	plane = -4
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "bP" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
 "bQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bR" = (
@@ -681,14 +661,18 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
 "bU" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/closet/crate/footlocker{
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/transparent/openspace,
+/obj/structure/sign/flag_texas{
+	pixel_y = 31
+	},
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/wasteland)
 "bV" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -707,14 +691,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "bX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rug/big/rug_fancy{
-	pixel_y = -17;
-	layer = 1;
-	color = "#334E23"
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "bY" = (
 /obj/item/kitchen/rollingpin,
 /obj/structure/table/craft_counter/bend{
@@ -745,13 +726,15 @@
 "cb" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
 /area/f13/building)
 "cd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "ce" = (
@@ -761,10 +744,6 @@
 	},
 /turf/open/water,
 /area/f13/building/tribal)
-"cf" = (
-/obj/structure/simple_door/room/dirty,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "cg" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -777,7 +756,7 @@
 /obj/structure/closet/cabinet/anchored{
 	pixel_y = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common{
@@ -785,9 +764,12 @@
 	},
 /area/f13/building)
 "ci" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
+	},
+/obj/structure/curtain/directional/north,
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "cj" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -818,39 +800,24 @@
 	},
 /area/f13/building/tribal)
 "ck" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/spacevine,
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/misc/stripper/mankini,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/clown,
+/obj/item/clothing/under/pants/chaps,
+/obj/item/clothing/under/pants/jeanshort,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/gear_harness,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/item/clothing/under/misc/stripper/green,
+/obj/structure/rug/big/rug_fancy,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "cl" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -932,10 +899,6 @@
 	color = "#A1BFFF"
 	},
 /area/f13/tribe)
-"cn" = (
-/obj/structure/table/wood/fancy/red,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "co" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -965,11 +928,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood)
-"cs" = (
-/obj/item/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "ct" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#695E56"
@@ -977,17 +935,6 @@
 /obj/structure/pondlily_big,
 /turf/open/water,
 /area/f13/building/tribal/cave)
-"cu" = (
-/obj/structure/clothes{
-	pixel_x = -2;
-	anchored = 1;
-	pixel_y = -1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"cw" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "cx" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -998,34 +945,25 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"cy" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "cz" = (
-/obj/structure/simple_door/tentflap_cloth,
-/obj/structure/spacevine{
-	opacity = 1
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/obj/machinery/light,
+/obj/structure/dresser,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "cB" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 5;
+	plane = -4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
+/obj/structure/flora/ausbushes/ywflowers{
+	randomize_xy = 0
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "cC" = (
 /obj/structure/table/booth,
 /obj/structure/table/booth,
@@ -1049,30 +987,23 @@
 	},
 /area/f13/building/tribal)
 "cF" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/obj/machinery/hydroponics/soil/pot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4";
+	color = "#CECECE"
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 3;
-	plane = -1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "cG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "cH" = (
@@ -1083,31 +1014,45 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "cJ" = (
-/obj/structure/railing{
-	plane = -2
+/obj/machinery/microwave/stove{
+	pixel_x = 18
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"cK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/table/wood/settler{
+	layer = 2.5;
+	alpha = 1;
+	pixel_x = -10
 	},
 /turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
+	icon_state = "darkrusty"
 	},
-/area/f13/caves)
+/area/f13/wasteland)
+"cK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/fake_stairs/south{
+	color = "#6F4F40"
+	},
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/obj/machinery/light/floor{
+	plane = -6
+	},
+/turf/open/floor/wood_worn{
+	color = "#6F4F40"
+	},
+/area/f13/wasteland)
 "cL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_fancy{
+	pixel_y = -16;
+	layer = 2.7
+	},
 /obj/structure/table/wood/settler,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "cM" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -1136,49 +1081,15 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"cP" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "cQ" = (
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/leather/ten,
-/obj/item/stack/sheet/hay/fifty,
-/obj/structure/closet/crate/large,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
-"cR" = (
-/obj/structure/barricade/wooden/planks{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/kink{
 	density = 0;
-	pixel_y = 3;
-	plane = -14
+	pixel_y = 31
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"cS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "cT" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -1205,7 +1116,7 @@
 	},
 /area/f13/building/tribal)
 "cU" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -1214,8 +1125,12 @@
 /obj/structure/flora/ausbushes/brflowers{
 	plane = -2
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/wasteland)
 "cW" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -1242,20 +1157,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "db" = (
-/obj/structure/towel_rack{
-	pixel_x = 32
+/obj/structure/railing{
+	pixel_y = -4;
+	plane = -6;
+	color = "#BECD44";
+	pixel_x = -1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_x = 8
-	},
-/obj/machinery/light{
-	pixel_x = 16
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "dc" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain/directional/south{
@@ -1264,13 +1173,28 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "dd" = (
-/obj/structure/chair/sofa/left{
-	color = "#4B724F";
-	dir = 8;
-	pixel_x = 8
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 5;
+	plane = -4
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/flora/tree/jungle{
+	color = "#999999";
+	pixel_x = -56
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "de" = (
 /obj/structure/barricade/wooden/planks{
 	density = 0;
@@ -1291,7 +1215,7 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "df" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks{
 	pixel_y = 27;
 	pixel_x = -2;
@@ -1308,12 +1232,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"dh" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "di" = (
 /turf/open/transparent/openspace,
 /area/f13/building)
@@ -1331,7 +1249,9 @@
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "dl" = (
 /obj/structure/decoration/rag,
-/turf/closed/wall/mineral/brick,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
 /area/f13/building)
 "dm" = (
 /obj/machinery/light/broken{
@@ -1378,33 +1298,19 @@
 /area/f13/wasteland)
 "dv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "dw" = (
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
+/obj/structure/fireplace{
+	dir = 4;
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/obj/machinery/shower{
-	pixel_y = 13
-	},
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
-"dx" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "dz" = (
 /obj/structure/railing/wood{
 	dir = 4
@@ -1455,15 +1361,15 @@
 /turf/open/transparent/openspace,
 /area/f13/caves)
 "dG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/double,
 /obj/item/bedsheet/doublesheet,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#888888"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "dH" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -1501,8 +1407,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood)
 "dK" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/splineplain,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 1
+	},
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "dL" = (
 /obj/structure/bookcase/manuals,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -1516,34 +1430,21 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "dN" = (
-/obj/structure/simple_door/interior,
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
-"dO" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheet{
+	color = "#4B724F"
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/tree/oak_two{
+/obj/structure/table/wood/settler{
 	density = 0;
-	plane = -1;
-	pixel_x = -2;
-	pixel_y = 22
+	alpha = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_worn{
+	color = "#FDF2C3"
+	},
+/area/f13/wasteland)
 "dP" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -1561,30 +1462,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"dR" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"dS" = (
-/obj/structure/railing/wood/post{
-	pixel_x = -13;
-	pixel_y = 17
-	},
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/curtain{
-	color = "#363636";
-	layer = 5
-	},
-/obj/structure/railing/wood/post{
-	pixel_x = 16;
-	pixel_y = 17
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "dU" = (
 /obj/structure/sink{
 	icon_state = "water";
@@ -1668,19 +1545,12 @@
 /turf/open/floor/carpet/blue,
 /area/f13/building)
 "dX" = (
-/obj/structure/simple_door/interior,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
-"dZ" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "ea" = (
 /obj/structure/bed/old,
 /turf/open/floor/f13{
@@ -1691,15 +1561,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/vault,
 /area/f13/brotherhood)
-"ec" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "ed" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -1721,12 +1582,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"eg" = (
-/obj/structure/railing,
-/turf/open/floor/wood_common{
-	icon_state = "common-broken3"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "eh" = (
 /obj/structure/closet/crate/wicker{
 	pixel_y = 8
@@ -1747,14 +1602,14 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "ej" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "ek" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "el" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "em" = (
@@ -1763,16 +1618,15 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "en" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/storage/box/dice{
-	pixel_y = 7
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/flora/ausbushes/ywflowers{
+	randomize_xy = 0
 	},
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/obj/structure/flora/tree/cherryblossom4,
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "ep" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -1791,25 +1645,8 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"es" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = 6;
-	layer = 3.1
-	},
-/obj/item/lighter/heart,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "et" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eu" = (
@@ -1843,11 +1680,16 @@
 	},
 /area/f13/building/tribal)
 "ey" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/fake_stairs/south{
+	color = "#A47449"
 	},
-/area/f13/building)
+/obj/structure/curtain/directional/south{
+	color = "#4B724F"
+	},
+/turf/open/floor/wood_worn{
+	color = "#FDF2C3"
+	},
+/area/f13/wasteland)
 "ez" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -1867,7 +1709,7 @@
 	},
 /area/f13/building)
 "eB" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -1887,48 +1729,41 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eD" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
-"eE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"eF" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/building)
-"eG" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
+/obj/structure/table/wood/settler{
+	density = 0;
+	pixel_x = -10
 	},
+/obj/item/storage/fancy/cigarettes/cigpack_robustgold{
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/cigarette{
+	pixel_y = 14;
+	pixel_x = -10
+	},
+/obj/item/kirbyplants{
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi';
+	icon_state = "pot_3";
+	pixel_y = 4;
+	pixel_x = -14
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
+"eE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola{
+	pixel_y = 31;
+	density = 0
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"eG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_fancy,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland)
 "eH" = (
 /obj/structure/stone_tile/slab{
@@ -1938,52 +1773,32 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"eI" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building)
 "eJ" = (
-/obj/structure/rug/mat/welcome{
-	pixel_y = 7
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/wasteland)
+"eK" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
+"eP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/snescontroller{
+	pixel_x = -22;
+	pixel_y = 2
 	},
 /turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
-"eK" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"eL" = (
-/obj/structure/simple_door/metal/barred,
-/obj/structure/decoration/rag,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/caves)
-"eM" = (
-/obj/structure/chair/sofa/left{
-	dir = 8;
-	color = "#990033"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"eP" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/wasteland)
 "eQ" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteenXnineteen,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "bar"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/area/f13/wasteland)
 "eR" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
@@ -1999,19 +1814,22 @@
 	},
 /area/f13/building)
 "eV" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"eW" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/obj/structure/curtain/directional/south{
+	color = "#845f58"
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "eX" = (
 /obj/structure/rack/shelf_wood,
 /obj/item/crafting/abraxo,
 /obj/item/crafting/abraxo,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2{
 	plane = -4;
 	icon_state = "cobweb1"
@@ -2019,7 +1837,7 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "eY" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -2036,105 +1854,18 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"eZ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+"fd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cigarette{
+	density = 0;
+	pixel_y = 20
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/branch_broken{
-	plane = -4
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"fa" = (
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"fb" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/spacevine,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"fc" = (
-/obj/structure/rack/shelf_metal/modern,
-/obj/item/storage/belt/xenoarch/full{
-	pixel_y = -4
-	},
-/obj/item/storage/belt/xenoarch/full,
-/obj/item/storage/belt/xenoarch/full{
-	pixel_y = 4
-	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"ff" = (
+/obj/structure/cave/stalagmite/three,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"fd" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"ff" = (
-/obj/structure/table,
-/obj/machinery/processor/chopping_block,
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"fg" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/clothes{
-	pixel_x = 31;
-	anchored = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "fh" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/ladder/unbreakable{
@@ -2147,15 +1878,11 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"fi" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
 "fk" = (
 /obj/structure/table,
 /obj/structure/table,
 /obj/machinery/processor/chopping_block,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fl" = (
@@ -2179,14 +1906,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fn" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/closet/fridge{
+	pixel_x = 6
 	},
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/common_food{
+	pixel_x = 6
+	},
+/obj/effect/spawner/lootdrop/f13/common_food{
+	pixel_x = 6
+	},
+/obj/effect/spawner/lootdrop/f13/common_food{
+	pixel_x = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "fp" = (
 /obj/item/warpaint_bowl{
 	pixel_y = 11
@@ -2212,30 +1947,6 @@
 	name = "spring water"
 	},
 /area/f13/building/tribal)
-"ft" = (
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "fu" = (
 /obj/structure/chair/comfy/shuttle{
 	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
@@ -2307,11 +2018,11 @@
 /area/f13/tribe)
 "fC" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/spacevine{
-	name = "vines"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "fD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -2324,12 +2035,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"fE" = (
-/obj/structure/table,
-/obj/structure/table,
-/obj/machinery/processor/chopping_block,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "fF" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/spearquiver/empty,
@@ -2349,15 +2054,30 @@
 	},
 /area/f13/tribe)
 "fH" = (
-/obj/structure/closet/cabinet/anchored,
-/obj/effect/spawner/lootdrop/clothing_low,
-/obj/effect/spawner/lootdrop/f13/trash_toys,
-/obj/item/toy/cards/deck,
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/structure/sink/greyscale{
+	pixel_y = 20;
+	pixel_x = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = 14;
+	pixel_x = -8
+	},
+/obj/structure/toilet_paper{
+	pixel_x = -25;
+	pixel_y = 14
+	},
+/obj/structure/mirror{
+	pixel_x = 7;
+	pixel_y = 34
+	},
+/obj/structure/closet/locker/medcabinet{
+	pixel_y = 31;
+	pixel_x = -9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/wasteland)
 "fI" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8;
@@ -2385,19 +2105,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"fM" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
-"fN" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "fO" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common{
@@ -2425,27 +2132,16 @@
 	},
 /area/f13/caves)
 "fR" = (
-/obj/structure/table/wood/settler,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/chisel,
-/obj/structure/railing,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
-"fS" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen{
+	pixel_y = 19;
+	layer = 1.9
 	},
-/obj/structure/flora/tree/oak_five{
-	plane = -1;
-	density = 0;
-	pixel_y = 19
+/obj/structure/table/wood_counter{
+	pixel_y = 3
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "fT" = (
 /obj/structure/table/wood/settler,
 /obj/item/crowbar/crude,
@@ -2524,7 +2220,7 @@
 	},
 /area/f13/building/tribal)
 "fY" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -2537,8 +2233,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "fZ" = (
 /obj/item/plant_analyzer,
 /obj/item/shovel/spade,
@@ -2563,19 +2262,14 @@
 	},
 /area/f13/tribe)
 "ga" = (
-/obj/structure/nightstand/small{
-	pixel_x = 2
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
-/obj/item/flashlight/littlelamp{
-	pixel_x = 1;
-	pixel_y = 2
+/obj/structure/curtain/directional/east{
+	color = "#334E23"
 	},
-/obj/structure/rug/carpet4,
-/obj/structure/nightstand/small{
-	pixel_x = 2
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "gb" = (
 /obj/structure/chair/bench{
 	dir = 8
@@ -2594,30 +2288,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
-"gc" = (
-/obj/structure/cave/bigboards/westeast/four,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "gd" = (
-/obj/structure/closet/cabinet{
-	pixel_y = 22;
-	pixel_x = 4;
-	density = 0
+/obj/structure/curtain/directional/east{
+	color = "#845f58"
 	},
-/obj/item/clothing/under/dress/coyote/dinerdressmint{
-	pixel_x = 5;
-	pixel_y = 20
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
 	},
-/obj/item/clothing/under/dress/coyote/dinerdresspink{
-	pixel_y = 20;
-	pixel_x = 5
-	},
-/obj/item/clothing/under/kuddles/rattyskirtgreen{
-	pixel_y = 22;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "ge" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -2626,15 +2306,12 @@
 	},
 /area/f13/building)
 "gf" = (
-/obj/structure/curtain{
-	color = "#87A392";
-	layer = 5;
-	pixel_y = -1
+/obj/structure/window/fulltile/ruins,
+/obj/structure/curtain/directional/north{
+	color = "#334E23"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "gg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -2655,23 +2332,11 @@
 	name = "spring water"
 	},
 /area/f13/tribe)
-"gj" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "gl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "gm" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 4
@@ -2700,8 +2365,8 @@
 	},
 /area/f13/tribe)
 "go" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/support{
 	pixel_y = 26;
 	icon_state = "support_wall";
@@ -2725,12 +2390,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"gr" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
 "gt" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/glass,
@@ -2741,37 +2400,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "gu" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder/constructed,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/structure/bookcase,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_five)
-"gv" = (
-/obj/structure/dresser{
-	pixel_y = 10
-	},
+/area/f13/wasteland)
+"gx" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
 	dir = 8;
 	pixel_y = 28
 	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
-"gx" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/area/f13/wasteland)
 "gz" = (
 /obj/structure/railing{
 	dir = 1
@@ -2801,11 +2445,11 @@
 /area/f13/building)
 "gD" = (
 /obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "gE" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "gF" = (
@@ -2821,12 +2465,6 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
-"gH" = (
-/obj/structure/fireplace{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "gI" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -2845,25 +2483,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gL" = (
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"gM" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/area/f13/wasteland)
 "gO" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -2876,22 +2505,38 @@
 	},
 /area/f13/tribe)
 "gP" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "gQ" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"gR" = (
-/obj/structure/clothes{
-	pixel_x = -2;
-	anchored = 1
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/transparent/openspace,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 6;
+	plane = -4
+	},
+/obj/structure/table/wood/settler{
+	plane = -3
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_pyramid{
+	plane = -1;
+	pixel_y = 4
+	},
+/obj/item/lighter{
+	plane = -1;
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken5";
+	color = "#CECECE"
+	},
 /area/f13/wasteland)
 "gS" = (
 /obj/structure/closet/cabinet{
@@ -2930,7 +2575,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio44"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "gY" = (
@@ -2959,15 +2604,6 @@
 	name = "sand pit"
 	},
 /area/f13/building/tribal)
-"hc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "hd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3000,51 +2636,18 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"hg" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
 "hh" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/concrete{
 	desc = "A pre-War wall made of solid concrete."
 	},
 /area/f13/building)
-"hi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "hj" = (
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/wood_common{
-	icon_state = "common-broken2"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "hl" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt,
@@ -3058,15 +2661,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"hm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "hn" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -3088,7 +2682,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -3125,18 +2719,11 @@
 /turf/open/floor/wood_common,
 /area/f13/caves)
 "hr" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "ht" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -3166,13 +2753,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"hv" = (
-/obj/structure/chair/sofa/corner{
-	color = "#990000";
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "hw" = (
 /obj/structure/flora/tallgrass3,
 /obj/effect/turf_decal/weather/dirt{
@@ -3187,14 +2767,11 @@
 	},
 /area/f13/tribe)
 "hx" = (
-/obj/structure/rug/big/rug_blue_shag{
-	layer = 1;
-	color = "#4B724F";
-	dir = 8;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "hy" = (
 /turf/open/indestructible/ground/outside/gravel{
 	color = "#777777"
@@ -3208,30 +2785,18 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"hA" = (
-/obj/structure/bookcase,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"hB" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "hC" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain/directional/east{
+	color = "#450159"
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "hD" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -3242,12 +2807,12 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "hE" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
 /obj/item/clothing/glasses/f13/biker,
 /obj/item/tattoo_gun,
 /obj/item/razor,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hF" = (
@@ -3256,13 +2821,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"hG" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor2";
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
 "hI" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/table/booth,
@@ -3277,15 +2835,12 @@
 	},
 /area/f13/building/tribal)
 "hK" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"hL" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/simple_door/dirtyglass,
+/obj/item/lock_bolt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "hM" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -3304,33 +2859,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/building)
-"hP" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 9
-	},
-/obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#000000";
-	name = "shadow";
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 1
-	},
-/obj/item/flashlight/lantern/dim{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/turf/open/floor/f13/wood,
 /area/f13/building)
 "hQ" = (
 /obj/structure/filingcabinet,
@@ -3371,36 +2899,14 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "hU" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/structure/chair/office/dark{
+	dir = 4;
+	pixel_y = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2;
-	pixel_y = 15
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "hX" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -3412,14 +2918,13 @@
 	},
 /area/f13/building/tribal)
 "hZ" = (
-/obj/structure/rack/shelf_wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/machinery/reagentgrinder{
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 8;
+	color = "aqua"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "ia" = (
 /obj/structure/chair/bench,
 /turf/open/floor/wood_common{
@@ -3431,10 +2936,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ic" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to New Boston Nightclub, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "id" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -3469,6 +2976,15 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"ig" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
+/area/f13/building)
 "ih" = (
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
@@ -3490,7 +3006,9 @@
 	color = "#a98c5d";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/destructible/tribal_torch/wall/lit{
 	layer = 3
 	},
@@ -3517,7 +3035,7 @@
 /obj/item/paper/fluff/ruins/listeningstation/reports/september,
 /obj/item/paper/fluff/ruins/listeningstation/reports/october,
 /obj/item/paper/fluff/ruins/listeningstation/receipt,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/paper/fluff/ruins/listeningstation/odd_report,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
@@ -3551,10 +3069,9 @@
 	},
 /area/f13/building/tribal)
 "in" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 10
-	},
-/area/f13/building)
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "io" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6;
@@ -3581,7 +3098,7 @@
 	},
 /area/f13/brotherhood)
 "ir" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/room/dirty,
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -3607,25 +3124,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"iv" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "iw" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -23;
-	plane = -3
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/toy/cards/deck/cas,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "ix" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -3645,24 +3152,19 @@
 	},
 /area/f13/tribe)
 "iy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "iz" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "iA" = (
-/obj/structure/barricade/tentclothcorner{
-	dir = 4
-	},
-/obj/structure/barricade/tentclothedge{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "iB" = (
 /obj/structure/sign/barsign{
 	icon_state = "the_lightbulb"
@@ -3672,15 +3174,23 @@
 	},
 /area/f13/building)
 "iD" = (
-/obj/structure/railing{
-	dir = 5
+/obj/structure/fluff/beach_umbrella/science{
+	pixel_y = -17;
+	pixel_x = -15;
+	layer = 3.1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "iE" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2";
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "iF" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13;
@@ -3698,15 +3208,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"iG" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "iH" = (
 /obj/structure/simple_door/metal/fence/wooden{
 	dir = 2
@@ -3717,13 +3218,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"iI" = (
-/obj/structure/chair/sofa/right{
-	dir = 1;
-	color = "#990000"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "iJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -3745,18 +3239,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"iL" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"iM" = (
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "iN" = (
 /obj/structure/chair/sofa/right{
 	color = "#353535";
@@ -3764,44 +3246,19 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"iO" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-17";
-	pixel_y = 18;
-	pixel_x = 5
-	},
-/obj/structure/mirror/alt{
-	pixel_y = 34;
-	pixel_x = -16
-	},
-/obj/structure/towel_rack{
-	pixel_y = 31;
-	pixel_x = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	color = "#ADDEBA"
-	},
-/area/f13/building)
-"iP" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
 "iQ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/sofa/corner{
+	dir = 1;
+	color = "#333333"
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/paper/fluff/ruins/listeningstation/reports/november,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
-"iR" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetmime,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#3B2C25"
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "iS" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/reagent_containers/glass/bucket/wood{
@@ -3816,32 +3273,15 @@
 	},
 /area/f13/building/tribal)
 "iT" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/chair/wood{
+	dir = 1;
+	pixel_y = 15
 	},
-/area/f13/building)
-"iU" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "iV" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -3873,15 +3313,22 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "iY" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio33"
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_one_access_txt = "136"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "iZ" = (
@@ -3895,50 +3342,26 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"ja" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "jb" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+/obj/item/toy/plush/blackcat{
+	pixel_y = 15;
+	pixel_x = 6
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#3B2C25"
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4;
-	icon_state = "cobweb1"
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
 /area/f13/wasteland)
 "jc" = (
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/machinery/light_switch{
-	pixel_x = 22
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/bed/wooden,
-/turf/open/floor/carpet,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "jd" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -3952,9 +3375,24 @@
 	},
 /area/f13/building)
 "je" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/obj/structure/fluff/divine/convertaltar{
+	pixel_y = 20;
+	pixel_x = 1
+	},
+/obj/structure/railing{
+	pixel_y = -3;
+	color = "#BECD44";
+	plane = -2;
+	pixel_x = -1
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#BECD44"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "jf" = (
 /obj/structure/fluff/railing{
 	dir = 5
@@ -3965,34 +3403,31 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "jg" = (
-/obj/structure/toilet{
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
+/obj/effect/turf_decal/weather/splineplain,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/wasteland/city/newboston/house)
-"jh" = (
-/obj/machinery/light{
-	icon_state = "tube-burned"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
+"jh" = (
+/obj/item/lipstick,
+/obj/item/lipstick/black,
+/obj/structure/mirror{
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -4006,23 +3441,24 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/chair/wood{
-	plane = -6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
+/obj/structure/closet/crate/footchest{
+	pixel_x = -1;
+	pixel_y = 7
 	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/obj/item/toy/plush/borgplushie/meddrake,
+/obj/item/toy/plush/dr_scanny,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "jk" = (
 /obj/structure/simple_door/wood,
-/obj/structure/barricade/wooden{
-	layer = 3.5;
-	obj_integrity = 5;
-	name = "weak wooden boarding"
+/obj/item/lock_bolt{
+	dir = 8
 	},
 /obj/structure/barricade/wooden/crude{
 	layer = 3.4;
@@ -4032,8 +3468,8 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland/city/newboston/house/cabin_four)
 "jl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/f13/building)
@@ -4053,26 +3489,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"jo" = (
-/obj/structure/closet/crate/wicker,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"jp" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house)
-"jq" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "jr" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -4085,14 +3501,31 @@
 	},
 /area/f13/wasteland)
 "js" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/table/wood/settler{
+	layer = 3;
+	pixel_y = -2
 	},
-/obj/structure/railing{
-	plane = -2
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -13;
+	pixel_y = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/trash/plate{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/candle/infinite{
+	layer = 3.1;
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/cool_book/warandpeace{
+	pixel_x = 7
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "jt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4120,86 +3553,26 @@
 	},
 /area/f13/building/tribal)
 "jw" = (
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants{
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi';
+	icon_state = "pot_2";
+	pixel_y = 12;
+	pixel_x = 6
 	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
+/obj/item/reagent_containers/glass/maunamug,
+/obj/structure/table/wood_counter{
+	dir = 4
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "jy" = (
-/obj/structure/chair/sofa/corner{
-	color = "#990033";
-	dir = 8;
-	pixel_x = 7
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"jz" = (
-/obj/item/chair/stool{
-	icon_state = "bar"
-	},
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"jA" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
-"jB" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/south,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"jC" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/cave/stalagmite/two,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jD" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"jE" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "jF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4;
@@ -4222,48 +3595,15 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"jI" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
-"jK" = (
-/obj/machinery/shower{
+"jO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheetrd,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/wasteland/city/newboston/house/cabin_five)
-"jL" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
-	},
+/turf/open/floor/carpet/purple,
 /area/f13/wasteland)
-"jM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
-"jN" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
-/area/f13/building)
-"jO" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/outdoors)
 "jP" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -4279,7 +3619,7 @@
 	},
 /area/f13/tribe)
 "jQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -4287,9 +3627,9 @@
 "jR" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/slime_extract/grey,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "jS" = (
@@ -4299,10 +3639,6 @@
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
-/area/f13/building)
-"jT" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/carpet/red,
 /area/f13/building)
 "jV" = (
 /obj/machinery/chem_dispenser,
@@ -4336,16 +3672,14 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/reagent_containers/food/condiment/rice,
 /obj/item/storage/box/condimentbottles,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jX" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "jY" = (
 /obj/item/paper_bin{
 	pixel_x = 16;
@@ -4363,17 +3697,23 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "ka" = (
-/obj/structure/weightlifter,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"kb" = (
-/obj/structure/chair/metal{
-	icon = 'icons/obj/objects2.dmi';
-	icon_state = "shuttle_chair_r";
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 10;
+	plane = -4
+	},
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "kc" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/f13{
@@ -4409,14 +3749,12 @@
 	},
 /area/f13/tribe)
 "kg" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "ki" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -4432,24 +3770,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"kj" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
 "kk" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13{
@@ -4457,11 +3777,14 @@
 	},
 /area/f13/building)
 "kl" = (
-/obj/structure/railing/corner{
-	color = "#A47449"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy/purple{
+	dir = 4;
+	pixel_y = -2;
+	pixel_x = -4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
 "km" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -4521,10 +3844,17 @@
 /turf/closed/indestructible/rock,
 /area/f13/caves)
 "kq" = (
-/turf/open/floor/wood_common{
-	icon_state = "common-broken2"
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
+"ks" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "kt" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -4538,7 +3868,7 @@
 	},
 /area/f13/tribe)
 "ku" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 10
 	},
@@ -4559,10 +3889,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"kx" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "kz" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt,
@@ -4584,29 +3910,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"kB" = (
-/obj/structure/chair/sofa{
-	dir = 1;
-	color = "#990033";
-	pixel_x = 7
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"kC" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
-"kD" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
 "kE" = (
 /obj/structure/stone_tile/block{
 	pixel_x = -17
@@ -4620,6 +3923,18 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
+"kF" = (
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
+/area/f13/building)
 "kG" = (
 /obj/structure/spacevine{
 	name = "vines"
@@ -4640,19 +3955,16 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "kI" = (
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/building)
-"kJ" = (
-/obj/item/lock_bolt,
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/area/f13/wasteland)
 "kK" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -4664,19 +3976,15 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"kL" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "kM" = (
-/obj/structure/rug/mat/welcome,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "kN" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/toggle/labcoat/scribecoat,
@@ -4689,69 +3997,9 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kP" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"kQ" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"kS" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = -5;
-	layer = 3.1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
 "kU" = (
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kV" = (
-/obj/structure/table/wood/settler,
-/obj/item/trash/plate,
-/obj/item/candle/infinite{
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/building)
-"kW" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "kX" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/drinks/dry_ramen,
@@ -4760,7 +4008,7 @@
 /obj/item/reagent_containers/food/drinks/dry_ramen,
 /obj/item/reagent_containers/food/drinks/dry_ramen,
 /obj/item/reagent_containers/food/drinks/dry_ramen,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -4777,7 +4025,7 @@
 /area/f13/building)
 "kZ" = (
 /obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
@@ -4787,9 +4035,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"lb" = (
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "lc" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/greyscale,
@@ -4814,18 +4059,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "lf" = (
-/obj/structure/railing{
-	color = "#A47449"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp/left{
+	dir = 1;
+	pixel_x = 8;
+	color = "grey"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"lg" = (
-/obj/structure/punching_bag{
-	color = "#292929";
-	pixel_x = -6
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "lh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4845,68 +4086,62 @@
 	},
 /area/f13/tribe)
 "lj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"lk" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/area/f13/wasteland)
 "ll" = (
-/obj/structure/chair/office/dark,
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/item/bikehorn/rubberducky,
+/obj/structure/decoration/vent,
+/obj/structure/curtain{
+	color = "#450159"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
 "lm" = (
-/obj/structure/campfire/barrel{
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 6;
 	plane = -4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/support{
 	pixel_y = 26;
 	icon_state = "support_wall";
 	anchored = 1
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/indestructible/ground/outside/civ/grass0,
 /area/f13/wasteland)
 "ln" = (
-/obj/structure/bed/roller/bedroll{
-	name = "tree shaded bedroll";
-	color = "#555555"
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/item/flashlight/flashdark{
-	light_on = 1;
-	dark_light_range = 1;
-	mouse_opacity = 0;
-	alpha = 0
+/obj/machinery/computer/terminal{
+	dir = 4;
+	doc_content_1 = "I'd like to report a crime happening at your house, Officer Mack. Your house is about to burn for the crimes you committed against the People's Republic of China! I hope your sleeping family wakes up in time.. GLORY TO CHINA.";
+	doc_title_1 = "Crime Report."
 	},
-/obj/structure/flora/tree/oak_two{
-	density = 0;
-	plane = -1;
-	pixel_x = -18;
-	pixel_y = 25
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "lo" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
+/obj/structure/chair/pew/left{
+	dir = 8
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "lq" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -4943,33 +4178,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/f13/building)
-"lt" = (
-/obj/machinery/light{
-	pixel_x = 16
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
 "lv" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/table/wood/settler,
+/obj/machinery/computer/terminal{
+	termtag = "Public"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
+	dir = 1
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "lw" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -4980,18 +4205,19 @@
 /obj/machinery/shower{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/obj/structure/curtain{
-	color = "#363636"
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
+	dir = 8
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/dark{
-	icon_state = "darkrusty";
-	color = "grey"
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "ly" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -5009,12 +4235,6 @@
 	color = "#777777"
 	},
 /area/f13/building/tribal)
-"lB" = (
-/obj/structure/flora/tree/cherryblossom{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "lC" = (
 /obj/structure/chair/bench{
 	dir = 1
@@ -5026,7 +4246,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "lD" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
 /obj/item/grown/log/tree,
@@ -5060,9 +4280,9 @@
 	},
 /area/f13/building/tribal)
 "lH" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_y = 26;
 	density = 0
@@ -5070,12 +4290,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "lI" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/sink/deep_water{
+	name = "bath water";
+	alpha = 1;
+	desc = "Nice warm water for bathing."
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	color = "#93BC9E";
 	dir = 1
 	},
-/turf/open/floor/wood_mosaic/wood_mosaic_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/indestructible/ground/outside/water{
+	name = "bath water";
+	desc = "Nice warm water for bathing."
+	},
+/area/f13/wasteland)
 "lJ" = (
 /obj/structure/table/wood/settler,
 /obj/structure/bookshelf{
@@ -5090,7 +4323,7 @@
 	},
 /area/f13/building)
 "lL" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
 /area/f13/building)
 "lM" = (
@@ -5137,66 +4370,45 @@
 	},
 /area/f13/building/tribal)
 "lO" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"lP" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"lQ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"lR" = (
-/obj/structure/chair/right{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"lS" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
-"lT" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheet{
-	color = "#706551"
+/obj/machinery/light/sign{
+	icon_state = "roulette_act";
+	name = "billards table";
+	desc = "A table for a game of billards";
+	layer = 2;
+	plane = -6
 	},
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
+/obj/structure/table/wood/settler{
+	layer = 2.5;
+	alpha = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"lP" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
+"lQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
+"lR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/wasteland)
+"lS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#90FF6E";
+	color = "lime"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "lU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -5213,17 +4425,20 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "lW" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/floor{
+	plane = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/wood_worn{
+	color = "#6F4F40"
+	},
+/area/f13/wasteland)
 "lX" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5236,9 +4451,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/building)
-"lZ" = (
-/turf/open/floor/carpet/purple,
 /area/f13/building)
 "mb" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5279,40 +4491,29 @@
 	},
 /area/f13/tribe)
 "me" = (
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_fancy{
+	pixel_y = -17;
+	layer = 1;
+	color = "#334E23"
 	},
-/obj/item/reagent_containers/rag/towel/random,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "mf" = (
-/turf/closed/indestructible/riveted/boss{
-	name = "ancient wall"
+/obj/effect/fake_stairs/west{
+	color = "#845f58";
+	dir = 2
 	},
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "mg" = (
-/obj/machinery/button/door{
-	id = "xenobio44";
-	name = "Containment Blast Doors";
-	pixel_y = 36;
-	req_access_txt = null;
-	pixel_x = 5;
-	req_one_access_txt = null
+/turf/closed/wall/f13/wood{
+	color = "#cababa"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
-"mi" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 6;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/area/f13/wasteland)
 "mj" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
@@ -5352,31 +4553,17 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"mn" = (
-/obj/structure/chair/sofa/right{
-	color = "#475340";
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "mo" = (
-/obj/structure/rug/mat/welcome{
-	pixel_y = -7;
-	pixel_x = -7
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"mp" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/ladder/unbreakable{
-	id = "nbguardtower";
-	height = 2
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "mq" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -5385,10 +4572,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"mr" = (
-/obj/structure/bed/dogbed,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "ms" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/turf_decal/weather/dirt{
@@ -5422,20 +4605,6 @@
 	},
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
-"mu" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/structure/closet/cabinet/anchored{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "mv" = (
 /obj/structure/chair/comfy/beige,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5459,7 +4628,7 @@
 	},
 /area/f13/building)
 "mz" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building)
 "mB" = (
@@ -5472,81 +4641,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mC" = (
-/obj/structure/closet/fridge,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -2
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"mD" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical"
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
-	},
-/turf/open/floor/wood_common,
-/area/f13/building)
-"mE" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink{
-	pixel_y = 20;
-	layer = 1.9
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#FF8CC9";
+	color = "#FF72D5"
 	},
-/obj/structure/mirror/alt{
-	pixel_y = 30
-	},
-/obj/item/soap{
-	pixel_y = 6
-	},
-/obj/structure/table/wood_counter{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "mF" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mG" = (
-/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
 /turf/open/floor/carpet/purple,
-/area/f13/building)
+/area/f13/wasteland)
 "mH" = (
 /obj/structure/rack,
 /obj/item/twohanded/fireaxe/bmprsword,
 /obj/item/twohanded/fireaxe/bmprsword,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"mI" = (
-/obj/structure/closet/cabinet/anchored{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
-"mJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"mK" = (
-/obj/item/kirbyplants,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "mL" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/structure/barricade/wooden/strong,
@@ -5613,8 +4730,8 @@
 	},
 /area/f13/building/tribal)
 "mR" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "mS" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table/greyscale,
@@ -5630,18 +4747,24 @@
 	},
 /area/f13/wasteland)
 "mT" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -26;
-	plane = -3;
-	pixel_x = -3
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "mU" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/splineplain,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "mV" = (
 /obj/item/vending_refill/coffee,
 /obj/item/vending_refill/coffee,
@@ -5691,23 +4814,24 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"nb" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "nc" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
 /obj/structure/railing{
-	pixel_y = -3
+	color = "#A47449";
+	plane = -6;
+	dir = 4;
+	pixel_y = -10
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/curtain/directional/west{
+	color = "#4B724F"
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "nd" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -5731,15 +4855,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"nf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/footchest,
-/obj/item/clothing/head/coyote/sheeppelt,
-/obj/item/clothing/head/helmet/f13/khan/pelt,
-/obj/item/clothing/neck/mantle/peltfur,
-/obj/item/clothing/head/coyote/blackcape,
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
 "ng" = (
 /obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/f13{
@@ -5768,7 +4883,7 @@
 /obj/item/multitool{
 	pixel_x = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/lamp{
 	pixel_y = 14
 	},
@@ -5806,19 +4921,14 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"nn" = (
-/obj/machinery/light,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "no" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/machinery/light{
+	pixel_x = 16
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "nq" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 4
@@ -5828,9 +4938,9 @@
 	},
 /area/f13/tribe)
 "nr" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/obj/structure/cave/bigboards/westeast/one,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ns" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -5874,7 +4984,7 @@
 	},
 /area/f13/building/tribal)
 "nu" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -5891,8 +5001,8 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "nv" = (
 /obj/structure/table/wood/settler,
 /obj/item/stack/wrapping_paper,
@@ -5929,16 +5039,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"nB" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/rum/empty,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	pixel_y = 10;
-	pixel_x = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "nC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -5990,12 +5090,21 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
 "nI" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/machinery/computer/arcade/amputation,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/carpet/arcade,
+/area/f13/wasteland)
 "nK" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain/directional/north{
@@ -6031,7 +5140,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/disk/xenobio_console_upgrade/monkey,
 /obj/item/disk/xenobio_console_upgrade/slimebasic,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -6083,26 +5192,25 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"nS" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "nT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
+/obj/item/book{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/regular/protected{
+	pixel_y = 10;
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bookcase{
+	density = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
 "nU" = (
 /obj/structure/flora/tallgrass3,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -6113,60 +5221,25 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"nV" = (
-/obj/structure/railing{
-	color = "#A47449";
+"nW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	light_color = "#E74AE2";
+	color = "#C000FF";
+	dir = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"oa" = (
+/obj/effect/turf_decal/weather/splineplain{
 	dir = 4
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
-"nW" = (
-/obj/structure/sign/poster/contraband/pinup_shower{
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
-"nX" = (
-/obj/structure/sink/greyscale{
-	pixel_y = 20;
-	pixel_x = 8
-	},
-/obj/structure/toilet{
-	color = "#D1D1D1";
-	pixel_y = 14;
-	pixel_x = -8
-	},
-/obj/structure/toilet_paper{
-	pixel_x = -25;
-	pixel_y = 14
-	},
-/obj/structure/mirror{
-	pixel_x = 7;
-	pixel_y = 34
-	},
-/obj/structure/closet/locker/medcabinet{
-	pixel_y = 31;
-	pixel_x = -9
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
-"nY" = (
-/obj/structure/rug/carpet3{
-	layer = 2.8
-	},
-/turf/open/floor/carpet,
-/area/f13/wasteland/city/newboston/house)
-"oa" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"ob" = (
-/obj/structure/simple_door/room/dirty,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "oc" = (
 /obj/structure/chair/bench,
 /turf/open/floor/plasteel/cult,
@@ -6186,27 +5259,6 @@
 /obj/effect/spawner/bundle/costume/plaguedoctor,
 /turf/open/floor/carpet/blue,
 /area/f13/building)
-"of" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/west,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"og" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "oh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa{
@@ -6217,10 +5269,17 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "oi" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 10;
+	plane = -4
 	},
-/turf/closed/wall/mineral/brick,
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
 /area/f13/building)
 "oj" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -6228,33 +5287,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"ok" = (
-/obj/structure/bookshelf{
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/building)
-"ol" = (
-/obj/structure/decoration/rag,
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "om" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
+/obj/structure/closet/crate/large,
+/obj/item/toy/plush/bigdeerplushie,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "on" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/f13{
@@ -6283,7 +5320,9 @@
 /turf/open/floor/engine,
 /area/f13/building)
 "os" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /obj/structure/fence/wooden{
 	density = 0;
 	pixel_x = 7
@@ -6293,29 +5332,22 @@
 	pixel_x = 7;
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#888888"
 	},
-/area/f13/building)
-"ot" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_south"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/area/f13/wasteland)
 "ou" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/structure/table/wood/settler{
+	plane = -3
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
+/area/f13/wasteland)
 "ov" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -6347,11 +5379,14 @@
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "ox" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/concrete{
-	desc = "A pre-War wall made of solid concrete."
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/building)
+/turf/closed/wall/mineral/concrete{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/wasteland)
 "oy" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -6376,15 +5411,11 @@
 /turf/open/floor/carpet/cyan,
 /area/f13/building)
 "oC" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/obj/structure/simple_door/room,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "oD" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 4
@@ -6453,7 +5484,7 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "oI" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/campfire/stove{
 	pixel_y = 10
 	},
@@ -6517,7 +5548,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "oQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "oR" = (
@@ -6533,14 +5564,13 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "oV" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/west,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"oW" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/sofa/left{
+	color = "#334E23";
+	dir = 1;
+	pixel_y = 4
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "oX" = (
 /obj/structure/fence/wooden{
 	pixel_x = -14;
@@ -6558,10 +5588,14 @@
 	},
 /area/f13/building/tribal)
 "pb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
+"pc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland/city/newboston/outdoors)
 "pd" = (
 /obj/machinery/shower{
 	dir = 4
@@ -6586,7 +5620,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio44"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "pg" = (
@@ -6644,24 +5678,52 @@
 	},
 /area/f13/tribe)
 "pn" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/reagentgrinder/constructed,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "po" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "pp" = (
-/obj/structure/bookcase{
-	pixel_y = 32;
-	density = 0
+/obj/structure/sink/cupboard{
+	pixel_y = 12;
+	pixel_x = 16
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = 14;
+	pixel_x = -8
+	},
+/obj/structure/closet/locker/medcabinet{
+	pixel_y = 31;
+	pixel_x = -8
+	},
+/obj/item/soap{
+	color = "#5B8CA4";
+	pixel_y = 36;
+	pixel_x = -8
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_y = 38;
+	pixel_x = -8
+	},
+/obj/structure/toilet_paper{
+	pixel_x = -25;
+	pixel_y = 14
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	color = "#ADDEBA"
+	},
+/area/f13/wasteland)
 "pq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -6694,7 +5756,7 @@
 /area/f13/caves)
 "pt" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building)
 "pv" = (
@@ -6709,16 +5771,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"pw" = (
-/obj/structure/chair/sofa/corner{
-	color = "#800000";
-	dir = 4
-	},
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "px" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6726,15 +5778,6 @@
 /obj/item/pen/fountain,
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
-"py" = (
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "pA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -6773,7 +5816,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "pD" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -6806,12 +5849,12 @@
 	},
 /area/f13/building/tribal)
 "pI" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -6827,17 +5870,25 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "pM" = (
-/obj/structure/flora/tree/cherryblossom{
-	plane = -2;
-	pixel_y = 13
+/obj/structure/closet/cabinet{
+	pixel_y = 22;
+	pixel_x = 4;
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"pN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mob_spawn/human/skeleton/alive,
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
+/obj/item/clothing/under/dress/coyote/dinerdressmint{
+	pixel_x = 5;
+	pixel_y = 20
+	},
+/obj/item/clothing/under/dress/coyote/dinerdresspink{
+	pixel_y = 20;
+	pixel_x = 5
+	},
+/obj/item/clothing/under/kuddles/rattyskirtgreen{
+	pixel_y = 22;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "pO" = (
 /obj/structure/stone_tile/block{
 	dir = 8;
@@ -6877,20 +5928,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/wood,
 /area/f13/wasteland)
-"pS" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
-"pT" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain/directional/east{
-	color = "#ACD1E9";
-	alpha = 200
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_two)
 "pU" = (
 /obj/structure/reagent_dispensers/barrel/explosive{
 	pixel_x = -2;
@@ -6910,7 +5947,7 @@
 	},
 /area/f13/building/tribal)
 "pX" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2{
 	plane = -2
 	},
@@ -6956,17 +5993,6 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
-"qc" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
-	},
-/area/f13/wasteland)
 "qd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -6995,21 +6021,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"qg" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "qh" = (
 /obj/structure/table/reinforced,
 /obj/item/chopping_block{
@@ -7049,26 +6060,14 @@
 /obj/structure/nest/molerat,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"ql" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"qm" = (
-/obj/structure/table,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
 "qo" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/abductor{
+	density = 0;
+	pixel_y = 8
 	},
-/area/f13/building)
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "qq" = (
 /obj/structure/dresser,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -7087,7 +6086,7 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "qt" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
@@ -7095,42 +6094,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"qv" = (
-/obj/structure/chair/sofa/left{
-	color = "#353535";
-	dir = 1
+/obj/structure/chair/sofa{
+	color = "#334E23";
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_three)
-"qw" = (
-/obj/structure/rack/shelf_metal/modern,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/pickaxe/drill,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"qy" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/tentwall,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
+"qv" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4;
+	pixel_x = 2
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "qA" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building)
 "qB" = (
-/obj/structure/glowshroom{
-	color = "#4F7942";
-	light_color = "#4F7942";
-	light_range = 3
-	},
-/turf/closed/wall/f13/ruins,
+/obj/structure/cave/stalagmite,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qD" = (
 /obj/structure/closet/cabinet,
@@ -7142,10 +6131,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qG" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/industrial/purple,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "qK" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 8
@@ -7167,29 +6158,6 @@
 "qO" = (
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"qP" = (
-/obj/structure/pool/ladder{
-	dir = 2;
-	pixel_y = 15
-	},
-/turf/open/indestructible/ground/outside/water{
-	name = "hot spring";
-	color = "#BBBBBB"
-	},
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"qR" = (
-/obj/structure/toilet{
-	pixel_y = 16;
-	pixel_x = 8
-	},
-/obj/structure/sink{
-	pixel_x = -7;
-	pixel_y = 25
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/building)
 "qS" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain/directional/east{
@@ -7206,15 +6174,13 @@
 	},
 /area/f13/tribe)
 "qU" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/comfy{
+	dir = 8;
+	color = "#845f58"
 	},
-/obj/structure/railing{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "qV" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -7250,21 +6216,25 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"ra" = (
-/obj/item/toy/tennis/blue,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "rb" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "rc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
+/obj/structure/window/fulltile/ruins,
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6
+	},
+/obj/structure/curtain/directional/north{
+	color = "#4B724F"
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "re" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -7279,11 +6249,11 @@
 	},
 /area/f13/building)
 "rf" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar{
 	pixel_y = 16
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "rg" = (
@@ -7293,29 +6263,25 @@
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
 /area/f13/wasteland)
-"ri" = (
+"rh" = (
 /obj/structure/railing{
-	plane = -2
+	color = "#A47449"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/hydroponics/soil/pot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "rj" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo/shotgun,
@@ -7324,18 +6290,13 @@
 	},
 /area/f13/building)
 "rk" = (
-/obj/machinery/light_switch{
-	pixel_y = -20
+/obj/vehicle/ridden/wheelchair{
+	desc = "A wheelchair, that seems to be wheels, it seems to be moveable by person on the wheelchair and it picks up bitches.";
+	name = "hawtrod bitch magnet"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
-"rl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/chair/metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "rn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookshelf{
@@ -7344,17 +6305,15 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "ro" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "rq" = (
-/obj/structure/spacevine{
-	name = "vines"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/brick,
 /area/f13/building)
 "rr" = (
@@ -7370,34 +6329,21 @@
 /turf/open/floor/plating/f13/outside/roof/red,
 /area/f13/wasteland)
 "rs" = (
-/turf/closed/wall/mineral/brick,
-/area/f13/building)
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "rt" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "ru" = (
-/obj/structure/chair/sofa/right{
-	color = "#334E23";
-	dir = 1;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4";
+	color = "#CECECE"
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/area/f13/wasteland)
 "rv" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1";
@@ -7458,65 +6404,35 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "rC" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/repaired,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	icon_state = "common-broken5";
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "rD" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"rE" = (
-/obj/structure/chair/wood{
-	plane = -6
-	},
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -24;
-	plane = -3
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
-"rF" = (
-/obj/structure/table/wood/settler{
-	density = 0
-	},
-/obj/structure/junk/small/prewartv,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891";
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"rG" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "rH" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/branch{
-	plane = -4
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
 	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "rI" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -7529,8 +6445,8 @@
 	},
 /area/f13/tribe)
 "rJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "rK" = (
@@ -7540,47 +6456,29 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"rL" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/east,
-/turf/open/floor/wood_common,
-/area/f13/building)
 "rN" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"rO" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building)
-"rP" = (
-/obj/structure/chair/metal{
-	icon = 'icons/obj/objects2.dmi';
-	icon_state = "shuttle_chair_g"
+/obj/structure/simple_door/dirtyglass,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "rQ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 11
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin{
+	pixel_y = 7;
+	pixel_x = -5
 	},
-/obj/structure/railing{
-	plane = -2
+/obj/item/pen{
+	pixel_y = 9
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "rR" = (
 /obj/structure/pondlily_big,
 /obj/effect/turf_decal/weather/dirt{
@@ -7605,54 +6503,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"rU" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
-"rV" = (
-/obj/structure/simple_door/tentflap_leather,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
-"rW" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/railing{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "rX" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -15;
-	plane = -3
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/area/f13/wasteland)
 "rY" = (
 /obj/structure/stone_tile/block{
 	pixel_x = -20
@@ -7708,21 +6566,19 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/house/cabin_one)
 "sc" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
 	},
-/obj/structure/railing{
-	plane = -2
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/structure/railing{
-	dir = 4
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "sd" = (
 /obj/structure/table,
@@ -7731,14 +6587,14 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/matches{
 	pixel_y = 9;
 	pixel_x = 9
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "se" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -7753,12 +6609,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"sf" = (
-/obj/structure/fireplace{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "sg" = (
 /obj/structure/flora/tallgrass3,
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -7774,14 +6624,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"sh" = (
-/obj/structure/cave/support{
-	pixel_y = 26;
-	icon_state = "support_wall";
-	anchored = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "si" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -7798,31 +6640,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"sn" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"so" = (
-/obj/structure/spacevine{
-	pixel_y = -22;
-	plane = -1
-	},
-/obj/structure/table/booth,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "sp" = (
 /obj/structure/stone_tile/block{
 	dir = 4;
@@ -7844,10 +6661,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "ss" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rug/big/rug_red{
+	pixel_y = -19;
+	layer = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "st" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -7933,68 +6753,16 @@
 	footstep = "grass"
 	},
 /area/f13/caves)
-"sC" = (
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"sD" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
 "sE" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/railing{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"sF" = (
 /obj/structure/table/wood/settler,
-/obj/structure/junk/small/tv{
-	pixel_y = 12;
-	pixel_x = 2
-	},
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "sG" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
-"sH" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/spacevine{
-	pixel_y = -25;
-	plane = -3;
-	pixel_x = -2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "sJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -8010,18 +6778,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"sK" = (
-/obj/structure/decoration/vent{
-	pixel_y = -7
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
-/area/f13/building)
 "sL" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d"
@@ -8033,7 +6789,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "sM" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -8069,7 +6825,7 @@
 	},
 /area/f13/building/tribal)
 "sQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -8104,7 +6860,7 @@
 	},
 /area/f13/building/tribal)
 "sU" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -8115,8 +6871,8 @@
 /obj/structure/flora/ausbushes/brflowers{
 	plane = -2
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "sV" = (
 /obj/structure/campfire/wallfire{
 	color = "#645A55";
@@ -8140,11 +6896,9 @@
 	},
 /area/f13/building)
 "sX" = (
-/obj/structure/chair/sofa/right{
-	color = "#990033"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/wasteland)
 "sY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -8159,26 +6913,17 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"sZ" = (
+"tb" = (
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor{
+	color = "#FF8CBA";
+	light_color = "#FF8CBA"
 	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
-"ta" = (
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
-"tb" = (
-/obj/structure/dresser{
-	pixel_y = 16;
+/obj/structure/table/wood/settler{
 	density = 0
 	},
 /turf/open/floor/carpet/black,
@@ -8195,11 +6940,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "td" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "te" = (
@@ -8218,29 +6963,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tg" = (
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/obj/structure/toilet{
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/building)
+/obj/item/kirbyplants{
+	icon_state = "plant-18";
+	pixel_y = 14;
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "th" = (
 /obj/effect/decal/cleanable/glass{
 	dir = 4
@@ -8254,22 +6990,33 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "tj" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
 	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
 /area/f13/wasteland)
 "tk" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/brown,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp{
+	dir = 8;
+	pixel_x = 8;
+	color = "grey"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "tl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -8311,12 +7058,6 @@
 	footstep = "grass"
 	},
 /area/f13/caves)
-"tn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "to" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/rolling,
@@ -8324,9 +7065,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"tp" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
 "tr" = (
 /obj/structure/chair/sofa/right{
 	color = "#353535"
@@ -8347,17 +7085,16 @@
 	},
 /area/f13/tribe)
 "tv" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/vent/rusty,
 /obj/effect/overlay/junk/shower{
 	dir = 1
 	},
-/obj/effect/overlay/junk/curtain,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "tw" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/toggle/labcoat/scribecoat,
@@ -8366,9 +7103,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood)
 "tx" = (
-/obj/structure/closet/fridge/standard,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/obj/structure/bookcase{
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "tz" = (
 /obj/structure/curtain{
 	color = "#450159"
@@ -8387,7 +7127,7 @@
 /area/f13/building)
 "tB" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tC" = (
@@ -8417,7 +7157,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -8425,7 +7165,7 @@
 	},
 /area/f13/caves)
 "tF" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "tG" = (
@@ -8439,17 +7179,12 @@
 	},
 /area/f13/building)
 "tH" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/building)
-"tI" = (
-/obj/item/lock_bolt{
+/obj/structure/chair/stool/bar,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/simple_door/house,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "tJ" = (
 /turf/closed/wall/f13/vault,
 /area/f13/brotherhood)
@@ -8485,16 +7220,6 @@
 "tN" = (
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"tP" = (
-/obj/machinery/grill,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
-"tQ" = (
-/turf/open/water{
-	icon = 'icons/turf/pool.dmi';
-	icon_state = "pool_tile"
-	},
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "tR" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/ausbushes/ppflowers{
@@ -8513,15 +7238,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "tV" = (
-/turf/open/indestructible/ground/outside/water{
-	name = "hot spring";
-	color = "#BBBBBB"
-	},
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"tW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "tX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -8556,7 +7275,7 @@
 /turf/open/floor/carpet,
 /area/f13/wasteland/city/newboston/house)
 "uc" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/support{
 	density = 1;
 	pixel_y = 16;
@@ -8565,21 +7284,22 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "ud" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/reagentgrinder{
-	pixel_x = 5;
-	pixel_y = 13
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/machinery/processor/chopping_block{
-	pixel_x = 7;
-	pixel_y = -1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "ue" = (
-/obj/structure/cave/bigboards/westeast,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/chair/bench{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "uf" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -8640,63 +7360,17 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"ul" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "um" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/structure/glowshroom{
-	color = "#4F7942";
-	light_color = "#4F7942";
-	light_range = 3
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
 /area/f13/wasteland)
 "uo" = (
@@ -8771,7 +7445,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -8786,14 +7460,21 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "ux" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	color = "#4F3528";
+	dir = 6;
+	plane = -4
 	},
-/obj/structure/simple_door/interior,
-/obj/item/lock_bolt{
-	dir = 8
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "uy" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/turf_decal/weather/dirt,
@@ -8834,15 +7515,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"uD" = (
-/obj/item/storage/fancy/rollingpapers{
-	pixel_y = 9
-	},
-/obj/structure/table/wood/junk{
-	pixel_y = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uE" = (
 /obj/machinery/computer/rdconsole/core/bos,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8863,7 +7535,7 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "uI" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -8890,24 +7562,27 @@
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "uK" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
+/area/f13/wasteland)
+"uG" = (
 /obj/structure/railing{
-	plane = -2
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
+/obj/item/kirbyplants{
+	icon_state = "plant-25";
+	pixel_y = 18
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
+"uH" = (
+/obj/structure/nest/radroach,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "uL" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/structure/table/craft_counter,
@@ -8921,22 +7596,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"uN" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/chilling/darkblue,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
-"uO" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Public"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "uP" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -8965,23 +7624,21 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "uT" = (
-/obj/machinery/microwave/gas_stove{
-	pixel_x = 1;
-	pixel_y = 1
+/obj/machinery/light,
+/obj/structure/dresser,
+/obj/structure/rug/big/rug_blue{
+	pixel_y = 15;
+	layer = 2
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "uU" = (
-/obj/structure/bookshelf{
-	pixel_y = 20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "uW" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/condiment/pack/coffee{
@@ -9026,10 +7683,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "vb" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	icon_state = "sofamiddle";
+	color = "#333333"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "vc" = (
@@ -9039,11 +7698,11 @@
 /turf/open/transparent/openspace,
 /area/f13/brotherhood)
 "vd" = (
-/obj/structure/nightstand/small{
-	pixel_x = 2;
-	pixel_y = 22
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ve" = (
@@ -9057,7 +7716,7 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "vh" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -9092,7 +7751,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "vk" = (
@@ -9116,43 +7775,14 @@
 	},
 /area/f13/building/tribal)
 "vp" = (
-/obj/structure/closet/crate/trashcart{
-	opened = 1;
-	name = "the humpster";
-	density = null;
-	pixel_y = 21;
-	opacity = 1;
-	mouse_opacity = 0;
-	pixel_x = -14
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
-"vq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"vr" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/f13/wood/house,
-/area/f13/building)
-"vt" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"vt" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "vu" = (
@@ -9171,25 +7801,22 @@
 	},
 /area/f13/building/tribal)
 "vy" = (
-/obj/machinery/shower{
-	pixel_y = 18
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/bikehorn/rubberducky,
-/obj/structure/curtain{
-	color = "#334E23"
+/turf/closed/wall/mineral/concrete{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
 	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "vz" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+/obj/structure/chair/sofa/right{
+	color = "#334E23";
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "vA" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/baguette,
@@ -9202,28 +7829,14 @@
 	},
 /area/f13/building)
 "vC" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"vD" = (
-/obj/structure/simple_door/repaired,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
-"vE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/carpet/arcade,
+/area/f13/wasteland)
 "vG" = (
-/obj/structure/chair/sofa/right{
-	color = "#353535"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/arcade,
+/area/f13/wasteland)
 "vH" = (
 /obj/structure/sink{
 	dir = 8;
@@ -9242,17 +7855,14 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"vJ" = (
-/obj/structure/railing,
-/obj/structure/easel,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
 "vK" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#4F3528";
 	dir = 1
 	},
 /turf/open/floor/wood_common{
-	icon_state = "common-broken4"
+	color = "#CECECE"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "vM" = (
@@ -9260,32 +7870,31 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vN" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bookcase{
-	pixel_y = 20
+/obj/machinery/light/fo13colored/Aqua{
+	dir = 1;
+	color = "aqua"
 	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "vO" = (
-/obj/structure/bookshelf{
-	pixel_y = 20
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "vP" = (
-/obj/structure/clothes{
-	pixel_x = -1;
-	anchored = 1;
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheetbrown,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland)
 "vS" = (
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -9337,9 +7946,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "vZ" = (
-/obj/structure/rug/carpet,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt{
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "wa" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
@@ -9371,15 +7985,6 @@
 	icon_state = "wide-broken3"
 	},
 /area/f13/wasteland)
-"wf" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "wg" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9397,21 +8002,24 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"wi" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
+"wj" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"wj" = (
-/obj/structure/lattice/catwalk,
-/obj/item/binoculars,
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 8;
+	plane = -4
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#4F3528";
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/pointybush{
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "wk" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9419,12 +8027,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"wl" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
 "wm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -9463,35 +8065,49 @@
 	},
 /area/f13/tribe)
 "wp" = (
-/obj/structure/rug/big/rug_blue_shag{
-	layer = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"wq" = (
-/obj/machinery/shower{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
 	dir = 4
 	},
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/wasteland/city/newboston/house)
-"wr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
+/area/f13/wasteland)
+"wq" = (
+/obj/item/chisel,
+/obj/item/chisel{
+	pixel_x = 7
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/crayons,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1;
+	plane = -6
+	},
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "ws" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/bench,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9521,15 +8137,13 @@
 	},
 /area/f13/building)
 "wz" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/fake_stairs/east{
+	color = "#A47449"
 	},
-/obj/structure/clothes{
-	pixel_x = 31;
-	anchored = 1
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "wA" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/lit{
@@ -9545,55 +8159,24 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"wC" = (
-/turf/open/floor/wood_common{
-	icon_state = "common-broken5"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"wD" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
-"wE" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "wF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "wG" = (
-/obj/effect/turf_decal/weather/splineplain{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
-"wH" = (
-/obj/structure/rug/mat/welcome{
-	pixel_y = -7;
-	pixel_x = -7
+/obj/structure/railing{
+	color = "#A47449"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	color = "#4F3528";
+	plane = -4
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"wI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/wood_mosaic/wood_mosaic_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/area/f13/wasteland)
 "wJ" = (
 /obj/structure/bookcase,
 /turf/open/floor/f13{
@@ -9654,9 +8237,6 @@
 	},
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"wS" = (
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "wT" = (
 /obj/structure/closet/crate/large,
 /turf/open/floor/wood_common{
@@ -9689,11 +8269,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/wasteland)
-"wX" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetbrown,
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "wY" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -9743,7 +8318,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building)
 "xd" = (
@@ -9753,28 +8328,16 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"xf" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "xg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/dresser{
+	pixel_y = 11;
+	pixel_x = 1
 	},
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/mirror/alt{
+	pixel_y = 34
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "xh" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -9806,17 +8369,25 @@
 	},
 /area/f13/building)
 "xm" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/weather/splineplain,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "xn" = (
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/structure/nightstand{
+	icon_state = "phone_black";
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "xp" = (
 /obj/structure/table/wood/settler,
 /obj/item/defibrillator/primitive,
@@ -9855,41 +8426,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
-"xs" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	pixel_y = 1;
-	pixel_x = -10
-	},
-/turf/closed/wall/f13/ruins,
-/area/f13/building)
-"xt" = (
-/obj/structure/curtain{
-	color = "#4B724F"
-	},
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/end{
-	color = "#93BC9E";
-	dir = 1
-	},
-/obj/machinery/door/window/left{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc{
-	color = "#ADDEBA"
-	},
-/area/f13/building)
-"xu" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/carpet/purple,
-/area/f13/building)
 "xv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -9900,50 +8436,39 @@
 	},
 /area/f13/building/tribal)
 "xx" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/fake_stairs/south{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/simple_door/room,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "xz" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"xA" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "xB" = (
-/obj/structure/table/booth,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/machinery/vending/games{
+	pixel_x = -31;
+	density = 0
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "xD" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 10
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/booth{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "xE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9953,21 +8478,19 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "xF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobiolockdown"
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
-"xG" = (
-/obj/structure/railing,
-/obj/structure/table/wood/settler,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
 "xH" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/coffee{
@@ -9989,12 +8512,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
-"xJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "xK" = (
 /turf/open/indestructible/ground/outside/civ/woodalt{
 	color = "#777777"
@@ -10008,8 +8525,13 @@
 /turf/open/transparent/openspace,
 /area/f13/building)
 "xM" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
+/obj/machinery/bookbinder{
+	pixel_x = 4
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "xN" = (
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -10030,14 +8552,14 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
 "xP" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/interior,
 /obj/item/lock_bolt{
 	dir = 4
@@ -10045,9 +8567,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "xQ" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "xR" = (
 /obj/structure/sink{
 	dir = 4;
@@ -10063,7 +8588,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "xT" = (
@@ -10072,11 +8597,6 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"xU" = (
-/obj/structure/curtain/directional/north,
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood_common,
 /area/f13/building)
 "xV" = (
 /turf/open/floor/plating/f13/outside/roof/wood/old,
@@ -10089,23 +8609,17 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "xZ" = (
-/obj/structure/simple_door/tent,
-/obj/item/lock_bolt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp{
+	dir = 1;
+	pixel_x = 8;
+	color = "grey"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"ya" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
+/obj/machinery/light{
+	pixel_x = -16
 	},
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "yb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
@@ -10115,7 +8629,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/spawner/lootdrop/f13/trash,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
@@ -10143,21 +8657,13 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "yg" = (
 /obj/structure/railing{
-	plane = -2
+	color = "#A47449"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"yh" = (
-/obj/structure/dresser{
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/area/f13/wasteland)
 "yi" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile,
@@ -10166,20 +8672,12 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"yj" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"yk" = (
-/obj/effect/turf_decal/tile/neutral{
+"yl" = (
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/weather/splineplain{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -10193,24 +8691,14 @@
 	},
 /area/f13/building)
 "yl" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
 	pixel_x = 12
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"ym" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "yn" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -10266,14 +8754,14 @@
 /area/f13/building)
 "ys" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
 "yt" = (
-/obj/structure/chair/stool/bar{
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "yv" = (
@@ -10285,28 +8773,13 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"yx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/structure/toilet_paper{
-	pixel_x = -17;
-	pixel_y = -4
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
 "yz" = (
-/obj/structure/chair/wood{
-	icon = 'icons/obj/objects2.dmi';
-	icon_state = "wooden_chair";
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster93{
+	pixel_y = 32
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "yA" = (
 /obj/item/clothing/under/f13/wayfarer,
 /obj/item/clothing/under/f13/wayfarer,
@@ -10330,7 +8803,7 @@
 	},
 /area/f13/tribe)
 "yD" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
@@ -10363,41 +8836,23 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "yH" = (
-/obj/structure/toilet_paper{
-	pixel_y = 16;
+/obj/effect/turf_decal/weather/splineplain,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
+"yI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp/corner{
+	pixel_y = 12;
+	color = "#363636";
+	dir = 4;
 	pixel_x = -8
 	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/obj/structure/toilet{
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
-"yI" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "yJ" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/bonfire/dense/prelit/grill,
@@ -10421,15 +8876,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"yN" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
 "yP" = (
 /obj/structure/chair/sofa/left{
 	color = "#353535";
@@ -10438,22 +8884,35 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "yQ" = (
-/obj/item/clothing/gloves/boxing/green{
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2";
+	color = "#CECECE"
 	},
-/obj/structure/table/rolling,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/area/f13/wasteland)
 "yR" = (
 /turf/closed/wall/mineral/concrete{
 	desc = "A pre-War wall made of solid concrete."
 	},
 /area/f13/brotherhood)
 "yT" = (
-/obj/structure/simple_door/dirtyglass,
-/obj/item/lock_bolt,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 6;
+	plane = -4
+	},
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "yU" = (
 /obj/structure/fluff/railing{
 	dir = 10
@@ -10480,36 +8939,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"yY" = (
-/obj/structure/campfire/stove{
-	pixel_y = 9;
-	density = 0
-	},
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/obj/item/grown/log/tree,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"yZ" = (
-/obj/structure/bed/roller/bedroll{
-	name = "tree shaded bedroll";
-	color = "#555555"
-	},
-/obj/item/flashlight/flashdark{
-	light_on = 1;
-	dark_light_range = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
-/obj/structure/flora/tree/cherryblossom3{
-	pixel_y = 21;
-	pixel_x = -23;
-	plane = -2;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "za" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -10525,13 +8954,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"zb" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/brick,
-/area/f13/building)
 "zc" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/glass,
@@ -10569,37 +8991,12 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"zi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"zj" = (
-/obj/effect/fake_stairs/south{
-	color = "#A47449"
-	},
-/obj/structure/curtain/directional/south{
-	color = "#4B724F"
-	},
-/turf/open/floor/wood_worn{
-	color = "#FDF2C3"
-	},
-/area/f13/building)
 "zk" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"zl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/decoration/rag{
-	icon_state = "skulls"
-	},
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building)
 "zm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8;
@@ -10630,12 +9027,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
-"zp" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "zq" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -10649,16 +9040,28 @@
 	},
 /area/f13/tribe)
 "zr" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/wood/bar,
+/obj/item/pickaxe,
+/obj/item/flashlight/lantern/dim{
+	icon_state = "lantern-on";
+	layer = 2.8;
+	light_on = 1;
+	on = 1;
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "zs" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
 "zt" = (
-/obj/structure/table/wood/fancy/green,
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "zv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -10671,13 +9074,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"zw" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "zx" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt,
@@ -10693,16 +9089,11 @@
 	},
 /area/f13/tribe)
 "zA" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-25";
-	pixel_y = 18
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/area/f13/wasteland)
 "zB" = (
 /obj/machinery/light{
 	dir = 8
@@ -10719,42 +9110,42 @@
 	},
 /area/f13/building)
 "zD" = (
-/obj/structure/clothes{
-	pixel_x = -2;
-	anchored = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 4;
+	plane = -4
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
 	},
-/turf/open/transparent/openspace,
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/obj/structure/flora/chomp/shrub2{
+	pixel_y = 4;
+	pixel_x = -4;
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
 /area/f13/wasteland)
 "zE" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 1
-	},
-/area/f13/building)
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "zF" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/obj/structure/simple_door/room/dirty,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/wasteland)
 "zG" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"zI" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
 "zJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -10773,10 +9164,10 @@
 	},
 /area/f13/building/tribal)
 "zM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "zO" = (
@@ -10821,21 +9212,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"zT" = (
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/flashlight/lamp{
-	pixel_y = 21
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white/corner,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "zU" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "120"
@@ -10848,20 +9224,13 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "zW" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	color = "#4F3528";
+	dir = 4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "zX" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -10905,28 +9274,16 @@
 	},
 /area/f13/building/tribal)
 "Ab" = (
-/obj/structure/flora/tree/oak_five{
-	plane = -1;
-	density = 0;
-	pixel_y = 19
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1;
+	plane = -4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Ac" = (
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/obj/structure/simple_door/wood,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "Ad" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing/wood{
@@ -10983,8 +9340,8 @@
 	},
 /area/f13/building)
 "Ai" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/building)
 "Aj" = (
@@ -11005,17 +9362,12 @@
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
 "Al" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/cave/supportbeams,
+/obj/structure/cave/support{
+	density = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "Am" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -11043,28 +9395,25 @@
 	},
 /area/f13/building/tribal)
 "An" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/bookshelf{
-	pixel_y = 20
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"Ao" = (
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/effect/decal/cleanable/blood,
+/obj/structure/junk/arcade,
+/turf/open/floor/carpet/arcade,
+/area/f13/wasteland)
 "Ap" = (
 /turf/open/transparent/openspace,
 /area/f13/caves)
 "Aq" = (
-/obj/structure/cave/support{
-	pixel_y = 26;
-	icon_state = "support_wall";
-	anchored = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/area/f13/wasteland)
 "Ar" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -11078,12 +9427,15 @@
 	},
 /area/f13/tribe)
 "As" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Au" = (
 /obj/structure/fence/wooden{
 	pixel_x = 13
@@ -11107,17 +9459,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"Av" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"Aw" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/carpet/red,
-/area/f13/building)
 "Ax" = (
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
@@ -11129,36 +9470,37 @@
 	},
 /area/f13/building)
 "Az" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/button/door{
-	id = "4210";
-	name = "Window Shutters";
-	pixel_y = 21;
-	req_one_access_txt = null
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/obj/structure/simple_door/dirtyglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "AA" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain/directional/east{
+	color = "#845f58"
 	},
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
 	},
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "AB" = (
-/obj/structure/cave/support{
-	density = 1;
-	pixel_y = 16;
-	anchored = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/closet/crate/footchest{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
 "AC" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -11167,103 +9509,6 @@
 /obj/structure/table,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"AE" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/particle_effect/water,
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/caves)
 "AF" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -11291,37 +9536,26 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"AI" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "AJ" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/caves)
-"AK" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/room,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "AL" = (
-/obj/machinery/light_switch{
-	pixel_x = 22
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#FF8CC9";
+	color = "#FF72D5"
 	},
-/obj/structure/dresser{
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "AM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/support{
 	pixel_y = 26;
 	icon_state = "support_wall";
@@ -11381,13 +9615,6 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
-"AT" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "AV" = (
 /obj/effect/landmark/start/f13/dualcitizen,
 /turf/open/indestructible/ground/inside/mountain{
@@ -11395,31 +9622,31 @@
 	},
 /area/f13/building/tribal)
 "AW" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
-/area/f13/building)
-"AX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood_mosaic/wood_mosaic_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"AY" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/computer/telecomms/server{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lock_bolt{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/room,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"AX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/retro{
+	pixel_y = 11
 	},
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"AY" = (
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2";
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "AZ" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -11445,7 +9672,7 @@
 /area/f13/building)
 "Bb" = (
 /obj/machinery/mineral/ore_redemption,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -11475,7 +9702,7 @@
 /obj/structure/rug/big/rug_red{
 	layer = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Bi" = (
@@ -11553,10 +9780,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"Bo" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
 "Bp" = (
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
@@ -11577,12 +9800,13 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "Bq" = (
 /turf/closed/wall/mineral/concrete{
-	desc = "A pre-War wall made of solid concrete."
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/wood_common,
 /area/f13/wasteland)
 "Br" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
 	},
@@ -11602,39 +9826,34 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "Bv" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/easel,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Bw" = (
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "Bx" = (
 /obj/structure/railing{
-	color = "#A47449"
+	color = "#A47449";
+	dir = 4
 	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
 /area/f13/wasteland)
 "By" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
-"Bz" = (
-/obj/structure/chair/sofa/right{
-	color = "#4B724F";
-	dir = 8;
-	pixel_x = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "BA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -11659,41 +9878,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"BF" = (
-/obj/structure/sink/cupboard{
-	pixel_y = 12;
-	pixel_x = 16
-	},
-/obj/structure/toilet{
-	color = "#D1D1D1";
-	pixel_y = 14;
-	pixel_x = -8
-	},
-/obj/structure/closet/locker/medcabinet{
-	pixel_y = 31;
-	pixel_x = -8
-	},
-/obj/item/soap{
-	color = "#5B8CA4";
-	pixel_y = 36;
-	pixel_x = -8
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_y = 38;
-	pixel_x = -8
-	},
-/obj/structure/toilet_paper{
-	pixel_x = -25;
-	pixel_y = 14
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	color = "#ADDEBA"
-	},
-/area/f13/building)
 "BG" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building/tribal/cave)
@@ -11701,7 +9885,7 @@
 /obj/structure/window/fulltile/wood{
 	max_integrity = 140
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
 	color = "#845f58"
 	},
@@ -11711,13 +9895,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "BI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "BJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
@@ -11775,19 +9959,8 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
-"BQ" = (
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2;
-	pixel_y = 17
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "BR" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/blanket{
 	pixel_x = 7;
 	pixel_y = 2
@@ -11796,9 +9969,9 @@
 	icon_state = "mattress2"
 	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "BS" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -11838,7 +10011,7 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "BW" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/building)
 "BX" = (
@@ -11851,15 +10024,22 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "BZ" = (
-/obj/structure/campfire/stove{
-	pixel_y = 9;
-	density = 0
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 8;
+	plane = -4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ca" = (
@@ -11871,31 +10051,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Cc" = (
-/obj/structure/closet/cabinet/anchored{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/effect/spawner/lootdrop/f13/common_toys,
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"Cd" = (
-/obj/effect/overlay/junk/toilet{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/structure/sink{
-	pixel_x = -7;
-	pixel_y = 20
-	},
-/obj/structure/mirror{
-	pixel_x = -6;
-	pixel_y = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "Ce" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -11903,25 +10058,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Cf" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
-"Cg" = (
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2;
-	pixel_y = 9
-	},
-/turf/open/transparent/openspace,
+/obj/structure/weightlifter,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/wasteland)
 "Ch" = (
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -11929,41 +10067,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"Cj" = (
-/obj/structure/table,
-/obj/item/lighter/gold{
-	desc = "A shiny and relatively expensive zippo lighter. There's a small world etched on the bottom that reads, ''Sunflower'";
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/storage/fancy/cigarettes/cigars/cohiba{
-	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Ck" = (
 /obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Cm" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/ruins,
-/area/f13/caves)
-"Cn" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Co" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -12015,20 +10124,19 @@
 /turf/open/floor/wood_common,
 /area/f13/wasteland/city/newboston/house/cabin_five)
 "Cs" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
 	pixel_x = 12
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/item/instrument/banjo,
+/obj/machinery/light/floor{
+	plane = -6
 	},
-/obj/structure/railing{
-	plane = -2
+/turf/open/floor/wood_worn{
+	color = "#6F4F40"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "Cu" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12039,10 +10147,12 @@
 /area/f13/building/tribal)
 "Cv" = (
 /obj/structure/railing{
-	dir = 8
+	color = "#A47449";
+	dir = 8;
+	pixel_x = -3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Cw" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -12055,10 +10165,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Cx" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood_mosaic/wood_mosaic_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "Cy" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -12068,12 +10174,18 @@
 	},
 /area/f13/tribe)
 "Cz" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 6;
+	plane = -4
 	},
-/turf/open/transparent/openspace,
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ywflowers{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
 /area/f13/wasteland)
 "CA" = (
 /obj/structure/chair/office/dark,
@@ -12106,7 +10218,7 @@
 	},
 /area/f13/building/tribal)
 "CC" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/grown/corn,
 /turf/open/floor/f13{
@@ -12126,16 +10238,11 @@
 	},
 /area/f13/building/tribal)
 "CF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheet{
-	color = "#334E23"
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "CG" = (
 /obj/structure/table/greyscale,
 /obj/item/pda/bar{
@@ -12151,54 +10258,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/wasteland)
-"CH" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/processor{
-	pixel_y = 20
-	},
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"CI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
-"CJ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "CK" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1";
@@ -12218,32 +10277,36 @@
 /turf/open/floor/plating/f13/outside/roof/wood,
 /area/f13/wasteland)
 "CM" = (
-/obj/structure/sign/painting/library{
-	pixel_x = 32
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 10;
+	plane = -4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/obj/structure/flora/wild_plant/flower/pink_three{
+	randomize_xy = 0;
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "CN" = (
 /obj/structure/chair/f13chair1{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
-"CO" = (
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
-/obj/structure/chair/sofa/left{
-	color = "#353535"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "CQ" = (
 /obj/structure/stone_tile/block,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "CR" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
 	},
@@ -12254,23 +10317,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/building)
 "CT" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8;
+	pixel_x = 8;
+	color = "grey"
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "CU" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -12301,7 +10356,7 @@
 	req_access_txt = null;
 	req_one_access_txt = null
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "CX" = (
@@ -12346,18 +10401,23 @@
 	},
 /area/f13/building/tribal)
 "CZ" = (
-/obj/structure/spacevine,
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building)
-"Da" = (
-/turf/closed/wall/f13/wood/interior{
-	icon_state = "interior4"
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
 	},
-/area/f13/building)
-"Db" = (
-/obj/structure/flora/tree/cherryblossom,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
+"Da" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	layer = 2.5;
+	alpha = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "Dc" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8;
@@ -12368,11 +10428,17 @@
 	},
 /area/f13/tribe)
 "Dd" = (
-/obj/structure/railing/corner{
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/splineplain{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "De" = (
 /obj/structure/table/abductor{
 	desc = "The Brotherhood has released the latest iteration of their advanced table. Designed by Head Knight Envy Sin";
@@ -12381,11 +10447,16 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "Df" = (
-/obj/structure/railing{
-	color = "#A47449"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheet{
+	color = "#334E23"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Dg" = (
 /obj/structure/bed/oldalt,
 /turf/open/floor/f13{
@@ -12412,16 +10483,15 @@
 	},
 /area/f13/tribe)
 "Dk" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/spacevine{
-	pixel_y = -24;
-	plane = -3
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 9
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/city/newboston/outdoors)
+"Dl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/vault,
+/area/f13/brotherhood)
 "Dm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -12431,16 +10501,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"Dn" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
 "Dp" = (
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
@@ -12485,14 +10545,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Ds" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/monkey_recycler,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building)
 "Dt" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/pondlily_small,
@@ -12501,63 +10553,46 @@
 	},
 /area/f13/building/tribal)
 "Du" = (
-/obj/structure/easel{
-	plane = -2;
-	density = 0
-	},
-/obj/structure/chair/stool/retro/black{
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"Dv" = (
-/obj/structure/table/booth,
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/spacevine{
-	pixel_y = -20;
-	plane = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"Dw" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Dx" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/bench,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
+"Dv" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
+"Dx" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
 	pixel_x = 12
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "Dz" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -12601,11 +10636,16 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "DC" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#4F3528"
+	},
+/obj/structure/fluff/hedge,
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "DD" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -12651,20 +10691,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"DF" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
 "DH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -12675,22 +10701,9 @@
 	},
 /area/f13/tribe)
 "DI" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"DJ" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"DK" = (
-/obj/structure/simple_door/room/dirty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	color = "#ADDEBA"
-	},
-/area/f13/building)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "DL" = (
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -12711,22 +10724,12 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"DO" = (
-/obj/machinery/blackbox_recorder,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
 "DP" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"DQ" = (
-/obj/structure/railing,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
 "DR" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -12735,7 +10738,7 @@
 /area/f13/building/tribal)
 "DS" = (
 /obj/structure/simple_door/interior,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -12799,9 +10802,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "DX" = (
-/obj/structure/fireplace,
-/turf/open/floor/carpet/purple,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/watertank/high{
+	icon = 'icons/fallout/farming/farming_structures.dmi';
+	icon_state = "rainwater_tank"
+	},
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 9
+	},
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "DY" = (
 /obj/structure/closet/fridge/standard,
 /obj/item/storage/box/ingredients/italian,
@@ -12828,14 +10838,18 @@
 	},
 /area/f13/building/tribal)
 "Ea" = (
-/obj/structure/closet/crate/bin{
-	density = 0;
-	pixel_x = -6;
-	pixel_y = -2;
-	layer = 2.7
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 8;
+	dir = 8
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Ec" = (
 /obj/structure/railing/wood{
 	pixel_y = 31;
@@ -12851,40 +10865,24 @@
 	},
 /area/f13/tribe)
 "Ed" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/chair/sofa/left{
+	color = "#4B724F";
+	dir = 8;
+	pixel_x = 8
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"Ef" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Eg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"Ei" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Ej" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "Ek" = (
 /obj/structure/fluff/railing,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -12912,64 +10910,23 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"En" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "Eo" = (
-/obj/structure/table,
-/obj/structure/rug/big/rug_red{
-	layer = 1
-	},
-/obj/item/storage/box/dice,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/curtain/directional/west,
+/obj/structure/window/fulltile/stainedglass/woodwindoworange,
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "Ep" = (
 /turf/open/indestructible/ground/outside/desert{
 	name = "sand pit"
 	},
 /area/f13/building/tribal)
 "Eq" = (
-/obj/effect/turf_decal/siding{
-	color = "#2e2e2e";
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
 	},
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood_mosaic/wood_mosaic_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"Er" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/wood_mosaic/wood_mosaic_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"Es" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/area/f13/wasteland)
 "Et" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -12993,7 +10950,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "Ew" = (
@@ -13027,18 +10984,12 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Ez" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"EB" = (
-/obj/structure/simple_door/room/dirty,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "EC" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/rug/mat/welcome{
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "ED" = (
 /obj/structure/dresser,
 /turf/open/floor/f13{
@@ -13076,33 +11027,27 @@
 	},
 /area/f13/building)
 "EI" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/snacks/rawbrahminliver,
-/obj/item/reagent_containers/food/snacks/rawbrahminliver,
-/obj/item/reagent_containers/food/snacks/rawbrahminliver,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/bbqsauce,
-/obj/item/reagent_containers/food/condiment/bbqsauce,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/drinks/bottle/fernet,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/yeast,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/storage/box/condimentbottles,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 5;
+	plane = -4
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "EJ" = (
 /obj/structure/simple_door/tent,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13150,17 +11095,18 @@
 	},
 /area/f13/tribe)
 "EO" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"EP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
 "EQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -13178,29 +11124,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"ES" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
-"ET" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "EU" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/cult,
@@ -13218,21 +11141,8 @@
 	},
 /area/f13/tribe)
 "EX" = (
-/obj/structure/curtain{
-	color = "#87A392";
-	layer = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/building)
-"EY" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/wasteland)
 "EZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
@@ -13265,28 +11175,16 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
-"Fd" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "Fe" = (
-/obj/structure/chair/sofa,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "Ff" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13321,7 +11219,7 @@
 	},
 /area/f13/building/tribal)
 "Fi" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "Fj" = (
@@ -13330,26 +11228,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/wasteland/city/newboston/house/cabin_seven)
 "Fk" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheethos,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"Fl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/building)
-"Fm" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland)
 "Fn" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -13371,12 +11252,14 @@
 	},
 /area/f13/tribe)
 "Fo" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lamp,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "Fp" = (
 /mob/living/simple_animal/chicken{
 	name = "Eats-Many-Seeds"
@@ -13401,11 +11284,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"Fs" = (
-/turf/open/floor/wood_common{
-	icon_state = "common-broken4"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "Fv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13436,39 +11314,12 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Fz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/obj/structure/simple_door/house,
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
 "FA" = (
-/obj/machinery/smartfridge/bottlerack/lootshelf/brews{
-	dir = 1
+/obj/structure/cave/supportwallbroken{
+	density = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"FB" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "FD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -13493,8 +11344,8 @@
 	dir = 2;
 	req_one_access_txt = "136"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "FF" = (
@@ -13508,15 +11359,8 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"FH" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "FJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp/green{
 	pixel_y = 14;
@@ -13534,37 +11378,24 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "FL" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior10"
 	},
 /area/f13/building)
 "FO" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"FP" = (
-/obj/structure/simple_door/house,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/area/f13/wasteland)
 "FR" = (
 /obj/item/slime_extract/grey,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "FS" = (
@@ -13585,18 +11416,13 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "FV" = (
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
+/obj/structure/simple_door/house,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "FW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -13614,7 +11440,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/ore_box,
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -13630,11 +11456,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Ga" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/south,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Gb" = (
 /obj/structure/table,
 /obj/structure/fluff/paper/stack,
@@ -13650,18 +11471,11 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "Gd" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
-"Ge" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "Gf" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -13693,7 +11507,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Gi" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/science/glass{
 	req_one_access_txt = "136";
 	name = "Storage Equipment"
@@ -13738,20 +11552,6 @@
 	color = "#777777"
 	},
 /area/f13/caves)
-"Gm" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = -5;
-	layer = 3.1
-	},
-/obj/item/toy/eightball,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
 "Gn" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-12";
@@ -13807,27 +11607,33 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
 "Gu" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/clothes{
+	anchored = 1;
+	pixel_x = 14
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Gv" = (
-/obj/effect/turf_decal/weather/splineplain{
-	dir = 8
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
+	pixel_x = -4;
+	pixel_y = 14
 	},
-/obj/structure/sink/greyscale{
-	dir = 1;
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
 	pixel_x = -4
 	},
-/obj/machinery/light{
-	pixel_x = 22
+/obj/structure/clothes{
+	anchored = 1;
+	pixel_x = 14;
+	pixel_y = 18
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "Gw" = (
 /obj/structure/bed{
 	pixel_y = 10
@@ -13840,28 +11646,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Gx" = (
-/obj/structure/curtain/directional/east{
-	color = "#8A806B"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	layer = 3.4
+/obj/effect/decal/cleanable/glitter/blue{
+	plane = -4;
+	layer = 3
 	},
-/obj/structure/decoration/rag{
-	layer = 3.4
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
-	},
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
-"Gy" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/turf/open/floor/wood_worn,
+/area/f13/wasteland)
 "Gz" = (
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
@@ -13887,7 +11684,9 @@
 	},
 /area/f13/building)
 "GD" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/dresser,
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -13895,32 +11694,17 @@
 /area/f13/building)
 "GE" = (
 /obj/structure/railing{
-	dir = 8
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = -31;
-	pixel_x = -1
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "GF" = (
-/obj/structure/table,
-/obj/structure/chopping_block,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"GG" = (
-/obj/item/storage/box/dice{
-	pixel_y = 7
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "GH" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -13930,37 +11714,20 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"GI" = (
-/obj/structure/sink/deep_water,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 9
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 10
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
 "GJ" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "GK" = (
-/obj/structure/wreck/trash/one_tire{
-	density = 0
+/obj/structure/chair/sofa/corner{
+	dir = 8;
+	color = "#333333"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "GL" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -14030,14 +11797,14 @@
 	},
 /area/f13/tribe)
 "GR" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	color = "#FF0000";
 	light_color = "#FF0000";
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "GS" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -14045,18 +11812,28 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "GT" = (
-/turf/closed/wall/f13/coyote/darkwoodwall,
-/area/f13/building)
+/obj/structure/towel_rack{
+	pixel_y = -30;
+	pixel_x = -4
+	},
+/obj/structure/rug/mat/welcome{
+	dir = 8
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "GU" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "GW" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp/corner{
+	pixel_y = 12;
+	pixel_x = 8;
+	color = "#363636"
 	},
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "GX" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -14126,18 +11903,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"He" = (
-/obj/structure/bed/mattress,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"Hh" = (
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
 "Hi" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/fence/wooden{
@@ -14166,22 +11931,6 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
-"Hl" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Hm" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding_tile{
@@ -14201,31 +11950,14 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"Hn" = (
-/obj/structure/dresser{
-	pixel_y = 11;
-	pixel_x = 1
-	},
-/obj/structure/mirror/alt{
-	pixel_y = 34
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"Ho" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/tree/cherryblossom{
-	plane = -2;
-	pixel_y = 13
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Hp" = (
-/turf/closed/wall/f13/ruins{
-	color = "#d9cdb9"
+/obj/structure/destructible/tribal_torch/wall/lit/wallcandle{
+	pixel_y = 33;
+	burning = 0;
+	icon_state = "wallcandle-lit"
 	},
-/area/f13/building)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "Hq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1;
@@ -14242,21 +11974,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Hs" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetbrown,
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_five)
-"Ht" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "Hv" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -14272,12 +11989,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Hw" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Hx" = (
 /obj/machinery/conveyor/auto{
 	dir = 4;
@@ -14287,31 +11998,10 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"Hy" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/closed/wall/f13/wood,
-/area/f13/building)
 "Hz" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"HA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
 "HB" = (
@@ -14321,9 +12011,6 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"HC" = (
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "HD" = (
 /obj/structure/curtain{
 	color = "#c40e0e";
@@ -14340,43 +12027,35 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "HF" = (
-/obj/structure/closet/crate/footlocker{
-	pixel_y = 10
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/table/wood/settler{
-	density = 0
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 4
 	},
-/obj/structure/sign/flag_texas{
-	pixel_y = 31
-	},
-/obj/item/lock_construct,
-/obj/item/key,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "HG" = (
-/obj/structure/table/wood/fancy/orange,
-/obj/item/storage/box/dice{
-	pixel_y = 7
+/obj/machinery/shower{
+	pixel_y = 18
 	},
-/obj/item/reagent_containers/food/snacks/cakeslice/apple,
-/turf/open/floor/carpet/orange,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/item/bikehorn/rubberducky,
+/obj/structure/curtain{
+	color = "#334E23"
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "HH" = (
 /obj/structure/chair/middle{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"HI" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
 "HJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -14385,7 +12064,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "HK" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood_common{
 	color = "#779999"
@@ -14429,9 +12108,12 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "HO" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/carpet/orange,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/structure/punching_bag{
+	color = "#292929";
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "HP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirtcorner{
@@ -14492,19 +12174,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"HV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "HW" = (
 /obj/structure/decoration/rag,
 /obj/structure/fence/wooden{
@@ -14533,13 +12202,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal/cave)
-"HX" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "HZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -14555,26 +12217,14 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Ib" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
-	},
-/obj/item/restraints/handcuffs/cable/random,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/caves)
 "Ic" = (
-/obj/machinery/door/airlock/science/glass{
-	req_one_access_txt = "136";
-	name = "Storage Equipment"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/carpet/arcade,
+/area/f13/wasteland)
 "Id" = (
 /obj/effect/turf_decal/weather/springflowers,
 /obj/effect/turf_decal/weather/dirt,
@@ -14595,29 +12245,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"If" = (
-/obj/structure/closet/cabinet/anchored{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/effect/spawner/lootdrop/clothing_high,
-/obj/item/razor,
-/obj/structure/sign/poster/contraband/pinup_bed{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
-"Ig" = (
-/obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 20
-	},
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "Ii" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -14634,40 +12261,36 @@
 	},
 /area/f13/tribe)
 "Ij" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
 /area/f13/building)
 "Ik" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	termtag = "Public"
+/obj/structure/campfire/wallfire{
+	pixel_y = -1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland)
 "Im" = (
-/obj/structure/chair/sofa/corner{
-	color = "#990000";
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 5
 	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"In" = (
-/turf/closed/wall/rust,
-/area/f13/building)
-"Io" = (
-/obj/structure/simple_door/wood/alt{
-	opacity = 1
+/obj/machinery/light/floor{
+	color = "#C000FF";
+	light_color = "#E74AE2"
+	},
+/obj/structure/table/wood/settler{
+	density = 0
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ip" = (
 /obj/structure/simple_door/interior,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/wasteland/city/newboston/house/cabin_six)
 "Iq" = (
@@ -14683,20 +12306,13 @@
 /obj/effect/spawner/lootdrop/f13/common_food{
 	pixel_x = 6
 	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
-"Ir" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
+"Iq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "Is" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13{
@@ -14710,14 +12326,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "Iu" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Ix" = (
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible,
+/obj/item/instrument/piano_synth,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Iy" = (
 /obj/item/hemostat/tribal,
 /obj/item/retractor/tribal,
@@ -14772,7 +12385,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "IE" = (
@@ -14791,10 +12404,12 @@
 /turf/open/floor/carpet/cyan,
 /area/f13/building)
 "IG" = (
-/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
 /turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
+/area/f13/wasteland)
 "IH" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/plasteel/f13{
@@ -14805,7 +12420,9 @@
 /obj/structure/decoration/rag{
 	icon_state = "skin"
 	},
-/turf/closed/wall/mineral/brick,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
 /area/f13/building)
 "IJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14815,16 +12432,23 @@
 	},
 /area/f13/building)
 "IK" = (
-/obj/structure/rug/big/rug_fancy{
-	pixel_y = -17;
-	layer = 1;
-	color = "#334E23";
-	pixel_x = -16
+/obj/effect/fake_stairs/west{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "IL" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -14842,7 +12466,9 @@
 /obj/item/clothing/head/aurora/fur,
 /obj/item/clothing/head/coyote/bisonpelt,
 /obj/item/clothing/shoes/f13/military/khan_pelt,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building)
 "IN" = (
@@ -14857,23 +12483,13 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "IQ" = (
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/building)
+/obj/structure/chair/stool/f13stool,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "IR" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"IS" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/siding/white/corner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "IT" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -14912,7 +12528,8 @@
 /area/f13/tribe)
 "IX" = (
 /obj/structure/window/fulltile/house{
-	dir = 2
+	dir = 2;
+	icon_state = "housewindowbroken"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/curtain{
@@ -14922,24 +12539,13 @@
 /turf/open/floor/wood_common,
 /area/f13/building)
 "IY" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/cave/stalagmite/four,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "IZ" = (
 /obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building)
 "Ja" = (
@@ -14958,13 +12564,26 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "Jd" = (
-/obj/structure/dresser{
-	pixel_x = 5;
-	pixel_y = 19;
-	density = 0
+/obj/item/storage/book/bible{
+	pixel_y = 12;
+	pixel_x = 6
 	},
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/obj/item/storage/book{
+	pixel_y = 12;
+	pixel_x = 7
+	},
+/obj/structure/guncase{
+	pixel_y = 14;
+	pixel_x = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	layer = 2.9;
+	pixel_x = -10;
+	pixel_y = 18
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Je" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -14981,14 +12600,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Jg" = (
-/obj/structure/flora/tree/pink_tree{
-	pixel_y = 24;
-	pixel_x = -38;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Jh" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/table/wood/settler,
@@ -14996,12 +12607,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "Ji" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Jj" = (
 /obj/structure/chair,
 /turf/open/floor/carpet/black,
@@ -15010,18 +12620,15 @@
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "Jl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 25
-	},
-/turf/open/floor/wood_mosaic/wood_mosaic_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Jm" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/weather/dirt,
@@ -15045,11 +12652,20 @@
 	},
 /area/f13/tribe)
 "Jo" = (
-/obj/structure/simple_door/dirtyglass,
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
+/obj/structure/railing{
+	color = "#A47449"
 	},
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
+	},
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2";
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Jp" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/f13{
@@ -15092,13 +12708,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"Js" = (
-/obj/machinery/door/window{
-	dir = 1;
-	req_one_access_txt = "124"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
 "Jt" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -15107,10 +12716,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "Ju" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1;
 	layer = 2.9
@@ -15118,11 +12727,13 @@
 /turf/open/floor/engine,
 /area/f13/building)
 "Jv" = (
-/obj/structure/destructible/tribal_torch/wall/lit,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
+/obj/structure/mirror/alt{
+	pixel_y = 30
 	},
-/area/f13/caves)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Jw" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt,
@@ -15131,11 +12742,11 @@
 	},
 /area/f13/tribe)
 "Jx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/slime_extract/grey,
 /turf/open/floor/engine,
 /area/f13/building)
@@ -15226,28 +12837,21 @@
 	name = "spring water"
 	},
 /area/f13/tribe)
-"JD" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "JE" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp{
+	pixel_y = 12;
+	color = "#363636";
+	dir = 8;
+	pixel_x = 8
 	},
-/obj/structure/chair/sofa/right,
-/turf/open/floor/carpet/orange,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/structure/chair/sofa/corp/left{
+	dir = 8;
+	color = "#363636";
+	pixel_x = 8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "JF" = (
 /obj/structure/closet/cabinet,
 /obj/item/canvas/nineteenXnineteen,
@@ -15258,6 +12862,13 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
+"JG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spacevine{
+	name = "vines"
+	},
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "JI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken,
@@ -15281,12 +12892,13 @@
 	},
 /area/f13/tribe)
 "JL" = (
-/obj/structure/simple_door/wood,
-/obj/structure/spacevine{
-	opacity = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	color = "#4F3528"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "JM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15309,12 +12921,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
-"JR" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/carpet/arcade,
-/area/f13/wasteland/city/newboston/house/cabin_two)
 "JS" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15324,7 +12930,7 @@
 	},
 /area/f13/building)
 "JT" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -15368,34 +12974,14 @@
 /area/f13/wasteland/city/newboston/house/cabin_one)
 "JY" = (
 /obj/structure/table/booth,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Ka" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/obj/structure/table/wood/settler{
-	density = 0;
-	pixel_x = -10
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robustgold{
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/cigarette{
-	pixel_y = 14;
-	pixel_x = -10
-	},
-/obj/item/kirbyplants{
-	icon = 'modular_coyote/icons/objects/miscellaneous.dmi';
-	icon_state = "pot_3";
-	pixel_y = 4;
-	pixel_x = -14
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "Kb" = (
 /obj/structure/spacevine,
 /obj/structure/flora/ausbushes/fullgrass{
@@ -15408,29 +12994,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "Kc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
-"Kd" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
-"Ke" = (
-/obj/structure/barricade/tentclothedge,
-/turf/closed/wall/f13/ruins,
-/area/f13/caves)
 "Kf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera,
@@ -15440,10 +13012,19 @@
 	},
 /area/f13/brotherhood)
 "Kg" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Ki" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -15454,18 +13035,14 @@
 /area/f13/tribe)
 "Kj" = (
 /obj/structure/railing{
-	dir = 1
+	color = "#A47449";
+	dir = 4
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/machinery/icecream_vat,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Kl" = (
 /mob/living/simple_animal/hostile/handy,
@@ -15477,14 +13054,25 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "Kn" = (
-/obj/structure/simple_door/interior,
-/obj/item/lock_bolt{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
+	},
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "Ko" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -15523,37 +13111,24 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Ku" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/building)
 "Kv" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4;
-	icon_state = "cobweb1"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp{
+	pixel_y = 12;
+	color = "#363636";
+	pixel_x = 8
 	},
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/structure/chair/sofa/corp{
+	pixel_y = 12;
+	color = "#363636";
+	pixel_x = -8
 	},
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "Kw" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/blue,
 /area/f13/building)
-"Kx" = (
-/obj/structure/chair/sofa/right{
-	color = "#990033";
-	dir = 8;
-	pixel_x = 7
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
 "Ky" = (
 /obj/structure/fence/wooden{
 	dir = 8;
@@ -15644,22 +13219,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"KF" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "KG" = (
 /obj/effect/turf_decal/weather/springflowers,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -15670,10 +13229,9 @@
 	},
 /area/f13/tribe)
 "KH" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "KJ" = (
 /turf/open/indestructible/ground/outside/water/running{
 	name = "tribe river";
@@ -15687,21 +13245,30 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
+"KM" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
+/area/f13/building)
 "KN" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
-"KO" = (
-/obj/structure/chair/sofa/left{
-	color = "#475340";
+/obj/machinery/door/window/left{
 	dir = 1
 	},
-/turf/open/floor/carpet/green,
-/area/f13/wasteland/city/newboston/house/cabin_five)
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc{
+	color = "#ADDEBA"
+	},
+/area/f13/wasteland)
 "KP" = (
 /obj/structure/chair/stool/retro/black,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -15740,16 +13307,9 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
-"KU" = (
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "KV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "KX" = (
@@ -15758,26 +13318,15 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "KY" = (
-/obj/item/storage/book/bible{
-	pixel_y = 12;
-	pixel_x = 6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
 	},
-/obj/item/storage/book{
-	pixel_y = 12;
-	pixel_x = 7
-	},
-/obj/structure/guncase{
-	pixel_y = 14;
-	pixel_x = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-17";
-	layer = 2.9;
-	pixel_x = -10;
-	pixel_y = 18
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "KZ" = (
 /obj/structure/wreck/trash/autoshaft,
 /obj/structure/wreck/trash/machinepile,
@@ -15785,11 +13334,19 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"La" = (
-/obj/structure/chair/comfy/black{
+"Lb" = (
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
+/area/f13/building)
+"Lb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#779999"
+	},
 /area/f13/building)
 "Lc" = (
 /obj/effect/decal/cleanable/dirt/dust{
@@ -15803,7 +13360,7 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/grenade/clusterbuster/cleaner,
 /turf/open/floor/plasteel/f13/vault_floor/purple/corner{
 	dir = 8
@@ -15815,17 +13372,19 @@
 	},
 /area/f13/building)
 "Lh" = (
-/obj/structure/clothes{
-	pixel_x = -2;
-	anchored = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
+/obj/structure/junk/small/prewartv{
+	pixel_x = -25
 	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
+/obj/structure/decoration/clock{
+	pixel_y = 26;
+	pixel_x = -16
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Li" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4;
@@ -15847,85 +13406,61 @@
 	},
 /area/f13/building/tribal)
 "Lk" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain/directional/east{
-	color = "#ACD1E9";
-	alpha = 200
+/obj/structure/chair/bench{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Ll" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/obj/structure/nightstand/small{
+	pixel_x = 6;
+	pixel_y = 18
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-05";
+	layer = 2.9;
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/obj/item/lock_construct{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/item/storage/keys_set{
+	pixel_y = 18;
+	pixel_x = 5;
+	plane = -5
+	},
+/obj/item/key{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Ln" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"Lo" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/suspenders,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/shoes/sneakers/mime,
-/obj/item/clothing/under/pants/black,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "Lp" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/black,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"Lq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
 /obj/structure/railing{
-	plane = -2
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Lr" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheet{
-	color = "#4B724F"
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/table/wood/settler{
-	density = 0;
-	alpha = 1
-	},
-/turf/open/floor/wood_worn{
-	color = "#FDF2C3"
-	},
-/area/f13/building)
-"Ls" = (
-/obj/machinery/computer/cloning{
-	req_access = null
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building)
+/area/f13/wasteland)
 "Lt" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -15973,42 +13508,26 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal/cave)
-"LB" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+"LC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
+"LE" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
 /obj/structure/railing{
-	plane = -2
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"LC" = (
-/obj/structure/closet/cabinet/anchored,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
+	dir = 1
+	},
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
-"LD" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -24;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"LE" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "LF" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
@@ -16023,29 +13542,19 @@
 	name = "ancient wall"
 	},
 /area/f13/tribe)
-"LI" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "LJ" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/structure/window/fulltile/wood{
+	max_integrity = 140
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/structure/curtain/directional/west,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "LL" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/chair/bench,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "LM" = (
 /obj/structure/table/craft_counter,
 /turf/open/floor/wood_common{
@@ -16076,9 +13585,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "LQ" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "LR" = (
 /obj/machinery/workbench/forge,
 /turf/open/floor/plasteel/cult,
@@ -16095,45 +13606,23 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
-"LU" = (
-/obj/structure/sink/cupboard{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/structure/mirror/alt{
-	pixel_x = -1;
-	pixel_y = 33
-	},
-/obj/item/flashlight/littlelamp{
-	light_on = 1;
-	pixel_x = -13;
-	pixel_y = 19
-	},
-/obj/machinery/light/floor{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
-/area/f13/building)
 "LV" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/mineral/ore_redemption,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "LW" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 8;
+	pixel_x = 8;
+	color = "grey"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "LX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -16150,10 +13639,20 @@
 	},
 /area/f13/tribe)
 "LY" = (
-/obj/item/reagent_containers/rag/towel/random,
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/structure/towel_rack{
+	pixel_x = 32
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 8
+	},
+/obj/machinery/light{
+	pixel_x = 16
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "Ma" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16184,16 +13683,16 @@
 	},
 /area/f13/building/tribal)
 "Mb" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
 	},
-/obj/structure/railing{
-	plane = -2
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "Mc" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -16219,25 +13718,6 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Mg" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/thinplating,
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
-"Mh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "Mi" = (
 /obj/structure/rack,
 /turf/open/floor/carpet/black,
@@ -16247,7 +13727,7 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/wasteland/city/newboston/house/cabin_three)
 "Ml" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -16267,6 +13747,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
+"Mo" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/plasteel/cult,
+/area/f13/building/tribal)
 "Mp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -16275,10 +13759,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"Mq" = (
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/carpet/orange,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "Mr" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/stone_tile/surrounding,
@@ -16296,19 +13776,6 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"Mt" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Mu" = (
 /obj/structure/stone_tile/surrounding_tile{
 	pixel_y = 26
@@ -16341,12 +13808,9 @@
 	},
 /area/f13/tribe)
 "Mx" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/room/dirty,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "My" = (
 /obj/structure/railing/wood{
 	dir = 4
@@ -16381,12 +13845,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"MC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "MD" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16396,36 +13854,19 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"ME" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
 "MF" = (
-/obj/structure/decoration/rag,
-/obj/structure/window/fulltile/wood,
-/obj/structure/decoration/rag,
-/obj/structure/barricade/bars{
-	max_integrity = 800;
-	name = "strong metal bars";
-	obj_integrity = 800
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/flora/ausbushes/ywflowers{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "MH" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -16433,21 +13874,17 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"MI" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "MJ" = (
-/obj/structure/window/fulltile/house,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/curtain{
 	color = "#845f58";
 	layer = 5
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "MK" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	color = "#11ff11"
@@ -16472,7 +13909,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio33"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "MN" = (
@@ -16500,7 +13937,7 @@
 	},
 /area/f13/building/tribal/cave)
 "MP" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -16511,39 +13948,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "MQ" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /turf/open/floor/carpet/black,
 /area/f13/building/tribal)
-"MS" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"MT" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"MU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "MV" = (
 /obj/machinery/shower{
 	pixel_y = 27
@@ -16555,10 +13966,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood)
 "MW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -16595,33 +14006,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Na" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland)
-"Nb" = (
-/obj/item/soap/homemade,
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/rag/towel/random{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/rag/towel/random{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "Nc" = (
 /obj/structure/fence/wooden{
 	dir = 8;
@@ -16705,6 +14093,12 @@
 	color = "#A1BFFF"
 	},
 /area/f13/tribe)
+"Ne" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
+/area/f13/building)
 "Nf" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = 3;
@@ -16767,7 +14161,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Nj" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1;
 	layer = 2.9
@@ -16775,11 +14169,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
 	},
-/area/f13/building)
-"Nk" = (
-/obj/structure/mirror,
-/turf/closed/wall/f13/ruins,
-/area/f13/building)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "Nl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bookshelf{
@@ -16789,21 +14180,9 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "Nm" = (
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
-	},
-/obj/machinery/shower{
-	dir = 1;
-	layer = 4.9
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/building)
+/obj/structure/simple_door/room,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "Nn" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/turf_decal/weather/dirt{
@@ -16865,7 +14244,7 @@
 /area/f13/caves)
 "Nu" = (
 /obj/structure/sign/poster/contraband/robust_softdrinks,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "Nv" = (
@@ -16877,24 +14256,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal/cave)
-"Nw" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "Nx" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -16922,25 +14283,15 @@
 	},
 /area/f13/building/tribal)
 "Ny" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain/directional/north{
+	color = "#845f58"
 	},
-/obj/structure/sink/deep_water{
-	name = "bath water";
-	alpha = 1;
-	desc = "Nice warm water for bathing."
+/obj/structure/window/fulltile/house{
+	dir = 2
 	},
-/obj/effect/turf_decal/siding/thinplating{
-	color = "#93BC9E";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	name = "bath water";
-	desc = "Nice warm water for bathing."
-	},
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Nz" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -16951,77 +14302,50 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"NA" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+"NC" = (
+/obj/effect/decal/cleanable/glitter/white{
+	layer = 3;
+	plane = -4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
-"NB" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
+/obj/structure/table/wood/settler{
+	density = 0
 	},
 /turf/open/floor/wood_common,
 /area/f13/building)
 "NC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "ND" = (
-/obj/structure/chair/sofa{
-	color = "#990033"
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 10;
+	plane = -4
 	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"NE" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/spacevine,
 /obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+	randomize_xy = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"NG" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "NH" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/microwave,
+/obj/structure/table/wood_counter{
+	dir = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "NI" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior1"
 	},
@@ -17039,15 +14363,21 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "NL" = (
-/turf/closed/wall/f13/wood{
-	color = "#cababa"
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
 	},
-/area/f13/building)
-"NM" = (
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "NN" = (
@@ -17091,34 +14421,22 @@
 	},
 /area/f13/tribe)
 "NS" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/window/fulltile/house,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "NT" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain/directional/north,
 /turf/open/floor/plating/tunnel,
 /area/f13/building)
 "NU" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
+/obj/structure/chair/folding,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
-"NV" = (
-/obj/structure/bed/mattress,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"NW" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/chilling/silver,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/area/f13/wasteland)
 "NX" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/turf_decal/weather/dirt{
@@ -17133,7 +14451,7 @@
 /area/f13/tribe)
 "NZ" = (
 /obj/structure/closet/fridge,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "Oa" = (
@@ -17158,23 +14476,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"Od" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Oe" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Of" = (
 /obj/structure/closet/cabinet/anchored,
 /obj/item/mop{
@@ -17226,20 +14527,18 @@
 	},
 /area/f13/building)
 "Ol" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/machinery/vending/nukacolavendfull{
+	pixel_x = -2
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Om" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/building)
-"On" = (
-/obj/structure/closet/crate/bin/trashbin{
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "Oo" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -17248,35 +14547,30 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
 "Oq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/junk/small/prewartv,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
 	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Os" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "Ot" = (
-/obj/structure/table/wood/settler,
-/obj/item/pen/fountain,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan,
-/obj/structure/sign/poster/prewar/poster93{
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/right{
+	dir = 1;
+	pixel_x = -6;
+	color = "#845f58"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Ou" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -17302,43 +14596,6 @@
 	},
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
-"Ow" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Ox" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	plane = -6;
-	dir = 4;
-	pixel_y = -10
-	},
-/obj/structure/barricade/bars{
-	color = "#A47449"
-	},
-/obj/structure/curtain/directional/west{
-	color = "#4B724F"
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "Oy" = (
 /obj/structure/rack,
 /obj/item/storage/box/syringes,
@@ -17377,7 +14634,7 @@
 	},
 /area/f13/tribe)
 "OC" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
@@ -17388,60 +14645,23 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/f13/building)
-"OE" = (
-/obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4;
-	icon_state = "cobweb1"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "OF" = (
-/obj/structure/closet/crate/large,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/fence/pole_b{
+	color = "#7F675D"
 	},
-/area/f13/building)
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/turf/open/floor/wood_worn,
+/area/f13/wasteland)
 "OG" = (
-/obj/structure/railing{
-	plane = -2
+/obj/item/binoculars,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"OH" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
-"OJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/area/f13/wasteland)
 "OK" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -17458,14 +14678,6 @@
 	name = "IBM PC"
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
-"OL" = (
-/obj/structure/chair/left{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
 /area/f13/building)
 "ON" = (
 /obj/structure/fence/wooden{
@@ -17509,80 +14721,30 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"OP" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"OQ" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/lattice/catwalk,
+"OS" = (
 /obj/structure/railing{
 	color = "#A47449";
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"OS" = (
-/obj/machinery/processor/slime,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building)
-"OU" = (
-/obj/structure/dresser{
-	pixel_y = 20;
-	pixel_x = 12;
+/obj/machinery/light/floor{
+	color = "lime";
+	light_color = "#90FF6E"
+	},
+/obj/structure/table/wood/settler{
 	density = 0
 	},
-/obj/structure/mirror/alt{
-	pixel_y = 34;
-	pixel_x = 11
+/turf/open/floor/wood_worn,
+/area/f13/wasteland)
+"OU" = (
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18";
-	pixel_x = -8;
-	pixel_y = 18
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "OV" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"OW" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4;
-	icon_state = "cobweb1"
-	},
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"OY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "OZ" = (
 /obj/structure/table/booth,
 /obj/structure/table/booth,
@@ -17636,7 +14798,9 @@
 /area/f13/building/tribal)
 "Pc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
 	pixel_y = 12;
@@ -17693,10 +14857,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Pk" = (
-/obj/machinery/iv_drip/telescopic,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
 "Pl" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -17737,8 +14897,8 @@
 /area/f13/building)
 "Pq" = (
 /obj/machinery/computer/message_monitor,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/paper/monitorkey,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
@@ -17755,11 +14915,18 @@
 	},
 /area/f13/tribe)
 "Ps" = (
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat,
+/obj/structure/table,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/wasteland)
 "Pt" = (
 /obj/structure/simple_door/repaired,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/lock_bolt{
 	dir = 8
 	},
@@ -17771,13 +14938,16 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"Pv" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "Pw" = (
 /obj/item/seeds/yucca,
 /obj/item/seeds/xander,
@@ -17861,11 +15031,6 @@
 	color = "#777777"
 	},
 /area/f13/building/tribal)
-"Px" = (
-/obj/item/storage/box/dice,
-/obj/structure/table/wood/fancy/red,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
 "Py" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -17878,46 +15043,33 @@
 	},
 /area/f13/tribe)
 "PA" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/lighter/gold,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"PB" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 6
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"PC" = (
-/obj/item/flashlight/lamp{
-	pixel_y = 6
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "PD" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland)
+"PE" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	color = "#4F3528";
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"PE" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
 /area/f13/wasteland)
-"PG" = (
-/obj/structure/campfire/stove,
-/obj/item/grown/log/tree,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "PH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ammo/shotgun,
@@ -17927,14 +15079,18 @@
 	},
 /area/f13/building)
 "PI" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#90FF6E";
+	color = "lime"
 	},
-/obj/item/chair/stool{
-	icon_state = "bar"
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "PJ" = (
 /obj/structure/stone_tile{
 	dir = 8;
@@ -17962,51 +15118,41 @@
 	},
 /area/f13/building/tribal)
 "PK" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/greyscale{
+	dir = 1;
+	pixel_x = 8
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = -2;
+	pixel_x = -8;
+	dir = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/toilet_paper{
+	pixel_x = -25;
+	pixel_y = -4
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/obj/structure/closet/locker/medcabinet{
+	pixel_y = -34;
+	pixel_x = -9
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/wasteland)
 "PL" = (
 /turf/open/indestructible/ground/inside/mountain{
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
 "PM" = (
-/obj/structure/closet/cabinet/anchored,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	plane = -4;
-	icon_state = "cobweb1"
+/obj/structure/closet/crate/bin{
+	density = 0;
+	pixel_x = -6;
+	pixel_y = -2;
+	layer = 2.7
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"PN" = (
-/obj/structure/table/booth,
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "PO" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/barricade/wooden/strong,
@@ -18018,71 +15164,55 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"PQ" = (
-/obj/structure/curtain/directional/east,
+"PS" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowvertical"
+/obj/structure/destructible/tribal_torch/lit{
+	pixel_y = 12;
+	pixel_x = 10
+	},
+/obj/structure/cave/signleft,
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"PV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/towel_rack{
+	pixel_y = 31;
+	pixel_x = -4
+	},
+/obj/structure/rug/mat/welcome{
+	dir = 8
 	},
 /turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
-"PR" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"PS" = (
-/obj/structure/chair/sofa/left,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"PV" = (
-/obj/structure/chair/sofa/left{
-	color = "#334E23";
-	dir = 1;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"PW" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/area/f13/wasteland)
 "PX" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"PY" = (
-/obj/machinery/chem_master,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+"PZ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 5;
+	plane = -4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building)
-"PZ" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "Qa" = (
 /obj/structure/stone_tile/block{
 	dir = 4;
@@ -18103,13 +15233,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"Qc" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north{
-	color = "#475340"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "Qd" = (
 /obj/structure/stone_tile/block{
 	dir = 4;
@@ -18117,20 +15240,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"Qe" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"Qf" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	pixel_y = 18;
+	pixel_x = 5
 	},
 /obj/item/reagent_containers/dropper,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/slime_scanner,
 /obj/item/gun/energy/laser/complianceregulator,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/cell/ammo/ec,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
@@ -18140,33 +15261,13 @@
 	pixel_x = 12;
 	pixel_y = -12
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
 "Qg" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/indestructible,
 /area/f13/tcoms)
-"Qh" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Qi" = (
 /obj/structure/chair/bench{
 	dir = 4
@@ -18176,10 +15277,28 @@
 	},
 /area/f13/building/tribal)
 "Qk" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/machinery/photocopier{
+	pixel_x = 12;
+	pixel_y = -4
+	},
+/obj/machinery/libraryscanner{
+	pixel_x = -14;
+	density = 0;
+	pixel_y = -2
+	},
+/obj/structure/rug/big/rug_fancy{
+	color = "grey";
+	dir = 1;
+	pixel_x = -26;
+	layer = 2.7;
+	pixel_y = 10
+	},
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Ql" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -18189,7 +15308,7 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "Qn" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -18221,26 +15340,38 @@
 	},
 /area/f13/tribe)
 "Qr" = (
-/obj/structure/window/fulltile/ruins{
-	icon_state = "ruinswindowvertical"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/obj/structure/curtain/directional/east{
-	color = "#334E23"
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/f13/outside/roof{
+	color = "grey"
+	},
+/area/f13/wasteland)
 "Qs" = (
 /mob/living/simple_animal/hostile/bs/knight,
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
 "Qt" = (
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"Qu" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/chilling/grey,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
+	},
+/obj/structure/chair/bench,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Qv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -18266,27 +15397,6 @@
 	color = "#695E56"
 	},
 /area/f13/tribe)
-"Qy" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "Qz" = (
 /obj/effect/landmark/start/f13/hunter,
 /turf/open/indestructible/ground/inside/mountain{
@@ -18294,27 +15404,22 @@
 	},
 /area/f13/building/tribal)
 "QA" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
+/obj/structure/dresser{
+	pixel_y = 20;
+	pixel_x = 12;
+	density = 0
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
+/obj/structure/mirror/alt{
+	pixel_y = 34;
+	pixel_x = 11
 	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
+/obj/item/kirbyplants{
+	icon_state = "plant-18";
+	pixel_x = -8;
+	pixel_y = 18
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "QB" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -18323,73 +15428,30 @@
 	},
 /area/f13/building)
 "QC" = (
-/obj/structure/spacevine,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 9;
+	plane = -4
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ywflowers{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/civ/grass0,
+/area/f13/wasteland)
 "QD" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"QF" = (
-/obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 6
-	},
-/obj/structure/fence/wooden{
-	color = "#BBBBBB";
-	dir = 4;
-	pixel_y = -5
-	},
-/obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = 9
-	},
-/obj/structure/fence/wooden{
-	dir = 4;
-	pixel_y = -2
-	},
-/obj/structure/dresser{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/flashlight/oldlamp{
-	light_on = 1;
-	pixel_x = -12;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#000000";
-	layer = 5;
-	name = "shadow";
-	pixel_y = -1
+/obj/machinery/light{
+	pixel_x = 16
 	},
 /obj/structure/railing{
 	color = "#A47449";
 	dir = 8;
 	pixel_x = -3
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"QH" = (
-/obj/structure/bed/roller/bedroll{
-	name = "tree shaded bedroll";
-	color = "#555555"
-	},
-/obj/item/flashlight/flashdark{
-	light_on = 1;
-	dark_light_range = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
-/obj/structure/flora/tree/oak_two{
-	density = 0;
-	pixel_x = -18;
-	pixel_y = 25
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "QI" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18405,29 +15467,16 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"QK" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
-"QL" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/east,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "QM" = (
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
-"QO" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house)
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/obj/structure/decoration/clock{
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "QP" = (
 /obj/machinery/vending/cola/starkist,
 /obj/machinery/vending/cola/starkist,
@@ -18447,45 +15496,23 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "QR" = (
-/obj/structure/decoration/rag,
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler{
+	pixel_y = -10;
+	pixel_x = 4
 	},
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood_common,
-/area/f13/building)
+/obj/item/kirbyplants/random{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "QS" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
-"QU" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	anchored = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/storage/fancy/egg_box,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"QV" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"QW" = (
-/obj/structure/chair/sofa{
-	dir = 4;
-	color = "#990000"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
 "QX" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -18496,7 +15523,7 @@
 	},
 /area/f13/tribe)
 "QY" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2
@@ -18553,12 +15580,6 @@
 /obj/item/grenade/homemade/coffeepotbomb,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"Rf" = (
-/obj/structure/chair/sofa/left{
-	color = "#800000"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Rg" = (
 /obj/structure/spacevine{
 	color = "#225522"
@@ -18594,32 +15615,6 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
-"Rn" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
-"Ro" = (
-/obj/structure/bed/roller/bedroll{
-	plane = 0
-	},
-/obj/structure/cave/support{
-	pixel_y = 26;
-	icon_state = "support_wall";
-	anchored = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"Rp" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "Rq" = (
 /obj/structure/barricade/wooden/strong{
 	obj_integrity = 500
@@ -18642,15 +15637,6 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"Rs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "Rt" = (
 /obj/structure/table/wood/settler,
 /obj/item/grenade/homemade/coffeepotbomb,
@@ -18660,31 +15646,22 @@
 /turf/open/floor/carpet/cyan,
 /area/f13/building)
 "Rv" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing{
+	color = "#4F3528"
 	},
-/obj/structure/table/wood/settler,
-/obj/item/clothing/shoes/jackboots,
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_x = -32
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Rw" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/table/wood_counter{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "Rx" = (
 /obj/item/clothing/head/f13/nursehat,
 /obj/structure/table,
@@ -18693,46 +15670,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Ry" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Rz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"RA" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
 "RB" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife{
-	pixel_x = 5
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "RC" = (
@@ -18764,13 +15712,6 @@
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluerustychess"
 	},
-/area/f13/building)
-"RG" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "RH" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -18810,94 +15751,55 @@
 	name = "spring water"
 	},
 /area/f13/tribe)
-"RM" = (
-/obj/structure/railing{
-	pixel_y = -3
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
 "RN" = (
-/obj/structure/toilet{
+/obj/effect/turf_decal/weather/splineplain{
 	dir = 4
 	},
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 20;
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/wasteland/city/newboston/house/cabin_three)
-"RO" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/carpet/red,
-/area/f13/building)
-"RP" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"RQ" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -18;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"RR" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
+"RO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/wasteland)
+"RQ" = (
+/obj/structure/nightstand/small{
+	pixel_x = 9;
+	pixel_y = 20
+	},
+/obj/item/flashlight/littlelamp{
+	pixel_y = 23;
+	pixel_x = 9;
+	color = "grey"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "RS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Xenobiology South";
 	dir = 6;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "RT" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowvertical"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain{
-	color = "#89A077";
-	layer = 5
+/obj/structure/easel,
+/obj/item/canvas{
+	pixel_x = 9
 	},
-/turf/open/floor/wood_common,
-/area/f13/building)
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "RU" = (
 /obj/structure/sink/well{
 	pixel_x = -20;
@@ -18917,7 +15819,7 @@
 	},
 /area/f13/tribe)
 "RV" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -18926,14 +15828,14 @@
 /area/f13/building)
 "RW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rug/big/rug_rubber{
 	pixel_y = -4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
 "RX" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Xenobiology South";
 	dir = 6;
@@ -18987,25 +15889,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"Sd" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Se" = (
 /obj/effect/turf_decal/weather/dirtcorner,
 /turf/open/indestructible/ground/outside/gravel{
@@ -19013,8 +15896,20 @@
 	},
 /area/f13/tribe)
 "Sf" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/curtain{
+	color = "#5B8CA4";
+	layer = 3.3
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/wasteland)
 "Sg" = (
 /obj/structure/railing/wood{
 	pixel_y = -12
@@ -19038,26 +15933,12 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal,
 /area/f13/wasteland)
-"Si" = (
-/obj/structure/dresser{
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/building)
 "Sj" = (
 /obj/machinery/door/airlock/hatch{
 	req_one_access_txt = "120"
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"Sk" = (
-/obj/structure/barricade/wooden,
-/obj/structure/fence/wooden{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "Sl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -19076,11 +15957,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "So" = (
-/obj/machinery/dna_scannernew{
-	pixel_x = -4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
-/area/f13/building)
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "Sp" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -19094,11 +15972,17 @@
 	},
 /area/f13/tribe)
 "Sq" = (
+/obj/structure/railing{
+	color = "#A47449"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/obj/structure/chair/folding{
+	dir = 1
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Sr" = (
 /obj/structure/chair/middle{
 	dir = 1
@@ -19125,25 +16009,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Su" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "Sv" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
 "Sw" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain/directional/east{
+	color = "#450159"
 	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Sx" = (
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/building)
@@ -19152,21 +16031,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
-"SA" = (
-/obj/structure/table/wood/fancy/black,
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "SB" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/area/f13/building)
-"SC" = (
-/obj/structure/campfire{
-	pixel_y = 12
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "SD" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -19186,38 +16060,17 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"SF" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/caves)
 "SG" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
 	pixel_x = 12
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "SH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19228,7 +16081,7 @@
 /turf/open/floor/plating/f13/outside/road,
 /area/f13/brotherhood)
 "SI" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/med_data/syndie{
 	dir = 4;
 	req_one_access = null
@@ -19263,28 +16116,21 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"SN" = (
-/obj/structure/spacevine,
-/obj/structure/spacevine,
-/obj/structure/flora/branch_broken{
-	plane = -4
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "SO" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheetbrown,
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
 	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "SP" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -19297,13 +16143,8 @@
 /obj/structure/railing{
 	plane = -2
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/rolling,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/wasteland)
 "SQ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -19329,23 +16170,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"ST" = (
-/obj/structure/decoration/vent{
-	name = "drain";
-	layer = 2.0
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/building)
-"SU" = (
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_five)
 "SV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -19368,7 +16192,7 @@
 	},
 /area/f13/building)
 "SX" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/f13/building)
@@ -19376,39 +16200,32 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "SZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building)
 "Ta" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
-"Tb" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Td" = (
-/obj/machinery/light_switch{
-	pixel_x = 22
+/obj/structure/chair/sofa/right{
+	color = "#4B724F";
+	dir = 8;
+	pixel_x = 8
 	},
-/obj/structure/dresser{
-	pixel_y = 16;
-	density = 0
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Te" = (
 /obj/effect/landmark/start/f13/chief,
 /turf/open/indestructible/ground/inside/mountain{
@@ -19450,7 +16267,7 @@
 /turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "Th" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "Ti" = (
@@ -19483,13 +16300,6 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"Tm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
 "Tn" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -19497,23 +16307,11 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"To" = (
-/obj/structure/table/wood/settler,
-/obj/structure/closet/crate/footchest{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/toy/dummy,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lock_construct,
-/obj/item/key,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "Tp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/f13/building)
 "Tq" = (
@@ -19534,9 +16332,9 @@
 	},
 /area/f13/building/tribal)
 "Tr" = (
-/obj/structure/rug/big/rug_blue_shag,
+/obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "Tt" = (
 /obj/item/vending_refill/cigarette,
 /obj/structure/rack,
@@ -19564,22 +16362,32 @@
 	},
 /area/f13/building)
 "Tw" = (
-/obj/structure/sign/poster/contraband/pinup_funk{
-	pixel_y = 32
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_y = 16;
+	pixel_x = -6
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	pixel_y = 18;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Tx" = (
-/obj/machinery/light,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"Ty" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
-/obj/structure/railing,
-/turf/open/transparent/openspace,
-/area/f13/building)
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/obj/machinery/computer/terminal,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Tz" = (
 /obj/structure/legion_extractor{
 	pixel_y = 6
@@ -19588,27 +16396,22 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/plasteel/cult,
 /area/f13/tribe)
-"TA" = (
-/obj/structure/simple_door/tent,
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "TC" = (
-/obj/structure/simple_door/dirtyglass,
-/obj/item/lock_bolt{
+/obj/structure/fluff/hedge,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
-"TD" = (
-/obj/structure/chair/sofa/right{
-	color = "#800000";
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "TE" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/bonfire/dense/prelit/grill,
@@ -19619,9 +16422,9 @@
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "TG" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/cabinet,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
@@ -19645,19 +16448,22 @@
 	},
 /area/f13/building/tribal)
 "TI" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"TJ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/effect/fake_stairs/west{
+	color = "#845f58";
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/table/wood/settler{
+	density = 0
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain"
+	},
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "TK" = (
 /obj/machinery/computer/terminal{
 	pixel_x = 16;
@@ -19689,24 +16495,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"TO" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
-/obj/structure/dresser{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/house/cabin_three)
 "TP" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/carpet/cyan,
-/area/f13/building)
-"TQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/cult,
 /area/f13/building)
 "TR" = (
 /obj/structure/closet/cabinet/anchored,
@@ -19744,17 +16537,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"TU" = (
-/obj/structure/rug/big/rug_fancy{
-	color = "grey";
-	dir = 4;
-	pixel_x = -16;
-	pixel_y = -18;
-	layer = 2.7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "TV" = (
 /obj/item/kirbyplants/dead{
 	desc = "It doesn't look very healthy...";
@@ -19772,8 +16554,8 @@
 /area/f13/wasteland)
 "TX" = (
 /obj/structure/campfire/barrel,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "TY" = (
@@ -19786,24 +16568,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Ub" = (
-/obj/structure/barricade/tentclothedge,
-/obj/structure/decoration/rag,
-/turf/closed/wall/f13/ruins,
-/area/f13/caves)
-"Uc" = (
-/obj/machinery/microwave/stove{
-	pixel_x = 18
-	},
-/obj/structure/table/wood/settler{
-	layer = 2.5;
-	alpha = 1;
-	pixel_x = -10
-	},
-/turf/open/floor/f13{
-	icon_state = "darkrusty"
-	},
-/area/f13/building)
 "Ud" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13{
@@ -19843,22 +16607,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"Ui" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
-"Uk" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood_mosaic/wood_mosaic_light,
-/area/f13/wasteland/city/newboston/house/cabin_two)
 "Um" = (
 /obj/structure/bookshelf,
 /turf/open/floor/wood_common{
@@ -19873,15 +16621,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Uo" = (
-/obj/structure/chair/stool/f13stool,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"Up" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/chilling/pyrite,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
 "Uq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -19894,7 +16633,7 @@
 	},
 /area/f13/tribe)
 "Ur" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19902,7 +16641,8 @@
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
-/area/f13/building)
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Us" = (
 /obj/structure/flora/twig4,
 /turf/open/indestructible/ground/outside/civ/grass3{
@@ -19912,35 +16652,43 @@
 	footstep = "grass"
 	},
 /area/f13/tribe)
+"Ut" = (
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
+	},
+/area/f13/building)
 "Uu" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
 "Uv" = (
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -21;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"Uw" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light/small,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"Ux" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/item/soap,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/obj/structure/chair/bench{
+	icon_state = "bench";
+	dir = 4;
+	color = "#363636"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"Ux" = (
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
+	},
+/obj/structure/sink/greyscale{
+	dir = 1;
+	pixel_x = -4
+	},
+/obj/machinery/light{
+	pixel_x = 22
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "Uy" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
 /area/f13/building)
@@ -19952,42 +16700,26 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"UA" = (
-/obj/structure/bed/dogbed,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"UC" = (
-/obj/structure/destructible/tribal_torch/lit,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
-"UD" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
 "UE" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "UF" = (
 /obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+	color = "#A47449"
 	},
-/obj/structure/chair/comfy/plywood{
-	dir = 4;
-	pixel_x = -10
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/obj/machinery/hydroponics/soil/pot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken5";
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "UG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -20007,32 +16739,6 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"UI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"UJ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "UK" = (
 /turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood)
@@ -20040,7 +16746,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/storage/box/bowls,
 /obj/item/clothing/neck/apron/chef,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "UN" = (
@@ -20099,16 +16805,6 @@
 	footstep = "grass"
 	},
 /area/f13/building/tribal)
-"UR" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "US" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -20151,23 +16847,18 @@
 	desc = "A pre-War wall made of solid concrete."
 	},
 /area/f13/wasteland)
-"UW" = (
-/obj/structure/window/reinforced{
+"UX" = (
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/trash,
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
-"UX" = (
-/obj/item/chair/stool{
-	icon_state = "bar"
+/obj/effect/fake_stairs/east{
+	color = "#A47449"
 	},
-/obj/structure/railing{
-	dir = 4
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "UZ" = (
 /obj/structure/table/wood/settler,
 /obj/item/seeds/rose,
@@ -20187,10 +16878,12 @@
 	},
 /area/f13/building/tribal)
 "Va" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/wood/interior,
-/area/f13/building)
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Vb" = (
 /obj/structure/stone_tile/block{
 	pixel_x = -17;
@@ -20198,58 +16891,24 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Vc" = (
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Vd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/engine,
-/area/f13/building)
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
 "Ve" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/toilet_paper{
-	pixel_y = 16;
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_y = 32;
-	pixel_x = 7
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24;
-	pixel_x = 7
-	},
-/obj/machinery/light/small{
-	dir = 1;
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/snack{
+	density = 0;
 	pixel_y = 20;
-	pixel_x = -9
+	pixel_x = -1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
-"Vf" = (
-/obj/structure/table,
-/obj/item/trash/f13/electronic/toaster{
-	pixel_y = 6;
-	pixel_x = -3
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Vg" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -20261,8 +16920,12 @@
 /area/f13/building/tribal)
 "Vh" = (
 /obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/structure/destructible/tribal_torch/wall/lit{
 	layer = 3
 	},
@@ -20285,23 +16948,20 @@
 	},
 /area/f13/building/tribal)
 "Vj" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/condiment/ketchup{
+	pixel_y = 14;
+	pixel_x = 16;
+	layer = 3.2
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/item/toy/plush/slaggy{
+	pixel_x = 7
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/turf/open/floor/wood_common{
+	color = "#CECECE"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/wasteland)
 "Vl" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -20309,7 +16969,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "Vm" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/support{
 	pixel_y = 26;
 	icon_state = "support_wall";
@@ -20318,16 +16978,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "Vn" = (
-/obj/structure/table/wood/settler{
-	density = 0
+/turf/open/floor/wood_common{
+	color = "#888888"
 	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	doc_content_1 = "I'd like to report a crime happening at your house, Officer Mack. Your house is about to burn for the crimes you committed against the People's Republic of China! I hope your sleeping family wakes up in time.. GLORY TO CHINA.";
-	doc_title_1 = "Crime Report."
-	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/area/f13/wasteland)
 "Vo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress1";
@@ -20352,59 +17006,11 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Vp" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Vq" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/industrial/red,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
-"Vr" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/turf/open/floor/carpet/orange,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "Vs" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"Vt" = (
-/obj/effect/turf_decal/siding{
-	color = "#2e2e2e";
-	dir = 8
-	},
-/obj/structure/dresser{
-	pixel_y = 16;
-	density = 0
-	},
-/turf/open/floor/wood_mosaic/wood_mosaic_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
-"Vu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
 "Vv" = (
 /obj/structure/table/booth,
 /obj/item/toy/figure/bartender{
@@ -20466,7 +17072,7 @@
 	},
 /area/f13/building)
 "VC" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/dead,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -20486,33 +17092,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood)
 "VF" = (
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = 3;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -6;
-	plane = -14
-	},
-/obj/structure/barricade/wooden/planks{
-	density = 0;
-	pixel_y = -2;
-	plane = -14
-	},
-/obj/machinery/grill,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"VH" = (
-/obj/structure/table/wood/fancy/blackred{
-	density = 0;
-	pixel_y = -10
-	},
-/obj/item/storage/box/dice,
-/obj/item/lighter/bullet,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/fridge,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "VJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -20538,18 +17121,14 @@
 	},
 /area/f13/tribe)
 "VL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	layer = 2.9;
-	pixel_y = 14
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "VM" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -20582,15 +17161,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt/light,
 /area/f13/wasteland)
-"VP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/obj/structure/spacevine{
-	pixel_y = -15;
-	plane = -3
-	},
-/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
-/area/f13/wasteland/city/newboston/house)
 "VQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -20614,41 +17184,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "VW" = (
-/obj/structure/chair/sofa/corner{
-	color = "#990033"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"VX" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/wasteland)
 "VZ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 6
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"Wa" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/food/snacks/pizzaslice/sassysage,
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_three)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "Wb" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -20748,15 +17295,17 @@
 	},
 /area/f13/tribe)
 "Wm" = (
-/obj/structure/window/fulltile/house,
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbroken"
+	},
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain{
-	color = "#845f58";
-	layer = 5
+/obj/structure/destructible/tribal_torch/lit{
+	pixel_y = 22;
+	layer = 4.2
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/closed/wall/f13/sunset/brick_small_dark{
+	color = "#AA5555"
 	},
 /area/f13/building)
 "Wn" = (
@@ -20769,16 +17318,14 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "Wo" = (
-/obj/structure/table/booth,
-/obj/structure/railing{
-	plane = -2
+/obj/structure/rug/big/rug_blue_shag{
+	layer = 1;
+	color = "#4B724F";
+	dir = 8;
+	pixel_y = -6
 	},
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
 "Wp" = (
 /obj/structure/railing/wood/post/underlayer{
 	pixel_y = 3
@@ -20789,18 +17336,32 @@
 	},
 /area/f13/tribe)
 "Wq" = (
-/obj/structure/fireplace{
-	dir = 4;
-	pixel_x = -8;
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/left{
+	dir = 1;
+	color = "#845f58"
 	},
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Wr" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/east,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/house/cabin_two)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet,
+/obj/item/melee/onehanded/slavewhip,
+/obj/item/toy/lewd/dildo/avian,
+/obj/item/toy/lewd/dildo/canine,
+/obj/item/toy/lewd/dildo/double,
+/obj/item/toy/lewd/dildo/dragon,
+/obj/item/toy/lewd/dildo/equine,
+/obj/item/toy/lewd/dildo/human,
+/obj/item/toy/lewd/dildo/tentacle,
+/obj/item/blacksmith/chain,
+/obj/item/restraints/handcuffs/fake/kinky,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/heart_box,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Ws" = (
 /obj/structure/railing{
 	dir = 4
@@ -20808,37 +17369,29 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "Wt" = (
-/obj/structure/cave/support{
-	density = 1;
-	pixel_y = 16;
-	icon_state = "stalagmite5"
+/obj/structure/curtain/directional/east{
+	color = "#5B8CA4"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"Wu" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Ww" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "Wy" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/weather/splineplain{
 	dir = 4
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 2;
-	req_one_access_txt = "136"
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "Wz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/grassybush{
@@ -20889,19 +17442,23 @@
 	},
 /area/f13/building)
 "WE" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/drawer,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
 /area/f13/building)
 "WF" = (
-/obj/structure/spacevine,
-/obj/structure/flora/branch_broken{
-	plane = -4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/greyscale{
+	dir = 1;
+	pixel_x = 8
 	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = -2;
+	pixel_x = -8;
+	dir = 1
 	},
 /obj/structure/flora/tree/oak_five{
 	plane = -1;
@@ -20911,100 +17468,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "WG" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube-burned";
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "bar"
 	},
-/area/f13/building)
-"WH" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "WI" = (
 /obj/structure/fence/wooden{
@@ -21019,7 +17491,7 @@
 	},
 /area/f13/tribe)
 "WK" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/wood_common{
@@ -21033,57 +17505,63 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/tribal)
 "WM" = (
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
-"WN" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants{
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi';
+	icon_state = "pot_4";
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/siding/white{
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"WO" = (
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain"
+	},
+/obj/effect/turf_decal/weather/splineplaincee{
+	icon_state = "spline_plain";
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/wasteland/city/newboston/house/cabin_two)
-"WO" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/stone/rugged,
-/area/f13/wasteland/city/newboston/house/cabin_four)
-"WP" = (
-/obj/structure/bookshelf{
-	pixel_y = 20
-	},
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_four)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "WQ" = (
-/obj/structure/table/glass,
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building)
+/obj/structure/flora/ausbushes/lavendergrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/grassybush{
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/dirt/light,
+/area/f13/wasteland)
 "WS" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/settler,
+/obj/structure/closet/crate/footchest{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/effect/spawner/lootdrop/f13/common_drugs,
+/obj/item/clothing/head/lilycrown,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "WU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/closed/wall/mineral/concrete{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
 	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
+/area/f13/wasteland)
 "WV" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -21099,56 +17577,35 @@
 	},
 /area/f13/tribe)
 "WW" = (
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 8;
-	color = "#453E38";
-	pixel_y = -2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/caves)
-"WX" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"WY" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/prewar/poster81{
+	pixel_y = 33
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"WY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/item/reagent_containers/rag,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common{
 	color = "#779999"
 	},
-/area/f13/building)
-"WZ" = (
 /obj/structure/table/wood/settler{
-	density = 0;
-	alpha = 1
+	density = 0
 	},
-/turf/open/floor/wood_worn{
-	color = "#FDF2C3"
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "Xa" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/industrial/cerulean,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "Xc" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -21166,11 +17623,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
-"Xd" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/slimecross/industrial/lightpink,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/building)
 "Xf" = (
 /obj/item/storage/fancy/heart_box{
 	desc = "A heart shaped chocolate box, in memory of Xena.  Fens cat who passed in 2015.  Her mob here has been rescued from ARFS Dallus 1 for 1 from the final version of its map."
@@ -21199,23 +17651,21 @@
 	name = "cobblestone"
 	},
 /area/f13/tribe)
-"Xi" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
-/area/f13/building)
-"Xk" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 6;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
 "Xl" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp{
+	pixel_y = 12;
+	color = "#363636";
+	dir = 4;
+	pixel_x = -8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "#363636";
+	pixel_x = -8
+	},
+/turf/open/floor/carpet/black,
+/area/f13/wasteland)
 "Xm" = (
 /obj/structure/fluff/railing/corner{
 	dir = 1
@@ -21258,9 +17708,25 @@
 	},
 /area/f13/building)
 "Xq" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/bronze{
+	color = "#533B62";
+	name = "stage";
+	desc = "A stage for dancing.";
+	density = 0
+	},
+/obj/item/instrument/saxophone,
+/obj/machinery/light/floor{
+	plane = -6
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 9
+	},
+/turf/open/floor/wood_worn{
+	color = "#6F4F40"
+	},
+/area/f13/wasteland)
 "Xr" = (
 /obj/machinery/smartfridge/bottlerack{
 	pixel_y = 32;
@@ -21281,17 +17747,26 @@
 	},
 /area/f13/building/tribal)
 "Xs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/brick,
-/area/f13/building)
+/obj/structure/chair/bench{
+	dir = 1
+	},
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Xt" = (
+/obj/structure/simple_door/dirtyglass,
+/obj/item/lock_bolt,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
+"Xv" = (
 /obj/structure/railing{
 	color = "#A47449"
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "Xv" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/l3closet/scientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/building)
@@ -21316,13 +17791,13 @@
 	},
 /area/f13/tribe)
 "XA" = (
-/obj/structure/decoration/rag,
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 1
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 9
 	},
-/turf/open/floor/wood_wide,
-/area/f13/building)
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "XB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -21343,18 +17818,11 @@
 	},
 /area/f13/tribe)
 "XD" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife{
-	pixel_x = 5
+/obj/structure/simple_door/room/dirty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	color = "#ADDEBA"
 	},
-/obj/item/storage/box/matches{
-	pixel_y = 10;
-	pixel_x = -8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland)
 "XF" = (
 /obj/structure/railing/wood{
 	pixel_y = -12
@@ -21384,52 +17852,14 @@
 	color = "#777777"
 	},
 /area/f13/tribe)
-"XJ" = (
-/obj/structure/closet/crate/large,
-/obj/item/toy/plush/bigdeerplushie,
-/turf/open/indestructible/ground/outside/civ/woodalt,
-/area/f13/building)
 "XK" = (
-/obj/structure/railing,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 17
-	},
-/obj/structure/spacevine{
-	pixel_y = -24;
-	plane = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
-"XL" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
-	},
-/area/f13/wasteland)
-"XM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/common_food,
+/obj/structure/table/wood_counter/bend{
 	dir = 8
 	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/wasteland)
 "XN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/barricade/wooden/strong{
@@ -21470,80 +17900,48 @@
 	color = "#A1BFFF"
 	},
 /area/f13/caves)
-"XQ" = (
-/obj/structure/cave/support{
-	density = 1;
-	anchored = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"XR" = (
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
 "XS" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/closet/crate/wooden{
+	pixel_y = -3
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"XT" = (
 /obj/machinery/light/small{
-	dir = 8;
-	light_color = "#880000"
-	},
-/turf/open/floor/f13{
-	color = "#818181";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/building)
-"XU" = (
-/obj/structure/railing/corner{
-	color = "#A47449";
 	dir = 8
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/wasteland)
+"XT" = (
+/obj/item/lipstick,
+/obj/structure/mirror{
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/caves)
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4;
+	color = "#121212"
+	},
+/obj/structure/table/wood/settler{
+	density = 0
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
+"XU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cabinet,
+/obj/item/toy/plush/duskull,
+/turf/open/floor/carpet/purple,
+/area/f13/wasteland)
 "XV" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
-"XW" = (
-/obj/structure/railing{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "XY" = (
-/obj/item/chair/stool{
-	icon_state = "bar"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/red{
+	pixel_x = -10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common{
+	color = "#CECECE"
+	},
+/area/f13/wasteland)
 "Ya" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -21578,13 +17976,14 @@
 	},
 /area/f13/tribe)
 "Ye" = (
-/obj/structure/simple_door/house,
-/obj/item/lock_bolt{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/room,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#413527"
+	},
 /turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
+/area/f13/wasteland)
 "Yf" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -21592,11 +17991,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "Yg" = (
-/obj/structure/chair/sofa/left{
-	color = "#990000"
+/obj/structure/chair/pew/right{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/house/cabin_six)
+/turf/open/floor/wood_common,
+/area/f13/wasteland)
 "Yh" = (
 /turf/closed/wall/mineral/concrete{
 	desc = "A pre-War wall made of solid concrete."
@@ -21623,25 +18022,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"Ym" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "Yn" = (
 /obj/structure/simple_door/glass,
 /obj/item/lock_bolt{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "Yo" = (
@@ -21675,11 +18062,6 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal)
-"Yu" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt,
-/turf/open/floor/wood_fancy/wood_fancy_light,
-/area/f13/wasteland/city/newboston/house/cabin_one)
 "Yv" = (
 /obj/machinery/smartfridge/bottlerack/grownbin{
 	pixel_y = 4
@@ -21703,14 +18085,18 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "Yy" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheethop,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/item/toy/plush/bird{
+	icon = 'modular_coyote/icons/mob/bird.dmi';
+	icon_state = "hooty";
+	pixel_y = 22
 	},
-/area/f13/building)
+/obj/structure/bookcase,
+/turf/open/floor/wood_common{
+	color = "#888888"
+	},
+/area/f13/wasteland)
 "Yz" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/chomp/bush2{
 	color = "#338833";
 	plane = -2;
@@ -21754,46 +18140,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"YD" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/effect/turf_decal/weather/splinefancy{
-	dir = 1;
-	color = "#453E38"
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
-"YE" = (
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain/directional/west,
-/turf/open/floor/f13/wood,
-/area/f13/building)
-"YF" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "YG" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	color = "#ffe9de";
-	icon_state = "darkrusty";
-	name = "dirty floor"
-	},
-/area/f13/caves)
-"YI" = (
-/obj/structure/chair/metal{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "YJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/trash,
@@ -21863,7 +18215,7 @@
 /area/f13/tribe)
 "YS" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/wasteland/city/newboston/house/cabin_two)
 "YT" = (
@@ -21891,7 +18243,7 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "YV" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack{
 	pixel_y = 20
@@ -21939,14 +18291,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"Za" = (
-/turf/open/floor/carpet/black,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
 "Zb" = (
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cigarette{
+	density = 0;
+	pixel_y = 30
 	},
-/area/f13/building)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/wasteland)
 "Zc" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/destructible/tribal_torch/lit{
@@ -21955,14 +18307,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"Zd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
 "Zf" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -21985,18 +18329,10 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal)
-"Zh" = (
-/turf/open/transparent/openspace,
-/area/f13/wasteland/city/newboston/outdoors)
 "Zj" = (
-/obj/structure/table,
-/obj/item/kitchen/knife/butcher,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife{
-	pixel_x = 5
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "Zk" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -22024,8 +18360,8 @@
 	},
 /area/f13/wasteland)
 "Zm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "Zn" = (
@@ -22055,14 +18391,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "Zr" = (
-/obj/item/warpaint_bowl{
-	pixel_y = 8
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/table/wood/settler,
-/obj/item/lock_construct,
-/obj/item/key,
-/turf/open/floor/plasteel/cult,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/wasteland)
 "Zs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
@@ -22100,7 +18437,7 @@
 "Zz" = (
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/snacks/meat/steak/radroach_meat,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ZA" = (
@@ -22131,7 +18468,7 @@
 	dir = 4;
 	networks = list("nash")
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/building)
 "ZE" = (
@@ -22139,18 +18476,17 @@
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood)
 "ZF" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/spacevine{
-	pixel_y = -17;
-	plane = -3
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "ZG" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cave/bigboards/westeast,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -22168,22 +18504,27 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "ZJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/wood/interior{
 	icon_state = "interior3"
 	},
 /area/f13/building)
 "ZK" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/decoration/rag{
 	icon_state = "skin";
 	pixel_x = -31
 	},
 /obj/structure/table,
 /turf/open/floor/wood_common{
-	color = "#779999"
+	color = "#CECECE"
 	},
-/area/f13/building)
+/area/f13/wasteland)
+"ZI" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/f13/wasteland)
 "ZM" = (
 /obj/structure/railing/wood{
 	dir = 4
@@ -22202,7 +18543,7 @@
 /area/f13/building)
 "ZO" = (
 /obj/machinery/microwave/stove,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ZP" = (
@@ -22214,14 +18555,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/whitepurplechess,
 /area/f13/building)
-"ZS" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	color = "#990033";
-	pixel_x = 7
+"ZR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	color = "#779999"
 	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/wasteland/city/newboston/house/cabin_seven)
+/area/f13/building)
+"ZS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
+	},
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "ZT" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	pixel_y = -4;
@@ -22250,14 +18596,15 @@
 /turf/open/floor/carpet/cyan,
 /area/f13/building)
 "ZY" = (
-/obj/structure/bed/wooden{
-	color = "#323538"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 4
 	},
-/obj/item/blanket{
-	color = "#800000"
+/obj/effect/turf_decal/weather/splineplain{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/floor/plating/f13/outside/roof,
+/area/f13/wasteland)
 "ZZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -41802,12 +38149,12 @@ Yj
 "}
 (77,1,1) = {"
 Yj
-GU
-GU
-qF
-GU
-GU
-GU
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
 tN
 tN
 tN
@@ -42060,8 +38407,8 @@ Yj
 (78,1,1) = {"
 Yj
 GU
-qF
-ib
+GU
+GU
 GU
 GU
 tN
@@ -42317,7 +38664,7 @@ Yj
 (79,1,1) = {"
 Yj
 GU
-qF
+GU
 GU
 GU
 GU
@@ -42574,10 +38921,10 @@ Yj
 (80,1,1) = {"
 Yj
 GU
-qF
 GU
 GU
-tN
+GU
+GU
 tN
 tN
 tN
@@ -42831,12 +39178,12 @@ Yj
 (81,1,1) = {"
 Yj
 GU
-qF
 GU
 GU
-tN
-tN
-tN
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -43087,15 +39434,15 @@ Yj
 "}
 (82,1,1) = {"
 Yj
-ib
-qF
 GU
 GU
-tN
-tN
-tN
-tN
-tN
+GU
+us
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -43344,17 +39691,17 @@ Yj
 "}
 (83,1,1) = {"
 Yj
-qF
+GU
+GU
+GU
+GU
+us
+us
 GU
 GU
 GU
 GU
 GU
-GU
-tN
-tN
-tN
-tN
 tN
 tN
 tN
@@ -43601,13 +39948,18 @@ Yj
 "}
 (84,1,1) = {"
 Yj
-qF
 GU
 GU
 GU
 GU
 GU
 GU
+us
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -43630,12 +39982,7 @@ tN
 tN
 tN
 tN
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
+tN
 tN
 tN
 tN
@@ -43858,12 +40205,18 @@ Yj
 "}
 (85,1,1) = {"
 Yj
-qF
+GU
+us
 GU
 GU
 GU
 GU
 GU
+us
+GU
+GU
+us
+GU
 GU
 tN
 tN
@@ -43886,13 +40239,7 @@ tN
 tN
 tN
 tN
-RM
-XY
-so
-ZB
-LV
-lE
-sE
+tN
 tN
 tN
 tN
@@ -44115,13 +40462,21 @@ Yj
 "}
 (86,1,1) = {"
 Yj
-qF
+GU
+GU
+us
 GU
 GU
 GU
 GU
 GU
 GU
+us
+us
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -44143,27 +40498,19 @@ tN
 tN
 tN
 tN
-RM
-XY
-PN
-FB
-aS
-bq
-tc
 tN
 tN
 tN
 tN
 tN
-GT
-Gx
-Gx
-Gx
-GT
-PQ
-PQ
-PQ
-CZ
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -44372,13 +40719,34 @@ Yj
 "}
 (87,1,1) = {"
 Yj
-ib
-En
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
 GU
 GU
 GU
 GU
 GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -44400,27 +40768,6 @@ tN
 tN
 tN
 tN
-RM
-dK
-dK
-ZB
-ul
-AK
-qU
-tN
-tN
-tN
-tN
-tN
-GT
-nf
-pN
-IM
-GT
-cs
-OY
-Lo
-GT
 tN
 tN
 tN
@@ -44630,12 +40977,36 @@ Yj
 (88,1,1) = {"
 Yj
 GU
-En
+GU
+GU
+GU
+us
 GU
 GU
 GU
 GU
 GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -44644,40 +41015,16 @@ tN
 tN
 tN
 tN
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Fm
-dK
-dK
-ZB
-CJ
-iU
-Lq
-Ws
-Ws
 tN
 tN
 tN
-CZ
-Pc
-TQ
-Vh
-GT
-Zd
-TU
-IG
-GT
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -44887,12 +41234,37 @@ Yj
 (89,1,1) = {"
 Yj
 GU
-En
+GU
+GU
+GU
+GU
+us
+GU
+us
 GU
 GU
 GU
 GU
 GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
@@ -44900,41 +41272,16 @@ tN
 tN
 tN
 tN
-RM
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-OG
 tN
 tN
 tN
-GT
-TQ
-lT
-Zr
-GT
-OY
-iR
-To
-GT
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -45144,54 +41491,54 @@ Yj
 (90,1,1) = {"
 Yj
 GU
-En
 GU
 GU
 GU
 GU
 GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
 tN
-Ws
-Ws
-Fm
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-OG
 tN
 tN
 tN
-GT
-TQ
-zl
-EP
-GT
-OY
-GT
-GT
-GT
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -45401,54 +41748,54 @@ Yj
 (91,1,1) = {"
 Yj
 GU
-En
 GU
 GU
 GU
-nV
-nV
-dt
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
-RM
-dK
-dK
-dK
-dK
-EC
-bx
-bx
-bx
-bx
-bx
-bx
-bx
-bx
-bx
-bx
-Bq
-Bq
-Bq
-Bq
-Bq
-Bq
-Bq
-Bq
-nb
-OG
 tN
 tN
 tN
-GT
-Pc
-jM
-ii
-GT
-Zd
-bh
-bt
-GT
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -45658,32 +42005,43 @@ Yj
 (92,1,1) = {"
 Yj
 GU
-En
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+us
+us
+us
+us
+us
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
-Bx
-lB
-oa
-Al
-mM
-mM
-QL
-mM
-MT
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-UD
 tN
 tN
 tN
@@ -45692,20 +42050,9 @@ tN
 tN
 tN
 tN
-nb
-OG
 tN
 tN
 tN
-GT
-TQ
-GT
-GI
-GT
-OY
-GT
-lx
-EP
 tN
 tN
 tN
@@ -45931,7 +42278,7 @@ MT
 Ql
 Dn
 aC
-Zm
+ks
 NB
 mD
 mM
@@ -45939,7 +42286,7 @@ mM
 mM
 NB
 wR
-fC
+JG
 yj
 tN
 tN
@@ -45949,20 +42296,8 @@ tN
 tN
 tN
 tN
-nb
-OG
 tN
 tN
-tN
-GT
-Fz
-GT
-GT
-GT
-Ye
-GT
-GT
-EP
 tN
 tN
 tN
@@ -46194,7 +42529,7 @@ jI
 lw
 uz
 ch
-UI
+ZR
 Fo
 eD
 iw
@@ -46204,21 +42539,10 @@ tN
 tN
 tN
 tN
-Ws
-Ws
-nb
-OG
-Ws
-Ws
-Ws
-og
-dK
-Qh
-Ym
-xf
-dK
-Ei
-Oe
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -46445,10 +42769,10 @@ Al
 eV
 zW
 mM
-Ku
+Zx
 Uu
-Ku
-Ku
+Zx
+Zx
 HK
 UI
 ll
@@ -46461,24 +42785,12 @@ tN
 tN
 tN
 tN
-nb
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-OG
-Ws
-Ws
-Ws
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -46699,7 +43011,7 @@ kU
 uT
 mM
 zW
-qu
+pc
 Al
 mM
 ec
@@ -46718,25 +43030,12 @@ tN
 tN
 tN
 tN
-nb
-mM
-mM
-NB
-NB
-NB
-mM
-mM
-mM
-mM
-mM
-mM
-mM
-LV
-dK
-dK
-dK
-rW
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -46944,56 +43243,56 @@ Yj
 Yj
 GU
 GU
-Df
-ME
-Ui
-Ui
-dZ
-IY
-mM
-mG
-lZ
-ud
-mM
-Al
-qu
-VZ
-tF
-YV
-oC
-pI
-Kc
-FL
-ZJ
-NI
-mz
-mM
-EC
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
 tN
 tN
-nb
-mM
-pw
-TD
-kU
-kU
-hE
-mM
-mE
-ys
-aa
-yx
-Zm
-Oq
-LV
-lE
-dK
-cJ
-PE
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -47214,12 +43513,12 @@ kM
 XA
 dK
 dK
-ws
+xC
 tF
 bg
 sM
 sM
-UI
+ZR
 HK
 WG
 VC
@@ -47229,28 +43528,13 @@ EC
 Ws
 tN
 tN
-Ws
-Ws
 tN
-nb
-Ef
-Rf
-Cj
-kU
-kU
-nB
-mM
-tF
-vD
-Zm
-mM
-tF
-ZB
-LV
-lE
-dK
-Cn
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -47458,56 +43742,56 @@ Yj
 Yj
 GU
 GU
-Df
-sZ
-ES
-ES
-dZ
-XS
-Ga
-Iu
-kU
-kU
-tH
-Al
-qu
-ws
-mM
-vN
-ql
-ql
-AC
-uz
-Cd
-FV
-vr
-mM
-dK
-oW
-dK
-dK
-xm
-ya
-PE
-nb
-mM
-Ni
-kU
-kU
-kU
-mM
-mM
-VL
-tW
-Uy
-Sq
-mM
-FB
-aS
-bq
-dK
-jz
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+us
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -47715,56 +43999,56 @@ Yj
 Yj
 GU
 GU
-xx
-xx
-xx
-xx
-dK
-Al
-mM
-bf
-Io
-bf
-mM
-VZ
-dK
-Al
-mM
-fC
-RT
-IL
-Kn
-tF
-tF
-RR
-yN
-mM
-dK
-EC
-lS
-Ti
-nc
-fa
-PE
-nb
-mM
-ZY
-kU
-kU
-kU
-ni
-mM
-Ux
-tW
-RW
-tW
-QC
-ZB
-ul
-bD
-dK
-Dv
-PE
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+us
+us
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -47973,55 +44257,55 @@ Yj
 GU
 GU
 GU
-xx
-xx
-xx
-dK
-Al
-mM
-hP
-kU
-ga
-mM
-Al
-dK
-UR
-lE
-LV
-lE
-Vp
-dK
-pM
-dK
-dK
-dK
-dK
-dK
-Dd
-Cv
-Cv
-GE
-fa
-PE
-nb
-mM
-uD
-VX
-kU
-kU
-kU
-mM
-Ll
-ys
-tW
-Uy
-QC
-ZB
-CJ
-iU
-dK
-aq
-PE
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -48228,57 +44512,57 @@ Yj
 (102,1,1) = {"
 Yj
 GU
+us
 GU
 GU
-Xt
-ME
-xx
-dK
-Al
-mM
-QF
-kU
-dS
-mM
-oa
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-Qk
-Qk
-Qk
-Qk
-Qk
-Qk
-sb
-Qk
-fa
-Kd
-nb
-Ef
-mM
-Ef
-jC
-mM
-mM
-mM
-mM
-vD
-QC
-QC
-QC
-FB
-NE
-Oq
-dK
-Ho
-PE
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -48487,55 +44771,55 @@ Yj
 GU
 GU
 GU
-Xt
-sZ
-xx
-dK
-IY
-mM
-mM
-YE
-mM
-mM
-Al
-dK
-oa
-Jg
-dK
-dK
-dK
-dK
-dK
-dK
-Qk
-JX
-ax
-WS
-WM
-gH
-WM
-QV
-dK
-dK
-dK
-LV
-lE
-Vp
-dK
-cF
-LV
-lE
-Vp
-dK
-LV
-lE
-Vp
-TJ
-Oq
-Nh
-dK
-hB
-PE
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+us
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -48741,58 +45025,58 @@ Yj
 "}
 (104,1,1) = {"
 Yj
+us
 GU
 GU
 GU
 GU
 GU
-xx
-dK
-Gu
-lE
-lE
-Ow
-lE
-LV
-lE
-dK
-oa
-oa
-dK
-ET
-Qk
-Qk
-Qk
-Qk
-Qk
-AL
-Bv
-Qk
-vO
-cy
-WM
-QV
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-xm
-xm
-xm
-OG
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -48998,58 +45282,58 @@ Yj
 "}
 (105,1,1) = {"
 Yj
+us
+GU
+GU
+GU
+GU
+us
 GU
 GU
 GU
 GU
 GU
-xx
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-lf
-WW
-Qk
-Qy
-PR
-PR
-Qk
-oV
-Qk
-Qk
-vO
-WM
-WM
-QV
-oW
-wz
-xm
-xm
-xm
-dK
-dK
-dK
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-tj
-Cz
-Cz
-kL
-PE
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -49255,59 +45539,59 @@ Yj
 "}
 (106,1,1) = {"
 Yj
+us
+GU
+GU
+GU
+GU
+us
 GU
 GU
 GU
 GU
 GU
-kl
-vz
-vz
-vz
-vz
-dK
-vz
-vz
-vz
-vz
-vz
-vz
-lf
-zI
-Qk
-xA
-cR
-cR
-cR
-fg
-cR
-Yu
-Wu
-Wu
-bd
-Qk
-jX
-lS
-Ti
-Ti
-Ti
-jp
-jp
-jp
-cw
-IS
-gu
-cw
-Es
-bM
-jK
-cw
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
-kL
-Kd
-Ws
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -49512,60 +45796,60 @@ Yj
 "}
 (107,1,1) = {"
 Yj
+us
 GU
 GU
 GU
-AJ
-AJ
-Df
-ou
-dF
-dF
-dF
-wi
-ou
-dF
-dF
-dF
-dF
-dF
-Cf
-zI
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-Qk
-JE
-HG
-wH
-sC
-EC
-dx
-Zh
-Zh
-Zh
-jp
-jg
-wq
-cw
-Ig
-iM
-cw
-rG
-cw
-cw
-cw
-PE
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
 tN
-nb
-XY
-CV
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -49769,60 +46053,60 @@ Yj
 "}
 (108,1,1) = {"
 Yj
+us
 GU
 GU
 GU
-AJ
-xx
-ps
-NH
-NH
-xD
-zI
-wi
-zI
-Ap
-Ap
-Ap
-Ap
-Ap
-Cf
-zI
-Ap
-Ap
-Ap
-Ap
-Ap
-Ap
-Ap
-jB
-Mq
-Vr
-HO
-Qk
-EC
-dx
-Zh
-jp
-jp
-jp
-dN
-jp
-cw
-mu
-tn
-HX
-tn
-Rs
-tn
-Qc
-PE
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
 tN
 tN
-nb
-XY
-Wo
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -50029,60 +46313,60 @@ Yj
 GU
 GU
 GU
-AJ
-Df
-dF
-dF
-dF
-XU
-eP
-xx
-hq
-hq
-hq
-hq
-hq
-eP
-xx
-KF
-Sf
-QA
-QA
-DU
-zI
-Ap
-Ap
-Qk
-Qk
-Qk
-Qk
-Qk
-Dd
-Cv
-Cv
-jp
-mI
-Gm
-fi
-nY
-cw
-yh
-ym
-Ji
-aR
-zt
-KO
-Qc
-PE
-Ws
-Ws
-nb
-dK
-OG
-Kd
-Ws
-Ws
-Ws
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -50285,62 +46569,62 @@ Yj
 Yj
 GU
 GU
-mM
-mM
-dX
-tF
-mM
-mM
-xx
-xx
-xx
-Df
-ou
-Lh
-dF
-dF
-zF
-xx
-vq
-Sf
-kj
-VF
-CT
-OQ
-OQ
-OQ
-ss
-Uk
-aZ
-xb
-Sf
-dK
-OH
-dK
-QO
-eJ
-wl
-fi
-ua
-cw
-Hs
-Ik
-Ji
-iG
-en
-mn
-Qc
-kP
-LV
-lE
-dK
-xm
-dR
-lj
-vE
-vE
-Ir
-WH
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -50542,62 +46826,62 @@ Yj
 Yj
 GU
 GU
-mM
-yY
-kU
-vM
-uF
-mM
-xx
-lQ
-lQ
-Df
-zI
-Ap
-Ap
-eP
-xx
-xx
-lQ
-Sf
-Sf
-Sf
-pT
-Sf
-Wr
-Sf
-Sf
-xS
-JR
-TF
-rN
-dK
-YD
-dK
-jp
-jp
-jp
-jp
-jp
-cw
-cw
-cw
-Ac
-cw
-cw
-Cr
-SU
-pC
-lE
-lE
-dK
-kW
-ET
-Vp
-SO
-Gj
-yg
-WH
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -50798,63 +47082,63 @@ Yj
 (112,1,1) = {"
 Yj
 GU
+us
 GU
-mM
-qt
-et
-rJ
-NV
-mM
-xx
-AI
-AI
-Df
-zI
-Ap
-Ap
-gj
-xx
-xx
-XR
-MI
-MI
-Sf
-me
-kD
-cS
-cS
-kD
-BY
-NM
-AX
-rN
-dK
-YD
-dK
-dK
-dK
-dK
-JL
-Hh
-CI
-Hh
-rV
-Hh
-Hh
-wF
-Fs
-xG
-hr
-Sd
-WF
-dK
-hU
-Rw
-ln
-SC
-bq
-ri
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -51055,63 +47339,63 @@ Yj
 (113,1,1) = {"
 Yj
 GU
+us
 GU
-mM
-Kg
-et
-kU
-kU
-mM
-xx
-xx
-xx
-xx
-eP
-eP
-eP
-xx
-xx
-xx
-XR
-MI
-MI
-Sf
-jw
-Sf
-uU
-NG
-Sf
-Fi
-YS
-ID
-lI
-dK
-YD
-ci
-eW
-FP
-eW
-eW
-eW
-eW
-eW
-eW
-GK
-kq
-Hh
-zr
-vJ
-ja
-lv
-UJ
-dK
-Nh
-ZB
-Hl
-fb
-bq
-ri
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -51311,64 +47595,64 @@ Yj
 "}
 (114,1,1) = {"
 Yj
-jb
-rh
-mM
-XD
-fE
-EI
-kU
-mM
-xx
-xx
-mM
-Lk
-mM
-rL
-IP
-mM
-Fd
-xx
-xx
-zp
-zp
-Sf
-Sf
-Sf
-vu
-bi
-Sf
-Jl
-SY
-Pu
-rN
-dK
-YD
-dK
-Xq
-GW
-Uw
-eW
-hv
-QW
-Im
-Pv
-Hh
-Hh
-wC
-Hh
-fR
-hr
-eZ
-ZB
-dK
-ul
-Kb
-SN
-ck
-wf
-LB
-PE
+GU
+us
+us
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -51568,64 +47852,64 @@ Yj
 "}
 (115,1,1) = {"
 Yj
-jL
-qc
-mM
-mM
-mM
-mM
-mM
-mM
-nS
-nS
-mM
-ST
-kx
-rc
-rc
-xU
-Rp
-ac
-xx
-Db
-Rn
-Rp
-Sf
-Sf
-Td
-KH
-Sf
-WN
-lW
-ff
-Sf
-dK
-YD
-dK
-eW
-eW
-eW
-eW
-Yg
-cn
-iI
-Pv
-hj
-Hh
-Hh
-Hh
-DQ
-pC
-ye
-iU
-dK
-CJ
-kW
-ET
-Vp
-bq
-Oe
-PE
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -51825,64 +48109,64 @@ Yj
 "}
 (116,1,1) = {"
 Yj
-XL
-Na
-qF
-Wt
 GU
 GU
 GU
-AB
-yo
-XQ
-mM
-tg
-PC
-ok
-mG
-mM
-NA
-nT
-xx
-hm
-xJ
-cB
-Sf
-Sf
-Sf
-Sf
-Sf
-Sf
-Sf
-Sf
-Sf
-dK
-DF
-dK
-eW
-zT
-pn
-eW
-Vt
-ZH
-Eq
-Pv
-cQ
-Hh
-tP
-Hh
-Hh
-dK
-dK
-dK
-dK
-WX
-hU
-Rw
-QH
-SC
-Oe
-PE
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+us
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -52082,64 +48366,64 @@ Yj
 "}
 (117,1,1) = {"
 Yj
-sh
-uc
-Qw
-qF
 GU
 GU
 GU
-qF
-ue
-qF
-mM
-mM
-mM
-DX
-eF
-xU
-Nw
-zi
-xx
-hc
-hL
-qg
-hC
-RN
-nI
-tQ
-hC
-Ot
-Rv
-JF
-hC
-Ej
-dK
-dK
-eW
-CH
-oq
-Er
-oq
-oq
-eW
-eW
-jO
-vK
-Hh
-Hh
-eg
-RP
-dO
-FO
-rH
-jE
-Nh
-ZB
-Hl
-Vc
-XW
-PE
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -52340,63 +48624,63 @@ Yj
 (118,1,1) = {"
 Yj
 GU
-Ro
-qF
-Qw
 GU
 GU
 GU
-AB
-ld
-XQ
+us
 GU
-mM
-mM
-Si
-xu
-mM
-Rp
-ac
-xx
-Db
-Rn
-Rp
-hC
-ad
-LY
-tQ
-hC
-Tw
-HC
-HC
-Cq
-dK
-pB
-dK
-eW
-QU
-wI
-wI
-dk
-oq
-Ip
-Eu
-jO
-rP
-qm
-kb
-DQ
-ja
-Ym
-iU
-NE
-fS
-ZB
-Ym
-sn
-aD
-rQ
-PE
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -52597,63 +48881,63 @@ Yj
 (119,1,1) = {"
 Yj
 GU
-lm
-qF
-uc
 GU
-sh
-qF
-qF
-yo
-eG
 GU
-mM
-mM
-mM
-mM
-mM
-Rp
-Rn
-xx
-xx
-xx
-Rp
-hC
-hC
-Mk
-hC
-hC
-eQ
-yz
-rk
-hC
-dK
-Mg
-dK
-eW
-eW
-Nf
-jc
-UN
-Cx
-eW
-ft
-tp
-tp
-tp
-tp
-EC
-fd
-Vp
-ET
-lE
-lE
-LV
-lE
-Ab
-bq
-sE
-PE
+us
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -52853,64 +49137,64 @@ Yj
 "}
 (120,1,1) = {"
 Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+us
 GU
-sh
-Qw
-Qw
 GU
-sh
 GU
-AB
-gc
-XQ
+GU
+GU
+us
+us
 GU
 GU
 GU
 GU
 GU
 GU
-tZ
-gM
-nS
-PK
-xx
-Rp
-hC
-Wa
-HC
-HC
-hC
-nW
-HC
-HC
-Cq
-dK
-Mg
-dK
-LI
-eW
-eW
-eW
-eu
-eW
-eW
-eW
-tp
-Ve
-pd
-tp
-dK
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-PE
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -53110,62 +49394,62 @@ Yj
 "}
 (121,1,1) = {"
 Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
 GU
-jZ
-go
-qF
-TA
-qF
-GU
-qF
-ue
-qF
 GU
 GU
 GU
 GU
 GU
 GU
-AE
-AI
-aY
-SF
-xx
-Fd
-hC
-es
-xg
-OJ
-LW
-OJ
-OJ
-OJ
-tI
-dK
-py
-dK
-dK
-rl
-xQ
-YI
-dK
-tp
-fH
-tx
-tp
-hK
-tp
-tp
-dK
-ae
-ae
-AY
-EY
-ZD
-SI
-ij
-iQ
-ic
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -53367,6 +49651,20 @@ Yj
 "}
 (122,1,1) = {"
 Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
 GU
 GU
 GU
@@ -53374,55 +49672,41 @@ GU
 GU
 GU
 GU
-AB
-yo
-XQ
 GU
 GU
 GU
 GU
 GU
 GU
-yZ
-aY
-AI
-ih
-xx
-Rp
-hC
-TO
-Ao
-nn
-hC
-vG
-SA
-qv
-Cq
-dK
-dK
-xm
-xm
-xm
-xm
-dK
-dK
-kJ
-lO
-lO
-kQ
-rg
-ZS
-tp
-dK
-ae
-Pq
-SB
-SB
-yk
-MP
-el
-MP
-ic
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -53624,62 +49908,62 @@ Yj
 "}
 (123,1,1) = {"
 Yj
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Yj
 GU
 GU
 GU
 GU
 GU
 GU
-AJ
-Ub
-xZ
-Ke
-AJ
-AJ
-AJ
 GU
 GU
 GU
 GU
 GU
 GU
-Al
-dK
-Al
-hC
-If
-bH
-xn
-hC
-CO
-GG
-Mm
-hC
-dK
-EC
-tj
-Cz
-Cz
-Cz
-HI
-dK
-tp
-Jd
-Za
-mJ
-VH
-kB
-tp
-dK
-ae
-kZ
-SB
-SB
-Ty
-HA
-HA
-ag
-ic
+GU
+GU
+GU
+us
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -53881,62 +50165,62 @@ Yj
 "}
 (124,1,1) = {"
 Yj
-GU
-GU
-GU
-AJ
-AJ
-AJ
-AJ
+EX
+Wr
+ir
 Vm
-ZG
-DA
+EX
+Wr
+ae
+Vm
+EX
+Wr
 hZ
-NZ
-DA
-DA
-DA
-DA
-DA
+Vm
+EX
+Yj
 GU
 GU
+GU
+ff
+qF
 IY
-dK
-VZ
-hC
-hC
-hC
-hC
-hC
-hC
-hC
-hC
-hC
-dK
-EC
-PE
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+us
+GU
+GU
+GU
 tN
 tN
 tN
-QK
-dK
-tp
-kS
-Fj
-mJ
-Kx
-jy
-tp
-dK
-ae
-ae
-ae
-nj
-ae
-DO
-Jk
-ae
-ae
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -54138,62 +50422,62 @@ Yj
 "}
 (125,1,1) = {"
 Yj
-GU
-GU
-GU
-AJ
-bK
+EX
 Jv
-Cm
+iy
 eG
-xx
-DA
-lH
-xM
-gE
-DA
-eX
-kU
-DA
+EX
+Jv
+iy
+eG
+EX
+Jv
+iy
+eG
+EX
+Yj
 GU
 GU
-Al
-dK
-Al
-TI
-tb
-DJ
-Ix
-Ez
-wS
-sf
-wS
-DI
-dK
-yj
-PE
+aN
+qF
+qF
+qF
+GU
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
-Cz
-nb
-tp
-tp
-tp
-ux
-tp
-of
-tp
-xm
-xm
-xm
-ae
-ae
-ae
-ae
-ae
-ae
-ae
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -54395,52 +50679,52 @@ Yj
 "}
 (126,1,1) = {"
 Yj
-GU
-GU
-GU
-AJ
-jQ
-jQ
-eL
+EX
 iy
-ej
-DA
-df
-gD
-rf
-vt
-qR
-kU
-DA
+iy
+iy
+EX
+iy
+iy
+iy
+EX
+iy
+iy
+iy
+EX
+Yj
 GU
 GU
-zW
-dK
-zW
-TI
-wX
-uO
-Cc
-TI
-WP
-PZ
-Tx
-TI
-dK
-yj
-PE
+zr
+qF
+qF
+qF
+qF
+Yj
+Yj
+PD
+PD
+PD
+PD
+PD
+GU
+GU
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
-iD
-EC
-PE
 tN
-nb
-dK
-EC
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -54652,52 +50936,52 @@ jD
 "}
 (127,1,1) = {"
 Yj
-GU
-GU
-GU
-AJ
-Ib
+EX
 jQ
-AJ
-zM
-ej
-DA
 FJ
-OC
-yt
-vt
-ir
-DA
-DA
+iy
+EX
+jQ
+FJ
+iy
+EX
+jQ
+FJ
+iy
+EX
+Yj
 GU
 GU
-Al
-dK
-Al
-TI
-TI
-TI
-TI
-TI
-An
-hi
-QD
-TI
-dK
-yj
-PE
+LV
+qF
+qF
+qF
+qB
+Yj
+Yj
+PD
+SO
+TF
+WO
+PD
+GU
+us
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
-Cz
-ZF
-PE
 tN
-iD
-xm
-uw
-PE
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -54909,51 +51193,51 @@ jD
 "}
 (128,1,1) = {"
 Yj
-GU
-GU
-GU
+EX
+EX
+EX
 AJ
-AJ
-AJ
-AJ
+EX
+EX
+EX
 AM
-KV
-Hp
-pS
-wD
-xM
-jN
-rJ
-kU
-DA
+EX
+EX
+EX
+AM
+EX
+Yj
 GU
 GU
-Al
-dK
-mf
-mf
-mf
-mf
-mf
+Zq
+qF
+qF
+qF
+qF
+GU
+GU
+PD
+lv
+Fe
 TI
-sX
-PA
-MU
-DI
-dK
-yj
-PE
+PD
+GU
+GU
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
 tN
-Mx
-PE
 tN
-Cz
-Cz
-Cz
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -55166,46 +51450,46 @@ jD
 "}
 (129,1,1) = {"
 Yj
-In
-In
-In
-lL
-In
-In
-In
-KV
+EX
+rk
+hZ
 iy
-Hp
+iy
+AL
+iy
+iy
+lS
+iy
+iy
 bu
-bu
-gE
-vt
-EB
-DA
-DA
+EX
 Yj
-Yj
-Ry
-dK
-mf
-lk
+GU
+GU
+mF
+qF
+qF
+qF
+qF
+GU
+GU
 PD
-WO
-cz
+PD
+PD
 jk
-ND
-Px
-mo
-vC
-dK
-EC
-PE
+PD
+us
+GU
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
 tN
-Mx
 tN
 tN
 tN
@@ -55423,46 +51707,46 @@ jD
 "}
 (130,1,1) = {"
 Yj
-In
-OE
-Zb
-FH
-OL
+EX
+EX
+EX
+EX
+iy
 lR
-In
-Vm
-um
-vt
+EX
+EX
+EX
+EX
 AW
-ot
-xM
-DA
-kU
-FA
-DA
-qB
+EX
+EX
 Yj
-Al
-dK
-mf
-wE
-qP
+us
+GU
+GU
+qB
+qF
+qF
+qF
+GU
+GU
+PD
 tV
 mf
-TI
+iA
 VW
-eM
-UA
-DI
-dK
-EC
-PE
+VW
+PD
+Yj
+Yj
+GU
+GU
+GU
+GU
+GU
 tN
 tN
 tN
-tN
-tN
-IC
 tN
 tN
 tN
@@ -55683,8 +51967,8 @@ Yj
 In
 yI
 Zb
-UI
-AC
+ZR
+Lb
 Zb
 NT
 ej
@@ -55717,9 +52001,6 @@ PE
 tN
 tN
 tN
-tN
-tN
-Mx
 tN
 tN
 tN
@@ -55942,48 +52223,48 @@ In
 gf
 In
 xO
-AC
+Lb
 kI
 xx
 KV
 xx
-xx
-xx
-xx
-DA
-DA
-DA
-xs
-hG
+iy
+ck
+EX
 Yj
+GU
+GU
+GU
+GU
+GU
 Al
-dK
-mf
-mf
-mf
-mf
-mf
+yo
+Al
+GU
+PD
+Hp
+wF
 rt
-LL
+rt
 Bp
-LL
-Bp
-dK
-yj
-PE
+PD
+us
+Yj
+Yj
+Yj
+GU
+GU
+GU
+GU
 tN
 tN
 tN
 tN
 tN
-ZF
-PE
 tN
-Ws
-Ws
-Ws
-Ws
-Ws
+tN
+tN
+tN
 tN
 tN
 tN
@@ -56194,12 +52475,12 @@ jD
 "}
 (133,1,1) = {"
 Yj
-In
+EX
 Kv
 qo
 In
 Zb
-AC
+Lb
 NT
 xx
 NC
@@ -56451,54 +52732,54 @@ jD
 "}
 (134,1,1) = {"
 Yj
-In
+EX
 Ah
-AA
+qo
 In
-LC
+iy
 Fk
-In
-Aq
+bs
+NC
 cG
-TX
-Ps
-Ps
-cG
-ro
-ro
-Ps
-um
-AJ
+EX
+jh
+XT
+EX
 Yj
-Gu
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-EC
-mM
-pD
-Ml
-Ml
-UC
-mM
-XK
-PE
+GU
+GU
+GU
+GU
+GU
+Al
+ld
+Al
+GU
+PD
+lo
+Yg
+KH
+lo
+Yg
+PD
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
-Tm
-QM
-iP
-wj
-rE
-Cg
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -56708,53 +52989,53 @@ jD
 "}
 (135,1,1) = {"
 Yj
-In
-In
-In
-In
-In
-In
-In
-xx
-Ps
-Ps
-NC
-ro
-vb
-vb
-vb
-Gd
-Ps
-pe
-mM
-mM
-dX
-mM
-tF
-mM
-dK
-mM
-mM
+EX
+GW
+JE
+lR
+vN
+Fk
+Im
+lL
+tb
+lR
+EX
+EX
+EX
+EX
+EX
+EX
+GU
+us
+IL
+vd
+qF
+vd
+IY
+PD
 lo
-mM
-xP
-mM
-mM
-EC
-mM
-jq
-Qf
-oQ
+Yg
+KH
+lo
+Yg
+PD
+GU
+PD
+PD
+PD
+PD
+PD
+PD
 mU
-XA
-yj
-PE
+sc
 tN
-Tm
-iP
-aH
-Az
-By
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -56965,53 +53246,53 @@ Yj
 "}
 (136,1,1) = {"
 Yj
-In
-PM
-Zb
-FH
-OL
-lR
-In
+EX
+EX
+EX
+EX
+iy
+Uv
+cU
 Aq
 Ps
-FK
+lR
 Yn
-Nu
+Yn
 xB
-Zz
-JY
-aN
-DA
-DA
-mM
+Yn
+Yn
+EX
+So
+wq
+RT
 Kg
-kU
-sd
-RB
-mM
-dK
-mM
+jW
+jW
+jW
+PD
+yD
+Eo
 eK
 Eo
 yD
-et
-az
-mM
-EC
-mM
-cL
+PD
+GU
+PD
+pp
+lI
+PD
 Ta
 rc
-om
-mM
-LD
-BQ
+bw
+sc
 tN
-Tm
-QM
-mp
-iP
-VP
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -57224,8 +53505,8 @@ Yj
 Yj
 In
 Yy
-UI
-UI
+ZR
+ZR
 Zb
 Zb
 NT
@@ -57479,64 +53760,64 @@ Yj
 "}
 (138,1,1) = {"
 Yj
-In
-In
-In
-In
+Yj
+Yj
+Yj
+EX
 eE
-Zb
+Mo
 kI
-xx
-Ps
-lV
+Aq
+WY
+EX
 aL
 et
 UL
 kX
 Gh
-Vf
+EX
 GF
-DA
-mM
+ZG
+vK
 ZO
-kU
-rJ
-et
-mM
-dK
-mM
+Va
+Va
+Va
+mz
+kY
+sQ
 PS
-tB
-et
-et
+Zj
+Zj
+sQ
 EI
-ta
-EC
-mM
-hg
-mR
-mM
+PD
+XD
+PD
+PD
+bx
+PD
 yH
-mM
-EC
-PE
-tN
-tN
-vP
+sc
 tN
 tN
 tN
 tN
-Yh
-Yh
-ZC
-ZC
-Yh
-Yh
-Yh
-Yh
-Yh
-Yh
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -57736,47 +54017,45 @@ Yj
 "}
 (139,1,1) = {"
 Yj
-In
-OW
-XT
+Yj
+Yj
+Yj
 EX
-Zb
-Zb
-In
-AJ
-AJ
-DA
-DA
+cQ
+oq
+cU
+Aq
+sb
+lR
+Yn
 ZI
-DA
-MF
-MF
-MF
-MF
-DA
-QC
-lD
-et
-et
+ZI
+ZI
+Yn
+EX
+tg
+vK
+Va
+Va
+Va
+Va
 wp
-mM
+As
 dK
-mM
-vd
-et
-et
-kU
+sc
+tN
+tN
+rq
+sQ
 Zj
-ta
-EC
-mM
+PD
+Ll
+mR
 dw
 mR
-mM
-Nm
-mM
-EC
-PE
+PD
+bw
+sc
 tN
 tN
 tN
@@ -57784,16 +54063,18 @@ tN
 tN
 tN
 tN
-Yh
-mK
-kU
-kU
-tA
-Yh
-jT
-AQ
-Aw
-Yh
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -57993,47 +54274,45 @@ Yj
 "}
 (140,1,1) = {"
 Yj
-In
-Ah
-lP
-In
+Yj
+Yj
+Yj
+EX
 mC
-DC
-In
-GU
-GU
-GU
-GU
-GU
-GU
-tN
-tN
-tN
-tN
-tN
+iy
+pX
+PI
+eX
+lR
+Ve
+iy
+iy
+iy
+iy
+Az
+Va
+Va
 QC
 BZ
 CM
 NV
 uF
-mM
-dK
-mM
-tk
-kU
-Od
-et
-Gh
-mM
+Sq
+sU
+sc
+tN
+tN
+rq
+Zj
+Zj
+Xt
 EC
-mM
-mM
+mR
+Wo
 LQ
-mM
-mM
-mM
-LD
-PE
+rc
+WQ
+sc
 tN
 tN
 tN
@@ -58041,16 +54320,18 @@ tN
 tN
 tN
 tN
-Yh
-kU
-kU
-kU
-kU
-Yh
-Fl
-AQ
-AQ
-ZC
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -58250,64 +54531,64 @@ Yj
 "}
 (141,1,1) = {"
 Yj
-In
-In
-In
-In
-In
-In
-In
-GU
-GU
-GU
-GU
-GU
-GU
+Yj
+Yj
+Yj
+EX
+oC
+EX
+EX
+lR
+EX
+EX
+fd
+iy
+iy
+iy
+iy
+Az
+Va
+Va
+Ab
+en
+MF
+Va
+kM
+yd
+GD
+sc
 tN
 tN
-tN
-tN
-tN
-QC
-mM
-MF
-MF
-mM
-mM
-dK
-mM
-mM
-MF
-MF
-MF
-mM
-mM
-EC
-tF
+rq
+sQ
+Zj
+PD
+tx
+Td
 Ed
-Zb
-Zb
-no
-iv
-yj
-PE
-tN
-tN
-cu
+qG
+PD
+VO
+sc
 tN
 tN
 tN
 tN
-Yh
-mK
-kU
-vZ
-kU
-je
-AQ
-RO
-La
-ZC
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -58507,20 +54788,45 @@ Yj
 "}
 (142,1,1) = {"
 Yj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Yj
+Yj
+Yj
+lR
+iy
+ic
+oC
+iy
+vp
+iy
+iy
+iy
+iy
+Cv
+QD
+EX
+Tw
+Va
+cB
+zD
+Cz
+Va
+Va
+yd
+aq
+sc
 tN
 tN
+rq
+sQ
+fk
+PD
+Mx
+PD
+PD
+PD
+PD
+Sy
+sc
 tN
 tN
 tN
@@ -58543,7 +54849,7 @@ Mx
 tF
 Av
 Zb
-UI
+ZR
 BH
 Cs
 Uv
@@ -58555,16 +54861,14 @@ tN
 tN
 tN
 tN
-Yh
-kU
-Uo
-kU
-kU
-Yh
-Yh
-ox
-Yh
-ox
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -58764,64 +55068,64 @@ Yj
 "}
 (143,1,1) = {"
 Yj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Yj
+Yj
+Yj
+lR
+IZ
+ic
+oC
+iy
+iy
+iy
+iy
+iy
+iy
+qv
+qv
+EX
+Va
+wp
+Va
+Va
+Va
+wp
+Va
+rf
+dK
+sc
 tN
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-Mx
-PE
-tN
-tN
-tN
-tN
-tN
-tN
-Mx
-tF
+rq
+sQ
+iY
+PD
+QA
+RB
 ey
-Zb
-Zb
-BH
-SP
-yj
-PE
-tN
-tN
-gR
+NZ
+rc
+bw
+sc
 tN
 tN
 tN
 tN
-Yh
-AT
-gQ
-MZ
-kU
-OP
-MC
-di
-di
-ox
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -59021,32 +55325,54 @@ Yj
 "}
 (144,1,1) = {"
 Yj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-gR
-tN
-tN
-tN
-tN
+Yj
+Yj
+Yj
+EX
+EX
+EX
+EX
+EX
+Ye
+EX
+iy
+iy
+iy
+iy
+bC
+EX
+NV
+uF
+gx
+Va
+NV
+uF
+LE
+aY
 ZF
-PE
+sc
+tN
+tN
+rq
+Zj
+iY
+PD
+pM
+tF
+PD
+dN
+rc
+VO
+sc
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -59055,8 +55381,8 @@ tN
 tN
 Mx
 tF
-UI
-UI
+ZR
+ZR
 Zb
 BH
 as
@@ -59066,19 +55392,6 @@ tN
 tN
 tN
 tN
-tN
-tN
-tN
-Yh
-bC
-Uo
-kU
-Ol
-Yh
-kU
-kU
-kU
-ox
 tN
 tN
 tN
@@ -59278,64 +55591,64 @@ Yj
 "}
 (145,1,1) = {"
 Yj
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Yj
+Yj
+Yj
+Yj
+EX
+xO
+vG
+vG
+vG
+EX
+lQ
+lO
+Yn
+iy
+bC
+EX
+mT
+Bx
+GE
+GE
+GE
+lw
+DX
+VZ
 Dk
-PE
 tN
 tN
 tN
-tN
-tN
-tN
-Mx
-tF
-Lp
-Zb
-GD
-tF
+rq
+Zj
+EI
+PD
+nc
+xb
+PD
+PD
+PD
+HQ
 sc
-EC
-Kd
-tN
-Ws
-Ws
 tN
 tN
 tN
 tN
-Yh
-Yh
-Yh
-ox
-ox
-Yh
-Yh
-Yh
-Yh
-Yh
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -59535,57 +55848,57 @@ Yj
 "}
 (146,1,1) = {"
 Yj
+tN
+tN
 Yj
 Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-Ws
-sH
-PE
+EX
+nI
+An
+Ic
+vC
+lR
+Yn
+Da
+Yn
+jc
+bC
+EX
+mo
+Mb
+ZY
+mo
+Dd
+Mb
+PA
+Dk
+tN
+tN
+tN
+tN
+II
+Zj
+Kn
+ks
+Wy
+ZS
+SB
+RN
+oa
+VL
+sc
 tN
 tN
 tN
 tN
 tN
 tN
-Mx
-tF
-tF
-tF
-tF
-tF
-dK
-dK
-dK
-dK
-dK
-EC
-mM
-mM
-mM
-mM
-mM
-mM
-mM
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -59792,57 +56105,57 @@ Yj
 "}
 (147,1,1) = {"
 Yj
-GU
-GU
-GU
-GU
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-GU
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-mT
-PE
 tN
 tN
+Yj
+Yj
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+fY
 rs
 rs
 rs
 rs
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-Qn
-Ow
-dK
-Vj
-vh
-mM
-BF
-Ny
-mM
-As
-mr
-bB
+rs
+rs
+tN
+tN
+tN
+tN
+tN
+rs
+Ut
+Ut
+rs
+rs
+rs
+rs
+rs
+rs
+rs
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -60049,38 +56362,38 @@ Yj
 "}
 (148,1,1) = {"
 Yj
+tN
+tN
+tN
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
 GU
 GU
 GU
-GU
-IQ
-ZP
-eI
-qA
-xc
-UW
-sD
-IQ
-GU
-qF
-GU
-GU
-JD
-LL
-Dw
-sU
-LL
-Vj
-dK
-dK
-dR
-PE
+rs
+rs
+rs
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 dl
 ZK
 Ur
-rs
+Ut
 dK
 Vj
 Yz
@@ -60306,42 +56619,42 @@ Yj
 "}
 (149,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-Ls
-eI
-IZ
-eI
-Js
-nr
-IQ
-qF
-qF
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Yj
+Yj
 GU
-LE
-lb
-Xl
-Xl
-Xl
-iA
-YF
-dK
-dK
-Kj
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
 Wm
-WK
+sQ
 kg
 MJ
-qu
+pc
 dK
 dK
-qu
+pc
 dK
 dK
 dK
@@ -60563,57 +56876,46 @@ Yj
 "}
 (150,1,1) = {"
 Yj
-IQ
-Vq
-RG
-NW
-IQ
-So
-eI
-eI
-eI
-gP
-sD
-IQ
-qF
-qF
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Yj
 GU
-Sk
-ZA
-fn
-OF
-MS
-lb
-qy
-dK
-dK
-bU
+GU
+GU
+GU
 tN
 tN
 tN
-Xs
+Ne
 sQ
-UI
+ZR
 oi
 LL
-LL
+IM
 Vj
-LL
-uI
-dK
-dK
-Qn
-dK
-XY
-dK
-JT
-mM
-Tg
-Qt
-Wq
-Qt
-bB
-bw
+Xs
+Ur
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -60837,8 +57139,8 @@ qF
 GU
 LE
 He
-UI
-UI
+KM
+KM
 Zb
 Tb
 ol
@@ -60848,13 +57150,13 @@ bU
 tN
 tN
 tN
-Xs
+Ne
 oI
-UI
+ZR
 oi
 Xs
-Xs
-Xs
+Ne
+Ne
 Xs
 yl
 dK
@@ -60863,7 +57165,7 @@ bl
 dK
 dK
 dK
-qu
+pc
 yT
 uJ
 Qt
@@ -61094,9 +57396,9 @@ qF
 GU
 lb
 sF
-UI
+KM
 os
-UI
+KM
 Zb
 XA
 dK
@@ -61107,27 +57409,27 @@ tN
 tN
 II
 WE
-UI
+ZR
 BR
 Va
-WY
+Va
 tv
 Xs
 yl
-dK
-dK
-cU
-dK
-XY
-dK
-QY
-mM
-pp
-Bz
-dd
-gx
-mM
-Sy
+OU
+OU
+OU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 tN
 tN
 tN
@@ -61352,8 +57654,8 @@ GU
 oP
 PG
 Zb
-UI
-UI
+KM
+KM
 bJ
 qy
 dK
@@ -61362,14 +57664,14 @@ bU
 tN
 tN
 tN
-zb
+ig
 TG
-AC
-UI
+Lb
+ZR
 rC
 NU
 iT
-Xs
+Ne
 Dx
 dK
 dK
@@ -61620,12 +57922,12 @@ Ws
 Ws
 Ws
 rq
-rq
+kF
 Pt
-rs
-Xs
-Xs
-zb
+Ut
+Ne
+Ne
+oN
 zb
 EO
 dK
@@ -61848,57 +58150,57 @@ Yj
 "}
 (155,1,1) = {"
 Yj
-IQ
-Wy
-pb
-Pk
-SZ
-Th
-IQ
-Nj
-di
-IQ
-qF
-qF
-qF
-qF
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Yj
+Yj
 GU
-cb
-fM
-cb
-fM
-cb
-cb
-fM
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
-dK
+GU
+GU
+GU
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+rq
+Zj
+dd
+ux
+SX
+Va
+Va
+Va
+rH
+vt
+lj
 Yz
-Mt
-dK
-Dw
-Mb
-mM
-gd
-Du
-mM
-Lr
-bB
-VO
+PD
+PD
+PD
+PD
+PD
+PD
+PD
+PD
+tN
+tN
+tN
 tN
 tN
 tN
@@ -62105,57 +58407,57 @@ Yj
 "}
 (156,1,1) = {"
 Yj
-xF
-Ds
-PW
-uG
-KN
-ku
-CR
-Gi
-IQ
-IQ
-qF
-qF
-qF
-qF
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+Yj
 GU
 GU
 GU
 GU
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-nb
-dK
-dK
-dK
-dK
-dK
-dK
+GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+rq
+sQ
+Lb
+Ol
+Va
+Va
+gD
+Pp
+rH
+Eq
+vt
 xm
-xm
-xm
-xm
-xm
-xm
-xm
+PD
+Yy
+gu
 js
-mM
-Ox
+PD
 ow
-mM
-mM
-mM
-HQ
+ow
+PD
+tN
+tN
+tN
 tN
 tN
 tN
@@ -62362,24 +58664,22 @@ Yj
 "}
 (157,1,1) = {"
 Yj
-xF
-OS
-pb
-Qe
-CS
-Ai
-Th
-zE
-IQ
-qF
-qF
-qF
-qF
-qF
-qF
-qw
-GU
-GU
+tN
+tN
+tN
+tN
+tN
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
 tN
 tN
 tN
@@ -62391,25 +58691,27 @@ tN
 tN
 tN
 tN
-fY
+tN
+Zj
+Zj
+pn
 XY
-XY
-dK
-dK
-dK
+iE
+Va
+Va
 OG
 tj
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-Cz
-tN
-tN
-tN
-tN
+yt
+vt
+xm
+PD
+Ej
+Vn
+dF
+PD
+jb
+iQ
+ci
 tN
 tN
 tN
@@ -62619,24 +58921,22 @@ Yj
 "}
 (158,1,1) = {"
 Yj
-IQ
-rO
-jA
-nN
-CS
-Xv
-Bo
-zE
-IQ
-qF
-qF
-Ht
+tN
+tN
+tN
+tN
+tN
 sG
-Mh
-qF
-fc
-GU
-GU
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
 tN
 tN
 tN
@@ -62648,25 +58948,27 @@ tN
 tN
 tN
 tN
-fY
+tN
+Zj
+sQ
+Zj
 gL
-gL
-dK
-EO
-dK
+Va
+Va
+iD
 SG
 PE
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+Eq
+lj
+Yz
+PD
+rQ
+Vn
+Qk
+Ik
+Vn
+vb
+ci
 tN
 tN
 tN
@@ -62876,24 +59178,22 @@ Yj
 "}
 (159,1,1) = {"
 Yj
-IQ
-PY
-DT
-WQ
-CR
-Lf
-Th
-Br
-Gi
-qF
-uv
-kC
-hp
-XM
-Mh
-qw
-GU
-GU
+tN
+tN
+tN
+tN
+tN
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
+sG
 tN
 tN
 tN
@@ -62905,25 +59205,27 @@ tN
 tN
 tN
 tN
-nu
-PI
+tN
+Fo
+Zj
+Bw
 UX
-xm
-mM
+wz
 TC
-mM
-mM
+TC
+DC
+bB
 Qr
-mM
-mM
-mM
-Qr
-mM
-mM
-tN
-tN
-tN
-tN
+Dv
+jg
+PD
+hU
+Vn
+xM
+PD
+RQ
+GK
+ci
 tN
 tN
 tN
@@ -63133,24 +59435,22 @@ Yj
 "}
 (160,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-CR
-mi
-zE
-IQ
-NS
-tE
-fN
-Bb
+tN
+tN
+tN
+tN
+tN
+sG
 WU
-RA
-us
-GU
-GU
+WU
+NS
+NS
+WU
+WU
+WU
+WU
+WU
+WU
 tN
 tN
 tN
@@ -63162,25 +59462,27 @@ tN
 tN
 tN
 tN
-Cz
-Cz
-Cz
-Cz
-mM
-Qt
-Qt
-Qt
-Qt
-Qt
-cf
-Qt
+tN
+tN
+ud
+sQ
+sQ
+Zj
+Zj
+Bw
+Bw
+Zj
+Zj
+Zj
+Zj
+PD
 Ea
 Vn
-mM
-tN
-tN
-tN
-tN
+Vn
+ot
+Vn
+Vn
+ci
 tN
 tN
 tN
@@ -63390,24 +59692,22 @@ Yj
 "}
 (161,1,1) = {"
 Yj
-IQ
-Ij
-SX
-jR
-MM
-wr
-in
-zE
-IQ
-GU
+tN
+tN
+tN
+tN
+tN
+sG
+WU
+Br
+Ax
+Ax
 MW
-HV
+WU
 FY
 Ns
 gl
-GU
-GU
-GU
+WU
 tN
 tN
 tN
@@ -63421,23 +59721,25 @@ tN
 tN
 tN
 tN
-tN
-tN
-mM
-hA
-Qt
-PV
+rq
+Zj
+Zj
+sQ
+sQ
+Zj
+Bw
+Zj
 kY
-Gv
-mM
-KY
-Qt
+Zj
+Zj
+PD
+PD
 LJ
-Pp
-tN
-tN
-tN
-tN
+LJ
+PD
+PD
+vZ
+PD
 tN
 tN
 tN
@@ -63647,24 +59949,22 @@ Yj
 "}
 (162,1,1) = {"
 Yj
-IQ
-Vd
-BI
-td
-iY
-Gy
-BW
-zE
-IQ
-GU
-qF
-cK
+tN
+tN
+tN
+tN
+tN
+sG
+WU
+Ax
+Ax
+Ax
+Ax
+WU
 YG
-gl
-qF
-GU
-GU
-GU
+Ns
+Ns
+NS
 tN
 tN
 tN
@@ -63678,24 +59978,26 @@ tN
 tN
 tN
 tN
-tN
-tN
-mM
-rF
+sX
+tZ
+EX
+AA
+AA
+EX
 IK
 aB
-wG
-Uc
-mM
-Hn
+wj
+Zj
+Bw
 bX
-Qt
-Pp
-tN
-tN
-tN
-tN
-tN
+bX
+bX
+bX
+bX
+bX
+bX
+Zj
+Ur
 tN
 tN
 tN
@@ -63904,55 +60206,55 @@ Yj
 "}
 (163,1,1) = {"
 Yj
-IQ
-bs
-FR
-bs
-or
-CW
-BW
+tN
+tN
+tN
+tN
+tN
+sG
+WU
 Br
-IQ
-GU
-GU
-qF
-qF
-qF
-us
-GU
-GU
-GU
+Ax
+tE
+Ax
+Nm
+Ns
+hj
+Nh
+NS
 tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-mM
-hA
-Qt
+EX
+gd
+gd
+gd
+EX
+Wt
+Wt
+Wt
+EX
+hC
+hC
+Sw
+EX
+iy
+AC
+iy
+IG
+lR
+Va
 ru
 wG
 Iq
-mM
+Zj
 HF
-CF
-Qt
-mM
-tN
-tN
-tN
-tN
-tN
+HF
+HF
+HF
+HF
+HF
+HF
+gE
+Ur
 tN
 tN
 tN
@@ -64161,50 +60463,50 @@ Yj
 "}
 (164,1,1) = {"
 Yj
+tN
+tN
+tN
+tN
+tN
+sG
+WU
+Ax
 IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-RS
-Br
-IQ
-GU
-GU
-qF
-qF
-qF
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-us
-GU
-GU
-mM
-mM
-mM
-mM
+Ax
+Ax
+WU
+WU
+vy
+WU
+vy
+tN
+EX
+Bv
+AX
+Ji
+EX
+Tx
+iT
+Iu
+EX
+XU
+kl
+nT
+EX
+hE
+iy
+iy
+iw
+eV
+zA
+Va
 Jo
-mM
-mM
-mM
-mM
-ob
-mM
+Ka
+Zj
+Ur
+tN
+tN
+tN
 tN
 tN
 tN
@@ -64418,50 +60720,50 @@ Yj
 "}
 (165,1,1) = {"
 Yj
-IQ
-BJ
-jl
-Tp
-gX
-wr
-Ai
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-qF
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-us
-GU
-GU
-GU
-GU
-GU
-us
-GU
-GU
-Yj
-Yj
+tN
+tN
+tN
+tN
+tN
+sG
+WU
+tH
+Tr
+pV
+Ax
+bH
+Gd
+tN
+tN
+vy
+tN
+Ny
+iy
+ss
+cz
+EX
+WW
+iy
+uT
+EX
+mG
+LC
+Vd
+EX
+hE
+iy
+iy
+SI
+EX
 yQ
-lg
+Va
 Qt
-YT
-XJ
-mM
-nX
-lt
-mM
+Ka
+Zj
+Ur
+tN
+tN
+tN
 tN
 tN
 tN
@@ -64675,50 +60977,50 @@ Yj
 "}
 (166,1,1) = {"
 Yj
-IQ
-Ju
-BI
-Jx
-FE
-Ev
-mg
+tN
+tN
+tN
+tN
+tN
+sG
+WU
 zE
 IQ
-GU
-GU
-qF
-qF
-qF
-qF
-qF
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-Yj
-Yj
-ka
-Qt
-Qt
-Qt
-On
-mM
+Ax
+DI
+WU
+Ax
+Ax
+Ax
 vy
-db
-mM
+tN
+kF
+Na
+vP
+WS
+EX
+Na
+ig
+jj
+EX
+AB
+jO
+Vd
+EX
+hE
+iy
+iy
+pB
+eV
+ka
+dX
+rh
+sQ
+Ka
+Ur
+tN
+tN
+tN
 tN
 tN
 tN
@@ -64932,50 +61234,50 @@ Yj
 "}
 (167,1,1) = {"
 Yj
-IQ
-bs
-iz
-cd
-pf
-vj
-BW
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-GU
-GU
-qF
-us
-GU
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-Yj
-Yj
+tN
+tN
+tN
+tN
+tN
+sG
+WU
+WU
+WU
+vy
+vy
+WU
+WU
+WU
+WU
+WU
+tN
+Ny
+iy
+SY
+EX
+EX
+yz
+SY
+EX
+EX
+lR
+lR
+xQ
+EX
+xn
+iy
+ij
+Wq
+eV
 NL
 zA
 UF
 Ka
-NL
-mM
-mM
-mM
-mM
+Zj
+Ur
+tN
+tN
+tN
 tN
 tN
 tN
@@ -65189,47 +61491,47 @@ Yj
 "}
 (168,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-RX
-Br
-IQ
-GU
-GU
-qF
-qF
-qF
-GU
-us
-GU
-qF
-qF
-GU
-qF
-us
-GU
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+tN
+tN
+tN
+tN
+tN
+tN
+tN
+tN
 Yj
-Yj
+GU
+GU
+GU
+GU
+GU
+GU
+GU
 tN
-tN
-tN
-tN
+Ny
+Na
+eQ
+WF
+EX
+pc
+eJ
+PK
+EX
+fH
+RO
+hr
+EX
+Lh
+eP
+iy
+Ot
+eV
+NL
+zA
+cF
+Zj
+Zj
+Ur
 tN
 tN
 tN
@@ -65446,47 +61748,47 @@ Yj
 "}
 (169,1,1) = {"
 Yj
-IQ
-BJ
-jl
-Tp
-gX
-wr
-Ai
-Br
-IQ
-GU
-GU
-GU
-qF
-qF
-GU
-us
-GU
-GU
-GU
-GU
-GU
-GU
-qF
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Yj
 tN
 tN
 tN
 tN
+tN
+tN
+tN
+Yj
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+tN
+EX
+sM
+lR
+bg
+EX
+GT
+lR
+Sf
+EX
+ll
+EX
+PV
+EX
+xP
+iy
+qU
+WM
+eV
+yT
+Va
+rh
+Ka
+Zj
+Ur
 tN
 tN
 tN
@@ -65703,47 +62005,47 @@ Yj
 "}
 (170,1,1) = {"
 Yj
-IQ
-Ju
-BI
-Jx
-FE
-Ev
-Ai
-zE
-IQ
+Yj
+Yj
+tN
+tN
+tN
+tN
+tN
+Yj
+Yj
 GU
-GU
-qF
-qF
-qF
 GU
 us
 GU
 GU
-GU
-GU
-GU
-GU
-GU
-qF
-qF
-qF
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-tN
-tN
-tN
-tN
+Yj
+EX
+lR
+EX
+FV
+EX
+EX
+EX
+FV
+EX
+EX
+EX
+EX
+EX
+FV
+lR
+FO
+iy
+Xq
+BJ
+EX
+ue
+dX
+wG
+Ka
+Zj
+Ur
 tN
 tN
 tN
@@ -65960,47 +62262,47 @@ Yj
 "}
 (171,1,1) = {"
 Yj
-IQ
-bs
-iz
-cd
-pf
-vj
-mg
-zE
-IQ
 GU
-GU
-qF
-qF
-qF
-qF
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-av
-us
-jZ
-qF
-Rz
-jZ
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-jZ
+Yj
+Yj
+Yj
+Yj
 tN
 tN
-tN
-tN
+Yj
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+EX
+ax
+Na
+Na
+iy
+iy
+Na
+iy
+iy
+Na
+iy
+iy
+iy
+iy
+iy
+iy
+iy
+aa
+Cq
+eV
+Lk
+Ne
+Lp
+Zj
+Zj
+Ur
 tN
 tN
 tN
@@ -66217,47 +62519,47 @@ Yj
 "}
 (172,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-RX
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-qF
-us
-GU
-GU
-uH
 GU
 GU
 GU
 GU
-us
-GU
-GU
-qF
-uR
-jZ
-GU
-jZ
-GU
+Yj
+Yj
+Yj
+Yj
 GU
 us
 GU
 GU
 GU
-tN
-tN
-tN
-tN
+GU
+Yj
+EX
+iy
+iy
+zW
+zW
+jc
+Na
+iy
+iy
+iy
+jc
+iy
+iy
+iy
+iy
+iy
+iy
+cK
+lW
+lR
+ue
+Va
+aH
+Zj
+Ka
+Ur
 tN
 tN
 tN
@@ -66474,22 +62776,10 @@ Yj
 "}
 (173,1,1) = {"
 Yj
-IQ
-BJ
-jl
-Tp
-gX
-wr
-BW
-Br
-IQ
 GU
 GU
-qF
-qF
-qF
-qF
-us
+GU
+GU
 GU
 GU
 GU
@@ -66500,21 +62790,33 @@ GU
 us
 GU
 GU
-GU
-av
-Fv
-jZ
-GU
-GU
-GU
-GU
-GU
-GU
-GU
+Yj
+EX
+vO
+Rv
 tN
 tN
-tN
-tN
+EX
+EX
+EX
+lP
+EX
+EX
+EX
+Xa
+EX
+EX
+EX
+EX
+lR
+lR
+sX
+ou
+AY
+gQ
+Ka
+Zj
+Ur
 tN
 tN
 tN
@@ -66731,54 +63033,54 @@ Yj
 "}
 (174,1,1) = {"
 Yj
-IQ
-Ju
-BI
-Jx
-FE
-Ev
-BW
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-qF
-GU
-qF
 GU
 GU
 GU
 GU
 GU
 GU
-us
-jZ
 GU
 GU
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+EX
+xQ
+JL
+tN
+tN
+EX
+FR
+fC
+qA
+FR
+EX
 bQ
-us
-GU
-GU
-GU
-GU
-GU
-GU
-GU
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+bQ
+bQ
+EX
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+PD
+hK
+PD
+PD
+ga
+PD
+PD
+PD
+ga
+PD
+PD
 tN
 tN
 tN
@@ -66988,54 +63290,54 @@ Yj
 "}
 (175,1,1) = {"
 Yj
-IQ
-bs
-iz
-cd
-pf
-vj
-BW
-zE
-IQ
-GU
-GU
-GU
-qF
-qF
-qF
-GU
-qF
 GU
 GU
 GU
 GU
-GU
-GU
-us
-GU
-GU
-GU
-Rz
-Rz
 us
 us
 GU
 GU
 GU
 GU
-jZ
 GU
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+Yj
+EX
+xQ
+Na
+Na
+iy
+EX
+QM
+SZ
+qA
+zt
+EX
+kq
+Zr
+rX
+EX
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+PD
+mR
+mR
+mR
+mR
+mR
+Mx
+mR
+PM
+ln
+PD
 tN
 tN
 tN
@@ -67245,24 +63547,6 @@ Yj
 "}
 (176,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-RX
-Br
-IQ
-GU
-GU
-qF
-qF
-qF
-qF
-GU
-qF
-qF
 GU
 GU
 GU
@@ -67270,29 +63554,47 @@ GU
 GU
 GU
 GU
-jZ
-GU
-gF
-jZ
 GU
 GU
 GU
 GU
+us
 GU
-jZ
+GU
+Yj
+EX
+vj
+iy
+iy
+lf
+EX
+uU
+qA
+qA
+xD
+EX
+EX
+EX
+EX
+EX
+Yj
 GU
 GU
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+Yj
+PD
+Kb
+mR
+oV
+XA
+Ux
+PD
+Jd
+mR
+nu
+gf
 tN
 tN
 tN
@@ -67502,34 +63804,13 @@ Yj
 "}
 (177,1,1) = {"
 Yj
-IQ
-BJ
-jl
-Tp
-gX
-wr
-Ai
-Br
-IQ
-GU
-GU
-qF
-GU
-qF
-qF
-GU
-GU
-qF
-GU
-GU
-GU
+us
 GU
 GU
 us
 GU
 GU
 GU
-gF
 GU
 GU
 GU
@@ -67537,19 +63818,40 @@ GU
 GU
 GU
 GU
+Yj
+EX
+hE
+iy
+cL
+FE
+EX
+JF
+qA
+NH
+EX
+EX
+Yj
+Yj
+Yj
+Yj
 GU
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+GU
+Yj
+PD
+Oq
+cb
+qu
+Uy
+cJ
+PD
+xg
+me
+mR
+gf
 tN
 tN
 tN
@@ -67759,54 +64061,54 @@ Yj
 "}
 (178,1,1) = {"
 Yj
-IQ
-Ju
-BI
-Jx
-FE
-Ev
-Ai
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-GU
-GU
-GU
-qF
 GU
 GU
 GU
 GU
 GU
-qF
 GU
 GU
 GU
-Qw
 GU
 GU
-us
-jZ
 GU
 GU
-us
-us
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+Yj
+EX
+hE
+iy
+By
+xZ
+EX
+fR
+qA
+or
+EX
+Yj
+Yj
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+PD
+Kb
+mR
+vz
+Uy
+fn
+PD
+bU
+Df
+mR
+PD
 tN
 tN
 tN
@@ -68016,54 +64318,54 @@ Yj
 "}
 (179,1,1) = {"
 Yj
-IQ
-bs
-iz
-cd
-pf
-vj
-mg
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-us
 GU
 GU
 GU
-qF
-qF
 GU
 GU
 GU
-qF
-GU
-GU
-Rz
-GU
-jZ
-GU
-us
-jZ
-GU
-jZ
 GU
 GU
 GU
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+GU
+Yj
+EX
+QR
+LW
+tk
+CT
+EX
+VF
+Tp
+hx
+EX
+Yj
+Yj
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+PD
+PD
+PD
+PD
+rN
+PD
+PD
+PD
+PD
+zF
+PD
 tN
 tN
 tN
@@ -68273,54 +64575,54 @@ Yj
 "}
 (180,1,1) = {"
 Yj
-IQ
-IQ
-IQ
-IQ
-IQ
-IQ
-Xk
-zE
-IQ
-GU
-GU
-qF
-qF
-qF
-us
-us
 GU
 GU
 GU
-qF
 GU
 GU
 GU
-qF
 GU
 GU
 GU
-jZ
 GU
 GU
 GU
-Fv
-jZ
+GU
+GU
+Yj
+EX
+EX
+EX
+EX
+EX
+EX
+jw
+Rw
+XK
+EX
+Yj
+Yj
 GU
 GU
 GU
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+Yj
+Yj
+SP
+HO
+mR
+XS
+om
+PD
+ad
+no
+PD
 tN
 tN
 tN
@@ -68535,17 +64837,6 @@ GU
 GU
 GU
 GU
-IQ
-IQ
-IQ
-IQ
-GU
-GU
-qF
-qF
-qF
-qF
-us
 GU
 GU
 GU
@@ -68553,31 +64844,42 @@ GU
 GU
 GU
 GU
-us
 GU
 GU
-jZ
-jZ
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+EX
+EX
+EX
+EX
+EX
+Yj
+Yj
 GU
 GU
-us
-us
 GU
 GU
 GU
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+Yj
+Yj
+Yj
+Cf
+mR
+mR
+mR
+ac
+PD
+HG
+LY
+PD
 tN
 tN
 tN
@@ -68790,51 +65092,51 @@ Yj
 GU
 GU
 GU
-us
 GU
 GU
 GU
 GU
 GU
 GU
-qF
-GU
-qF
-qF
-qF
 GU
 GU
 GU
 GU
 GU
 GU
-us
 GU
-qF
-Rz
 GU
-jZ
 GU
-us
 GU
-Rz
-Rz
-us
-us
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
 GU
-us
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+GU
+Yj
+mg
+uG
+Xv
+eD
+mg
+PD
+PD
+PD
+PD
 tN
 tN
 tN
@@ -69073,17 +65375,17 @@ jZ
 GU
 GU
 GU
-us
+GU
 uR
 jZ
 GU
 GU
 GU
 GU
-tN
-tN
-tN
-tN
+GU
+GU
+Yj
+Yj
 tN
 tN
 tN
@@ -69336,11 +65638,11 @@ GU
 GU
 GU
 GU
-us
-tN
-tN
-tN
-tN
+GU
+GU
+GU
+GU
+Yj
 tN
 tN
 tN
@@ -69592,11 +65894,11 @@ jZ
 GU
 GU
 us
+GU
+GU
+GU
+GU
 Yj
-tN
-tN
-tN
-tN
 tN
 tN
 tN
@@ -69849,11 +66151,11 @@ GU
 jZ
 GU
 us
+GU
+GU
+GU
+GU
 Yj
-tN
-tN
-tN
-tN
 tN
 tN
 tN
@@ -70106,10 +66408,10 @@ jZ
 GU
 GU
 GU
-Yj
-Yj
-Yj
-Yj
+GU
+GU
+GU
+GU
 Yj
 tN
 tN
@@ -70365,8 +66667,8 @@ GU
 us
 GU
 GU
-Yj
-Yj
+GU
+GU
 Yj
 GU
 GU

--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -34,10 +34,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/obj/structure/bonfire/dense/prelit/grill,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "abn" = (
 /obj/structure/table,
 /obj/item/rack_parts,
@@ -57,10 +56,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/booth,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/kitchenspike,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "acc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -95,10 +93,6 @@
 /obj/structure/junk/locker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
-"acE" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "acI" = (
 /obj/structure/bed/oldalt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -154,10 +148,10 @@
 	},
 /area/f13/building/tribal/cave)
 "ads" = (
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/building/trader)
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "adu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
@@ -264,28 +258,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
 "afZ" = (
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/slab/meatproduct,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/meat/rawbacon,
-/obj/item/reagent_containers/food/snacks/grown/meatwheat,
-/obj/item/reagent_containers/food/snacks/grown/meatwheat,
-/obj/structure/closet/crate/freezer{
-	anchored = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 15
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "agk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fence/corner,
@@ -304,18 +284,13 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
-"aha" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "61"
-	},
-/turf/open/floor/plating,
-/area/f13/building)
 "ahq" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "aht" = (
 /obj/structure/stairs/east,
 /obj/structure/railing,
@@ -346,95 +321,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aiy" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "aiB" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/dirt,
@@ -464,99 +357,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "aiR" = (
-/obj/structure/flora/chomp/bones/lrock4{
-	plane = -5-4;
-	pixel_x = -16
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "aiU" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/reagent_containers/food/snacks/donut/caramel,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "aiV" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -578,14 +391,12 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "ajs" = (
-/obj/structure/chair/office/dark{
-	dir = 4;
-	pixel_y = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "ajM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2right"
@@ -602,11 +413,11 @@
 	},
 /area/f13/building)
 "akj" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/filingcabinet{
+	pixel_x = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "akk" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -713,18 +524,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"anM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "anR" = (
 /obj/structure/table,
 /obj/item/clothing/head/sombrero,
@@ -757,13 +556,6 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/building/abandoned)
-"aoQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/safe_home,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "aoT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -782,9 +574,19 @@
 	},
 /area/f13/wasteland)
 "apm" = (
-/obj/structure/barricade/bars,
-/turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/structure/barricade/bars{
+	color = "#A47449"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "apw" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
@@ -804,16 +606,14 @@
 	},
 /area/f13/building)
 "aqT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_y = -4
+/obj/structure/sink/deep_water{
+	name = "river water";
+	alpha = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
+/turf/open/indestructible/ground/outside/water/running{
+	dir = 8
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "ara" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -893,29 +693,22 @@
 /obj/structure/chair/bench,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"asT" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/rollingpin,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
-"atc" = (
-/obj/machinery/seed_extractor,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "atd" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "atg" = (
-/turf/open/water{
-	icon = 'icons/turf/pool.dmi';
-	icon_state = "pool_tile"
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 8;
+	plane = -4
 	},
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/city/newboston/outdoors)
 "atz" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
@@ -949,15 +742,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "aul" = (
-/obj/structure/railing{
-	dir = 4
+/turf/closed/indestructible/f13/matrix{
+	plane = 0
 	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/open/floor/pod/light,
-/area/f13/building/workshop/nash)
+/area/f13/caves)
 "aun" = (
 /obj/structure/cave/support{
 	pixel_y = 26;
@@ -991,18 +779,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "auL" = (
-/obj/item/toy/plush/blackcat{
-	pixel_y = 15;
-	pixel_x = 6
+/obj/machinery/reagentgrinder,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#3B2C25"
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building)
 "auS" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1043,18 +827,13 @@
 	},
 /area/f13/building)
 "awl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side,
-/area/f13/building)
+/obj/effect/landmark/start/f13/followersscientist/recguard,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "awt" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "awO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1128,11 +907,18 @@
 	},
 /area/f13/building/abandoned)
 "azm" = (
-/obj/structure/respawner_blocker{
-	pixel_y = 9
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/flora/wild_plant/flower/purple_two{
+	pixel_x = 4;
+	pixel_y = 8;
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/inside/mountain{
+	color = "#B18770"
+	},
+/area/f13/caves)
 "azF" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -1152,14 +938,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
 "aAs" = (
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "61"
-	},
-/obj/effect/turf_decal/weather/dirt{
+/obj/machinery/conveyor/auto{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "aAz" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1192,12 +976,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "aBY" = (
-/obj/effect/landmark/latejoin,
-/obj/effect/landmark/start/f13/wastelander,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#413527"
 	},
-/area/f13/building/trader)
+/obj/machinery/hydroponics/soil,
+/obj/effect/turf_decal/siding/wood{
+	color = "#413527"
+	},
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building)
 "aCb" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -1227,13 +1015,12 @@
 	},
 /area/f13/trainstation)
 "aCU" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "aCV" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1263,13 +1050,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aDw" = (
-/obj/structure/flora/tree/cherryblossom4{
-	pixel_y = 11;
-	pixel_x = -8;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/computer/terminal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "aDB" = (
 /mob/living/simple_animal/hostile/ghoul,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1279,41 +1064,12 @@
 	},
 /area/f13/building)
 "aEh" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = -1;
-	pixel_x = -32
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 4;
-	pixel_y = 7;
-	pixel_x = -32
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = -6
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/spawner/lootdrop/f13/uncommon_drugs,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aEo" = (
 /obj/structure/closet/anchored,
 /obj/item/clothing/head/f13/police,
@@ -1346,17 +1102,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"aFQ" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
-	},
-/obj/effect/overlay/palmtree_r{
-	color = "#BE24FF";
-	pixel_y = 32;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "aGs" = (
 /obj/structure/fence{
 	dir = 4
@@ -1421,18 +1166,10 @@
 /obj/effect/spawner/lootdrop/f13/rare,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"aHs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate{
-	anchored = 1;
-	can_be_unanchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/building)
+"aHr" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aHH" = (
 /obj/structure/pool/ladder{
 	dir = 2;
@@ -1451,13 +1188,17 @@
 	},
 /area/f13/building/tribal)
 "aHM" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#413527";
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red";
+	pixel_x = 16
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/water,
+/area/f13/building)
 "aIf" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/f13{
@@ -1642,13 +1383,25 @@
 	},
 /area/f13/building)
 "aPO" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
+/obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 9
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/building)
 "aQm" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -1665,62 +1418,27 @@
 	light_range = 2
 	},
 /area/f13/caves)
-"aQG" = (
-/obj/item/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
 "aRb" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/spacevine,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building/abandoned)
-"aRi" = (
-/obj/structure/chair/comfy/plywood{
-	dir = 4
-	},
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
 "aRn" = (
-/obj/item/storage/trash_stack,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/smartfridge/chemistry{
+	density = 0;
+	pixel_y = 32
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"aRr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/structure/fluff/divine/convertaltar{
-	pixel_y = 20;
-	pixel_x = 1
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
+"aRr" = (
+/obj/effect/overlay/junk/sink{
+	pixel_y = 23
 	},
-/obj/structure/railing{
-	pixel_y = -3;
-	color = "#BECD44";
-	plane = -2;
-	pixel_x = -1
-	},
-/obj/structure/railing{
-	dir = 4;
-	color = "#BECD44"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/overlay/junk/urinal,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aRD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/right{
@@ -1730,10 +1448,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"aSe" = (
-/obj/structure/table/booth,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "aSS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1748,9 +1462,11 @@
 /area/f13/building/workshop/nash)
 "aUg" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/wood/alt/window,
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "aUX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1795,13 +1511,10 @@
 	},
 /area/f13/brotherhood)
 "aVF" = (
-/obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
+	dir = 9
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#aaaaaa"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "aWc" = (
 /obj/structure/closet/crate/freezer/blood/anchored,
@@ -1848,15 +1561,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "aXY" = (
+/obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet,
-/obj/machinery/light/small/broken{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "aYb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1992,12 +1699,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"bbN" = (
-/obj/structure/bookcase,
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
 "bbS" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/ash,
@@ -2023,16 +1724,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
-"bci" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
 "bcw" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -2048,11 +1739,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
 	icon_state = "bar"
-	},
-/area/f13/building)
-"bdp" = (
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
 	},
 /area/f13/building)
 "bdK" = (
@@ -2075,23 +1761,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"beC" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/toilet_paper{
-	pixel_y = 27
-	},
-/obj/structure/rug/mat{
-	dir = 8;
-	pixel_x = -15
-	},
-/obj/structure/mirror/alt{
-	pixel_x = 31;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland/city/newboston/sauna)
 "beU" = (
 /obj/item/trash/f13/steak,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2171,26 +1840,20 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "bgq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833"
-	},
-/obj/structure/flora/wild_plant/flower/red_two,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"bgu" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/start/f13/followersscientist,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "bgz" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "bgC" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -2201,26 +1864,35 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
 "bgN" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/chair/bench{
+	dir = 8;
+	plane = -6
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "bgP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2230,20 +1902,22 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "bgW" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty";
+	color = "grey"
+	},
+/area/f13/building)
 "bgX" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/helmet/gladiator,
@@ -2281,16 +1955,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"biy" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
 "biz" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -2319,41 +1983,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"bjJ" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/bowls,
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = -2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = -2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = -2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = -2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 12;
-	pixel_y = -2
-	},
-/obj/item/kitchen/knife{
-	pixel_x = -11;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "bjV" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/mob/living/simple_animal/advanced/dog{
+	name = "Buddy"
 	},
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "bko" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2442,19 +2077,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"boR" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
 "boV" = (
-/obj/structure/dresser,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/cave/stalagmite/four{
+	anchored = 1
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bpk" = (
 /obj/structure/rack,
 /obj/item/binoculars,
@@ -2463,12 +2091,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bpm" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/building/workshop/nash)
+/obj/structure/junk/cabinet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bpA" = (
-/obj/structure/wreck/trash/halftire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	layer = 3
+	},
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "bpC" = (
 /obj/structure/table/wood/settler,
 /obj/item/candle/infinite,
@@ -2493,10 +2131,11 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "bqx" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/light{
+	pixel_x = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "bqQ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -2531,13 +2170,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/caves)
 "brC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "brR" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/dirt,
@@ -2565,9 +2207,15 @@
 	},
 /area/f13/building)
 "btb" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/chair/booth{
+	dir = 8;
+	icon_state = "booth_west_south";
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "btc" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2744,28 +2392,30 @@
 	},
 /area/f13/wasteland)
 "byb" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
+/obj/structure/chair/bench{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "byj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/clothing/heaven,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
-"bzc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/wreck/car{
+	dir = 4;
+	icon_state = "buggy_olive";
+	layer = 2;
+	pixel_y = 11
 	},
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/trash_trash,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "bzu" = (
-/obj/machinery/recycler,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/science_wardrobe/free,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/building)
 "bzA" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -2781,20 +2431,11 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "bzO" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
+/obj/structure/filingcabinet{
+	pixel_x = -10
 	},
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "bAd" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2840,13 +2481,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
-"bBH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "bBS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/phone,
@@ -2898,21 +2532,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bDj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/bonfire/prelit{
-	density = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "bDJ" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/planks,
@@ -2957,31 +2576,24 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bFG" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
 	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 39
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -7
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_y = -4
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_light,
+/area/f13/building)
 "bGc" = (
-/obj/effect/landmark/start/f13/followersscientist/recmechanic,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/f13/building)
 "bGs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3016,11 +2628,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"bGM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/observer_start,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "bGO" = (
 /obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3042,9 +2649,13 @@
 	},
 /area/f13/building)
 "bHK" = (
-/obj/machinery/chem_master/primitive,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "bHR" = (
 /obj/structure/chair/right,
 /turf/open/floor/f13{
@@ -3158,13 +2769,12 @@
 	},
 /area/f13/building)
 "bKo" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	pixel_x = 8;
-	pixel_y = -3
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	plane = -4
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "bKr" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/barricade/wooden/crude,
@@ -3179,33 +2789,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "bKI" = (
-/obj/structure/stairs/west{
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#bb3333";
-	dir = 8;
-	pixel_x = -2
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building/trader)
-"bLA" = (
-/obj/effect/fake_stairs/west{
-	color = "#845f58";
-	dir = 4
-	},
-/obj/structure/table/wood/settler{
-	density = 0
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain"
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "bLB" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
 	icon_state = "darkdirtysolid"
@@ -3229,13 +2816,12 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "bLR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	color = "#999999"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/start/f13/settler,
+/obj/effect/landmark/start/f13/settler,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "bLT" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -3260,11 +2846,10 @@
 	},
 /area/f13/building)
 "bNb" = (
-/obj/structure/wreck/trash/machinepile{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
-/area/f13/building)
+/obj/effect/landmark/start/f13/texasranger,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "bNd" = (
 /turf/open/indestructible/ground/outside/water,
 /turf/open/indestructible/ground/outside/water{
@@ -3307,14 +2892,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"bNY" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "bNZ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_4"
@@ -3342,40 +2919,42 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bPn" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/computer/cargo,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/decoration/hatch{
-	icon_state = "vault_cargo";
-	pixel_y = 39
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "bPG" = (
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "bQl" = (
-/obj/machinery/mineral/wasteland_trader{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/item/card/kingbounty{
-	pixel_y = 10;
-	mouse_opacity = 0;
-	anchored = 1
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/structure/chair/bench{
+	dir = 8;
+	plane = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "bQD" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -3480,23 +3059,8 @@
 	},
 /area/f13/building)
 "bVc" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "bVk" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -3599,13 +3163,13 @@
 	},
 /area/f13/building)
 "bYl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/science/glass{
-	req_one_access_txt = "136";
-	name = "RnD Lab"
+/obj/effect/landmark/latejoin,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/obj/effect/landmark/start/f13/followersdoctor,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "bYm" = (
 /mob/living/simple_animal/hostile/molerat,
 /obj/structure/flora/wasteplant/wild_fungus,
@@ -3701,12 +3265,10 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
 "cbv" = (
-/obj/structure/flora/tree/cherryblossom4{
-	pixel_y = 11;
-	pixel_x = -8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "cbI" = (
 /obj/structure/chair/booth{
 	dir = 4
@@ -3757,22 +3319,16 @@
 	},
 /area/f13/building)
 "ccQ" = (
-/obj/effect/turf_decal/weather/dirtcorner,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/red,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "cdu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"ceh" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "cej" = (
 /obj/machinery/shower{
 	dir = 8
@@ -3797,29 +3353,37 @@
 	},
 /area/f13/building)
 "cgk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/obj/structure/flora/tree/cherryblossom{
-	pixel_y = 6
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/bench{
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "cgQ" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"cgZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "chc" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -3873,27 +3437,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"ciA" = (
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 40
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 32
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ciG" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -3926,18 +3469,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "ckz" = (
-/obj/structure/table,
-/obj/machinery/processor/chopping_block,
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheetmime,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "ckH" = (
-/obj/structure/flora/wild_plant/flower/orange,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/bench{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "clr" = (
 /obj/structure/table/reinforced,
@@ -4030,11 +3577,10 @@
 	},
 /area/f13/building)
 "cnK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/brick{
-	weak_wall = 0
-	},
-/area/f13/building)
+/obj/effect/landmark/start/f13/wastelander/clubmanager,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "cnN" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -4092,26 +3638,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"cpu" = (
-/obj/structure/nightstand/small{
-	pixel_x = 9;
-	pixel_y = 20
-	},
-/obj/item/flashlight/littlelamp{
-	pixel_y = 23;
-	pixel_x = 9;
-	color = "grey"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-17";
-	layer = 2.9;
-	pixel_y = 22;
-	pixel_x = -4
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
 "cpx" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4165,11 +3691,16 @@
 	},
 /area/f13/wasteland/city)
 "cqF" = (
-/obj/structure/rack/shelf_metal{
-	pixel_x = -3
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/area/f13/building)
 "cqO" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/carpet/black,
@@ -4259,20 +3790,12 @@
 	},
 /area/f13/building)
 "ctp" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
-"ctu" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "ctv" = (
 /obj/machinery/vending/nukacolavendfull,
 /turf/open/floor/f13{
@@ -4280,9 +3803,11 @@
 	},
 /area/f13/building)
 "cty" = (
-/obj/machinery/vending/medical/becomingnook,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "ctB" = (
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
@@ -4395,26 +3920,21 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "cxU" = (
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/dropper,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "cyg" = (
-/obj/machinery/chem_master{
-	pixel_y = 20;
-	density = 0;
-	pixel_x = -6
+/obj/machinery/light,
+/obj/machinery/mineral/wasteland_vendor/general{
+	icon_state = "nugeneric_idle"
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/building)
 "cyi" = (
@@ -4539,17 +4059,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "cAt" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/barricade/wooden/strong,
+/turf/closed/wall/f13/wood{
+	color = "#cababa"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "cAF" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -4591,10 +4104,12 @@
 	},
 /area/f13/wasteland)
 "cBK" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 9
-	},
-/area/f13/building)
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/start/f13/followersscientist/recresearcher,
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "cBM" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -4669,13 +4184,12 @@
 /area/f13/building)
 "cEd" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
+	dir = 5
 	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/spacevine,
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "cEq" = (
 /obj/structure/barricade/wooden,
@@ -4684,13 +4198,6 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
-"cEt" = (
-/obj/structure/fence/door{
-	dir = 8;
-	pixel_x = 15
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "cEC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/f13chair1{
@@ -4723,92 +4230,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cFi" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
+/obj/structure/anvil/obtainable/basic,
+/obj/item/twohanded/sledgehammer/simple,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
 	pixel_y = 12;
-	plane = 0
+	pixel_x = 1
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "cFj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -4841,8 +4271,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "cFY" = (
-/obj/structure/table/wood/fancy/royalblack,
-/turf/open/floor/wood_common/wood_common_dark,
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "cGb" = (
 /obj/structure/window/fulltile/house{
@@ -4886,22 +4317,14 @@
 	},
 /area/f13/caves)
 "cHJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/table/booth,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "cHS" = (
 /obj/structure/chair{
 	dir = 1
@@ -4925,27 +4348,14 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"cIm" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 8;
+"cIE" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
 	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
-"cIE" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "cIF" = (
 /turf/closed/wall/f13/wood,
@@ -5007,13 +4417,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"cKt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
 "cKA" = (
 /obj/structure/rug/big/rug_yellow,
 /turf/open/floor/wood_common/wood_common_dark,
@@ -5031,9 +4434,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
 "cKP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
+/obj/structure/flora/big_bush{
+	icon_state = "burnedbush10"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "cKR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5042,9 +4450,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "cLc" = (
-/obj/machinery/mineral/wasteland_vendor/pipboy,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "cLm" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr11";
@@ -5056,11 +4466,14 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/city/newboston/outdoors)
 "cLp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/booth,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/leather,
+/obj/item/stack/sheet/leather,
+/obj/item/stack/sheet/leather,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "cLu" = (
 /obj/machinery/washing_machine,
 /obj/item/crafting/abraxo,
@@ -5116,24 +4529,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
-"cNI" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "cNK" = (
 /turf/open/indestructible/ground/outside/dirthole{
 	color = "#999999"
@@ -5157,31 +4552,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"cNZ" = (
-/obj/item/reagent_containers/food/condiment/mustard,
-/obj/item/reagent_containers/food/condiment/bbqsauce,
-/obj/item/reagent_containers/food/condiment/honey,
-/obj/item/reagent_containers/food/condiment/cherryjelly,
-/obj/item/reagent_containers/food/condiment/peanut_butter,
-/obj/item/reagent_containers/food/condiment/mayonnaise,
-/obj/item/reagent_containers/food/condiment/ketchup,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/glass/bottle/radium,
-/obj/item/reagent_containers/glass/bottle/radium,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "cOr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/high_chance,
@@ -5240,10 +4610,10 @@
 	},
 /area/f13/wasteland)
 "cQD" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/human/skeleton/alive,
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "cQP" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -5312,13 +4682,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"cUd" = (
-/obj/structure/bed/dogbed{
-	name = "Fuzz Bed"
-	},
-/mob/living/simple_animal/pet/dog/corgi/Lisa,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "cUm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -5403,21 +4766,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
-"cWl" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "cWt" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"cWY" = (
-/obj/effect/landmark/start/f13/followersscientist/recresearcher,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/building/trader)
 "cXg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/marking{
@@ -5428,15 +4780,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"cXj" = (
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/building/trader)
 "cXE" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5478,9 +4821,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "cZU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cZV" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13{
@@ -5531,13 +4876,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"dbn" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "dbo" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -5581,12 +4919,10 @@
 	},
 /area/f13/wasteland)
 "ddB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple/corner{
-	dir = 1
-	},
-/area/f13/building)
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/start/f13/followersscientist/recguard,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "ddT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/trash_stack,
@@ -5603,11 +4939,11 @@
 	},
 /area/f13/building/abandoned)
 "def" = (
-/obj/structure/campfire/stove{
-	density = 0;
-	pixel_y = 22
+/obj/machinery/mineral/equipment_vendor{
+	pixel_y = 14;
+	density = 0
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "dej" = (
 /obj/structure/wreck/trash/five_tires,
@@ -5696,29 +5032,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dgU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/booth{
-	dir = 8;
-	icon_state = "booth_west_north"
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
-"dha" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
 "dhu" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/singlecard,
@@ -5751,19 +5064,16 @@
 	},
 /area/f13/building)
 "diM" = (
-/obj/structure/table/reinforced,
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/barricade/barswindow{
-	layer = 3.5;
-	dir = 1
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "djf" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/turf_decal/weather/dirt{
@@ -5792,13 +5102,14 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "dkt" = (
-/obj/effect/landmark/start/f13/followersdoctor,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "dkE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -5836,16 +5147,104 @@
 	},
 /area/f13/building)
 "dlN" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
+	dir = 8;
+	pixel_y = 16
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
+	dir = 8;
+	pixel_y = 10
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	pixel_y = 15
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 2;
+	pixel_y = 12
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12;
+	pixel_y = 9
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8;
+	pixel_y = 12
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "dlP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5891,12 +5290,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "dmP" = (
-/obj/effect/landmark/start/f13/radiooperator,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/building/trader)
+/obj/structure/cave/stalagmite{
+	pixel_y = 12;
+	plane = -4;
+	anchored = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dmY" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -5970,11 +5373,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "dpV" = (
-/obj/structure/flora/tree/cherryblossom3{
-	pixel_y = 11;
-	pixel_x = -23
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/city/newboston/outdoors)
 "dpX" = (
 /obj/effect/decal/cleanable/oil/streak,
@@ -5984,17 +5386,15 @@
 	},
 /area/f13/building)
 "dqa" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#3B2B1A"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "dqo" = (
 /obj/structure/table/booth,
@@ -6030,10 +5430,18 @@
 	},
 /area/f13/wasteland)
 "drL" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/decoration/hatch{
+	icon_state = "vault_diner";
+	plane = 0;
+	pixel_y = -26;
+	alpha = 150;
+	name = "sign"
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "dse" = (
 /obj/structure/closet/crate/wicker,
 /obj/item/locked_box/misc/money/legion/low,
@@ -6079,17 +5487,12 @@
 	},
 /area/f13/wasteland)
 "dts" = (
-/obj/structure/sign/departments/medbay,
-/obj/structure/decoration/hatch{
-	icon_state = "vault_clinic";
-	pixel_y = 6;
-	name = "sign";
-	alpha = "150"
+/obj/effect/spawner/lootdrop/f13/trash_trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/closed/wall/r_wall/f13vault{
-	icon_state = "2-i"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "dtE" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6098,12 +5501,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dtH" = (
-/obj/structure/stairs/north{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "dtW" = (
 /obj/structure/decoration/clock{
 	pixel_y = 27
@@ -6162,17 +5559,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"dvh" = (
-/obj/effect/landmark/start/f13/wastelander,
-/obj/effect/landmark/latejoin,
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/building/trader)
 "dvk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/water,
@@ -6259,23 +5645,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"dyo" = (
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/effect/turf_decal/caution{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/open/floor/pod{
-	name = "tiles"
-	},
-/area/f13/building/workshop/nash)
 "dyy" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -6293,12 +5662,42 @@
 	},
 /area/f13/building)
 "dzT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/corner{
-	dir = 8
+/obj/machinery/light/sign{
+	icon_state = "oldcockinn";
+	pixel_y = 5;
+	pixel_x = -3
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/siding/wideplating{
+	color = "#525252";
+	pixel_y = 2;
+	pixel_x = -2
+	},
+/obj/item/toy/plush/bird{
+	icon = 'icons/fallout/mobs/animals/farmanimals.dmi';
+	icon_state = "chicken_brown";
+	anchored = 1;
+	usesound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	throwhitsound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	pokesound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	sound_dualwield_end = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	sound_dualwield_start = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	hitsound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	unwieldsound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	wieldsound = list('sound/creatures/chicken/chicken1.ogg','sound/creatures/chicken/chicken2.ogg','sound/creatures/chicken/chicken3.ogg','sound/creatures/chicken/chicken4.ogg');
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "dzW" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6307,19 +5706,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"dAg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/decoration/vent/rusty{
-	color = "#aaaaFE";
-	alpha = 50
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "dAj" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
@@ -6347,14 +5733,13 @@
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
 "dAH" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/closet/crate/large,
+/obj/item/stack/ore/blackpowder/fifty,
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "dAM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -6575,15 +5960,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"dJE" = (
-/obj/item/kitchen/knife/butcher,
-/obj/structure/table/wood/settler,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/tray,
-/obj/item/clothing/neck/apron/chef,
-/obj/item/clothing/head/collectable/chef,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "dJR" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -6761,9 +6137,12 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland)
 "dOt" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/wild_plant/flower/pink,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/beacon{
+	mouse_opacity = 0;
+	alpha = 0;
+	name = "RTN Teleporter Beacon"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "dOu" = (
 /obj/structure/nest/randomized{
@@ -6796,15 +6175,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"dOM" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "dOQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -6863,12 +6233,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"dQQ" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
 "dRf" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -6977,13 +6341,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"dUS" = (
-/obj/effect/landmark/start/f13/wastelander,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/building/trader)
 "dUX" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/singlecard,
@@ -7070,9 +6427,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "dWA" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "dWD" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -7175,16 +6535,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"dZY" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "eae" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -7195,15 +6545,12 @@
 	},
 /area/f13/building)
 "eam" = (
-/obj/item/beacon{
-	mouse_opacity = 0;
-	alpha = 0;
-	name = "RTN Teleporter Beacon"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "eav" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -7222,15 +6569,16 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "eay" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/window/fulltile/ruins,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "eaD" = (
 /obj/machinery/smartfridge/bottlerack/seedbin,
 /turf/open/indestructible/ground/inside/dirt,
@@ -7243,15 +6591,13 @@
 	},
 /area/f13/building)
 "ebe" = (
-/obj/structure/wreck/bus/orange{
-	pixel_y = -4;
-	pixel_x = -3;
-	name = "bus from somewhere"
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty";
+	color = "grey"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/building/trader)
+/area/f13/building)
 "ecf" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/indestructible/ground/inside/subway,
@@ -7277,25 +6623,14 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
 "ecy" = (
-/obj/structure/toilet{
-	dir = 1;
-	pixel_y = -1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
-"edi" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "edk" = (
-/obj/structure/simple_door/dirtyglass,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "edl" = (
 /obj/effect/decal/remains/human,
@@ -7410,12 +6745,9 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "egn" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/junk/drawer,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "egq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -7524,28 +6856,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "eir" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/chair/booth{
+	icon_state = "booth_east_south";
+	pixel_y = 11
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "eis" = (
-/obj/effect/landmark/start/f13/followersscientist/recslimeologist,
-/obj/machinery/light,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
 	},
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/rolling,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "eiu" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7582,18 +6912,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"ekg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lamp_post/doubles/bent{
-	dir = 4;
-	density = 0;
-	pixel_y = -14;
-	pixel_x = -42
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ekC" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -7629,11 +6947,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "elX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "emj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
@@ -7696,23 +7014,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "eoV" = (
-/obj/machinery/smartfridge/bottlerack/seedbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/machinery/button/door{
+	pixel_x = -32;
+	id = "DenGate";
+	name = "Den Gate"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "epa" = (
 /obj/structure/stairs,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"epk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 9
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "epr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -7746,10 +7062,6 @@
 	icon_state = "verticalleftborderleft1"
 	},
 /area/f13/wasteland)
-"eqe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "eqf" = (
 /mob/living/simple_animal/hostile/renegade/guardian,
 /turf/open/floor/f13/wood{
@@ -7807,18 +7119,14 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "etC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_x = -5;
-	pixel_y = -6
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/machinery/reagentgrinder,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "etQ" = (
 /obj/structure/sign/poster/official/ion_rifle{
 	pixel_x = -32
@@ -7910,11 +7218,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "exd" = (
-/obj/structure/flora/tree/cherryblossom{
-	pixel_y = 12
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "exh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -7922,9 +7230,21 @@
 	},
 /area/f13/wasteland)
 "exu" = (
-/obj/structure/flora/wild_plant/flower/purple_two,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water{
+	color = "#33FF48";
+	light_color = "#33FF48";
+	light_power = 2;
+	light_range = 2
+	},
+/area/f13/caves)
 "exA" = (
 /obj/machinery/vending/bigredvend{
 	pixel_x = -10;
@@ -8002,10 +7322,10 @@
 	},
 /area/f13/trainstation)
 "ezN" = (
+/obj/structure/chair/stool/retro,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "ezQ" = (
 /obj/structure/flora/rock/pile/largejungle,
@@ -8016,12 +7336,14 @@
 	},
 /area/f13/tribe)
 "eAc" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "eAg" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -8134,14 +7456,19 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "eCS" = (
-/obj/item/storage/trash_stack{
-	alpha = 80
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/towel_rack{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/item/kirbyplants{
+	icon_state = "plant-02";
+	layer = 2.9;
+	pixel_x = 3
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "eCT" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -8238,22 +7565,10 @@
 	},
 /area/f13/building)
 "eGh" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/effect/turf_decal/caution{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/open/floor/pod{
-	name = "tiles"
-	},
-/area/f13/building/workshop/nash)
+/obj/effect/landmark/start/f13/followersscientist/recslimeologist,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "eGq" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -8289,89 +7604,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "eHl" = (
-/obj/structure/table/wood/settler,
-/obj/item/toy/poolnoodle{
-	pixel_x = -10;
-	pixel_y = 9
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/item/toy/poolnoodle{
-	pixel_x = -10;
-	pixel_y = 9
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/item/toy/poolnoodle{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/toy/poolnoodle{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/toy/poolnoodle{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/blue{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/obj/item/toy/poolnoodle/yellow{
-	pixel_y = -8
-	},
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "eHy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"eHQ" = (
-/obj/item/chair/wood,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "eHZ" = (
 /obj/structure/stairs/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8423,22 +7669,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "eKD" = (
-/obj/structure/bookcase,
-/turf/open/floor/wood_common{
-	color = "#CECECE"
+/obj/machinery/mineral/wasteland_vendor/traderspecial{
+	icon_state = "trade_,mining"
 	},
-/area/f13/wasteland/city/newboston/library)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "eKF" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood)
-"eKM" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/mask/cigarette,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "eLh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -8635,17 +7876,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ePP" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced{
-	icon_state = "innercity";
-	name = "gatehouse"
-	},
-/obj/machinery/door/poddoor/shutters/old/preopen{
-	id = "4211"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
 "ePQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -8705,14 +7935,9 @@
 	},
 /area/f13/building)
 "eRa" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/ladder/unbreakable{
-	id = "nbguardtower";
-	pixel_x = -9;
-	pixel_y = -13;
-	height = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "eRj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8720,17 +7945,15 @@
 	},
 /area/f13/wasteland)
 "eRs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8
 	},
-/obj/structure/mirror{
-	pixel_x = -32
+/obj/structure/wreck/bus/rusted{
+	pixel_y = -15
 	},
-/obj/item/soap/deluxe,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "eRR" = (
 /obj/structure/nest/molerat,
 /turf/closed/mineral/random/high_chance,
@@ -8777,22 +8000,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"eUj" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "eUt" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8809,12 +8016,14 @@
 /area/f13/building/tribal)
 "eVf" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/booth{
-	dir = 8;
-	icon_state = "booth_west_south"
+/obj/structure/mirror/alt{
+	pixel_y = 34
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/sink/cupboard{
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "eVF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8855,36 +8064,25 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"eWR" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_y = 11
+"eWG" = (
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin{
-	pixel_y = 7;
-	pixel_x = -5
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/area/f13/building)
 "eXd" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
 "eXe" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/closet{
+	pixel_x = 8
 	},
-/obj/item/lipstick/random,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eXk" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/carpet/black,
@@ -8924,30 +8122,16 @@
 	name = "rocky dirt"
 	},
 /area/f13/building/tribal)
-"eYo" = (
-/obj/structure/nest/frog,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "eYt" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall/rust,
 /area/f13/building)
 "eYu" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/f13/coyote/darkwoodwall,
 /area/f13/building)
 "eYw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9031,10 +8215,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"faP" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "faT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/food,
@@ -9171,17 +8351,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"fdd" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "fde" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9193,22 +8362,23 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "fdm" = (
-/obj/machinery/mineral/equipment_vendor{
-	pixel_y = 14;
-	density = 0
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "fdv" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "fef" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/pondlily_big,
+/mob/living/simple_animal/hostile/retaliate/frog{
+	wander = 0
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "fej" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9249,9 +8419,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fft" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/cave/stalagmite/one{
+	anchored = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ffu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -9281,16 +8453,16 @@
 	},
 /area/f13/building/abandoned)
 "fgh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/item/reagent_containers/food/snacks/donut/jelly/berry,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "fgs" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -9344,15 +8516,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city)
 "fhn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/water/running{
+	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirtcorner,
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "fhy" = (
 /obj/machinery/door/airlock/security,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -9405,22 +8573,22 @@
 	},
 /area/f13/caves)
 "fjo" = (
-/obj/effect/landmark/latejoin,
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/landmark/start/f13/settler,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "fjq" = (
 /turf/open/floor/carpet/red,
-/area/f13/building)
-"fjt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 8
-	},
 /area/f13/building)
 "fjC" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -9473,11 +8641,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/building/abandoned)
-"flc" = (
-/turf/closed/wall/f13/wood/interior{
-	icon_state = "interior1"
-	},
-/area/f13/building)
 "flJ" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/structure/curtain{
@@ -9506,12 +8669,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "fmt" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#777777"
-	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/springflowers,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "fmw" = (
 /obj/machinery/vending/dinnerware,
@@ -9865,9 +9025,18 @@
 	},
 /area/f13/trainstation)
 "fpl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/cave/stalagmite{
+	pixel_y = 12;
+	plane = -4;
+	anchored = 1
+	},
+/obj/structure/cave/stalagmite/three{
+	anchored = 1;
+	pixel_y = -8;
+	plane = -4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fpV" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -9944,10 +9113,11 @@
 	},
 /area/f13/building)
 "frB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/guncase,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "frX" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10002,15 +9172,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ftw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "ftT" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -10349,12 +9517,14 @@
 	},
 /area/f13/wasteland)
 "fDN" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/flora/tallgrass5,
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#111111"
 	},
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "fDO" = (
@@ -10421,16 +9591,12 @@
 	},
 /area/f13/building)
 "fFk" = (
-/obj/structure/sink{
-	pixel_y = 19
-	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	pixel_y = 18;
-	pixel_x = 16
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "fFs" = (
 /obj/structure/table/wood/settler,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -10473,13 +9639,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"fHm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
 "fIm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -10510,11 +9669,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fJF" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "fJO" = (
 /obj/structure/simple_door/metal/barred,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10541,36 +9703,25 @@
 	},
 /area/f13/wasteland)
 "fKF" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/blackbox_recorder,
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "fKN" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
+/obj/effect/turf_decal/siding/wood/end,
+/obj/structure/flora/wild_plant/flower/purple_two{
+	pixel_x = 4;
+	pixel_y = 8;
+	randomize_xy = 0
 	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
+/turf/open/indestructible/ground/inside/mountain{
+	color = "#B18770"
 	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 31
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "fLZ" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -10609,11 +9760,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"fNr" = (
-/turf/closed/wall/mineral/brick{
-	weak_wall = 0
-	},
-/area/f13/building)
 "fNs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/dirt,
@@ -10639,14 +9785,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "fOb" = (
-/obj/structure/chair/office/dark{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "fOy" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10662,16 +9805,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fPh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "fPt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10717,23 +9850,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "fRz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/overlay/junk/shower{
-	pixel_y = 15
+/obj/item/storage/trash_stack{
+	layer = 2
 	},
-/obj/structure/decoration/vent/rusty,
-/turf/open/floor/plating/rust,
-/area/f13/building)
-"fRA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "fRS" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10774,31 +9895,25 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fSq" = (
-/obj/structure/chair/sofa/right{
-	dir = 4;
-	icon_state = "sofaend_left"
-	},
-/turf/open/floor/wood_common/wood_common_dark,
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "fTf" = (
-/obj/structure/sign/directions/science{
-	dir = 1;
-	pixel_y = 23
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/soap,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/obj/item/mop,
+/obj/item/storage/bag/trash,
+/obj/structure/closet/anchored,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 39
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/structure/chair/bench{
-	pixel_y = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "fTt" = (
 /obj/structure/sink,
 /turf/open/floor/plasteel/f13{
@@ -10825,14 +9940,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"fTO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetgreen,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "fTP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10860,11 +9967,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "fUC" = (
-/obj/structure/campfire/wallfire{
-	pixel_y = -1
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "fUJ" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/water,
@@ -10906,18 +10011,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fVx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "fVX" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -10940,26 +10033,31 @@
 	},
 /area/f13/building)
 "fXH" = (
-/obj/structure/nest/frog,
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#413527"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
+	pixel_x = -12
+	},
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "fXS" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/flora/tree/jungle,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "fYi" = (
 /obj/structure/sign/crosswalk{
@@ -11034,9 +10132,13 @@
 	},
 /area/f13/brotherhood)
 "gah" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
+	},
+/obj/machinery/smartfridge/bottlerack/grownbin,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "gan" = (
 /obj/structure/chair/left{
@@ -11046,13 +10148,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/trainstation)
-"gao" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/trader)
-"gaA" = (
-/obj/structure/table,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
 "gaC" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building/abandoned)
@@ -11137,24 +10232,11 @@
 	},
 /area/f13/building)
 "gcp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gcE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -11176,13 +10258,42 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "gdU" = (
-/obj/effect/landmark/start/f13/followersscientist/recarcheologist,
-/obj/machinery/light,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/area/f13/building/trader)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/structure/chair/bench{
+	dir = 1;
+	plane = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "gdV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/rotten,
@@ -11196,16 +10307,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gfa" = (
-/obj/structure/rack{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/jukebox{
+	pixel_x = -2
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "gfN" = (
 /obj/structure/rack,
@@ -11236,18 +10342,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/vault,
 /area/f13/brotherhood)
-"ghS" = (
-/obj/structure/stairs/north,
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "gie" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/machinery/door/poddoor/shutters{
+	id = "DenPharma"
+	},
+/obj/structure/table/booth,
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "giD" = (
 /obj/structure/bed/mattress{
@@ -11262,17 +10363,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"giQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "gje" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -11442,13 +10532,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"gla" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/flora/tree/cherryblossom4,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "glg" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -11473,31 +10556,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "glQ" = (
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
-"gma" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/landmark/start/f13/followersscientist/recresearcher,
-/obj/effect/landmark/latejoin,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/structure/chair/bench,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "gmd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/village)
-"gmg" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "gmu" = (
 /obj/machinery/vending/cola/starkist{
 	pixel_x = -4
@@ -11545,23 +10615,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "gnZ" = (
-/obj/structure/lamp_post/doubles/bent{
-	density = 0;
-	dir = 1;
-	pixel_y = -10;
-	pixel_x = -22
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 69;
-	pixel_x = -15;
-	plane = -6
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/reagent_containers/food/snacks/donut/matcha,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "goA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/tool_box,
@@ -11628,10 +10691,6 @@
 /obj/item/shovel/spade,
 /obj/item/cultivator,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"gpx" = (
-/obj/item/kirbyplants/random,
-/turf/open/indestructible/ground/outside/roof,
 /area/f13/building)
 "gpE" = (
 /obj/item/storage/trash_stack,
@@ -11776,10 +10835,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"guV" = (
-/obj/structure/campfire/wallfire,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
 "guW" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11829,9 +10884,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/caves)
 "gwe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/obj/structure/chair/bench{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "gwh" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11840,15 +10903,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gws" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/decoration/vent/rusty{
-	color = "#aaaaFE";
-	alpha = 50
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/mineral/wasteland_vendor/attachments,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "gww" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11864,15 +10921,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"gwL" = (
-/obj/structure/campfire/stove{
-	pixel_y = 10
-	},
-/obj/item/grown/log/tree,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
 /area/f13/building)
 "gwP" = (
 /obj/structure/table/reinforced,
@@ -11917,13 +10965,14 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"gyo" = (
-/obj/structure/flora/tree/cherryblossom3,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "gyr" = (
-/turf/closed/wall/f13/wood,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "gza" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11991,27 +11040,22 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "gBt" = (
-/turf/closed/wall/f13/wood/interior{
-	icon_state = "interior2"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/city/newboston/outdoors)
 "gBT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "gCf" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gCr" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindowvertical"
@@ -12032,13 +11076,8 @@
 	},
 /area/f13/building/abandoned)
 "gCD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/closed/wall/f13/tunnel,
+/area/f13/building/tunnel)
 "gCG" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/outside/dirt,
@@ -12101,20 +11140,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gFj" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"gFJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
+"gFJ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "gGl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/cram_large,
@@ -12251,9 +11288,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "gJk" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/building)
 "gJw" = (
@@ -12276,8 +11313,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "gKS" = (
-/obj/machinery/light/small,
-/turf/open/indestructible/ground/outside/roof,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4;
+	color = "#E0B69F"
+	},
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/building)
 "gKU" = (
 /obj/structure/rug/big/rug_yellow{
@@ -12293,21 +11333,14 @@
 	},
 /area/f13/caves)
 "gLd" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
+/obj/structure/cave/stalagmite/two{
+	anchored = 1;
+	pixel_x = 4;
+	pixel_y = 12;
+	plane = -2
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
-"gLP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/f13/followersscientist/recarcheologist,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/building/trader)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "gMi" = (
 /obj/structure/sink{
 	dir = 8;
@@ -12389,11 +11422,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
 "gOj" = (
-/obj/structure/simple_door/interior,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "gOA" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -12412,13 +11443,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "gPx" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/obj/structure/pondlily_small,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "gPH" = (
 /obj/structure/table/wood/fancy/green,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12445,16 +11475,6 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"gRn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "gRu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -12544,37 +11564,6 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/city/newboston/outdoors)
-"gTE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/survivalcapsule,
-/obj/item/survivalcapsule{
-	pixel_y = 9
-	},
-/obj/item/survivalcapsule/blacksmith{
-	pixel_y = -10
-	},
-/obj/item/survivalcapsule/farm{
-	pixel_x = 10
-	},
-/obj/item/survivalcapsule/fortuneteller{
-	pixel_x = -9
-	},
-/obj/item/survivalcapsule{
-	pixel_y = 9
-	},
-/obj/item/survivalcapsule,
-/obj/item/survivalcapsule/farm{
-	pixel_x = 10
-	},
-/obj/item/survivalcapsule/fortuneteller{
-	pixel_x = -9
-	},
-/obj/item/survivalcapsule/blacksmith{
-	pixel_y = -10
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "gTF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -12733,10 +11722,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"gXv" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "gXY" = (
 /obj/structure/chair/right{
 	dir = 8
@@ -12781,16 +11766,11 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/caveofforever)
 "gZh" = (
-/obj/structure/curtain/directional/east{
-	color = "#1e549c"
-	},
-/obj/machinery/door/airlock/medical/glass{
-	req_one_access_txt = "136";
-	name = "Medical"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/structure/table/wood/bar,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "gZL" = (
@@ -12838,23 +11818,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "haJ" = (
+/obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "hbg" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -12887,89 +11856,15 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "hcp" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
+/obj/machinery/microwave/stove,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "hcJ" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12998,11 +11893,10 @@
 	},
 /area/f13/building)
 "hdy" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "hdI" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalright"
@@ -13093,12 +11987,11 @@
 /area/f13/caves)
 "hgB" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/spacevine,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "hgF" = (
@@ -13187,57 +12080,13 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"hjk" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
 "hjY" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
 "hkV" = (
+/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/one_tire{
-	density = 0
-	},
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "cross1";
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"hlA" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	pixel_x = 19;
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "hlT" = (
 /obj/structure/table/wood/settler,
@@ -13246,9 +12095,12 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "hmh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_x = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hmu" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/trash_stack,
@@ -13272,56 +12124,18 @@
 	},
 /area/f13/building)
 "hng" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "hnK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/tunnel)
 "hnQ" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/turf/open/indestructible/ground/outside/water,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "hnV" = (
 /obj/structure/table,
@@ -13348,12 +12162,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "hov" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "hox" = (
@@ -13385,12 +12199,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"hps" = (
-/obj/machinery/workbench/forge{
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
 "hpt" = (
 /turf/open/floor/f13,
 /area/f13/building)
@@ -13414,25 +12222,10 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
-"hqk" = (
-/obj/structure/flora/chomp/bones/lrock4{
-	alpha = 40
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "hrn" = (
 /obj/structure/flora/wasteplant/wild_prickly,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"hrr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/two_tire{
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "hry" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -13495,11 +12288,12 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "hsR" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "hti" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
@@ -13556,46 +12350,26 @@
 	},
 /area/f13/building)
 "hvb" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/under/swimsuit/red{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/structure/decoration/rag,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	pixel_y = -2;
+	opacity = 1
 	},
-/obj/item/clothing/under/swimsuit/red{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	pixel_y = -2;
+	opacity = 1;
+	pixel_x = 3
 	},
-/obj/item/clothing/under/swimsuit/red{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	pixel_y = -2;
+	opacity = 1;
+	pixel_x = -3
 	},
-/obj/item/clothing/under/swimsuit/red{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/clothing/under/swimsuit/striped{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/striped{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/striped{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/striped{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/white,
-/obj/item/clothing/under/swimsuit/white,
-/obj/item/clothing/under/swimsuit/white,
-/obj/item/clothing/under/swimsuit/white,
-/obj/item/clothing/under/swimsuit/white,
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hvc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13647,12 +12421,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"hzj" = (
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/building/trader)
 "hzo" = (
 /obj/structure/dresser,
 /turf/open/floor/f13{
@@ -13686,25 +12454,12 @@
 	},
 /area/f13/building)
 "hAh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "hAp" = (
 /obj/structure/sign/crosswalk{
@@ -13725,33 +12480,18 @@
 	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"hAL" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/f13/building)
 "hAU" = (
-/obj/structure/table/booth,
-/obj/effect/spawner/lootdrop/lighter,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "hBh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/f13/texasranger,
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
-	},
-/area/f13/building/trader)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "hBp" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/shiny,
@@ -13766,12 +12506,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "hBy" = (
-/obj/structure/decoration/rag,
-/obj/structure/simple_door/repaired,
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/floor/wood_wide,
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "hBz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13790,6 +12527,32 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
+"hBU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#413527"
+	},
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
+	pixel_x = -12
+	},
+/obj/item/reagent_containers/glass/bucket/wood{
+	name = "milk bucket";
+	pixel_y = 12
+	},
+/obj/item/storage/bag/easterbasket{
+	name = "egg basket";
+	desc = "A basket for carrying eggs!"
+	},
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "hBX" = (
 /obj/structure/reagent_dispensers/compostbin,
 /turf/open/indestructible/ground/outside/dirt,
@@ -13807,23 +12570,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"hCq" = (
-/obj/machinery/vending/medical/nash{
-	pixel_x = 26;
-	density = 0
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/custom/leechjar{
-	pixel_y = 18;
-	pixel_x = 21;
-	desc = "Why do the lumps in that jar look vaguely catlike?";
-	name = "Mereks brain juice"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
 "hCv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -13834,23 +12580,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "hCz" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"hCR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/computer/teleporter,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "hDe" = (
 /obj/structure/window/fulltile/house,
@@ -13875,26 +12606,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood_common,
 /area/f13/building)
-"hDP" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "hDS" = (
+/obj/structure/rug/mat/welcome,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "hDV" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14009,20 +12725,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/building)
-"hHP" = (
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = 32;
-	pixel_x = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	dir = 5;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "hHS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -14073,12 +12775,12 @@
 	},
 /area/f13/building)
 "hIT" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/machinery/smartfridge/bottlerack/drug_storage{
+	density = 0;
+	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "hIY" = (
 /obj/structure/table/wood/settler,
@@ -14111,29 +12813,8 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/wasteland/city/newboston/house)
 "hKg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 4;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/machinery/teleport/hub,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "hKs" = (
 /obj/structure/car/rubbish3,
@@ -14224,15 +12905,13 @@
 	},
 /area/f13/building/abandoned)
 "hMT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/junglebush/large,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/structure/flora/ausbushes/leafybush,
 /turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "hNi" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -14263,21 +12942,14 @@
 	},
 /area/f13/caves)
 "hNR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/retro,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
-"hNT" = (
-/obj/structure/table/wood/settler,
-/obj/item/flashlight/lamp{
-	pixel_y = 11
+/obj/structure/closet{
+	pixel_x = 8
 	},
-/obj/item/storage/fancy/cigarettes/cigars/havana,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lighter/royalgold,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	pixel_x = -10
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hNU" = (
 /obj/structure/flora/tree/pink_tree{
 	color = "#00DD00";
@@ -14355,12 +13027,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
-"hQs" = (
-/obj/structure/table/booth,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+"hQe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "hQP" = (
 /obj/structure/closet/fridge/standard,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14429,10 +13102,18 @@
 	},
 /area/f13/building)
 "hTc" = (
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
-"hTd" = (
-/turf/closed/mineral/random/low_chance,
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 10
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-23";
+	pixel_x = -10
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-17"
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "hTe" = (
 /obj/structure/spacevine{
@@ -14506,10 +13187,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hUc" = (
-/obj/item/lock_bolt,
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/turf_decal/siding/wood{
+	color = "#413527"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#413527"
+	},
+/turf/open/water,
+/area/f13/building)
 "hUq" = (
 /turf/open/indestructible/ground/outside/water{
 	color = "#33FF48";
@@ -14527,8 +13213,34 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "hVc" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "hVm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink{
@@ -14659,13 +13371,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"iaR" = (
-/obj/structure/fluff/rails{
-	dir = 1;
-	layer = -1
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/workshop/nash)
 "iaY" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14699,22 +13404,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"ibu" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "ibL" = (
 /obj/structure/chair/middle{
 	dir = 4
@@ -14722,17 +13411,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"ibY" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
 "icf" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/wild_plant/flower/red,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/crate/trashcart{
+	pixel_y = 12
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "icl" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -14742,13 +13429,6 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
-"icA" = (
-/obj/effect/landmark/start/f13/followersscientist/recslimeologist,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/building/trader)
 "idA" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalright"
@@ -14774,10 +13454,6 @@
 	name = "the watering hole"
 	},
 /area/f13/wasteland)
-"ied" = (
-/obj/structure/simple_door/wood/alt/window,
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
 "ieq" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14792,9 +13468,6 @@
 	color = "#999999"
 	},
 /area/f13/caves)
-"ifw" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/chapel)
 "ifZ" = (
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn/calf,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14846,9 +13519,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "ihO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#a1a1a1"
 	},
 /area/f13/building)
 "ihP" = (
@@ -14929,25 +13602,6 @@
 /turf/open/indestructible/ground/outside/road{
 	color = "#999999"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
-"ijO" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "ikl" = (
 /obj/structure/closet,
@@ -15051,14 +13705,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned)
-"iop" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/random,
-/obj/item/toy/plush/coffeefox,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "ioQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15073,14 +13719,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "ipD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 1
+/obj/machinery/gear_painter,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/area/f13/building)
+/area/f13/caves)
 "ipK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15109,35 +13755,29 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
-"iqa" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/library)
 "iql" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/flora/tree/cherryblossom4{
-	pixel_y = 11;
-	pixel_x = -8;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "iqw" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/carpet/purple,
 /area/f13/building/abandoned)
 "iqN" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "housewindowbrokenvertical"
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/glass/beaker,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = 1
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/curtain{
-	color = "#845f58";
-	layer = 5
-	},
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "iqO" = (
 /obj/effect/decal/marking{
@@ -15169,32 +13809,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"irW" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
 "irX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
-"isr" = (
-/obj/structure/closet/cabinet/anchored,
-/obj/item/lock_construct,
-/obj/item/key,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "isv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/securitron,
@@ -15209,8 +13829,16 @@
 	},
 /area/f13/wasteland)
 "isE" = (
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/bed/dogbed{
+	pixel_y = -6
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	name = "Otto von Dogmark";
+	wander = 0
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "isQ" = (
 /obj/item/storage/box/donkpockets,
 /obj/structure/table,
@@ -15225,16 +13853,34 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "itb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/greyscale{
+	dir = 1;
+	pixel_x = 8
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/toilet{
+	color = "#D1D1D1";
+	pixel_y = -2;
+	pixel_x = -8;
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/toilet_paper{
+	pixel_x = -25;
+	pixel_y = -4
+	},
+/obj/structure/mirror{
+	pixel_y = -30;
+	pixel_x = 7
+	},
+/obj/structure/closet/locker/medcabinet{
+	pixel_y = -34;
+	pixel_x = -9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty";
+	color = "grey"
+	},
+/area/f13/building)
 "itw" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
@@ -15283,13 +13929,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/building)
-"ivc" = (
-/mob/living/simple_animal/raccoon/red{
-	name = "Lil Kuddler";
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
 "ivk" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -15329,17 +13968,6 @@
 	dir = 8
 	},
 /area/f13/building)
-"iwf" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "iwh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/car/rubbish1{
@@ -15419,13 +14047,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"iyT" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/autolathe/ammo,
-/obj/item/stack/ore/blackpowder/fifty,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "iyV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15437,16 +14058,10 @@
 	},
 /area/f13/wasteland)
 "iyZ" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	id = "spawn2"
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/snack,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "izc" = (
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
@@ -15460,11 +14075,9 @@
 /area/f13/building/abandoned)
 "izz" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lighter,
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/simple_door/house,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "izN" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -15506,19 +14119,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"iAG" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = -14;
-	layer = 2.8;
-	density = 0;
-	pixel_y = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
 "iAI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15586,15 +14186,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/caves)
-"iCh" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/trader)
 "iCp" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -15628,8 +14219,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "iCP" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/wood_common/wood_common_dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
 /area/f13/building)
 "iCU" = (
 /obj/structure/rack,
@@ -15687,10 +14281,11 @@
 	},
 /area/f13/tribe)
 "iEm" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "iEq" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15796,11 +14391,11 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned)
 "iJo" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
+/obj/structure/closet,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/area/f13/building/trader)
+/area/f13/building)
 "iJs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15827,14 +14422,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"iKC" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "iKV" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/ruins,
@@ -15854,14 +14441,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"iLq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "iLy" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -15877,8 +14456,11 @@
 	},
 /area/f13/building)
 "iLC" = (
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
+/obj/machinery/porta_turret/f13/turret_22lr/burstfire{
+	faction = list("neutral")
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "iLF" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
@@ -15919,12 +14501,6 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"iNm" = (
-/obj/machinery/vending/snack,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/trader)
 "iND" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -15942,13 +14518,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "iOa" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/packaged_respawner_blocker,
-/obj/item/packaged_respawner_blocker{
-	pixel_y = 10
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/crowbar,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/area/f13/building)
 "iOd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -16006,21 +14583,26 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "iQJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "iQQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/sheet/metal/five,
@@ -16200,14 +14782,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "iUe" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 6
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "iUk" = (
 /obj/structure/sign/departments/security{
 	pixel_x = -32
@@ -16239,12 +14821,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building/abandoned)
 "iUQ" = (
-/obj/structure/furnace{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "iVD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -16344,14 +14939,10 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/caves)
 "iXY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/bigredvend,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "iYc" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -16369,16 +14960,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/trainstation)
-"iYx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "iZb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/fridge,
@@ -16459,12 +15040,12 @@
 	},
 /area/f13/building)
 "jas" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-18";
-	pixel_x = -2;
-	pixel_y = 25
+/obj/structure/simple_door/house,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "jaI" = (
 /obj/structure/table/wood/settler,
@@ -16568,11 +15149,13 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building/abandoned)
 "jed" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/nest/frog,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/computer/telecomms/server{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/building)
 "jeg" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/item/storage/box/drinkingglasses,
@@ -16583,10 +15166,13 @@
 	},
 /area/f13/building)
 "jeh" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/machinery/door/airlock/science/glass{
+	req_one_access_txt = "136";
+	name = "RnD Lab"
 	},
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "jer" = (
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
@@ -16599,25 +15185,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jeE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6
 	},
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = -1;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"jeH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/window/fulltile/ruins,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "jeI" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -16626,9 +15203,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "jfc" = (
-/obj/machinery/autolathe,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/footchest,
+/obj/item/clothing/head/coyote/sheeppelt,
+/obj/item/clothing/head/helmet/f13/khan/pelt,
+/obj/item/clothing/neck/mantle/peltfur,
+/obj/item/clothing/head/coyote/blackcape,
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "jfg" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -16644,11 +15226,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"jfm" = (
-/obj/structure/curtain/directional/west,
-/obj/structure/window/fulltile/stainedglass/woodwindoworange,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "jfx" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -16657,9 +15234,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jfA" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/sauna)
 "jfT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -16720,14 +15294,14 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned)
 "jhh" = (
-/obj/structure/dresser,
-/obj/item/flashlight/lamp{
-	pixel_y = 14
+/obj/structure/junk/jukebox,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = 1
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jhG" = (
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/weather/dirt{
@@ -16770,9 +15344,27 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jiy" = (
-/obj/machinery/mineral/wasteland_vendor/medical,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "jiz" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/f13{
@@ -16819,24 +15411,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"jjv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2;
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "jjA" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/f13{
@@ -16852,10 +15426,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "jjT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "jjU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16944,47 +15517,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "jmQ" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain,
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/wasteland/city/newboston/sauna)
-"jmV" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/shower{
-	pixel_y = 14
-	},
-/turf/open/floor/plating,
-/area/f13/building)
-"jnu" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 30;
-	pixel_x = 1;
-	light_color = "#FF55FF";
-	light_range = 1;
-	light_power = 2
-	},
 /obj/structure/chair/bench{
-	pixel_y = 12
+	dir = 8
 	},
-/obj/effect/overlay/palmtree_l{
-	color = "#BE24FF";
-	pixel_y = 32;
-	density = 0
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"jnB" = (
-/obj/structure/sink/well{
-	pixel_y = 7;
-	pixel_x = -6;
-	layer = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jnR" = (
 /obj/structure/table/wood/settler,
 /obj/structure/bedsheetbin/empty,
@@ -17100,11 +15637,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "jri" = (
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/building/trader)
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "jrx" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -17142,14 +15678,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jsL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/railing{
+	climbable = 0;
+	color = "#A47449";
+	resistance_flags = 64
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/closet/crate/trashcart{
+	opened = 1;
+	name = "the humpster"
+	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "jsX" = (
 /obj/structure/flora/grass/wasteland{
@@ -17180,13 +15718,9 @@
 	},
 /area/f13/building/tribal)
 "jtS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/booth{
-	dir = 4;
-	icon_state = "booth_east_north"
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/light/small,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jut" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -17319,18 +15853,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"jxi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "jxs" = (
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
@@ -17350,9 +15872,37 @@
 	},
 /area/f13/building)
 "jxT" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/structure/table/wood/settler,
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/machinery/cell_charger{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "jye" = (
 /obj/structure/simple_door/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17363,10 +15913,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/building)
-"jzb" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
 "jze" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -17376,10 +15922,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"jzg" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "jzQ" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17420,33 +15962,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"jAP" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/open/floor/pod{
-	name = "tiles"
-	},
-/area/f13/building/workshop/nash)
-"jBm" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "jBp" = (
 /obj/structure/stone_tile/block{
 	layer = 5
@@ -17581,13 +16096,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "jEY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/bar,
-/obj/item/storage/lockbox/dueling/hugbox{
-	pixel_y = 5
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building)
 "jFa" = (
 /obj/structure/closet/wardrobe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -17620,12 +16132,6 @@
 /obj/structure/debris/v3,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
-"jGw" = (
-/obj/structure/chair/pew/left{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "jGJ" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -17664,11 +16170,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
 "jIg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/building)
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "jIx" = (
 /mob/living/simple_animal/hostile/bs,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17694,11 +16201,11 @@
 	},
 /area/f13/building)
 "jJj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+/obj/machinery/telecomms/relay/preset/ruskie{
+	use_power = 0
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/f13/building)
 "jJl" = (
 /obj/structure/table_frame/wood,
@@ -17771,94 +16278,24 @@
 	},
 /area/f13/building)
 "jLW" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/mob/living/simple_animal/cow/brahmin/cow{
+	name = "Belle"
+	},
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "jMc" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
+/obj/machinery/computer/terminal{
+	dir = 1
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/structure/nest/frog,
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "jMg" = (
 /obj/structure/chair/f13chair2{
 	dir = 8
@@ -17875,12 +16312,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"jMH" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "jMJ" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/chem_dispenser/drinks,
@@ -17921,12 +16352,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "jOa" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/wild_plant/flower/pink,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/kirbyplants/random,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "jOo" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -17946,15 +16374,18 @@
 	},
 /area/f13/building)
 "jOD" = (
-/obj/structure/flora/wild_plant/flower/blue_two,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "jOM" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/building)
 "jON" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13{
@@ -17962,54 +16393,10 @@
 	},
 /area/f13/building)
 "jOV" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
+/obj/structure/sign/departments/medbay{
+	name = "\improper PHARMACY"
 	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	pixel_x = 19;
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15;
-	pixel_x = 18
-	},
-/turf/open/indestructible/ground/outside/water,
+/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "jPi" = (
 /obj/structure/simple_door/interior,
@@ -18051,12 +16438,13 @@
 	},
 /area/f13/caves)
 "jQt" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/suspenders,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/shoes/sneakers/mime,
+/obj/item/clothing/under/pants/black,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/machinepile{
-	layer = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "jQA" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -18101,12 +16489,14 @@
 	},
 /area/f13/building)
 "jSc" = (
-/obj/machinery/light/small{
-	dir = 8;
-	plane = -5
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "jSC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/nest/randomized{
@@ -18166,72 +16556,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"jUu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "jUx" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/table/wood/bar,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"jUA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/recharger{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/structure/table/wood/settler,
-/obj/machinery/cell_charger{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/cell_charger{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/machinery/cell_charger{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/machinery/cell_charger{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/machinery/cell_charger{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/area/f13/building)
 "jUF" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18244,11 +16575,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "jVq" = (
-/obj/machinery/door/poddoor/shutters/old/preopen{
-	id = "garbageshutters"
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "jVs" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -18256,12 +16591,11 @@
 	},
 /area/f13/building)
 "jVv" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "jVB" = (
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18383,15 +16717,6 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"jXT" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe/free,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/painting/library{
-	pixel_y = 35
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "jXY" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18450,15 +16775,11 @@
 	},
 /area/f13/wasteland)
 "jZR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_bed{
-	pixel_x = 32
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building)
 "jZS" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -18507,7 +16828,40 @@
 	},
 /area/f13/wasteland)
 "kbr" = (
-/turf/open/floor/plating/rust,
+/obj/structure/closet/crate/freezer{
+	storage_capacity = 30
+	},
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/heart,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/lungs,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/stomach,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/liver,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/eyes,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/ears,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/item/organ/tongue,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "kbs" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18672,14 +17026,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"kgw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "kgD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/darkbrown/corner{
@@ -18767,13 +17113,6 @@
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"kkM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 16
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
 "kkN" = (
 /obj/structure/chair/stool/bar,
 /turf/open/indestructible/ground/inside/subway,
@@ -18810,95 +17149,15 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "kma" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
+/obj/machinery/button/door{
+	pixel_x = -32;
+	id = "DenGate";
+	name = "Den Gate"
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/machinery/shower{
-	dir = 1;
-	layer = 4.9;
-	on = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "kmd" = (
 /obj/structure/table,
@@ -18973,9 +17232,20 @@
 	},
 /area/f13/building)
 "koc" = (
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#777777"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#3B2B1A"
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "koo" = (
 /obj/structure/rack,
@@ -18994,10 +17264,12 @@
 	},
 /area/f13/building)
 "koP" = (
+/obj/structure/curtain{
+	color = "#1F1F1F"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/caves)
 "koY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19045,20 +17317,10 @@
 	},
 /area/f13/building)
 "kqO" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/wreck/trash/two_tire,
-/obj/structure/wreck/trash/two_tire{
-	pixel_x = 10
-	},
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "kqP" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/bars,
@@ -19094,13 +17356,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"krF" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/library)
 "krG" = (
 /obj/effect/decal/marking{
 	pixel_x = 14
@@ -19116,17 +17371,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "kse" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/f13chair2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "ksO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19166,21 +17415,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"kun" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "kuz" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -19257,21 +17491,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"kwu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/booth{
-	dir = 8;
-	icon_state = "booth_west_south"
-	},
-/obj/machinery/light,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "kwv" = (
-/obj/machinery/gear_painter,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/trader)
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building)
+"kwB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kwJ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -19281,25 +17508,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"kwQ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "kxa" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/stairs/east{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "kxz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -19345,9 +17559,28 @@
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/caves)
 "kzV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "kzY" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -19364,13 +17597,13 @@
 	},
 /area/f13/building)
 "kAz" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/right,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "kAN" = (
 /obj/structure/table/reinforced{
 	color = "#3c2c21"
@@ -19379,10 +17612,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "kAR" = (
-/obj/machinery/computer/teleporter,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
+/obj/machinery/teleport/station,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "kBj" = (
 /obj/machinery/vending/games,
@@ -19400,14 +17631,6 @@
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"kBW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/caution{
-	pixel_x = -6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "kCb" = (
 /obj/effect/decal/cleanable/glass,
@@ -19515,12 +17738,6 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"kEZ" = (
-/turf/open/floor/f13{
-	dir = 6;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "kFi" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19581,11 +17798,13 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "kFU" = (
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = -1
+/obj/structure/curtain/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
 	},
-/turf/closed/wall/f13/coyote/oldwood,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "kFZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19670,22 +17889,12 @@
 	},
 /area/f13/building)
 "kIc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
-"kID" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 5
+	dir = 5;
+	color = "#E0B69F"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/building)
 "kIE" = (
 /obj/structure/window/fulltile/wood_window,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19703,35 +17912,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "kIY" = (
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/chair/bench{
+	pixel_y = 10
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "kJh" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
-"kJs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "kJC" = (
 /obj/structure/chair/middle{
 	dir = 8
@@ -19740,13 +17935,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"kJF" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "kJS" = (
 /turf/open/floor/wood_common,
 /area/f13/building)
@@ -19755,40 +17943,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kKO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "kKQ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"kKR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/airlock/hatch{
-	req_one_access_txt = "61"
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
 "kLc" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -19834,31 +17999,15 @@
 	},
 /area/f13/caves)
 "kMz" = (
-/obj/structure/window/fulltile/wood{
-	layer = 3
-	},
-/obj/structure/curtain{
-	color = "#c40e0e"
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/structure/legion_extractor,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "kMK" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 5
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
+/obj/structure/flora/tree/jungle/small,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "kMU" = (
 /obj/structure/chair/right{
@@ -19869,11 +18018,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"kMX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/wild_plant/flower/pink_two,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "kNh" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/f13/blacksmith,
@@ -19906,13 +18050,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "kOh" = (
+/obj/machinery/mineral/wasteland_vendor/medical,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "kOB" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19924,13 +18064,36 @@
 	},
 /area/f13/wasteland)
 "kOC" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/area/f13/building)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/chair/bench{
+	dir = 8;
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "kOR" = (
 /obj/structure/chair/sofa/right,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -19956,16 +18119,6 @@
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"kQs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
 "kQZ" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20004,8 +18157,25 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "kSI" = (
-/obj/structure/flora/tree/cherryblossom,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#3B2B1A"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#3B2B1A"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8;
+	pixel_y = -17
+	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "kSL" = (
 /obj/machinery/button{
@@ -20046,15 +18216,13 @@
 	},
 /area/f13/brotherhood)
 "kTZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/decoration/vent{
-	icon = 'icons/obj/structures.dmi';
-	icon_state = "manhole_closed"
+/obj/machinery/computer/camera_advanced{
+	dir = 4;
+	networks = list("nash")
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "kUo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermainright"
@@ -20139,11 +18307,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "kWU" = (
-/obj/structure/stairs/north{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "kXc" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/plasteel/f13{
@@ -20226,24 +18395,27 @@
 	},
 /area/f13/building)
 "kZb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/rack{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#dedcdc"
+/obj/item/multitool{
+	pixel_x = 9
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp{
+	pixel_y = 14
+	},
+/obj/item/binoculars,
+/obj/item/binoculars,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "kZm" = (
-/obj/structure/closet/fridge{
-	anchored = 1
+/obj/structure/table/wood/bar,
+/obj/machinery/computer/terminal{
+	termtag = "Public"
 	},
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "kZn" = (
 /obj/structure/window/fulltile/wood_window,
@@ -20284,20 +18456,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "lah" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/followersscientist/recarcheologist,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "lai" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20385,14 +18548,35 @@
 	},
 /area/f13/building)
 "lbs" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
-"lbD" = (
-/obj/structure/rack/shelf_metal{
-	pixel_x = -3
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_6"
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
+"lbD" = (
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "lbG" = (
 /obj/machinery/telecomms/server/presets/town,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -20439,21 +18623,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"lel" = (
-/obj/structure/lamp_post{
-	dir = 8
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 78;
-	pixel_x = -25;
-	plane = -6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "les" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -20508,11 +18677,8 @@
 	},
 /area/f13/wasteland)
 "lfa" = (
-/obj/machinery/teleport/station,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "lfl" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -20530,14 +18696,6 @@
 /obj/structure/wreck/trash/one_tire,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"lgv" = (
-/obj/effect/landmark/start/f13/texasranger,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
-	},
-/area/f13/building/trader)
 "lgG" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/indestructible/ground/outside/road{
@@ -20659,20 +18817,13 @@
 	},
 /area/f13/wasteland)
 "liW" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#777777"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "liZ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -20680,15 +18831,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"lje" = (
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/machinery/workbench/advanced,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "ljl" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 1
@@ -20759,15 +18901,11 @@
 	},
 /area/f13/building)
 "lkQ" = (
-/obj/structure/chair/bench{
-	pixel_y = 6
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/effect/landmark/start/f13/followersscientist/recnanspec,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/workshop/nash)
+/area/f13/building)
 "llg" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -20783,10 +18921,13 @@
 	},
 /area/f13/wasteland)
 "lln" = (
-/obj/machinery/biogenerator,
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/building)
 "llz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20853,16 +18994,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "lmZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/floorgrime,
-/area/f13/building)
-"lna" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "lny" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20908,19 +19041,12 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "lon" = (
-/obj/structure/table/wood/settler{
-	density = 0
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/step_trigger/player_choice_log{
+	question = "Welcome to New Boston hotpspring, this location is considered a public 'free erp' area where players can safetly choose to be lewd in public without worry of breaking peoples prefs.  This means that you may see things you are not personally interested within, though the rules for player consent and no underaged play still stand.  Do you wish to continue onwards?"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 1
-	},
-/obj/effect/fake_stairs/west{
-	color = "#845f58"
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "loU" = (
 /obj/structure/wreck/trash/brokenvendor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20959,19 +19085,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"lqr" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "lqs" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21015,24 +19128,12 @@
 	color = "#888888"
 	},
 /area/f13/building/tribal/cave)
-"lsg" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/lighter,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "lsj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 10
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lsq" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
@@ -21096,14 +19197,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "lvH" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8;
-	color = "#333333"
+/obj/machinery/reagentgrinder,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/obj/machinery/button/door{
+	name = "Pharmacy Window";
+	id = "DenPharma";
+	pixel_y = -22
 	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "lwh" = (
 /obj/structure/table,
 /obj/structure/table,
@@ -21228,29 +19332,6 @@
 	color = "#666666"
 	},
 /area/f13/caves)
-"lxW" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
-"lxX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "lyi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2left"
@@ -21274,13 +19355,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"lyW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_3"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building)
 "lzp" = (
 /obj/structure/simple_door/room,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21300,17 +19374,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"lzy" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 5;
-	height = 7;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/workshop/nash)
 "lzB" = (
 /obj/structure/table/wood/settler,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21319,11 +19382,10 @@
 /area/f13/building)
 "lzG" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/medical/glass{
-	req_one_access_txt = "136";
-	name = "Medical"
+/obj/structure/fermenting_barrel,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "lzJ" = (
 /obj/structure/closet/fridge,
@@ -21339,12 +19401,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/abandoned)
 "lAl" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "4211";
-	name = "outpost gate1"
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "lAz" = (
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/plasteel/neutral,
@@ -21411,50 +19469,47 @@
 "lCj" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
-"lCk" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "finalbossladder"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"lCl" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
 "lCP" = (
-/obj/machinery/photocopier{
-	pixel_x = 12;
-	pixel_y = -4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/machinery/libraryscanner{
-	pixel_x = -14;
-	density = 0;
-	pixel_y = -2
-	},
-/obj/structure/rug/big/rug_fancy{
-	color = "grey";
-	dir = 1;
-	pixel_x = -26;
-	layer = 2.7;
-	pixel_y = 10
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/obj/item/reagent_containers/food/snacks/donut/laugh,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "lCU" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/structure/chair/bench{
+	dir = 8;
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "lDa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -21495,30 +19550,6 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/building)
-"lDV" = (
-/obj/machinery/conveyor_switch{
-	pixel_y = 22;
-	id = "spawn2"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/building/trader)
-"lDW" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "lEg" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -21535,21 +19566,14 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "lFc" = (
-/obj/machinery/chem_heater{
-	pixel_y = 17;
-	pixel_x = 8;
-	density = 0
+/obj/effect/turf_decal/weather/springflowers,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/obj/machinery/chem_dispenser/fullupgrade{
-	density = 0;
-	pixel_x = -12;
-	pixel_y = 19
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "lFj" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -21650,23 +19674,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "lIo" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 7;
-	pixel_y = 11
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/obj/item/storage/box/medsprays{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/storage/box/pillbottles{
-	pixel_x = 10;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes,
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "lIw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21737,22 +19752,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/caves)
 "lKL" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/structure/stairs/east{
+	color = "#6F4F40"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/building)
 "lLd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -21814,13 +19818,33 @@
 	},
 /area/f13/building)
 "lNX" = (
-/obj/structure/anvil/obtainable/basic{
-	pixel_x = -6;
-	pixel_y = 12;
-	density = 0
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "lOg" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -21907,70 +19931,16 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "lQM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -2
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"lQN" = (
-/obj/structure/table/wood/settler,
-/obj/item/stamp/denied{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/stamp{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/obj/item/export_scanner{
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/area/f13/building)
 "lQV" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -22020,34 +19990,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "lUi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/start/f13/followersdoctor,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "lUl" = (
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/closed/wall/f13/coyote/oldwood,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/building)
 "lUv" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22132,11 +20092,10 @@
 	},
 /area/f13/building)
 "lXh" = (
-/obj/structure/flora/tree/cherryblossom{
-	pixel_y = 12;
-	plane = -2
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_8"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "lXu" = (
 /obj/structure/table/wood/settler,
@@ -22144,13 +20103,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/building)
-"lXA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "lYb" = (
 /obj/structure/junk/drawer,
 /turf/open/floor/f13/wood,
@@ -22162,15 +20114,10 @@
 	},
 /area/f13/wasteland)
 "lYs" = (
-/obj/effect/turf_decal/weather/dirtcorner{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirtcorner,
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "lYt" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/cig_packs,
@@ -22199,15 +20146,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"lYX" = (
-/obj/structure/railing{
-	pixel_y = -4;
-	plane = -6;
-	color = "#BECD44";
-	pixel_x = -1
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "lZh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22226,11 +20164,12 @@
 	},
 /area/f13/building)
 "lZC" = (
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/closet/locker,
+/obj/item/clothing/suit/armor/outfit/overalls/blacksmith,
+/obj/item/clothing/gloves/f13/blacksmith,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "lZG" = (
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "cross1"
@@ -22255,10 +20194,6 @@
 /obj/structure/bed/old,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"maY" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
 "mbk" = (
 /obj/structure/closet/crate/large,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -22321,11 +20256,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mcE" = (
-/obj/machinery/vending/cigarette,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/trader)
+/obj/structure/flora/grass/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "mcT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22338,15 +20271,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "mdo" = (
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "mdx" = (
 /obj/structure/chair/pew,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22375,11 +20304,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "mdK" = (
-/obj/structure/flora/wild_plant/flower/purple{
-	pixel_y = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#413527"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
+	pixel_x = -12
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "mec" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -22440,19 +20382,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building/abandoned)
 "mfY" = (
-/obj/structure/spacevine,
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/barricade/barswindow,
+/obj/machinery/door/poddoor/shutters{
+	id = "DenPharma"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/table/booth,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "mgj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -22519,11 +20455,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "miw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
-	dir = 8
-	},
-/area/f13/building)
+/obj/effect/landmark/start/f13/followersscientist/recarcheologist,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "miK" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 8
@@ -22552,11 +20487,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"mke" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/building/trader)
 "mkl" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/jacket/flannel,
@@ -22640,32 +20570,13 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building)
-"mln" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "mlo" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/decoration/hatch{
-	icon_state = "vault_diner";
-	plane = 0;
-	pixel_y = 13;
-	pixel_x = 16;
-	alpha = 150;
-	name = "sign"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "mlr" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -22719,23 +20630,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mnq" = (
-/obj/structure/chair/bench{
-	pixel_y = 6
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/effect/landmark/start/f13/followersscientist/recguard,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/workshop/nash)
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "mnA" = (
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449";
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/mob/living/simple_animal/axolotl{
+	wander = 0
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "mnD" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/brotherhood)
@@ -22766,9 +20674,11 @@
 	},
 /area/f13/building)
 "moZ" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "mpj" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -22796,16 +20706,6 @@
 /obj/item/grenade/empgrenade,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"mpY" = (
-/obj/structure/wreck/trash/halftire,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "mqb" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -22899,12 +20799,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"msP" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
 "msX" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/road{
@@ -22957,11 +20851,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "mvq" = (
-/obj/structure/chair/comfy/purple{
-	dir = 8
-	},
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "mvt" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/indestructible/ground/outside/water,
@@ -22971,16 +20863,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mvw" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_west_north";
-	pixel_y = 11
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "mvI" = (
 /obj/machinery/biogenerator,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23066,11 +20948,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "myf" = (
-/obj/structure/fermenting_barrel{
-	pixel_y = 9
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "myM" = (
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
@@ -23084,10 +20967,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"mzj" = (
-/obj/machinery/mineral/wasteland_vendor/attachments,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "mzm" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -23113,27 +20992,46 @@
 	},
 /area/f13/building)
 "mzO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/bed/dogbed,
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 1;
+	name = "wood post";
+	pixel_x = -15
 	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/fence/wooden{
+	density = 0;
+	dir = 1;
+	name = "wood post";
+	pixel_x = 15
+	},
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_y = 11
+	},
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_y = 6
+	},
+/obj/structure/fence/wooden{
+	dir = 4;
+	pixel_y = 11
+	},
+/obj/structure/cave/bigboards/westeast{
+	pixel_y = 12
+	},
+/obj/structure/tires{
+	pixel_y = 14
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "mzQ" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/trainstation)
 "mzS" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
-"mzT" = (
-/obj/structure/barricade/bars,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/workshop/nash)
+/obj/structure/junk/locker,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mzV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -23179,11 +21077,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mAu" = (
-/obj/machinery/microwave/stove,
+/obj/structure/table/wood/bar,
+/obj/item/storage/box/cups,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "mBd" = (
 /obj/machinery/door/airlock/ckey/highsecurity/andy{
@@ -23227,90 +21124,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "mDl" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/glowshroom/shadowshroom,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mDm" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -23418,28 +21234,33 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"mHx" = (
-/obj/machinery/vending/coffee,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
 "mHJ" = (
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
-"mHP" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9;
-	plane = -2
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
+"mHP" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/machinery/light/floor{
+	plane = -6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mHQ" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23480,18 +21301,13 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
 "mJp" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/structure/chair/bench{
-	pixel_y = 6
-	},
-/obj/effect/landmark/start/f13/followersscientist/recguard,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "mJu" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -23647,21 +21463,18 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "mOl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/paper/fluff/ruins/listeningstation/reports/november,
+/obj/item/pen,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "mOz" = (
 /turf/closed/indestructible/riveted/boss{
 	name = "temple wall"
@@ -23715,27 +21528,10 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/workshop/nash)
-"mQX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 4;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"mRh" = (
-/obj/structure/flora/chomp/bones/lrock4{
-	plane = -5-4;
-	pixel_x = -16;
-	alpha = 50
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+"mQH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/ruins,
+/area/f13/brotherhood)
 "mSr" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -23745,9 +21541,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "mSJ" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_11"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -23767,8 +21562,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mTe" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/towel_rack{
+	pixel_y = 27
+	},
+/obj/structure/table/wood/bar,
+/obj/structure/bedsheetbin/towel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mTp" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23904,12 +21704,20 @@
 	},
 /area/f13/tribe)
 "mWc" = (
-/obj/item/toy/beach_ball,
-/turf/open/water{
-	icon = 'icons/turf/pool.dmi';
-	icon_state = "pool_tile"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 8;
+	plane = -4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/wasteland/city/newboston/outdoors)
 "mWr" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23928,17 +21736,19 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"mXo" = (
-/obj/machinery/porta_turret/f13/turret_22lr/burstfire{
-	faction = list("neutral")
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "mXK" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/turf/open/floor/wood_common,
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/stock_parts/chem_cartridge/pristine,
+/obj/item/stock_parts/chem_cartridge/pristine,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "mYh" = (
 /obj/structure/nest/randomized{
@@ -23959,11 +21769,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "mYB" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/mob/living/simple_animal/chicken,
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "mYK" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/ground/inside/mountain,
@@ -24034,24 +21844,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"naL" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "naQ" = (
 /obj/structure/table/wood/settler,
 /obj/item/toy/clockwork_watch,
@@ -24077,10 +21869,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned)
 "nbV" = (
-/turf/open/floor/f13{
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/chem_wardrobe/free,
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/area/f13/building)
 "nbY" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress6"
@@ -24220,17 +22014,12 @@
 	},
 /area/f13/wasteland)
 "ngm" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_3";
-	pixel_y = 5
-	},
+/obj/structure/flora/tree/jungle/small,
 /obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
+	dir = 10
 	},
-/mob/living/simple_animal/cow/brahmin/cow/tan,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/area/f13/wasteland/city/newboston/outdoors)
 "ngs" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -24242,16 +22031,6 @@
 	icon_state = "outerborder - N"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"ngx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
 "ngC" = (
 /obj/structure/fluff/blocker,
 /turf/open/indestructible/ground/outside/road,
@@ -24307,15 +22086,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"niY" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "njU" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter - W"
@@ -24329,18 +22099,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "njY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/chair/booth{
+	icon_state = "booth_west_north";
+	pixel_y = 11
 	},
-/obj/effect/turf_decal/weather/dirt{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "nku" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/obj/machinery/smartfridge/bottlerack/gardentool,
+/obj/item/reagent_containers/glass/bucket/wood,
+/obj/item/reagent_containers/glass/bucket/wood,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator/rake,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "nlh" = (
 /obj/structure/target_stake,
@@ -24360,22 +22139,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"nlU" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "nmr" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24405,10 +22168,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"nnK" = (
-/obj/structure/stairs/north,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/building)
 "nnS" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/f13/wood,
@@ -24524,14 +22283,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"nrx" = (
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 4;
-	alpha = 80;
-	mouse_opacity = 0
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "nsl" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -24559,15 +22310,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/building/abandoned)
-"ntV" = (
-/obj/effect/landmark/latejoin,
-/obj/effect/landmark/start/f13/followersscientist,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
-	},
-/area/f13/building/trader)
 "nua" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -24646,33 +22388,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "nwh" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "nwr" = (
-/obj/structure/lamp_post/doubles/bent{
-	dir = 4;
-	density = 0;
-	pixel_y = -14;
-	pixel_x = -42
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 64;
-	pixel_x = 17;
-	plane = -6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - E"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/window/fulltile/ruins,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "nwS" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/decoration/vent/rusty{
@@ -24757,13 +22480,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nxO" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "nxZ" = (
 /obj/structure/junk/cabinet,
 /turf/open/floor/wood_common,
@@ -24873,17 +22592,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"nAu" = (
-/obj/structure/simple_door/interior,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lock_bolt{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "nAx" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24923,13 +22631,17 @@
 	},
 /area/f13/building)
 "nBt" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/reedbush{
+	randomize_xy = 0;
+	pixel_x = 8;
+	pixel_y = 23
 	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "nBZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
@@ -24965,14 +22677,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"nDn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/booth{
-	dir = 4;
-	icon_state = "booth_east_south"
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "nDo" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -25001,15 +22705,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nDA" = (
-/obj/structure/simple_door/room,
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#CECECE"
-	},
-/area/f13/wasteland/city/newboston/library)
 "nDF" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -25021,18 +22716,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"nDI" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "nDJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -25072,26 +22755,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "nEI" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
 	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/area/f13/building)
+/obj/effect/decal/cleanable/glitter/blue{
+	plane = -4;
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "nEX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25161,19 +22848,25 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "nHr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/obj/item/weapon/copperpot2,
+/obj/item/weapon/copperpot,
+/obj/structure/closet/cabinet,
+/obj/item/weapon/spatula{
+	color = "#C48822";
+	name = "spathula";
+	desc = "The priestess of the Mars Bars one true weapon";
+	force = 30;
+	force_unwielded = 30;
+	force_wielded = 40;
+	layer = 1
+	},
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/f13{
-	icon_state = "stagestairs"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"nHE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+	icon_state = "redrustyfull"
 	},
 /area/f13/building)
 "nHJ" = (
@@ -25258,12 +22951,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building)
-"nKa" = (
-/obj/machinery/mineral/wasteland_vendor/general{
-	icon_state = "nugeneric_idle"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "nKj" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses,
@@ -25308,24 +22995,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "nLi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/smartfridge/bottlerack{
-	pixel_y = 21;
-	density = 0
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -14;
-	pixel_y = -1
+/obj/structure/decoration/hatch{
+	icon_state = "vault_clinic";
+	pixel_y = -26;
+	name = "sign";
+	alpha = "150"
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
-"nLy" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/obj/structure/nest/frog,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "nLL" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25333,10 +23012,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"nMc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/sauna)
 "nMs" = (
 /obj/effect/decal/marking{
 	pixel_x = -14
@@ -25356,10 +23031,6 @@
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
-/area/f13/building)
-"nMD" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "nMF" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -25433,24 +23104,39 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "nOT" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"nOU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal,
-/obj/item/choice_beacon/pet/mountable,
-/obj/item/choice_beacon/pet/mountable,
-/obj/item/choice_beacon/pet/mountable,
-/obj/item/storage/box/tools/ranching,
-/obj/item/storage/box/tools/ranching,
-/obj/item/storage/box/tools/ranching,
-/obj/item/storage/box/tools/ranching,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
+"nOU" = (
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "nPb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/white/line{
@@ -25464,22 +23150,14 @@
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland/city/newboston/outdoors)
 "nPr" = (
-/obj/structure/mirror{
-	pixel_y = 25;
-	pixel_x = -5
+/obj/item/toy/tennis,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/obj/machinery/shower{
-	pixel_y = 21;
-	pixel_x = 6
-	},
-/obj/structure/curtain,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "nPu" = (
 /obj/structure/sign/stop{
 	pixel_y = 9;
@@ -25526,6 +23204,13 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
+	},
+/area/f13/building)
+"nQu" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/building)
 "nQv" = (
@@ -25617,16 +23302,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nSj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "nSF" = (
 /obj/structure/bed,
 /obj/item/bedsheet/gondola,
@@ -25688,19 +23363,6 @@
 /obj/structure/simple_door/repaired,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nUK" = (
-/obj/structure/beebox{
-	pixel_y = 11;
-	layer = 4;
-	density = 0
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "nUZ" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -25728,14 +23390,12 @@
 	},
 /area/f13/wasteland)
 "nVE" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "4210";
-	name = "outpost gate2"
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nVF" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/road{
@@ -25781,12 +23441,13 @@
 	},
 /area/f13/building)
 "nWz" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/item/warpaint_bowl{
+	pixel_y = 8
 	},
+/obj/structure/table/wood/settler,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/plasteel/cult,
 /area/f13/building)
 "nWC" = (
 /obj/structure/table/wood/settler,
@@ -25845,15 +23506,32 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "nZa" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "nZb" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -25872,21 +23550,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"nZK" = (
-/obj/structure/lamp_post{
-	dir = 4
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 79;
-	pixel_x = 26;
-	plane = -6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "nZL" = (
 /obj/structure/chair/stool/f13stool{
 	dir = 1;
@@ -25913,29 +23576,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"obh" = (
-/obj/machinery/button/door{
-	id = "4210";
-	name = "Window Shutters";
-	pixel_x = -22;
-	pixel_y = 21;
-	req_one_access_txt = null
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/building)
-"obz" = (
-/obj/machinery/vending/wardrobe/science_wardrobe/free,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
 "ocl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26005,11 +23645,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "oeO" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/obj/structure/curtain/directional/west,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "oeT" = (
 /obj/structure/table/wood/settler,
@@ -26052,30 +23692,17 @@
 	icon_state = "horizontalinnermainleft"
 	},
 /area/f13/wasteland)
-"ogc" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "ogd" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
 "ogq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/flora/chomp/shrub0,
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ogr" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -26100,88 +23727,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"oiX" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = -4
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = -4
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = -4
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ojp" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26200,11 +23745,13 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "ojx" = (
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/bed/double,
+/obj/item/bedsheet/doublesheet{
+	color = "#706551"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "ojC" = (
 /obj/structure/toilet{
 	pixel_y = 7
@@ -26279,14 +23826,14 @@
 	},
 /area/f13/building)
 "okY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 6
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/reedbush{
+	randomize_xy = 0;
+	pixel_x = -16
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "olr" = (
 /obj/structure/table,
 /obj/item/cautery,
@@ -26309,16 +23856,6 @@
 	icon_state = "verticaloutermain2bottom"
 	},
 /area/f13/wasteland)
-"olP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/flora/tree/cherryblossom3{
-	pixel_y = 11;
-	pixel_x = -23
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "olR" = (
 /turf/open/indestructible/ground/outside/water,
 /turf/open/indestructible/ground/outside/water{
@@ -26341,97 +23878,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"oms" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
 "omT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/spacevine,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/building)
 "ond" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26446,14 +23895,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"onB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/building/trader)
 "onZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -26475,17 +23916,12 @@
 	},
 /area/f13/building)
 "oor" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/obj/structure/sign/flag_arkansas{
-	pixel_y = 33
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/spawner/lootdrop/f13/trash_drugs,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ooP" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4"
@@ -26493,14 +23929,15 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/village)
 "ooY" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/wild_plant/flower/pink_three,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "opB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "opN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26567,31 +24004,6 @@
 	icon_state = "horizontaltopbordertop3"
 	},
 /area/f13/wasteland)
-"osc" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/item/shovel{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/open/indestructible/ground/outside/desert{
-	color = "#705454";
-	name = "sand pit"
-	},
-/area/f13/building/workshop/nash)
 "ose" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26612,12 +24024,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/black,
 /area/f13/building)
-"ott" = (
-/obj/structure/chair/pew/right{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "oub" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/filingcabinet,
@@ -26639,8 +24045,13 @@
 	},
 /area/f13/building)
 "ovp" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/building)
+/obj/effect/landmark/start/f13/radiooperator,
+/obj/effect/landmark/latejoin,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "ovv" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -26778,16 +24189,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/building)
-"ozY" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/mining_scanner,
-/obj/item/pickaxe,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
 "oAo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -26868,9 +24269,35 @@
 	},
 /area/f13/building)
 "oFe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/building)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/chair/bench{
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "oFT" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/plasteel/f13{
@@ -26895,19 +24322,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"oGm" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/doublesheetbrown,
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
 "oGq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26948,11 +24362,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"oIz" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "oII" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -26960,9 +24369,35 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "oKm" = (
-/obj/machinery/mineral/wasteland_vendor/ammo,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/chair/bench{
+	dir = 1;
+	plane = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "oKw" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -27113,10 +24548,8 @@
 	},
 /area/f13/wasteland)
 "oMQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/mineral/brick{
-	weak_wall = 0
-	},
+/obj/structure/flora/junglebush/b,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "oNo" = (
 /obj/structure/barricade/wooden,
@@ -27307,20 +24740,6 @@
 "oRq" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland/city/newboston/outdoors)
-"oRJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "oRR" = (
 /turf/open/floor/f13{
 	icon_state = "floordirty"
@@ -27380,16 +24799,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "oUB" = (
-/mob/living/simple_animal/cow/brahmin/cow,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
+/obj/structure/window/fulltile/ruins,
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6;
+	dir = 1;
+	pixel_y = -10
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "oUG" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -27419,13 +24840,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "oVe" = (
-/obj/structure/closet/crate/bin{
-	pixel_x = -7
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "oVf" = (
 /turf/closed/wall/f13/vault,
 /area/f13/brotherhood)
@@ -27513,11 +24932,6 @@
 "oXN" = (
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/village)
-"oXT" = (
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
 "oYa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt{
@@ -27544,13 +24958,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "oYs" = (
-/obj/structure/flora/tree/cherryblossom2,
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "oYu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/food/drinks/mug/coco,
@@ -27598,16 +25009,36 @@
 	},
 /area/f13/tribe)
 "oZJ" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	plane = -4;
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "pag" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
@@ -27673,28 +25104,21 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"pcM" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
 "pde" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 27
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building)
 "pdv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/gun/ballistic/revolver/hobo/pepperbox{
-	color = "#FF0000";
-	desc = "A perfectly normal pepperbox gun, this one is made with kitchen themes."
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "pdK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -27702,8 +25126,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "peg" = (
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side,
+/area/f13/building)
 "pej" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleplate"
@@ -27835,16 +25260,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "phB" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7;
-	plane = -1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/vending/wardrobe/medi_wardrobe/free,
+/turf/open/floor/plasteel/f13/vault_floor/white,
+/area/f13/building)
 "phF" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -27853,15 +25271,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"pii" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "pix" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -27884,16 +25293,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pjg" = (
-/obj/structure/junk/small/tv{
-	desc = "Advertisements would've played on this tv before the bombs dropped.";
-	icon = 'icons/fallout/objects/decorations.dmi';
-	icon_state = "television";
-	name = "pre-war advertising television"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pjP" = (
 /obj/structure/sign/poster/prewar/poster69{
 	pixel_x = -32
@@ -27945,17 +25352,12 @@
 /turf/open/floor/carpet/black,
 /area/f13/building/abandoned)
 "pmh" = (
-/obj/structure/curtain{
-	color = "#845f58"
+/obj/structure/chair/wood{
+	icon_state = "wooden_chair_settler_toppled"
 	},
-/obj/structure/simple_door/room{
-	name = null
-	},
-/obj/item/lock_bolt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pmY" = (
 /obj/machinery/chem_master/primitive,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28027,13 +25429,21 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "poD" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/storage/box/rxglasses,
+/obj/item/storage/box/rxglasses,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	pixel_x = 31
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
 	},
-/obj/structure/junk/small,
-/turf/open/floor/wood_common,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "poK" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28053,10 +25463,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"ppc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building/workshop/nash)
 "ppi" = (
 /obj/structure/lamp_post/doubles/bent{
 	dir = 4;
@@ -28072,14 +25478,6 @@
 	icon_state = "outerborder - E"
 	},
 /area/f13/wasteland)
-"ppk" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/chomp/bones/lrock4,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "ppv" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/outside/dirt,
@@ -28092,8 +25490,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ppD" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tree/cherryblossom,
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "ppM" = (
@@ -28144,9 +25544,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "prE" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "prH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/airlock/hatch{
@@ -28198,15 +25600,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"psq" = (
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "psI" = (
 /turf/open/floor/f13{
 	icon_state = "yellowdirtyfull"
@@ -28233,17 +25626,6 @@
 /obj/structure/fluff/blocker,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
-"ptC" = (
-/obj/structure/bed/wooden,
-/obj/effect/spawner/lootdrop/bedsheet,
-/obj/structure/railing/wood/post{
-	pixel_x = -16
-	},
-/obj/structure/railing/wood/post{
-	pixel_x = 14
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "ptW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblack,
@@ -28284,13 +25666,8 @@
 	},
 /area/f13/building)
 "puy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	color = "#999999"
-	},
-/obj/structure/curtain/directional/north,
-/turf/open/floor/f13/wood,
+/obj/machinery/smartfridge/bottlerack/seedbin,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "pvl" = (
 /obj/effect/decal/fakelattice,
@@ -28313,15 +25690,9 @@
 	},
 /area/f13/building)
 "pwc" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/helmet/f13/brahmincowboyhat,
-/obj/item/clothing/suit/armor/light/duster/brahmin,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/flora/chomp/thicket2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pws" = (
 /obj/structure/lamp_post/doubles/bent{
 	dir = 4;
@@ -28335,26 +25706,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "pwx" = (
-/obj/machinery/light,
-/turf/open/floor/plating/f13/outside/roof{
-	name = "\proper tiles"
-	},
-/area/f13/building/workshop/nash)
-"pwM" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	termtag = "Public"
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/flora/tree/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pwR" = (
 /obj/item/caution,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28370,32 +25725,11 @@
 	},
 /area/f13/building)
 "pxj" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 4;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"pxr" = (
-/obj/effect/landmark/party{
-	region = "Nash's bar"
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"pxB" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/stairs/west{
-	dir = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "pxC" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -28439,29 +25773,12 @@
 	},
 /area/f13/wasteland)
 "pyV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12;
-	opacity = 1
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pzz" = (
 /obj/structure/nest/protectron{
 	layer = 3;
@@ -28513,22 +25830,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pAP" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/car/rubbish2{
+	icon_state = "car_rubish3";
+	layer = 5
 	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
+"pAY" = (
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
-"pAY" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "pBa" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -28552,21 +25868,18 @@
 	},
 /area/f13/building/tribal)
 "pBs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/retro/backed{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "pBB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
+/obj/structure/flora/tree/jungle/small,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pBI" = (
 /obj/structure/rack,
 /obj/item/soap/homemade,
@@ -28582,92 +25895,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "pCI" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/junk/small/tv,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pDb" = (
 /obj/structure/table_frame,
 /turf/open/floor/f13{
@@ -28766,14 +25996,6 @@
 /obj/item/clothing/head/f13/hairband,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"pGm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "pGE" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28798,11 +26020,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"pHs" = (
-/obj/structure/curtain/directional/west,
-/obj/structure/window/fulltile/stainedglass/woodwindowmoonlight,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
 "pHF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -28827,11 +26044,10 @@
 	},
 /area/f13/caves)
 "pIg" = (
-/obj/machinery/vending/snack/random{
-	extended_inventory = 1
-	},
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
+/obj/structure/table/wood/junk,
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pIi" = (
 /obj/structure/fence{
 	dir = 4
@@ -28847,8 +26063,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "pIo" = (
-/obj/structure/flora/chomp/potplant2,
-/turf/open/floor/wood_common/wood_common_dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/chomp/potplant2{
+	pixel_x = -8;
+	randomize_xy = 0
+	},
+/obj/structure/flora/wasteplant/wild_xander{
+	pixel_y = 16;
+	pixel_x = 5;
+	layer = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/kirbyplants{
+	icon = 'modular_coyote/icons/objects/miscellaneous.dmi';
+	icon_state = "pot_1";
+	pixel_x = 4;
+	pixel_y = 11;
+	plane = -6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "pIy" = (
 /obj/machinery/vending/cola/starkist{
@@ -28876,13 +26111,9 @@
 	},
 /area/f13/brotherhood)
 "pJc" = (
-/obj/item/chair/stool{
-	icon_state = "bar"
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/glass,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "pJf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29093,14 +26324,9 @@
 	},
 /area/f13/wasteland)
 "pMb" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pMf" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29129,12 +26355,17 @@
 	},
 /area/f13/building)
 "pML" = (
-/obj/machinery/conveyor/auto{
-	dir = 4;
-	id = "spawn2"
+/obj/structure/table/wood/settler,
+/obj/structure/closet/crate/footchest{
+	pixel_x = -1;
+	pixel_y = 7
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building/trader)
+/obj/item/toy/dummy,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lock_construct,
+/obj/item/key,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "pMP" = (
 /obj/structure/table/wood/fancy/green,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29200,13 +26431,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "pOK" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 3
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "pOV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/debris/v2{
@@ -29234,16 +26464,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "pQh" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/machinery/light/small{
+	pixel_x = 16
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/building)
 "pQy" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -29273,17 +26498,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"pRQ" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "pSu" = (
 /obj/structure/chair/stool{
 	icon_state = "bench_center"
@@ -29291,20 +26505,21 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "pSy" = (
+/obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_bed,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "pSF" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "pTm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/stool/retro/backed,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "pTz" = (
 /obj/structure/chair/f13foldupchair,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -29322,11 +26537,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/building)
-"pUR" = (
-/obj/structure/bedsheetbin/towel,
-/obj/structure/table/wood/settler,
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
 "pUT" = (
 /obj/structure/simple_door/room,
 /obj/structure/curtain{
@@ -29475,9 +26685,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/building/abandoned)
 "qam" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe/free,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building/hospital/clinic/nash)
+/obj/structure/rug/big/rug_fancy{
+	color = "grey";
+	dir = 4;
+	pixel_x = -16;
+	pixel_y = -18;
+	layer = 2.7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "qas" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner - W"
@@ -29557,17 +26774,16 @@
 	},
 /area/f13/brotherhood)
 "qdr" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "qdC" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -29589,14 +26805,6 @@
 "qee" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/trainstation)
-"qei" = (
-/obj/machinery/bookbinder{
-	pixel_x = 4
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
 "qes" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -29606,12 +26814,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qex" = (
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "qez" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -29620,13 +26822,11 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/city/newboston/outdoors)
 "qeY" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "qfd" = (
 /obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/structure/table/wood/bar,
@@ -29636,16 +26836,17 @@
 	},
 /area/f13/building)
 "qfR" = (
-/turf/open/floor/plating/f13/outside/roof{
-	name = "\proper tiles"
-	},
-/area/f13/building/workshop/nash)
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "qgh" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#413527";
+	dir = 4
 	},
+/turf/open/water,
 /area/f13/building)
 "qgp" = (
 /obj/structure/wreck/trash/machinepiletwo,
@@ -29705,17 +26906,36 @@
 	},
 /area/f13/building)
 "qjn" = (
-/obj/structure/decoration/vent{
-	layer = 2.8
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
+/obj/structure/chair/bench{
+	dir = 1;
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "qjo" = (
 /obj/structure/grille,
 /turf/open/indestructible/ground/outside/road{
@@ -29733,11 +26953,12 @@
 /area/f13/wasteland)
 "qjB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/cabinet/anchored,
-/obj/item/key,
-/obj/item/lock_construct,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/item/kirbyplants{
+	icon_state = "plant-05";
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "qjD" = (
 /obj/structure/sign/crosswalk{
 	pixel_x = 7;
@@ -29771,12 +26992,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "qkq" = (
-/obj/machinery/door/unpowered/securedoor{
-	name = "Clinic";
-	req_access_txt = null
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "qkA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/campfire/wallfire{
@@ -29795,28 +27014,10 @@
 	},
 /area/f13/building)
 "qlE" = (
-/obj/structure/closet/fridge{
-	anchored = 1
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building)
 "qlJ" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -29830,19 +27031,7 @@
 /area/f13/building)
 "qlL" = (
 /obj/effect/turf_decal/weather/dirt,
-/obj/structure/decoration/vent/rusty{
-	color = "#aaaaFE";
-	alpha = 50
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"qlW" = (
-/obj/structure/stairs/north{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "qmj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29893,33 +27082,11 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"qnB" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1;
-	color = "#333333"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#3B2C25"
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
 "qnW" = (
-/obj/machinery/light/small{
-	dir = 8;
-	plane = -5
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
 	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	dir = 9;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "qnZ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -29965,9 +27132,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"qps" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/building/workshop/nash)
 "qpD" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29993,12 +27157,6 @@
 	color = "#766E65"
 	},
 /area/f13/building/tribal)
-"qru" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
 "qrG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30018,10 +27176,6 @@
 	name = "ancient wall"
 	},
 /area/f13/building/tribal/caveofforever)
-"qrX" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "qse" = (
 /obj/effect/decal/cleanable/blood/gibs/human/lizard/limb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30129,11 +27283,11 @@
 	},
 /area/f13/building)
 "qum" = (
-/obj/machinery/teleport/hub,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "qux" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -30142,12 +27296,9 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "quI" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/coyote/darkwoodwall,
+/area/f13/building)
 "quK" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/cleanable/oil,
@@ -30171,11 +27322,12 @@
 	},
 /area/f13/building)
 "qvh" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "qvE" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30254,11 +27406,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "qxf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/stairs/west{
+	color = "#A47449";
+	dir = 2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "qxl" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr26";
@@ -30303,16 +27459,11 @@
 	},
 /area/f13/caves)
 "qye" = (
-/obj/item/toy/plush/bird{
-	icon = 'modular_coyote/icons/mob/bird.dmi';
-	icon_state = "hooty";
-	pixel_y = 22
+/obj/effect/decal/cleanable/dirt/dust{
+	color = "#11ff11"
 	},
-/obj/structure/bookcase,
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "qyi" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30364,17 +27515,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "qzf" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "qzk" = (
 /obj/item/rack_parts,
 /turf/open/floor/f13/wood,
@@ -30439,32 +27582,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "qAj" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
+/obj/effect/overlay/junk/toilet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qAv" = (
 /obj/machinery/conveyor{
 	dir = 4
@@ -30473,9 +27593,9 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "qBj" = (
-/obj/machinery/mineral/wasteland_vendor/weapons,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/haybale,
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/building)
 "qBL" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -30521,18 +27641,9 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building)
 "qCp" = (
-/obj/machinery/microwave/gas_stove{
-	pixel_y = 19
-	},
-/obj/item/melee/onehanded/club/fryingpan/pot{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	pixel_x = -16;
-	pixel_y = 29
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "qCt" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood{
@@ -30756,23 +27867,24 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qFt" = (
-/obj/structure/chair/sofa/corp/corner{
+"qFz" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/table/rolling,
+/obj/item/clothing/gloves/boxing/green{
+	pixel_y = 8
+	},
+/obj/structure/rug/big/rug_rubber{
+	dir = 4;
+	pixel_x = -10;
+	layer = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
-"qFz" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "qFF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/road{
@@ -30834,9 +27946,12 @@
 	},
 /area/f13/caves)
 "qGt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	light_color = "#884444"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building/workshop/nash)
 "qGu" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
@@ -30853,11 +27968,9 @@
 	},
 /area/f13/caves)
 "qGQ" = (
-/obj/structure/towel_rack{
-	pixel_y = 27
-	},
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "qGS" = (
 /obj/structure/sign/poster/prewar/poster68,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30869,26 +27982,15 @@
 	},
 /area/f13/building)
 "qHI" = (
-/obj/effect/turf_decal/weather/dirtcorner,
-/obj/effect/turf_decal/weather/dirtcorner{
+/obj/structure/flora/tree/jungle,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
+"qHX" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
-"qHX" = (
-/obj/effect/fake_stairs/west{
-	color = "#845f58";
-	dir = 2
-	},
-/obj/structure/table/wood/settler{
-	density = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "qIc" = (
 /obj/structure/closet/anchored,
 /obj/item/clothing/head/f13/police,
@@ -30935,32 +28037,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"qIG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"qJw" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/wood_common,
-/area/f13/building)
 "qJz" = (
 /obj/item/chair/stool,
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qJY" = (
-/obj/structure/decoration/rag{
-	layer = 4.3
-	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "qJZ" = (
 /obj/effect/decal/marking{
@@ -31006,45 +28091,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"qKJ" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/under/misc/bathrobe,
-/obj/item/clothing/shoes/f13/swimfins{
-	pixel_y = 14
-	},
-/obj/item/clothing/shoes/f13/swimfins{
-	pixel_y = 14
-	},
-/obj/item/clothing/shoes/f13/swimfins{
-	pixel_y = 14
-	},
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
 "qLi" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -31159,8 +28205,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qOI" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "qOM" = (
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/indestructible/ground/outside/dirt,
@@ -31188,11 +28239,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "qQB" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "qQD" = (
 /obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31218,34 +28269,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "qQQ" = (
-/obj/machinery/light/small{
-	brightness = 7
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 1
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qRi" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
-"qRl" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_vixen{
-	pixel_x = -15;
-	pixel_y = 32
-	},
-/obj/structure/sign/poster/contraband/pinup_shower{
-	pixel_x = 15;
-	pixel_y = 32
-	},
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "qRI" = (
 /obj/structure/table/wood/settler,
 /obj/item/binoculars{
@@ -31274,25 +28305,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"qSa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "qSd" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31320,18 +28332,14 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "qSy" = (
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = 14
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "DenGate"
 	},
-/obj/structure/fence/wooden{
-	density = 0;
-	dir = 1;
-	pixel_x = -14
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "qSL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -31418,23 +28426,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"qWI" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "qXh" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/flashlight{
-	pixel_y = -12
+/obj/effect/landmark/start/f13/wastelander,
+/obj/effect/landmark/latejoin,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "qXK" = (
 /obj/structure/dresser,
 /turf/open/floor/f13/wood,
@@ -31522,17 +28521,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"qZI" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/window/fulltile/house,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain/directional/west{
-	color = "#845f58"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/city/newboston/bar)
 "qZN" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -31568,32 +28556,49 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "rbr" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/area/f13/building)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/blue{
+	plane = -4;
+	layer = 3
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "rbC" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "rbN" = (
-/obj/structure/wreck/trash/halftire,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/computer/message_monitor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/monitorkey,
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "rbO" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -31614,12 +28619,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "rce" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontalinnermain0"
+/obj/structure/simple_door/house,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "rcY" = (
 /obj/structure/car/rubbish1{
 	icon_state = "car_rubish3"
@@ -31652,14 +28656,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"rdO" = (
-/obj/machinery/smartfridge/bottlerack/grownbin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "reb" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland)
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "rev" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin,
@@ -31698,15 +28699,6 @@
 	icon_state = "storewindowleft"
 	},
 /turf/open/floor/f13,
-/area/f13/building)
-"rgB" = (
-/obj/structure/table,
-/obj/machinery/processor/chopping_block,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
 /area/f13/building)
 "rgF" = (
 /obj/structure/bed,
@@ -31858,11 +28850,16 @@
 	},
 /area/f13/building)
 "rmI" = (
+/obj/item/reagent_containers/food/snacks/donut/jelly/trumpet,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/building)
 "rmJ" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31877,18 +28874,10 @@
 	},
 /area/f13/wasteland)
 "rnN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = -1;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/simple_door/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "rnS" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -31917,21 +28906,6 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal)
-"rpa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_y = -4
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "rpz" = (
 /obj/machinery/light/small{
 	light_color = "#884444"
@@ -31940,29 +28914,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
 "rpE" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 10
-	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "rpQ" = (
 /obj/structure/campfire/stove,
 /obj/item/grown/log/tree,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rpU" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
-"rpW" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
 "rqj" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32078,31 +29037,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"rtp" = (
-/obj/structure/rug/big/rug_yellow{
-	layer = 2;
-	pixel_y = 17
-	},
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_y = 5;
-	termtag = "Business"
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "rtw" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"rtz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
 "rtA" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/indestructible/ground/outside/road{
@@ -32199,20 +29137,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "rvE" = (
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/effect/turf_decal/caution{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/open/floor/pod/light,
-/area/f13/building/workshop/nash)
+/area/f13/building)
 "rwb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/road{
@@ -32275,15 +29205,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"rxK" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/wreck/trash/halftire,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "rxO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
@@ -32329,16 +29250,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"ryH" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
 "ryS" = (
 /obj/structure/simple_door/room,
 /obj/structure/decoration/ruins{
@@ -32364,25 +29275,25 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "rzn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 6;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 10
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/flora/chomp/shrub4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rzu" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/curtain/directional/east{
+	color = "#8A806B"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	layer = 3.4
+	},
+/obj/structure/decoration/rag{
+	layer = 3.4
+	},
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/turf/open/floor/plasteel/cult,
 /area/f13/building)
 "rAq" = (
 /obj/effect/decal/cleanable/oil{
@@ -32424,12 +29335,9 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "rBg" = (
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/knife,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/wreck/car,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "rBA" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32446,13 +29354,6 @@
 /obj/effect/spawner/lootdrop/f13/rare_armor,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"rBV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
 "rBY" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -32502,19 +29403,16 @@
 	},
 /area/f13/building)
 "rDQ" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/wasteland/city/newboston/bar)
-"rDY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/food/snacks/donut/choco,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "rDZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32522,22 +29420,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"rEv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirtcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"rEK" = (
-/obj/effect/landmark/start/f13/wastelander/clubmanager,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/building/trader)
 "rFt" = (
 /turf/open/floor/plasteel/darkbrown/corner{
 	dir = 8
@@ -32549,25 +29431,33 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "rGC" = (
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#dedcdc"
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rGP" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 6
 	},
 /area/f13/building)
 "rHb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_y = -4
+/obj/structure/simple_door/metal/barred,
+/obj/structure/flora/rock/jungle{
+	randomize_xy = 0
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	opacity = 1
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/water/running{
+	dir = 8
+	},
+/area/f13/building)
 "rHe" = (
 /obj/structure/fence{
 	dir = 4
@@ -32597,12 +29487,14 @@
 	},
 /area/f13/trainstation)
 "rHz" = (
-/obj/structure/railing{
-	dir = 6
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lock_bolt{
+	dir = 8
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "rHW" = (
 /obj/structure/bonfire/prelit,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32676,28 +29568,10 @@
 /area/f13/building)
 "rJa" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"rJd" = (
-/obj/structure/chair/booth{
-	dir = 4;
-	icon_state = "booth_east_north";
-	pixel_y = 11
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/simple_door/room,
+/obj/item/lock_bolt,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "rJj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
@@ -32743,19 +29617,6 @@
 	dir = 4
 	},
 /area/f13/building)
-"rKs" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "rKz" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -32794,15 +29655,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"rLl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "rLm" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/uncommon,
@@ -32821,13 +29673,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "rLL" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/structure/flora/wasteplant/fever_blossom{
+	randomize_xy = 0
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rLP" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/road{
@@ -32964,30 +29814,22 @@
 	},
 /area/f13/brotherhood)
 "rOW" = (
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
-"rPr" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/punching_bag{
+	color = "#292929"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "rPv" = (
 /obj/machinery/door/unpowered/securedoor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "rPM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblack,
+/area/f13/building)
 "rPR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine,
@@ -33010,11 +29852,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "rQH" = (
-/obj/structure/chair/booth{
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/building)
 "rRe" = (
@@ -33030,13 +29870,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "rRs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 4
+/obj/structure/chair/f13chair2{
+	dir = 1
 	},
-/obj/item/trash/waffles,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "rRD" = (
 /obj/structure/railing/wood/post,
@@ -33093,25 +29931,6 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/city/newboston/outdoors)
-"rSw" = (
-/obj/structure/bed/roller/bedroll{
-	name = "tree shaded bedroll";
-	color = "#555555"
-	},
-/obj/item/flashlight/flashdark{
-	light_on = 1;
-	dark_light_range = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
-/obj/structure/flora/tree/oak_two{
-	density = 0;
-	plane = -1;
-	pixel_x = -18;
-	pixel_y = 25
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "rSO" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -33133,14 +29952,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/workshop/nash)
-"rTM" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/wild_plant/flower/blue,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "rTP" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
@@ -33166,13 +29977,10 @@
 	},
 /area/f13/building)
 "rUy" = (
-/obj/structure/chair/bench{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/start/f13/followersscientist/recmechanic,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "rUH" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -33228,8 +30036,12 @@
 	},
 /area/f13/building/abandoned)
 "rVG" = (
-/turf/open/floor/bamboo,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/city/newboston/outdoors)
 "rVZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -33258,36 +30070,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"rWf" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"rWC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = -1;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "rWF" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -33300,27 +30082,11 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
-"rXx" = (
-/obj/structure/decoration/clock/active{
-	pixel_y = 24
-	},
-/obj/machinery/mecha_part_fabricator,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
 "rYc" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
-"rYw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "rYO" = (
 /obj/item/trash/can{
 	icon_state = "lemon-lime"
@@ -33536,27 +30302,15 @@
 /area/f13/building/workshop/nash)
 "sfn" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common,
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "sfC" = (
-/obj/structure/sign/directions/science{
-	dir = 1;
-	pixel_y = 23
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 39
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/obj/machinery/vending/medical,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/chem_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "sfN" = (
 /obj/structure/holohoop{
 	dir = 4
@@ -33579,16 +30333,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "sfS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_6"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sgf" = (
 /obj/structure/table{
 	layer = 2.9
@@ -33608,25 +30357,10 @@
 	},
 /area/f13/building/abandoned)
 "sgl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/start/f13/radiooperator,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "sgt" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -33797,14 +30531,11 @@
 	},
 /area/f13/wasteland)
 "snD" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "snF" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -33823,13 +30554,18 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "soG" = (
-/obj/effect/landmark/start/f13/followersscientist/recmechanic,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0";
-	color = "#999999"
+/obj/structure/table/wood/bar,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/head/welding,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -16
 	},
-/area/f13/building/trader)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "soI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -33839,17 +30575,16 @@
 	},
 /area/f13/brotherhood)
 "soW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/trash_trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "spd" = (
-/obj/effect/landmark/start/f13/wastelander,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/machinery/vending/wardrobe/medi_wardrobe/free{
+	density = 0
 	},
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "spi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/recharge_station,
@@ -33881,9 +30616,8 @@
 	},
 /area/f13/wasteland)
 "spU" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
+/obj/machinery/mineral/wasteland_vendor/ammo,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
 "sqv" = (
 /obj/structure/fence{
@@ -33917,12 +30651,8 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "sri" = (
-/obj/structure/closet/locker/fridge,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/food,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "srq" = (
 /obj/structure/table,
@@ -33933,20 +30663,19 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "srI" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/texasranger,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "srN" = (
-/turf/closed/indestructible/f13/matrix{
-	plane = 0
-	},
-/area/f13/building/trader)
+/obj/machinery/mineral/wasteland_vendor/weapons,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "ssj" = (
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/f13/wood,
@@ -33956,16 +30685,14 @@
 /turf/closed/wall/f13/wood/house/clean,
 /area/f13/building)
 "ssY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/cloth,
+/obj/item/stack/sheet/cloth,
+/obj/item/stack/sheet/cloth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 4;
-	alpha = 80;
-	mouse_opacity = 0
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "stn" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -33973,14 +30700,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "stq" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "sty" = (
 /obj/structure/campfire/barrel,
@@ -34002,20 +30726,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "suy" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/dirt/harsh,
 /area/f13/wasteland/city/newboston/outdoors)
 "suY" = (
 /obj/structure/bed,
@@ -34100,10 +30814,13 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "sxA" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
 /area/f13/building)
 "sxB" = (
@@ -34142,14 +30859,6 @@
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"syx" = (
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "syB" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -34176,12 +30885,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"szu" = (
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "szF" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -34444,24 +31147,21 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "sHE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/settler,
-/obj/structure/railing{
-	color = "#A47449"
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/flora/junglebush,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "sHQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side{
 	dir = 1
 	},
 /area/f13/building)
-"sHW" = (
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/city/newboston/outdoors)
 "sId" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -34497,11 +31197,7 @@
 /area/f13/wasteland)
 "sIw" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/campfire/stove{
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "sIE" = (
 /obj/structure/table/wood/settler,
@@ -34529,16 +31225,6 @@
 	color = "#999999"
 	},
 /area/f13/wasteland)
-"sJj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/grenade/clusterbuster/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/building)
 "sJr" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood{
@@ -34573,27 +31259,12 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "sLZ" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/building)
-"sMp" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/machinery/shower{
+/obj/structure/chair/bench{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "sMx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34608,34 +31279,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13,
-/area/f13/building)
-"sNk" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	pixel_x = 19;
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/building)
 "sNx" = (
 /obj/structure/filingcabinet,
@@ -34696,20 +31339,13 @@
 	},
 /area/f13/caves)
 "sPf" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
+/obj/machinery/vending/medical/becomingnook,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/obj/structure/chair/bench{
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "sPo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34722,15 +31358,6 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"sPE" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/grille,
-/obj/structure/curtain{
-	color = "#845f58";
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/building)
 "sPM" = (
 /obj/structure/closet/wardrobe,
 /obj/item/stack/medical/suture/five,
@@ -34758,19 +31385,15 @@
 	},
 /area/f13/building)
 "sQo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/structure/chair/booth{
+	dir = 4;
+	icon_state = "booth_east_north";
+	pixel_y = 11
 	},
-/area/f13/building/trader)
-"sQy" = (
-/obj/structure/simple_door/wood,
-/obj/item/lock_bolt{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/obj/structure/table/wood/settler,
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/area/f13/building)
 "sQz" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontalcorroded"
@@ -34977,13 +31600,9 @@
 /turf/open/floor/carpet/black,
 /area/f13/building)
 "sUQ" = (
+/obj/structure/flora/ausbushes/grassybush,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
@@ -35069,21 +31688,24 @@
 	},
 /area/f13/building)
 "sXy" = (
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "sXG" = (
 /obj/structure/debris/v4,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "sXH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/building)
+/obj/effect/landmark/start/f13/followersscientist/recresearcher,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "sYA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35105,9 +31727,8 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "sYT" = (
-/obj/structure/table/wood/settler,
-/obj/item/weapon/spatula,
-/turf/open/floor/f13/wood,
+/obj/structure/spacevine,
+/turf/closed/wall/f13/coyote/darkwoodwall,
 /area/f13/building)
 "sZg" = (
 /obj/structure/decoration/clock/old/active,
@@ -35191,11 +31812,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "tdl" = (
-/obj/structure/campfire/stove,
-/obj/item/grown/log/tree,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "tdm" = (
 /obj/structure/bed/wooden,
@@ -35244,19 +31864,29 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "tfB" = (
-/obj/machinery/button/door{
-	id = "4210";
-	name = "Window Shutters";
-	pixel_x = -22;
-	pixel_y = 21;
-	req_one_access_txt = null
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#3B2B1A"
 	},
-/obj/item/chair/stool{
-	icon_state = "bar"
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1;
+	plane = -5
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/item/kirbyplants{
+	icon_state = "plant-05";
+	pixel_x = 8;
+	pixel_y = 14
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-02";
+	pixel_x = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-04";
+	pixel_x = -8
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "tfS" = (
 /obj/structure/nest/randomized{
@@ -35279,31 +31909,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tgK" = (
-/obj/structure/curtain{
-	color = "#363636";
-	layer = 5
-	},
-/turf/open/floor/bamboo,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building)
-"thg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = -1;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "thp" = (
-/obj/structure/chair/booth{
-	dir = 8;
-	icon_state = "booth_west_north"
+/obj/structure/table/optable/primitive,
+/obj/item/chopping_block{
+	pixel_x = -1;
+	pixel_y = 10
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/item/kitchen/knife/butcher/tribal,
+/obj/item/kitchen/knife/butcher{
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "thB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -35318,94 +31939,9 @@
 	},
 /area/f13/wasteland)
 "thJ" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/green{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/under/swimsuit/earth{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/earth{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/earth{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/earth{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/earth{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/blue{
-	pixel_x = -5
-	},
-/obj/item/clothing/under/swimsuit/black{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/swimsuit/black{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/swimsuit/black{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/swimsuit/black{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/item/clothing/under/swimsuit/black{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "thM" = (
 /turf/closed/wall/mineral/concrete,
 /area/f13/building)
@@ -35430,16 +31966,15 @@
 	},
 /area/f13/building)
 "tiJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "tiN" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35457,10 +31992,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tjz" = (
-/obj/structure/flora/wild_plant/flower/red_two,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "tjF" = (
 /obj/structure/cave/bigboards/westeast/four{
 	pixel_y = -7;
@@ -35487,9 +32018,13 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/building)
 "tkh" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tkD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/fakespace,
@@ -35521,23 +32056,6 @@
 	icon_state = "outerborder - S"
 	},
 /area/f13/wasteland)
-"tlo" = (
-/obj/structure/table/wood/bar,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 11;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/brown/wine{
-	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "tlA" = (
 /obj/structure/debris/v4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35545,18 +32063,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building)
-"tlI" = (
-/obj/structure/flora/wild_plant/flower/orange{
-	pixel_y = 10
-	},
+"tlW" = (
+/obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
-"tlW" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
 "tlY" = (
 /obj/structure/simple_door/wood,
 /obj/structure/decoration/rag{
@@ -35636,13 +32146,6 @@
 "tot" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"toG" = (
-/obj/structure/table/wood/settler,
-/obj/structure/fence/pole_b{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "toQ" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -35682,22 +32185,11 @@
 	},
 /area/f13/brotherhood)
 "tpM" = (
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 89;
-	pixel_x = 15;
-	plane = -6
-	},
-/obj/structure/lamp_post/doubles/bent{
-	density = 0;
-	pixel_y = 10;
-	pixel_x = -43
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - S"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tpU" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -35705,16 +32197,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
-/area/f13/building)
-"tqo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/reagent_containers/rag,
-/obj/item/reagent_containers/glass/bucket/wood{
-	desc = "It's a bucket. Made for seeing a man about a dog.";
-	name = "Poop Bucket";
-	pixel_y = 10
-	},
-/turf/open/floor/plating/rust,
 /area/f13/building)
 "tqx" = (
 /obj/effect/decal/marking{
@@ -35742,18 +32224,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tru" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "trG" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -35836,27 +32306,23 @@
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "tuf" = (
-/obj/machinery/vending/cola/space_up{
-	pixel_x = 2;
-	pixel_y = 21;
-	density = 0
+/obj/structure/stairs/west{
+	color = "#A47449"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "tuk" = (
-/obj/structure/table/wood/settler,
-/obj/structure/sign/poster/contraband/pinup_vixen{
-	pixel_x = 1;
-	pixel_y = 32
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/reedbush{
+	randomize_xy = 0;
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "tum" = (
 /obj/structure/sink/puddle,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35884,9 +32350,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "tvw" = (
-/obj/structure/closet/cabinet/anchored,
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/machinery/mineral/wasteland_vendor/medical,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/building)
 "tvy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35901,6 +32369,14 @@
 "tvB" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"tvO" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/turf/open/floor/carpet/royalblack,
 /area/f13/building)
 "tvS" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35920,13 +32396,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
-"twx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "twD" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /turf/open/indestructible/ground/inside/dirt,
@@ -35938,10 +32407,6 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"twS" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "twX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36069,14 +32534,6 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/building)
-"tzX" = (
-/obj/structure/chair/booth{
-	dir = 8;
-	icon_state = "booth_west_south";
-	pixel_y = 11
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "tAb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -36097,14 +32554,10 @@
 	},
 /area/f13/building)
 "tAh" = (
-/obj/machinery/button/door{
-	id = "garbageshutters";
-	name = "Window Shutters";
-	pixel_y = 21;
-	req_one_access_txt = null
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/structure/rack/shelf_metal,
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "tAp" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2"
@@ -36120,9 +32573,18 @@
 	},
 /area/f13/caves)
 "tAT" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen{
+	pixel_y = 19;
+	layer = 1.9
+	},
+/obj/structure/table/booth{
+	color = "#EFCCC0"
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/building)
 "tBH" = (
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
@@ -36134,15 +32596,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tCf" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "tCv" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt,
@@ -36193,18 +32646,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "tDR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	color = "#999999"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/decoration/hatch{
-	icon_state = "vault_botany";
-	plane = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tDV" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -36257,20 +32703,9 @@
 	},
 /area/f13/building/tribal)
 "tEZ" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/item/storage/box/monkeycubes,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
-	dir = 8;
-	icon_state = "yellowdirtychess"
-	},
-/area/f13/building)
+/obj/structure/flora/chomp/potplant2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tFc" = (
 /obj/machinery/mineral/wasteland_vendor/pipboy,
 /turf/open/floor/f13{
@@ -36297,11 +32732,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tFZ" = (
-/obj/structure/chair/comfy/purple{
-	dir = 4
-	},
-/turf/open/floor/wood_common/wood_common_dark,
-/area/f13/building)
+/obj/structure/junk/machinery,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tGI" = (
 /obj/structure/simple_door/tent,
 /obj/structure/decoration/rag,
@@ -36311,14 +32744,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"tGZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "tHh" = (
 /obj/item/circuitboard/computer/arcade/battle,
 /obj/item/stack/sheet/glass/ten,
@@ -36330,25 +32755,10 @@
 	},
 /area/f13/building)
 "tHs" = (
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/f13/outside/roof{
-	name = "\proper tiles"
-	},
-/area/f13/building/workshop/nash)
-"tHB" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/left,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "tHN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -36375,12 +32785,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
-"tJq" = (
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/gravel,
-/area/f13/wasteland/city/newboston/outdoors)
 "tJK" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36414,12 +32818,11 @@
 	},
 /area/f13/building)
 "tKS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mineral/wasteland_vendor/traderspecial{
-	icon_state = "trade_,mining"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/wasteland/city/newboston/outdoors)
 "tLa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/defibrillator_mount/loaded{
@@ -36520,10 +32923,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"tNi" = (
-/obj/structure/flora/chomp/bones/lrock4,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "tNA" = (
 /obj/structure/fence{
 	dir = 4
@@ -36550,13 +32949,15 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal)
 "tNI" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/wreck/bus/orange{
+	pixel_y = -4;
+	pixel_x = -3;
+	name = "bus from somewhere"
 	},
-/turf/open/floor/wood_common{
-	color = "#888888"
+/turf/open/indestructible/ground/outside/road{
+	color = "#999999"
 	},
-/area/f13/wasteland/city/newboston/library)
+/area/f13/caves)
 "tOp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/blamco,
@@ -36585,15 +32986,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tPe" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/structure/curtain/directional/south{
-	color = "#ACD1E9";
-	alpha = 200
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/sauna)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/city/newboston/outdoors)
 "tPi" = (
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13{
@@ -36601,18 +32998,20 @@
 	},
 /area/f13/building)
 "tPm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 9
+/obj/machinery/computer/telecomms/monitor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
 	},
 /area/f13/building)
 "tPo" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "tPz" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -36679,9 +33078,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tRA" = (
-/obj/machinery/mineral/wasteland_vendor/mining,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowvertical"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "tRQ" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 1
@@ -36760,21 +33163,34 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "tUj" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/chair/bench{
+	plane = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "tVx" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontaldegraded"
@@ -36835,16 +33251,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "tXS" = (
-/obj/structure/rug/carpet,
-/obj/structure/nightstand/small{
-	pixel_x = 2
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/obj/item/flashlight/littlelamp{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland/city/newboston/outdoors)
 "tYd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -36863,16 +33275,111 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "tZu" = (
-/obj/structure/flora/wild_plant/flower/pink,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/landmark/start/f13/settler,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "tZD" = (
-/obj/structure/campfire/churchfire{
-	pixel_y = 4;
-	density = 1
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
+	dir = 8
 	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
+	dir = 8;
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = -10;
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	pixel_y = 15
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 2;
+	pixel_y = 12
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "mist";
+	opacity = 1;
+	layer = 2.7;
+	pixel_x = -12;
+	pixel_y = 9
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8;
+	pixel_y = 12
+	},
+/obj/structure/sink{
+	icon_state = "water";
+	name = "water";
+	pixel_x = 6;
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/outside/water/running{
+	dir = 8
+	},
+/area/f13/caves)
 "tZH" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -36964,14 +33471,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
-"ucs" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/bed/mattress/pregame,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
 "ucK" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft0";
@@ -36997,12 +33496,17 @@
 	},
 /area/f13/wasteland)
 "udy" = (
-/obj/structure/table/wood/settler,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
+/obj/machinery/mineral/wasteland_trader{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/card/kingbounty{
+	pixel_y = 10;
+	mouse_opacity = 0;
+	anchored = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "udO" = (
 /obj/machinery/computer/operating,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37021,9 +33525,13 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "ueL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/mob/living/simple_animal/cow/brahmin/cow/tan{
+	name = "Bonnie"
+	},
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "ueX" = (
 /obj/structure/simple_door/interior,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37172,16 +33680,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"uiB" = (
-/obj/structure/stairs/west{
-	dir = 2
-	},
-/obj/structure/railing{
-	color = "#A47449";
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/building/trader)
 "uiG" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -37191,9 +33689,21 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "ujm" = (
-/obj/structure/destructible/tribal_torch/lit,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/rolling,
+/obj/structure/mirror/alt{
+	pixel_y = -30
+	},
+/obj/structure/bedsheetbin/towel,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
+"ujy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "ujA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermainbottom"
@@ -37287,26 +33797,15 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "ulP" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/curtain/directional/north,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "umm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/junglebush/b,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "umq" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -37391,10 +33890,9 @@
 	},
 /area/f13/building)
 "upz" = (
+/obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/drawer,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "uqo" = (
 /obj/structure/anvil/obtainable/basic,
@@ -37428,73 +33926,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"usv" = (
-/obj/structure/lamp_post/doubles/bent{
-	density = 0;
-	dir = 8;
-	pixel_y = 10;
-	pixel_x = -21
-	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 88;
-	pixel_x = -15;
-	plane = -6
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"usZ" = (
-/obj/structure/barricade/tentclothedge{
-	dir = 1;
-	pixel_y = -3
-	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/structure/wreck/trash/two_tire,
-/obj/structure/wreck/trash/two_tire{
-	pixel_x = 10
-	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = -17;
-	pixel_y = -5
-	},
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/chapel)
 "ute" = (
-/obj/machinery/vending/cola/starkist{
-	pixel_x = 6;
-	pixel_y = 21;
-	density = 0
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"utH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "utJ" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -37590,19 +34028,15 @@
 	},
 /area/f13/caves)
 "uwV" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/stairs/east{
+	color = "#6F4F40"
 	},
-/obj/structure/flora/ausbushes/ppflowers{
-	plane = -2
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common,
+/area/f13/building)
 "uxd" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/vending/boozeomat,
@@ -37672,11 +34106,37 @@
 	},
 /area/f13/wasteland)
 "uyW" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/structure/chair/bench{
+	dir = 1;
+	plane = -6
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "uzc" = (
 /obj/structure/bed,
 /turf/open/floor/plasteel/f13{
@@ -37716,9 +34176,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"uAH" = (
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
 "uAO" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder - E"
@@ -37752,20 +34209,9 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
 "uBw" = (
-/obj/structure/spacevine,
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/closed/wall/f13/coyote/oldwood,
+/area/f13/building)
 "uBV" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -37904,28 +34350,22 @@
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
-"uGm" = (
-/obj/effect/landmark/start/f13/radiooperator,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/building/trader)
 "uGn" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "uGB" = (
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/fakespace,
@@ -37946,17 +34386,6 @@
 	icon_state = "verticaloutermain0"
 	},
 /area/f13/wasteland)
-"uHp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/obj/structure/dresser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/carpet/purple,
-/area/f13/wasteland/city/newboston/bar)
 "uHx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken{
@@ -37998,13 +34427,9 @@
 	},
 /area/f13/wasteland)
 "uIt" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8;
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/spawner/lootdrop/f13/trash_weps,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "uIx" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/f13/brahmincowboyhat,
@@ -38057,12 +34482,10 @@
 	},
 /area/f13/wasteland)
 "uJn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side{
-	dir = 1
-	},
-/area/f13/building)
+/obj/effect/landmark/start/f13/wastelander,
+/obj/effect/landmark/latejoin,
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "uJD" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -38090,29 +34513,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uJK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
+/obj/structure/destructible/tribal_torch/lit,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 8
+	dir = 5
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
-"uJT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/building)
 "uKk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38142,33 +34548,12 @@
 	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"uLU" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "uMb" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"uMh" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/random,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
 /area/f13/building)
 "uMw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38177,23 +34562,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood)
-"uMA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"uMI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "uMZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -38235,23 +34603,11 @@
 	},
 /area/f13/building)
 "uNE" = (
+/obj/structure/flora/ausbushes/genericbush,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "uNF" = (
 /obj/structure/lamp_post/doubles/bent{
@@ -38321,16 +34677,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"uQa" = (
-/obj/structure/railing{
-	color = "#A47449"
-	},
-/obj/structure/window/fulltile/wood,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "uQq" = (
 /obj/structure/glowshroom{
 	color = "#4F7942";
@@ -38342,16 +34688,12 @@
 	},
 /area/f13/caves)
 "uQt" = (
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 64;
-	pixel_x = -15;
-	plane = -6
+/obj/item/fishingrod,
+/obj/effect/turf_decal/siding/wood{
+	color = "#4F3528";
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/wasteland/city/newboston/outdoors)
 "uQE" = (
 /obj/structure/junk/cabinet,
@@ -38367,12 +34709,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "uRH" = (
-/obj/effect/landmark/start/f13/wastelander,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerbordercorner - E"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/area/f13/building/trader)
+/area/f13/building)
 "uRR" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -38437,13 +34779,11 @@
 	},
 /area/f13/wasteland)
 "uUl" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/storage/trash_stack{
-	icon_state = "trash_2"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "uUn" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -38465,15 +34805,8 @@
 	},
 /area/f13/building)
 "uVl" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/decoration/vent/rusty{
-	color = "#aaaaFE";
-	alpha = 50
-	},
-/turf/open/indestructible/ground/outside/water,
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland/city/newboston/outdoors)
 "uVs" = (
 /obj/structure/chair/pew{
@@ -38488,16 +34821,6 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
-"uVF" = (
-/obj/structure/dresser,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "uVQ" = (
 /obj/structure/dresser,
 /turf/open/floor/f13,
@@ -38588,9 +34911,10 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "uXJ" = (
+/obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/white,
 /area/f13/building)
 "uYj" = (
 /obj/structure/sign/crosswalk{
@@ -38608,25 +34932,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/caves)
 "uYT" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = -4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/caves)
 "uZh" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38662,15 +34988,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "vad" = (
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain"
+/obj/machinery/processor/chopping_block{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/building)
 "val" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -38718,8 +35045,31 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "vaO" = (
-/turf/closed/wall/r_wall/f13/vault,
-/area/f13/building/workshop/nash)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/flora/wild_plant/flower/white{
+	randomize_xy = 0;
+	pixel_x = 4;
+	pixel_y = 24
+	},
+/obj/structure/flora/wild_plant/flower/pink_three{
+	randomize_xy = 0;
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/structure/flora/wild_plant/flower/white{
+	randomize_xy = 0;
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/open/indestructible/ground/inside/mountain{
+	color = "#B18770"
+	},
+/area/f13/caves)
 "vaQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -38740,28 +35090,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vbG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/effect/landmark/start/f13/wastelander,
+/obj/effect/landmark/latejoin,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 1
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/building/tunnel)
 "vbL" = (
 /obj/structure/fence/wooden,
 /obj/structure/fence/wooden{
@@ -38774,11 +35113,10 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "vbR" = (
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/building/trader)
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "vck" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/structure/sign/stop{
@@ -38842,11 +35180,8 @@
 	},
 /area/f13/building)
 "veJ" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
+/obj/effect/spawner/lootdrop/f13/trash_trash,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "veP" = (
 /obj/structure/barricade/sandbags,
@@ -38856,24 +35191,18 @@
 	},
 /area/f13/wasteland)
 "vfa" = (
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/structure/closet/locker/fridge,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14;
-	opacity = 1
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"vfd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/area/f13/building)
 "vfL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38941,13 +35270,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building)
-"vij" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "viJ" = (
 /obj/machinery/processor,
 /turf/open/floor/f13{
@@ -39065,23 +35387,17 @@
 	},
 /area/f13/wasteland)
 "vlD" = (
-/obj/structure/lamp_post/doubles/bent{
-	density = 0;
-	dir = 1;
-	pixel_y = -10;
-	pixel_x = -22
+/obj/structure/table/booth{
+	color = "#EFCCC0"
 	},
-/obj/machinery/light{
-	light_color = "#e8eaff";
-	dir = 1;
-	pixel_y = 69;
-	pixel_x = -15;
-	plane = -6
+/obj/item/reagent_containers/food/snacks/donut/jelly/apple,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - N"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "vlE" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/f13{
@@ -39227,10 +35543,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"vqf" = (
-/obj/structure/nest/frog,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "vqt" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -39251,34 +35563,18 @@
 	},
 /area/f13/building)
 "vqR" = (
-/obj/structure/decoration/vent{
-	layer = 2.8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 17
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cmo,
-/area/f13/building)
-"vqW" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "vrQ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/building)
 "vsv" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "vsB" = (
 /obj/structure/fence{
 	dir = 1
@@ -39343,18 +35639,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "vuQ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 10
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_x = 27
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/destructible/tribal_torch/wall/lit{
+	layer = 3
+	},
+/obj/item/reagent_containers/glass/rag{
+	name = "smelly rag";
+	color = "#8A806B";
+	desc = "For cleaning up 'messes', you suppose. It smells terrible";
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bucket/wood{
+	desc = "It's a bucket. Made for seeing a man about a dog.";
+	name = "Poop Bucket";
+	pixel_x = -9
+	},
+/turf/open/indestructible/ground/outside/dirt/harsh,
+/area/f13/building)
 "vuT" = (
 /obj/structure/flora/rock/pile/largejungle,
 /obj/effect/turf_decal/weather/dirt{
@@ -39443,113 +35750,23 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/city/newboston/outdoors)
-"vwZ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
-/area/f13/building)
 "vxf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/r_wall/rust,
 /area/f13/building)
 "vxh" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/machinery/shower{
-	dir = 1;
-	layer = 4.9;
-	on = 1;
-	mouse_opacity = 0;
-	alpha = 0
-	},
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
+/obj/structure/wreck/car{
+	icon_state = "bike_rust_med";
+	layer = 2;
+	pixel_y = 16;
+	pixel_x = -15
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "vxi" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -39576,17 +35793,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
 "vyo" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/suture,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vyp" = (
 /obj/effect/decal/marking{
 	icon_state = "doublevertical"
@@ -39599,27 +35810,12 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "vyJ" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
-	},
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
+/obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "vyR" = (
 /obj/structure/junk/machinery,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39630,13 +35826,6 @@
 "vyX" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/building)
-"vzp" = (
-/obj/structure/window/fulltile/wood{
-	max_integrity = 140
-	},
-/obj/structure/curtain/directional/west,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland/city/newboston/library)
 "vzy" = (
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
@@ -39673,12 +35862,14 @@
 	},
 /area/f13/building)
 "vAD" = (
-/obj/item/bikehorn/rubberducky,
-/turf/open/water{
-	icon = 'icons/turf/pool.dmi';
-	icon_state = "pool_tile"
+/obj/structure/reagent_dispensers/watertank/high{
+	icon = 'icons/fallout/farming/farming_structures.dmi';
+	icon_state = "rainwater_tank";
+	name = "rainwater tank";
+	desc = "A huge metal tank with a tap on the front. Rainwater is collected on larger surfaces then poured into a tank like this for storage."
 	},
-/area/f13/wasteland/city/newboston/sauna)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "vAY" = (
 /obj/structure/closet/cabinet/anchored{
 	pixel_x = 5;
@@ -39734,9 +35925,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vDh" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "vDt" = (
 /turf/open/indestructible/ground/outside/road{
@@ -39753,7 +35946,10 @@
 	},
 /area/f13/building)
 "vEa" = (
-/obj/structure/flora/wild_plant/flower/pink_two,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/springflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "vEF" = (
@@ -39767,12 +35963,19 @@
 	},
 /area/f13/building/abandoned)
 "vFa" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland/city/newboston/bar)
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/yeast,
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/building)
 "vFh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -39786,13 +35989,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
 "vFW" = (
-/obj/structure/respawner_blocker{
-	pixel_y = 9
+/obj/machinery/hydroponics/soil,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#413527"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder - W"
+/obj/effect/turf_decal/siding/wood{
+	color = "#413527"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/building)
 "vGJ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
@@ -39816,25 +36022,21 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "vIt" = (
-/obj/effect/overlay/junk/curtain,
-/turf/open/floor/plating/rust,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -16
+	},
+/turf/open/indestructible/ground/outside/civ/woodalt,
 /area/f13/building)
 "vIQ" = (
-/obj/structure/sign/directions/science{
-	pixel_y = 23
+/obj/structure/glowshroom{
+	color = "green"
 	},
-/obj/structure/sign/directions/medical{
-	pixel_y = 31
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 4;
-	pixel_y = 40
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vJk" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -39944,12 +36146,12 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/building)
 "vNr" = (
-/obj/structure/railing{
-	dir = 9
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/wasteland)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "vNt" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -39979,12 +36181,11 @@
 	},
 /area/f13/building)
 "vOc" = (
-/obj/structure/decoration/vent/rusty{
-	color = "#aaaaFE";
-	alpha = 50
+/obj/structure/chair/folding{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vOg" = (
 /obj/structure/spacevine{
 	icon = 'icons/effects/effects.dmi';
@@ -40039,8 +36240,12 @@
 	},
 /area/f13/building)
 "vOY" = (
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/towel_rack{
+	pixel_y = 27
+	},
+/obj/structure/table/wood/bar,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vPo" = (
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building)
@@ -40069,132 +36274,9 @@
 	},
 /area/f13/building)
 "vQW" = (
-/obj/structure/table/wood/settler{
-	layer = 3;
-	pixel_y = -2
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -13;
-	pixel_y = 13
-	},
-/obj/item/trash/plate{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/candle/infinite{
-	layer = 3.1;
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/obj/item/cool_book/warandpeace{
-	pixel_x = 7
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
-"vRd" = (
-/obj/effect/landmark/start/f13/wastelander/clubmanager,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/building/trader)
-"vRH" = (
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -1;
-	pixel_y = 12;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = -6;
-	pixel_y = 15;
-	plane = 0
-	},
-/obj/structure/sink{
-	icon_state = "water";
-	name = "water";
-	pixel_x = 5;
-	pixel_y = 7;
-	plane = 0
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = 18;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_y = -14;
-	pixel_x = -19
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	layer = 2;
-	pixel_x = -17
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/junk/micro,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vRI" = (
 /obj/machinery/microwave/stove,
 /turf/open/floor/f13{
@@ -40227,20 +36309,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vSn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/med_data/syndie{
+	dir = 4;
+	req_one_access = null
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/dark,
+/area/f13/building)
 "vSN" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/structure/flora/tree/jungle/small,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "vSW" = (
 /obj/structure/window/fulltile/wood_window,
@@ -40274,25 +36357,27 @@
 	},
 /area/f13/building)
 "vUF" = (
-/obj/structure/closet/crate/bin{
-	pixel_y = 3;
-	density = 0
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
-"vVb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
+"vVb" = (
+/obj/structure/chair/bench{
+	plane = -6
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "vVD" = (
 /obj/effect/spawner/lootdrop/f13/rare,
 /obj/item/grenade/empgrenade,
@@ -40373,12 +36458,9 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "vYz" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1
+	dir = 10
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "vYR" = (
 /obj/structure/table,
@@ -40408,13 +36490,6 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/wasteland/city)
-"vZX" = (
-/obj/structure/simple_door/interior,
-/obj/item/lock_bolt{
-	dir = 8
-	},
-/turf/open/floor/wood_fancy/wood_fancy_dark,
-/area/f13/building)
 "wah" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -40465,13 +36540,14 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "wbp" = (
-/obj/structure/chair/bench{
-	pixel_y = 12
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
+/obj/machinery/chem_master/primitive,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "wcj" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -40494,14 +36570,31 @@
 	},
 /area/f13/building)
 "wcp" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/structure/closet/crate/wicker{
+	anchored = 1
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "wda" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -40510,38 +36603,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/building)
-"wdk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/water/running{
-	name = "tribe river";
-	dir = 4;
-	color = "#A1BFFF"
-	},
-/area/f13/wasteland)
 "wdM" = (
+/obj/machinery/deepfryer,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/directions/science{
-	dir = 1;
-	pixel_y = 23
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
 	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 8;
-	pixel_y = 39
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = 31
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "wex" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -40558,13 +36626,26 @@
 	},
 /area/f13/building)
 "weC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/sign/heaven{
-	pixel_y = 32
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#413527"
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/fence/wooden{
+	density = 0;
+	layer = 3;
+	name = "wooden post";
+	pixel_x = -12
+	},
+/obj/structure/fermenting_barrel{
+	pixel_y = 4
+	},
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "weL" = (
 /obj/structure/nest/randomized{
 	randomizer_difficulty = 1;
@@ -40577,11 +36658,10 @@
 	},
 /area/f13/building)
 "wfp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/decoration/rag{
-	icon_state = "skin"
+/obj/structure/chair/left{
+	dir = 1
 	},
-/turf/closed/wall/f13/coyote/oldwood,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "wfu" = (
 /obj/machinery/door/airlock/hatch{
@@ -40591,19 +36671,8 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "wfv" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/gravel,
 /area/f13/wasteland/city/newboston/outdoors)
 "wfy" = (
 /obj/structure/toilet{
@@ -40623,18 +36692,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"wfI" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4;
-	pixel_y = -7
-	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "wfN" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/f13{
@@ -40656,13 +36713,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
-"whm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack/shelf_metal{
-	pixel_x = -3
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "whw" = (
 /obj/machinery/workbench/bottler,
 /turf/open/floor/plasteel/freezer,
@@ -40709,20 +36759,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "wjp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
+/obj/structure/closet/cabinet,
+/obj/item/storage/book/bible/booze,
+/obj/item/clothing/suit/armor/light/kit/punk/prehistoricfur,
+/obj/item/clothing/head/aurora/fur,
+/obj/item/clothing/head/coyote/bisonpelt,
+/obj/item/clothing/shoes/f13/military/khan_pelt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/plasteel/cult,
+/area/f13/building)
 "wjF" = (
 /obj/structure/bookshelf{
 	pixel_y = 20
@@ -40756,14 +36803,8 @@
 	},
 /area/f13/wasteland)
 "wkh" = (
-/obj/machinery/iv_drip/telescopic,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wks" = (
 /obj/structure/chair/sofa/right{
 	dir = 4;
@@ -40785,23 +36826,11 @@
 	icon_state = "verticaloutermainbottom"
 	},
 /area/f13/building)
-"wkV" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "wla" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
 	},
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "wlC" = (
 /obj/structure/wreck/trash/one_barrel,
@@ -40836,31 +36865,23 @@
 	},
 /area/f13/building)
 "wmG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"wmH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "wmS" = (
-/obj/structure/stairs/north{
-	dir = 2
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
+"wmT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building/abandoned)
 "wmZ" = (
 /obj/structure/sink{
 	icon_state = "water";
@@ -40984,17 +37005,10 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"woy" = (
-/obj/structure/rack/shelf_metal{
-	pixel_x = -3
-	},
-/obj/item/twohanded/sledgehammer/simple,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
 "wpb" = (
-/obj/structure/haybale,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
+/obj/effect/spawner/lootdrop/f13/trash_weps,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wpk" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41081,14 +37095,26 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "wse" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "4210";
-	name = "outpost gate2"
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#413527"
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
+/obj/structure/railing/wood{
+	dir = 4
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#413527"
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	randomize_xy = 0
+	},
+/obj/structure/flora/ausbushes/grassybush{
+	layer = 2.1;
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/outside/dirt/dark,
+/area/f13/building)
 "wsp" = (
 /obj/effect/spawner/lootdrop/f13/common,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41136,9 +37162,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
 "wuh" = (
-/obj/structure/flora/tree/cherryblossom2,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
+	},
+/area/f13/building)
 "wum" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft2"
@@ -41153,8 +37186,23 @@
 	},
 /area/f13/building)
 "wuq" = (
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/ketchup,
+/obj/item/reagent_containers/food/condiment/mustard,
+/obj/item/reagent_containers/food/condiment/soysauce,
+/obj/item/reagent_containers/food/condiment/vinegar,
+/obj/item/reagent_containers/food/condiment/quality_oil,
+/obj/item/reagent_containers/food/condiment/bbqsauce,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/food/condiment/peanut_butter,
+/obj/item/reagent_containers/food/condiment/cherryjelly,
+/obj/item/reagent_containers/food/condiment/honey,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/building)
 "wuv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
@@ -41171,20 +37219,10 @@
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"wuZ" = (
-/obj/structure/flora/tree/cherryblossom2{
-	pixel_y = 9;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "wvd" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8
-	},
-/obj/structure/chair/bench,
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wvn" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/effect/turf_decal/weather/dirt{
@@ -41249,22 +37287,6 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/building)
-"wwP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/tree/cherryblossom3{
-	pixel_y = 11;
-	pixel_x = -23;
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"wxa" = (
-/obj/structure/simple_door/wood,
-/turf/open/floor/wood_fancy,
-/area/f13/wasteland/city/newboston/sauna)
 "wxh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41340,13 +37362,9 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wze" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house,
-/obj/structure/curtain/directional/north{
-	color = "#845f58"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "wzg" = (
 /mob/living/simple_animal/hostile/pillbug,
 /turf/open/floor/f13{
@@ -41375,21 +37393,10 @@
 	},
 /area/f13/building/abandoned)
 "wzP" = (
-/obj/structure/chair/sofa/left{
-	dir = 1;
-	icon_state = "sofamiddle";
-	color = "#333333"
-	},
-/obj/structure/rug/big/rug_fancy{
-	color = "grey";
-	dir = 1;
-	pixel_x = -16;
-	layer = 2.7
-	},
-/turf/open/floor/wood_common{
-	color = "#888888"
-	},
-/area/f13/wasteland/city/newboston/library)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "wAc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
@@ -41575,9 +37582,18 @@
 	},
 /area/f13/building)
 "wHT" = (
-/obj/structure/barricade/bars,
-/turf/closed/wall/f13/tunnel,
-/area/f13/building/workshop/nash)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/area/f13/building)
 "wIg" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -41593,12 +37609,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wIP" = (
-/obj/machinery/hydroponics/soil{
-	name = "riverbed soil";
-	yieldmod = 1.3
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -2
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/building/workshop/nash)
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = -7
+	},
+/obj/structure/barricade/wooden/planks{
+	density = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "wJg" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/f13/biker{
@@ -41618,20 +37642,20 @@
 	},
 /area/f13/wasteland)
 "wJl" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_y = 14
+/obj/machinery/recycler,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
+/turf/open/indestructible/ground/outside/gravel{
+	color = "#B7ABAB";
+	footstep = "dirt";
+	name = "rocky dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building/tunnel)
 "wJF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -41647,11 +37671,8 @@
 	},
 /area/f13/building/tribal/cave)
 "wKt" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/obj/structure/simple_door/house,
+/turf/open/floor/wood_common,
 /area/f13/building)
 "wKw" = (
 /obj/structure/window/reinforced/fulltile,
@@ -41684,13 +37705,17 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/caveofforever)
 "wLd" = (
-/obj/structure/bonfire/prelit{
-	density = 1
+/obj/structure/reagent_dispensers/barrel/explosive{
+	pixel_x = -9;
+	pixel_y = 8
 	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/reagent_dispensers/barrel/explosive{
+	pixel_x = 6;
+	pixel_y = 8
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "wLg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/coffee,
@@ -41712,14 +37737,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wMH" = (
-/obj/machinery/computer/operating,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 3
+/obj/structure/flora/rock/jungle,
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/building)
+/area/f13/wasteland/city/newboston/outdoors)
 "wMX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -41811,26 +37836,6 @@
 /obj/effect/spawner/lootdrop/f13/common,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"wPV" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "wPW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -41847,10 +37852,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "wQA" = (
-/turf/closed/wall/mineral/brick{
-	weak_wall = 0
-	},
-/area/f13/building/trader)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/booth,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "wQX" = (
 /obj/effect/decal/cleanable/glitter/white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41898,13 +37903,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wRR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_topless{
-	pixel_x = -32;
-	pixel_y = -5
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/turf_decal/weather/springflowers,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland/city/newboston/outdoors)
 "wSa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/chem_master/advanced,
@@ -41935,13 +37936,6 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/building)
-"wTa" = (
-/obj/structure/table/booth,
-/obj/item/fishingrod,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "wTs" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom3"
@@ -41983,37 +37977,20 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "wVC" = (
-/obj/structure/chair/bench{
-	dir = 4
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
-"wVD" = (
-/obj/structure/sink/deep_water{
-	pixel_y = 3;
-	color = "#996633"
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6;
+	dir = 4;
+	pixel_y = -10
 	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#996633"
-	},
-/area/f13/building/workshop/nash)
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "wVY" = (
 /obj/effect/turf_decal/weather/dirtcorner{
 	dir = 1
@@ -42086,14 +38063,9 @@
 	},
 /area/f13/building)
 "wXv" = (
-/obj/machinery/microwave/stove,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "red"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/structure/simple_door/room,
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
 	},
 /area/f13/building)
 "wXQ" = (
@@ -42114,13 +38086,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "wYj" = (
-/obj/structure/decoration/vent,
-/obj/machinery/shower{
-	pixel_y = 17
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = 1
 	},
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
+/turf/open/indestructible/ground/outside/gravel,
+/area/f13/wasteland)
 "wYD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -42142,11 +38115,33 @@
 	},
 /area/f13/wasteland)
 "wZe" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/glitter/white,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "wZg" = (
 /obj/structure/simple_door/wood,
 /obj/item/lock_bolt{
@@ -42401,10 +38396,38 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xgZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house,
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam"
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
+	},
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
+	},
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "xht" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -42417,23 +38440,15 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "xhQ" = (
-/obj/effect/landmark/start/f13/texasranger,
-/obj/effect/landmark/latejoin,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
+/obj/structure/railing{
+	color = "#A47449";
+	plane = -6
 	},
-/area/f13/building/trader)
-"xhW" = (
-/obj/structure/table/booth,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/structure/barricade/bars{
+	color = "#A47449"
 	},
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
+/obj/structure/window/fulltile/ruins,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "xhZ" = (
 /turf/closed/indestructible/f13/matrix/transition,
@@ -42484,13 +38499,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building)
-"xju" = (
-/obj/structure/chair/booth{
-	icon_state = "booth_east_south";
-	pixel_y = 11
-	},
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
 "xkj" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42500,13 +38508,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/abandoned)
-"xkz" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
-/area/f13/building)
 "xlb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -42541,41 +38542,27 @@
 	},
 /area/f13/wasteland)
 "xlV" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 16
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
+/area/f13/caves)
 "xlY" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42590,21 +38577,37 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building)
-"xmO" = (
-/obj/effect/landmark/latejoin,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/f13/followersdoctor,
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999"
-	},
-/area/f13/building/trader)
 "xnv" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/item/survivalcapsule,
+/obj/item/survivalcapsule{
+	pixel_y = 9
 	},
-/obj/structure/flora/wild_plant/flower/orange,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/item/survivalcapsule/blacksmith{
+	pixel_y = -10
+	},
+/obj/item/survivalcapsule/farm{
+	pixel_x = 10
+	},
+/obj/item/survivalcapsule/fortuneteller{
+	pixel_x = -9
+	},
+/obj/item/survivalcapsule{
+	pixel_y = 9
+	},
+/obj/item/survivalcapsule,
+/obj/item/survivalcapsule/farm{
+	pixel_x = 10
+	},
+/obj/item/survivalcapsule/fortuneteller{
+	pixel_x = -9
+	},
+/obj/item/survivalcapsule/blacksmith{
+	pixel_y = -10
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "xnF" = (
 /obj/effect/spawner/lootdrop/f13/uncommon,
 /turf/open/indestructible/ground/inside/subway,
@@ -42634,32 +38637,6 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"xow" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 23
-	},
-/obj/structure/sign/directions/science{
-	icon_state = "direction_supply";
-	dir = 1;
-	pixel_y = 39;
-	layer = 4
-	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 31
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
 "xoy" = (
 /obj/structure/necropolis_gate{
 	desc = "A massive stone gateway with a very heavy stone door.";
@@ -42670,10 +38647,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "xoK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/indestructible/ground/outside/savannah,
+/area/f13/building)
 "xoM" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13{
@@ -42752,16 +38727,11 @@
 	},
 /area/f13/building/tribal)
 "xpO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
-"xqu" = (
-/obj/structure/rug/big/rug_red,
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/building)
+/obj/structure/closet/crate/large,
+/obj/item/fishingrod,
+/obj/item/fishingrod,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xqN" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -42811,25 +38781,6 @@
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
-"xrX" = (
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	color = "#a98c5d";
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water{
-	color = "#33FF48";
-	light_color = "#33FF48";
-	light_power = 2;
-	light_range = 2
-	},
-/area/f13/caves)
 "xsc" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/ground/inside/subway,
@@ -42865,17 +38816,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xtY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/wasteland/city/newboston/bar)
 "xut" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -42901,10 +38841,6 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"xuF" = (
-/obj/machinery/light,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
 "xuQ" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -42963,12 +38899,6 @@
 	light_range = 2
 	},
 /area/f13/caves)
-"xxa" = (
-/obj/structure/respawner_blocker{
-	pixel_y = 9
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/building/workshop/nash)
 "xxc" = (
 /obj/structure/billboard/powerlines2{
 	icon_state = "rr18";
@@ -43022,18 +38952,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "xyl" = (
+/obj/structure/simple_door/room,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/contraband/pinup_ride{
-	pixel_x = -33;
-	pixel_y = 32
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
-	},
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/civ/woodalt,
+/area/f13/building)
 "xyu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/common,
@@ -43076,39 +39000,15 @@
 /turf/open/floor/f13,
 /area/f13/brotherhood)
 "xzN" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -30
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = -3
-	},
-/obj/item/lighter{
-	pixel_x = 7;
-	pixel_y = -3
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/toilet{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/toilet_paper{
+	pixel_x = -17;
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building)
 "xAk" = (
 /obj/structure/stone_tile/block{
@@ -43142,33 +39042,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/tribal/cave)
 "xBd" = (
-/obj/machinery/light/floor{
-	mouse_opacity = 0
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/siding/wideplating{
+	color = "#525252";
+	pixel_y = 2;
+	pixel_x = -5
 	},
-/area/f13/building)
+/turf/open/indestructible/ground/outside/civ/grass3{
+	color = "#CCCCCC";
+	barefootstep = "grass";
+	clawfootstep = "grass";
+	footstep = "grass"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "xBn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/wooden{
-	pixel_y = 12
-	},
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/orange{
-	pixel_y = 14
-	},
-/obj/item/bedsheet/orange,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/obj/structure/furnace,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/building)
 "xBD" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -43205,8 +39099,10 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/building/tribal/cave)
 "xCx" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/tires/five,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/building)
 "xCL" = (
 /obj/structure/sink{
@@ -43289,15 +39185,6 @@
 	color = "#A1BFFF"
 	},
 /area/f13/tribe)
-"xDs" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "xEu" = (
 /obj/machinery/door/airlock/silver,
 /turf/open/floor/f13{
@@ -43355,28 +39242,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"xGp" = (
-/obj/structure/railing{
-	dir = 4;
-	color = "#bb3333";
-	pixel_x = 2
-	},
-/obj/structure/ladder/unbreakable{
-	pixel_y = 13;
-	color = "#FF33FF";
-	id = "heavens_night"
-	},
-/obj/structure/decoration/hatch{
-	icon_state = "vault_erp";
-	pixel_y = 34;
-	alpha = 150;
-	name = "sign"
-	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs";
-	color = "#FF33FF"
-	},
-/area/f13/wasteland/city/newboston/bar)
 "xGw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/marking{
@@ -43392,13 +39257,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "xGF" = (
-/obj/item/paper_bin/bundlenatural{
-	pixel_y = 6
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/pen/fountain,
-/obj/structure/table/wood/bar,
-/turf/open/floor/wood_common,
-/area/f13/wasteland/city/newboston/bar)
+/turf/open/floor/plating/dirt{
+	color = "#E0B69F"
+	},
+/area/f13/building)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/aug_manipulator,
@@ -43460,25 +39325,11 @@
 /area/f13/wasteland)
 "xJm" = (
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1
+	dir = 9
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	opacity = 1
-	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
-	pixel_x = 12
-	},
+/obj/effect/turf_decal/weather/springflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
-"xJn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/junk/small/table,
-/turf/open/floor/wood_common,
-/area/f13/building)
 "xJS" = (
 /obj/structure/lamp_post/doubles/bent{
 	density = 0;
@@ -43514,61 +39365,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building)
-"xKH" = (
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	pixel_x = 19;
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15
-	},
-/obj/structure/spacevine{
-	icon = 'icons/effects/effects.dmi';
-	icon_state = "smoke";
-	name = "steam";
-	plane = 2;
-	pixel_y = 15;
-	pixel_x = 18
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/building)
 "xKL" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -43600,58 +39396,9 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood)
-"xLP" = (
-/obj/effect/decal/cleanable/dirt/dust{
-	color = "#11ff11"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
-"xLY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
-	},
-/turf/open/indestructible/ground/outside/ruins{
-	name = "stepping stones";
-	color = "#bfbfbf"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
-"xMx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/building)
 "xMB" = (
 /obj/effect/spawner/lootdrop/clothing_low,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"xML" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
 /area/f13/building)
 "xMS" = (
 /turf/open/indestructible/ground/outside/road{
@@ -43694,11 +39441,14 @@
 	},
 /area/f13/building)
 "xOu" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/f13/vault_floor/misc/bar,
+/area/f13/building)
 "xOF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/coyote/oldwood,
@@ -43716,15 +39466,28 @@
 	},
 /area/f13/building)
 "xOW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	pixel_x = 4
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_x = 19
 	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/gravel{
-	color = "#AAAAAA"
+/obj/structure/spacevine{
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "smoke";
+	name = "steam";
+	pixel_y = 12;
+	pixel_x = 17
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/glitter/blue,
+/turf/open/indestructible/ground/outside/water{
+	name = "hot spring";
+	color = "#90DBFE";
+	light_range = 2;
+	light_power = 2;
+	light_color = "#BAF8FF"
+	},
+/area/f13/caves)
 "xPc" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -43768,11 +39531,6 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/wasteland/city/newboston/outdoors)
-"xPV" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/wall/f13/coyote/oldwood,
-/area/f13/wasteland/city/newboston/bar)
 "xQr" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43816,15 +39574,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
-"xRq" = (
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = -1;
-	alpha = 80;
-	mouse_opacity = 0;
-	pixel_y = 4
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
 "xRx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43990,11 +39739,9 @@
 	},
 /area/f13/building)
 "xVN" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/common,
-/obj/item/paper_bin,
-/turf/open/floor/wood_common{
-	color = "#779999"
+/obj/machinery/mineral/wasteland_vendor/pipboy,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/building)
 "xWe" = (
@@ -44037,19 +39784,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xXi" = (
-/obj/structure/spacevine,
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/fullgrass{
-	plane = -3
-	},
-/obj/structure/flora/ausbushes/palebush{
-	plane = -1;
-	pixel_y = 10
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/spawner/lootdrop/f13/trash_trash,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "xXv" = (
 /obj/structure/rack,
@@ -44065,13 +39801,6 @@
 "xXE" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
-"xXJ" = (
-/obj/item/reagent_containers/food/snacks/cola_float,
-/turf/open/water{
-	icon = 'icons/turf/pool.dmi';
-	icon_state = "pool_tile"
-	},
-/area/f13/wasteland/city/newboston/sauna)
 "xYi" = (
 /obj/structure/table/wood/settler,
 /obj/item/flashlight/lamp,
@@ -44140,17 +39869,10 @@
 	},
 /area/f13/building)
 "xZl" = (
+/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/flag_texas{
-	pixel_y = 27
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/building)
 "xZm" = (
 /obj/effect/spawner/lootdrop/bedsheet,
 /obj/structure/bed,
@@ -44227,6 +39949,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
+"ybd" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white,
+/area/f13/building)
 "ybe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/f13/rare,
@@ -44238,8 +39965,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "ybW" = (
-/turf/open/floor/wood_common,
-/area/f13/building/workshop/nash)
+/obj/structure/glowshroom/glowcap,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ycc" = (
 /obj/structure/stairs{
 	dir = 1
@@ -44348,23 +40076,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "yfs" = (
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/rolling,
+/obj/structure/mirror/alt{
+	pixel_y = -30
 	},
-/obj/structure/flora/chomp/bush2{
-	color = "#338833";
-	plane = -2;
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 9;
 	pixel_y = 14
 	},
-/obj/structure/flora/ausbushes/ywflowers{
-	plane = -2
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkrusty"
 	},
-/obj/structure/flora/ausbushes/brflowers{
-	plane = -2
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "yfC" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -44382,37 +40106,10 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
-"ygf" = (
-/obj/structure/stairs/north,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
 "ygn" = (
 /obj/structure/simple_door/interior,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/f13/wood,
-/area/f13/building)
-"ygv" = (
-/obj/structure/flora/ausbushes/leafybush{
-	pixel_x = 4;
-	alpha = 80;
-	mouse_opacity = 0
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/city/newboston/outdoors)
-"ygz" = (
-/obj/structure/chair/booth{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood_common{
-	color = "#779999"
-	},
 /area/f13/building)
 "ygG" = (
 /obj/effect/decal/remains/human,
@@ -44425,15 +40122,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "ygM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 6;
-	pixel_y = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1;
+	color = "#E0B69F"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/building)
 "ygV" = (
 /obj/structure/chair/sofa/left,
@@ -44488,12 +40181,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "yiG" = (
-/obj/effect/turf_decal/weather/splineplaincee{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/f13/wasteland/city/newboston/chapel)
+/obj/effect/spawner/lootdrop/f13/trash_food,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland/city/newboston/outdoors)
 "yjd" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -44517,16 +40208,6 @@
 	color = "#999999";
 	icon_state = "horizontalinnermain0"
 	},
-/area/f13/wasteland/city/newboston/outdoors)
-"yjs" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 7;
-	plane = -4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/city/newboston/outdoors)
 "yjM" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -44600,14 +40281,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ylm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light,
-/obj/structure/rack/shelf_metal{
-	pixel_x = -3
+/obj/structure/flora/wasteplant/fever_blossom{
+	pixel_y = 20;
+	randomize_xy = 0
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building/workshop/nash)
+/obj/structure/flora/wasteplant/fever_blossom{
+	pixel_y = 20;
+	randomize_xy = 0
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ylv" = (
 /obj/structure/table/booth,
 /obj/effect/decal/waste{
@@ -49092,22 +44775,22 @@ orL
 tPQ
 tPQ
 tPQ
-ppv
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 orL
 tPQ
-orL
-orL
 tPQ
 orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 orL
@@ -49348,23 +45031,23 @@ tPQ
 orL
 tPQ
 tPQ
-eHQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -49607,11 +45290,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
 orL
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -49620,8 +45300,11 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -49861,13 +45544,8 @@ tPQ
 orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
+orL
 orL
 tPQ
 tPQ
@@ -49875,6 +45553,11 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -50117,6 +45800,7 @@ tPQ
 tPQ
 orL
 tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -50130,11 +45814,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
 tPQ
 orL
-orL
+tPQ
 tPQ
 tPQ
 orL
@@ -50373,6 +46056,10 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -50382,16 +46069,12 @@ tPQ
 orL
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
 tPQ
 orL
-orL
-orL
+tPQ
 tPQ
 tPQ
 orL
@@ -50630,6 +46313,10 @@ tPQ
 tPQ
 orL
 orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -50638,12 +46325,8 @@ tPQ
 orL
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 orL
@@ -50886,6 +46569,10 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -50895,17 +46582,13 @@ tPQ
 orL
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
 tPQ
 tPQ
 orL
-orL
-orL
+tPQ
 tPQ
 orL
 tPQ
@@ -51150,19 +46833,19 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
 orL
 orL
+tPQ
 orL
+tPQ
 tPQ
 orL
 tPQ
@@ -51406,19 +47089,19 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
 tPQ
 orL
 orL
@@ -51655,13 +47338,6 @@ tPQ
 orL
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -51669,7 +47345,6 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -51677,7 +47352,15 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+orL
+tPQ
 orL
 tPQ
 tPQ
@@ -51910,6 +47593,9 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -51919,22 +47605,19 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
-orL
+tPQ
 orL
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -52173,25 +47856,25 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
 orL
 orL
 dVq
@@ -52423,6 +48106,10 @@ tPQ
 orL
 orL
 tPQ
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -52431,24 +48118,20 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
-orL
-orL
-orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
 tPQ
 tPQ
 mql
@@ -52679,6 +48362,9 @@ tPQ
 orL
 orL
 tPQ
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -52688,16 +48374,12 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-orL
+tPQ
 tPQ
 orL
 tPQ
@@ -52705,6 +48387,7 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
 tPQ
 tPQ
 orL
@@ -52935,26 +48618,6 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
 orL
 tPQ
 tPQ
@@ -52962,6 +48625,26 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -53190,8 +48873,8 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
+orL
+orL
 tPQ
 tPQ
 tPQ
@@ -53204,21 +48887,21 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -53447,7 +49130,7 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -53461,21 +49144,21 @@ tPQ
 tPQ
 orL
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -53715,24 +49398,24 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+gIL
+gIL
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -53972,24 +49655,24 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-orL
 orL
 tPQ
 tPQ
 tPQ
 tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -54231,22 +49914,22 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
+gIL
 tPQ
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -54750,7 +50433,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -55005,7 +50688,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
+orL
 orL
 tPQ
 tPQ
@@ -55261,11 +50944,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
+orL
 orL
 tPQ
 tPQ
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -55507,12 +51190,9 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
-orL
-orL
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -55520,6 +51200,9 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -55751,7 +51434,24 @@ orL
 orL
 tPQ
 orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -55761,28 +51461,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
+gIL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 orL
@@ -56017,21 +51700,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -56040,26 +51710,39 @@ tPQ
 tPQ
 orL
 orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 orL
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -56265,22 +51948,15 @@ tPQ
 orL
 orL
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
-orL
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -56289,34 +51965,41 @@ tPQ
 tPQ
 orL
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -56528,16 +52211,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
-tPQ
-orL
-orL
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -56547,33 +52222,41 @@ orL
 orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
 orL
 orL
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 orL
 tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -56783,49 +52466,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -56834,6 +52478,45 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
 tPQ
 mdh
 klQ
@@ -57037,23 +52720,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -57065,7 +52739,9 @@ orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57077,16 +52753,23 @@ tPQ
 orL
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 orL
 orL
 tPQ
-orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57293,23 +52976,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -57317,7 +52987,16 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57326,22 +53005,26 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57552,34 +53235,6 @@ orL
 orL
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -57595,12 +53250,40 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
+tPQ
 tPQ
 orL
 orL
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57807,18 +53490,9 @@ tPQ
 orL
 orL
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
 orL
 orL
 tPQ
@@ -57829,21 +53503,9 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -57852,7 +53514,10 @@ orL
 tPQ
 orL
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -57861,7 +53526,25 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
 tPQ
 hWI
 gIm
@@ -58065,36 +53748,7 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -58108,17 +53762,46 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+orL
+orL
+tPQ
+tPQ
 orL
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -58321,19 +54004,10 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
 orL
 orL
 tPQ
-orL
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -58343,26 +54017,18 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
-tPQ
-orL
-orL
 orL
 tPQ
 tPQ
 tPQ
 orL
-tPQ
 tPQ
 tPQ
 orL
@@ -58372,8 +54038,25 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 orL
 tPQ
@@ -58581,32 +54264,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -58622,9 +54284,6 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -58632,7 +54291,31 @@ tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -58839,20 +54522,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -58863,14 +54540,9 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -58878,18 +54550,29 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -59093,33 +54776,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
 tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -59127,14 +54789,9 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
 orL
 tPQ
 tPQ
@@ -59147,6 +54804,32 @@ tPQ
 tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -59349,24 +55032,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -59375,23 +55040,31 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
-orL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -59403,7 +55076,17 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -59608,35 +55291,11 @@ orL
 orL
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -59646,8 +55305,21 @@ orL
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+gIL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+gIL
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -59661,6 +55333,17 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -59863,35 +55546,8 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
 orL
 tPQ
 tPQ
@@ -59907,16 +55563,43 @@ tPQ
 tPQ
 tPQ
 tPQ
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
+tPQ
+gIL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
 orL
+tPQ
+orL
+orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -60120,40 +55803,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -60166,14 +55817,46 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+gIL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -60378,44 +56061,8 @@ orL
 tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
 orL
 tPQ
 tPQ
@@ -60430,7 +56077,43 @@ tPQ
 orL
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+gIL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -60639,8 +56322,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -60650,24 +56331,8 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
 orL
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -60679,6 +56344,13 @@ tPQ
 tPQ
 tPQ
 tPQ
+gIL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -60687,6 +56359,17 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -60894,28 +56577,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -60927,10 +56590,18 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -60944,6 +56615,18 @@ tPQ
 tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -61150,27 +56833,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -61183,6 +56845,25 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -61192,14 +56873,16 @@ tPQ
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -61405,41 +57088,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -61457,6 +57105,41 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -61662,17 +57345,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -61680,9 +57352,6 @@ tPQ
 tPQ
 orL
 orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -61690,18 +57359,21 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -61710,11 +57382,22 @@ tPQ
 tPQ
 tPQ
 tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
 tPQ
-orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -61922,6 +57605,40 @@ tPQ
 tPQ
 tPQ
 tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -61936,45 +57653,11 @@ tPQ
 tPQ
 orL
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -62178,34 +57861,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -62224,13 +57880,40 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
+orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -62433,30 +58116,12 @@ orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 orL
 orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -62472,22 +58137,40 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
+gIL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -62689,6 +58372,14 @@ tPQ
 tPQ
 tPQ
 tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 orL
@@ -62697,23 +58388,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -62727,16 +58401,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 orL
 tPQ
 tPQ
@@ -62744,6 +58408,25 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -62947,45 +58630,16 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
+orL
 tPQ
+orL
 tPQ
 orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -63000,10 +58654,39 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
 tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 orL
@@ -63209,26 +58892,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
+gIL
 tPQ
 tPQ
 orL
-tPQ
 orL
 orL
 tPQ
@@ -63241,24 +58914,34 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -63461,33 +59144,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -63503,10 +59163,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -63515,7 +59172,33 @@ tPQ
 orL
 tPQ
 tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -63724,33 +59407,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -63762,18 +59423,40 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 orL
 orL
+orL
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 orL
@@ -63980,8 +59663,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 orL
@@ -63995,19 +59676,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -64018,14 +59687,28 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -64237,8 +59920,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
 orL
 orL
 tPQ
@@ -64249,26 +59930,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -64281,13 +59944,33 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
 orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -64492,23 +60175,15 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
 orL
 orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -64529,15 +60204,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -64545,7 +60212,23 @@ tPQ
 tPQ
 tPQ
 orL
-orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -64738,6 +60421,41 @@ tPQ
 gIL
 gIL
 tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -64751,45 +60469,12 @@ tPQ
 tPQ
 orL
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 orL
 orL
+gIL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -64801,8 +60486,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 orL
 tPQ
 tPQ
@@ -64952,8 +60635,8 @@ tot
 tot
 tot
 tot
-tPQ
-tPQ
+tot
+tot
 tPQ
 ucj
 orL
@@ -64971,7 +60654,7 @@ tPQ
 orL
 orL
 orL
-orL
+tPQ
 orL
 tPQ
 tPQ
@@ -64996,6 +60679,43 @@ gIL
 gIL
 gIL
 gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+gIL
+orL
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -65005,32 +60725,14 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -65039,25 +60741,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 orL
@@ -65209,13 +60892,36 @@ tot
 tot
 tot
 tot
+tot
+tot
+tot
+tot
 tPQ
 tPQ
 tPQ
-ucj
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -65224,44 +60930,15 @@ tPQ
 gIL
 gIL
 gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
-gIL
+tPQ
 gIL
 gIL
 gIL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-orL
-orL
+gIL
 tPQ
 tPQ
 tPQ
@@ -65283,12 +60960,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -65297,7 +60968,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -65308,13 +60984,20 @@ orL
 orL
 tPQ
 tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -65466,57 +61149,55 @@ tot
 tot
 tot
 tot
+tot
+tot
+tot
+tot
+tot
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-gIL
-gIL
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
 tPQ
 gIL
+gIL
+tPQ
+gIL
+gIL
+gIL
+tPQ
+tPQ
 tPQ
 gIL
 tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -65528,8 +61209,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -65549,10 +61228,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -65561,7 +61236,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 orL
 tPQ
 tPQ
@@ -65572,6 +61247,14 @@ tPQ
 tPQ
 tPQ
 tPQ
+orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -65723,52 +61406,64 @@ tot
 tot
 tot
 tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tPQ
 gIL
 gIL
 gIL
 gIL
 gIL
 tPQ
+tPQ
 gIL
+tPQ
+gIL
+tPQ
 gIL
 tPQ
 tPQ
-gIL
-gIL
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-hsD
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+orL
+orL
 tPQ
 tPQ
 tPQ
@@ -65782,22 +61477,13 @@ tPQ
 orL
 orL
 tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
+gIL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -65812,23 +61498,20 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -65980,73 +61663,57 @@ tot
 tot
 tot
 tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
 tPQ
 tPQ
 gIL
 gIL
 gIL
 gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-owE
-gIL
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 tPQ
+gIL
+gIL
 tPQ
 orL
-orL
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -66060,6 +61727,34 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -66069,23 +61764,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -66234,46 +61917,46 @@ hRl
 tot
 tot
 tot
-fNr
-fNr
-fNr
-fNr
-tPQ
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-uIn
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
 gIL
@@ -66282,13 +61965,12 @@ tPQ
 gIL
 gIL
 gIL
+tPQ
+tPQ
+tPQ
 gIL
 gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -66304,46 +61986,47 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
+gIL
+gIL
 tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -66488,59 +62171,57 @@ hRl
 "}
 (86,1,1) = {"
 hRl
-fNr
-fNr
-fNr
-fNr
-qJw
-kJS
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
 tPQ
 tPQ
 tPQ
-vdY
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 tPQ
-fNr
-fNr
-vPo
-vPo
-vPo
-lAl
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 gIL
 gIL
 tPQ
 tPQ
-tPQ
 gIL
 tPQ
-gIL
 gIL
 tPQ
 tPQ
@@ -66558,11 +62239,8 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -66575,19 +62253,19 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -66601,6 +62279,11 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+gIL
+orL
 tPQ
 orL
 tPQ
@@ -66745,61 +62428,31 @@ hRl
 "}
 (87,1,1) = {"
 hRl
-fNr
-fNr
-fNr
-fNr
-fNr
-pMb
-fNr
-fNr
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-fNr
-fNr
-vPo
-vPo
-vPo
-vPo
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
 tPQ
 tPQ
 tPQ
@@ -66809,11 +62462,35 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+gIL
+tPQ
+gIL
+gIL
+tPQ
+gIL
 tPQ
 tPQ
 orL
-orL
-orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -66831,17 +62508,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -66849,6 +62517,16 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -66858,6 +62536,11 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 orL
 tPQ
@@ -67002,48 +62685,45 @@ hRl
 "}
 (88,1,1) = {"
 hRl
-wQA
-dvh
-dUS
-uGm
-uRH
-jri
-fNr
-fNr
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-fNr
-fNr
-vPo
-vPo
-vPo
-vPo
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -67053,10 +62733,34 @@ tPQ
 tPQ
 gIL
 tPQ
-hsD
+tPQ
+tPQ
 gIL
 gIL
 gIL
+gIL
+tPQ
+gIL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -67072,14 +62776,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -67094,27 +62790,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -67259,67 +62942,67 @@ hRl
 "}
 (89,1,1) = {"
 hRl
-ebe
-spd
-spd
-dmP
-icA
-jri
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-vPo
-vPo
-fNr
-fNr
-nqx
-ePP
-fNr
-fNr
-fNr
-fNr
-fNr
-yde
-yde
-yde
-yde
-yde
-yde
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
-tPQ
-vdY
-tPQ
+gIL
+gIL
 gIL
 tPQ
 gIL
 tPQ
+gIL
+gIL
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
+orL
 tPQ
 orL
 orL
@@ -67340,15 +63023,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -67359,16 +63033,25 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
+orL
 tPQ
 tPQ
 orL
@@ -67516,73 +63199,67 @@ hRl
 "}
 (90,1,1) = {"
 hRl
-ads
-hzj
-spd
-aBY
-gdU
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-vPo
-vPo
-fNr
-fNr
-bdp
-tfB
-fNr
-fNr
-fNr
-yde
-yde
-yde
-fSq
-iEm
-izc
-tFZ
-yde
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 gIL
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+orL
+tPQ
+tPQ
 gIL
 tPQ
 tPQ
-tPQ
-tPQ
 orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -67600,23 +63277,11 @@ orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -67628,6 +63293,24 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -67773,81 +63456,64 @@ hRl
 "}
 (91,1,1) = {"
 hRl
-ads
-hzj
-aBY
-aBY
-gLP
-hVc
-wpb
-hTc
-xxa
-osc
-oUB
-wVD
-hVc
-ucs
-lbs
-lbs
-pmh
-cEd
-hgB
-omT
-pll
-mSJ
-pRQ
-aRn
-sUQ
-gRn
-xZc
-pll
-syK
-syK
-syK
-pii
-mxP
-syK
-pll
-kIY
-gCD
-gCD
-gCD
-gCD
-iCP
-izc
-izc
-izc
-izc
-izc
-cFY
-yde
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tPQ
+tPQ
+tPQ
+vdY
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 gIL
+tPQ
+tPQ
 gIL
-orL
-orL
-orL
 tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -67863,15 +63529,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -67880,10 +63537,36 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -68030,68 +63713,86 @@ hRl
 "}
 (92,1,1) = {"
 hRl
-srN
-ads
-xmO
-dkt
-cWY
-hVc
-hTc
-hTc
-hTc
-ctp
-hTc
-ngm
-hVc
-umm
-cQD
-tkh
-kqO
-yjs
-qez
-ijO
-nlU
-tUj
-mfY
-pll
-jUx
-hCR
-pll
-vij
-kIY
-pJc
-kIY
-kIY
-kIY
-pJc
-bDj
-wZe
-ndt
-lKL
-vyJ
-uBw
-yde
-pIo
-izc
-izc
-izc
-izc
-mvq
-yde
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+aQm
+cmv
+qxB
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+tot
+tot
+tot
+iFp
+exu
+qGl
+iLF
+iLF
+iLF
+iLF
+tot
+tPQ
+tPQ
+tPQ
+tPQ
+uIn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 gIL
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
 tPQ
 gIL
 tPQ
 tPQ
-gIL
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -68107,28 +63808,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -68140,6 +63819,10 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -68287,62 +63970,41 @@ hRl
 "}
 (93,1,1) = {"
 hRl
-ads
-hzj
-fjo
-ntV
-gma
-hVc
-bpA
-hTc
-hTc
-twS
-twS
-hTc
-hVc
-ifw
-ifw
-ifw
-usZ
-hcp
-nrx
-qez
-ibu
-naL
-nDI
-pll
-fDN
-kIY
-vij
-wLd
-pJc
-wTa
-pJc
-kIY
-pJc
-hQs
-pJc
-wZe
-jjv
-cHJ
-jUu
-jUu
-yde
-yde
-yde
-guV
-izc
-izc
-izc
-yde
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+vXl
+nJw
+uII
+iLF
+iLF
+iLF
+iLF
+hId
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+tot
+iLF
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+tot
 gIL
 gIL
 tPQ
@@ -68353,27 +64015,20 @@ tPQ
 tPQ
 tPQ
 tPQ
+gIL
 tPQ
 tPQ
 tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
 tPQ
 tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -68383,6 +64038,31 @@ tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -68393,14 +64073,17 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -68544,67 +64227,102 @@ hRl
 "}
 (94,1,1) = {"
 hRl
-ads
-hzj
-eAc
-aPO
-eis
-hVc
-hVc
-hTc
-hTc
-hTc
-hTc
-hTc
-hVc
-oGm
-yiG
-vad
-ulP
-mrr
-mrr
-hqk
-tHN
-tHN
-ygv
-xJm
-wPV
-kIY
-pJc
-kIY
-kIY
-pJc
-kIY
-pxr
-kIY
-pJc
-kIY
-wZe
-vbG
-wjp
-jsL
-vbG
-jsL
-vbG
-vfa
-yde
-tgK
-tgK
-tgK
-yde
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kzY
+iLF
+iLF
+iLF
+hId
+tot
+iLF
+iLF
+iLF
+iLF
+sOM
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+iLF
+kUY
+tny
 tPQ
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 tPQ
 tPQ
+gIL
+gIL
+gIL
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -68614,20 +64332,6 @@ tPQ
 tPQ
 orL
 tPQ
-orL
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -68636,28 +64340,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -68801,82 +64484,84 @@ hRl
 "}
 (95,1,1) = {"
 hRl
-gao
-hBh
-xhQ
-lgv
-bGc
-mJp
-hVc
-nUK
-rxK
-cEt
-syx
-syx
-hVc
-pwM
-irW
-bLA
-ifw
-hcp
-fXH
-mrr
-hcp
-hsR
-dcU
-pQh
-wkV
-pJc
-wTa
-pJc
-kIY
-kIY
-kIY
-kIY
-kIY
-kIY
-gCD
-rPM
-pll
-jUu
-vbG
-kJs
-vbG
-mOl
-yaZ
-yde
-hlA
-xKH
-xKH
-yde
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+hId
+tot
+iLF
+kyR
+iLF
+iLF
+kyR
+iLF
+bXm
+dLV
+iLF
+iLF
+hId
+xwY
+kFl
+tcf
+iLF
+tot
+iLF
+iLF
+tot
+kyR
+iLF
+iLF
+kUY
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+gIL
+gIL
+tPQ
 gIL
 gIL
 gIL
 gIL
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-orL
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -68887,30 +64572,28 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -69058,68 +64741,104 @@ hRl
 "}
 (96,1,1) = {"
 hRl
-iCh
-rEK
-vRd
-soG
-bGc
-mnq
-hVc
-jnB
-wIP
-wIP
-lbs
-myf
-hVc
-ifw
-ifw
-sQy
-ifw
-mrr
-nrx
-vOc
-mrr
-mrr
-mDl
-kKO
-iKC
-wwP
-pJc
-kIY
-kIY
-kIY
-kIY
-kIY
-kIY
-wZe
-fKF
-phB
-vVb
-vbG
-lUi
-jgs
-pyV
-xXi
-rSw
-cdu
-sNk
-jOV
-jOV
-yde
-fNr
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+tot
+tot
+iLF
+iLF
+iLF
+qLB
+iLF
+bXm
+hUq
+bVX
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+tot
+iLF
+iLF
+tot
+tot
+qLB
+iLF
+vhs
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+vdY
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
 gIL
 tPQ
 tPQ
 gIL
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
-gIL
-tPQ
-gIL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -69135,43 +64854,7 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -69315,64 +64998,63 @@ hRl
 "}
 (97,1,1) = {"
 hRl
-kwv
-sQo
-vbR
-iJo
-jeh
-lkQ
-hVc
-lbs
-ujm
-lbs
-lbs
-eoV
-hVc
-prE
-qHX
-btb
-qGt
-qGt
-ifw
-iqa
-iqa
-iqa
-iqa
-iqa
-iqa
-iqa
-uJK
-mHP
-kIY
-kIY
-kIY
-kIY
-kIY
-rPM
-gTr
-mrr
-ppk
-uwV
-jgs
-vSn
-jgs
-nSj
-pll
-sZG
-qAj
-hnQ
-hnQ
-yde
-fNr
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+vXl
+nJw
+tcf
+iLF
+iLF
+kyR
+iLF
+iLF
+tot
+tot
+tot
+iLF
+kyR
+kzY
+tot
+tot
+tot
+vhs
+tPQ
 gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+uIn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 gIL
 gIL
 gIL
 gIL
+tPQ
+gIL
+gIL
 gIL
 gIL
 tPQ
@@ -69388,13 +65070,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -69408,22 +65083,30 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
 orL
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -69572,65 +65255,41 @@ hRl
 "}
 (98,1,1) = {"
 hRl
-mcE
-mke
-vbR
-iJo
-jeh
-lkQ
-hVc
-lbs
-wIP
-wIP
-lbs
-rdO
-hVc
-tZD
-lYX
-aRr
-eqe
-tZD
-ifw
-qye
-bbN
-vQW
-iqa
-eKD
-eKD
-iqa
-gcp
-vJk
-qlW
-qlW
-kIY
-kIY
-rPM
-cvh
-hcp
-nrx
-dcU
-ydy
-ydy
-ydy
-yde
-yde
-yde
-yde
-sZG
-sZG
-yde
-yde
-sZG
-fNr
-fNr
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+tot
+jhX
+iLF
+kBz
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+kzY
+iLF
+iLF
+kyR
+iLF
+kBz
+iLF
+iLF
+iLF
+vhs
+tny
 gIL
 tPQ
 tPQ
@@ -69646,33 +65305,23 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+gIL
+gIL
+tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
+tPQ
+tPQ
+gIL
+gIL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -69686,8 +65335,42 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+gIL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
 orL
 tPQ
 tPQ
@@ -69829,70 +65512,70 @@ hRl
 "}
 (99,1,1) = {"
 hRl
-iNm
-mke
-onB
-iJo
-bjV
-hVc
-hVc
-lbs
-lbs
-lbs
-lbs
-acE
-hVc
-rOW
-eqe
-rOW
-rOW
-rOW
-ifw
-edi
-oXT
-oVe
-iqa
-auL
-qnB
-krF
-wmG
-vJk
-yde
-yde
-kIY
-wZe
-hDP
-mrr
-vqf
-tAT
-dcU
-ydy
-gie
-ibY
-boR
-aQG
-yde
-ygz
-sXy
-vwZ
-hov
-qeY
-sZG
-fNr
-fNr
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+jhX
+iLF
+iLF
+iLF
+iLF
+iLF
+vXl
+jQj
+iLF
+iLF
+tot
+tot
+iLF
+iLF
+jhX
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kzY
+oGF
+tny
 tPQ
-gIL
+tny
 tPQ
-gIL
-gIL
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 tPQ
+gIL
+tPQ
+gIL
+gIL
 tPQ
 tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -69903,17 +65586,7 @@ tPQ
 tPQ
 orL
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -69925,6 +65598,19 @@ tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
 orL
 tPQ
 tPQ
@@ -69938,13 +65624,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
+orL
 orL
 orL
 tPQ
@@ -70086,87 +65769,110 @@ hRl
 "}
 (100,1,1) = {"
 hRl
-gao
-cXj
-vbR
-iJo
-jeh
-hVc
-awt
-wIP
-wIP
-wIP
-lbs
-qrX
-hVc
-jGw
-ott
-isE
-jGw
-ott
-ifw
-eWR
-oXT
-lCP
-fUC
-oXT
-wzP
-krF
-wmG
-vJk
-kWU
-kWU
-kIY
-wZe
-aiy
-nrx
-tNi
-vOc
-dcU
-sZG
-wKt
-xkz
-cKP
-gie
-yde
-xhW
-sXy
-sXy
-sXy
-kZm
-sZG
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+pHG
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+tot
+tot
+iLF
+viS
+tot
+tot
+iLF
+vXl
+jQj
+iLF
+iLF
+iFp
+qxB
+iLF
+kyR
+iLF
+kyR
+kyR
+qGd
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+gIL
+gIL
+tPQ
 gIL
 gIL
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
+tPQ
+tPQ
 gIL
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -70177,29 +65883,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -70343,102 +66026,104 @@ gcX
 "}
 (101,1,1) = {"
 hRl
-pML
-lDV
-onB
-iJo
-jeh
-hVc
-lbs
-lbs
-ujm
-lbs
-lbs
-atc
-hVc
-jGw
-ott
-kzV
-jGw
-ott
-ifw
-ajs
-oXT
-qei
-iqa
-cpu
-lvH
-krF
-qSa
-vJk
-lQM
-kIY
-kIY
-kIY
-wcp
-dOM
-mrr
-nrx
-mDl
-sZG
-yde
-yde
-lmZ
-yde
-yde
-rQH
-ihO
-uMI
-sXy
-mAu
-sZG
-fNr
-fNr
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+pHG
+tot
+hId
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kzY
+iLF
+iLF
+iLF
+iLF
+bmC
+kyR
+kyR
+iLF
+iLF
+iLF
+qGd
 tPQ
 tPQ
 gIL
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
+tPQ
+gIL
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 tPQ
 orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -70451,12 +66136,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -70600,64 +66283,41 @@ vqy
 "}
 (102,1,1) = {"
 hRl
-iyZ
-mke
-vbR
-iJo
-bKI
-hVc
-lbs
-wIP
-wIP
-wIP
-lbs
-lln
-hVc
-jGw
-ott
-kzV
-jGw
-ott
-ifw
-cIm
-oXT
-oXT
-tNI
-oXT
-oXT
-krF
-wmG
-iwf
-lQM
-rbN
-kIY
-kIY
-wZe
-aiy
-crV
-crV
-dZY
-sZG
-gJk
-nWz
-sXy
-boV
-yde
-gwL
-sXy
-ihO
-sXy
-pAY
-sZG
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+iFp
+tcf
+tot
+tot
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+kyR
+iLF
+iLF
+kyR
+iLF
+iLF
+kyR
+iLF
+xHQ
+iLF
+iLF
+iLF
+iLF
+aQm
+dLV
 gIL
 gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
 gIL
 gIL
 tPQ
@@ -70676,25 +66336,17 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
+gIL
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
+gIL
+gIL
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -70703,17 +66355,48 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
+orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -70857,63 +66540,39 @@ vqy
 "}
 (103,1,1) = {"
 hRl
-bzu
-mke
-vbR
-iJo
-uiB
-hVc
-lbs
-wIP
-wIP
-wIP
-lbs
-kxa
-hVc
-pHs
-jfm
-faP
-jfm
-pHs
-ifw
-iqa
-vzp
-vzp
-iqa
-iqa
-nDA
-iqa
-gcp
-kJF
-lQM
-kIY
-kIY
-kIY
-kIY
-kgw
-jOa
-xZc
-uJK
-sZG
-qgh
-gPx
-ihO
-sXy
-kOh
-uMI
-pBB
-sXy
-kOC
-rgB
-sZG
-fNr
-fNr
-gIL
-gIL
-gIL
-tPQ
-vdY
-uIn
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+tot
+iLF
+iLF
+iLF
+hId
+tot
+sjN
+iLF
+iLF
+kyR
+iLF
+kBz
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+vXl
+tcf
 tPQ
 gIL
 gIL
@@ -70931,21 +66590,25 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-orL
+gIL
+tPQ
+gIL
+tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -70953,15 +66616,9 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
 tPQ
 orL
 tPQ
@@ -70969,6 +66626,32 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -71114,70 +66797,108 @@ vqy
 "}
 (104,1,1) = {"
 hRl
-gao
-vIQ
-tkO
-aub
-mdh
-jBm
-tru
-tru
-lQM
-wZe
-yfs
-tru
-aEh
-srI
-tru
-eUj
-tru
-bVc
-tru
-tru
-tru
-wJl
-tru
-tru
-uNE
-yfs
-wmG
-kma
-lQM
-kIY
-kIY
-kIY
-kIY
-fDY
-lZC
-ndt
-qSa
-sZG
-psq
-ihO
-pBB
-uMh
-yde
-oeO
-oeO
-vZX
-yde
-sZG
-sZG
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+kBz
+iLF
+iLF
+iLF
+kBz
+iLF
+tot
+tot
+iLF
+uJD
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+uJD
+iLF
+iLF
+tot
+tot
+iLF
+kyR
+kyR
+iLF
+iLF
+kUY
+tPQ
+tPQ
+vKu
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+uIn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
 gIL
 gIL
 gIL
 tPQ
-gIL
-gIL
-gIL
-gIL
 tPQ
 gIL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
-gIL
-tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -71189,45 +66910,7 @@ tPQ
 tPQ
 orL
 tPQ
-orL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 orL
@@ -71371,67 +67054,39 @@ blS
 "}
 (105,1,1) = {"
 hRl
-sHW
-klQ
-lUv
-dwQ
-mdh
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-rUy
-rUy
-avK
-avK
-avK
-avK
-rUy
-rUy
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-rUy
-rUy
-avK
-avK
-bGv
-sZG
-sZG
-oeO
-oeO
-sZG
-sZG
-wJl
-tru
-vYz
-fKF
-jVv
-fNr
-fNr
-fNr
-fNr
-fNr
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+uxV
+kyR
+iOs
+iLF
+iLF
+iLF
+tot
+hId
+aQm
+bVX
+kzY
+iLF
+iLF
+iLF
+iLF
+tot
+vXl
+qxB
+iLF
+viS
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+jhG
 tPQ
 gIL
 gIL
@@ -71440,42 +67095,29 @@ tPQ
 tPQ
 tPQ
 tPQ
+vdY
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 orL
+gIL
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
+gIL
 orL
 tPQ
 tPQ
@@ -71484,7 +67126,48 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -71628,64 +67311,67 @@ vqy
 "}
 (106,1,1) = {"
 hRl
-jqA
-klQ
-tkO
-aub
-hWI
-gIm
-gIm
-gIm
-nZK
-gIm
-gIm
-gIm
-bKF
-gIm
-gIm
-gIm
-gIm
-nZK
-iEq
-iEq
-bKF
-gIm
-gIm
-bKF
-gIm
-nZK
-gIm
-gIm
-gIm
-nZK
-gIm
-gIm
-gIm
-gIm
-gIm
-ekg
-nRM
-tru
-wJl
-tru
-tru
-bVc
-tru
-bVc
-lXh
-vYz
-hcp
-tdE
-fNr
-fNr
-fNr
-fNr
-fNr
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+tot
+tot
+vXl
+bVX
+iLF
+pJw
+iLF
+kyR
+iLF
+tot
+tot
+xSl
+iLF
+kyR
+tot
+jhX
+iLF
+kyR
+iLF
+iLF
+jhG
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
 tPQ
-gIL
-gIL
 tPQ
 gIL
 gIL
@@ -71694,47 +67380,44 @@ tPQ
 gIL
 tPQ
 tPQ
-orL
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
-tPQ
-tPQ
+gIL
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
+orL
+gIL
 tPQ
+orL
+orL
 tPQ
-tPQ
-tPQ
+orL
+orL
 tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -71885,83 +67568,113 @@ vqy
 "}
 (107,1,1) = {"
 hRl
-jqA
-klQ
-veJ
-mLI
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-rPr
-nxO
-nxO
-nxO
-nxO
-nxO
-rPr
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-iUe
-ftw
-uQt
-nRM
-fdd
-fdd
-fdd
-fdd
-kMK
-fdd
-kID
-qdr
-wZe
-tZu
-pll
-pll
-kwQ
-vyX
-vyX
-fNr
-dQQ
+tot
+tot
+tot
+tot
+tot
+tot
+qLB
+kyR
+jhX
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+pDU
+qLB
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+pHG
+iLF
+iLF
+kyR
+iLF
+jhG
+nza
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 gIL
 gIL
-gIL
-gIL
-tPQ
-gIL
 tPQ
 gIL
 gIL
 tPQ
 tPQ
+gIL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+orL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
 tPQ
@@ -71969,36 +67682,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
 orL
 orL
 orL
@@ -72142,69 +67825,41 @@ vqy
 "}
 (108,1,1) = {"
 hRl
-jqA
-klQ
-cIE
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-wfI
-eLP
-rLl
-mdh
-klQ
-kun
-jfA
-jfA
-jfA
-jfA
-jfA
-jfA
-jfA
-gCD
-kMK
-dlN
-kMK
-dlN
-aAs
-hAL
-fNr
-dQQ
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+pHG
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+kyR
+iLF
+iLF
+kyR
+iLF
+iLF
+uFd
+jQj
+iLF
+iLF
+iLF
+iLF
+vhs
 tPQ
-wdk
-biy
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 gIL
 tPQ
@@ -72216,45 +67871,73 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+orL
+tPQ
+orL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
 orL
 orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-orL
-tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -72399,69 +68082,41 @@ gcX
 "}
 (109,1,1) = {"
 hRl
-jqA
-lVZ
-avK
-avK
-lel
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-lel
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-lel
-avK
-avK
-avK
-avK
-avK
-avK
-lel
-avK
-avK
-avK
-avK
-usv
-aqT
-rce
-mcT
-klQ
-utH
-jfA
-jmQ
-jfA
-uAH
-jfA
-wvd
-jfA
-anM
-qez
-pll
-xLP
-tru
-vyX
-jmV
-fNr
-gIL
-gIL
-gIL
-ngx
-lYs
-biy
-gIL
-gIL
-gIL
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+pDU
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+tot
+aQm
+dLV
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+hDw
 tPQ
 gIL
 tPQ
@@ -72471,8 +68126,43 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+gIL
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -72480,16 +68170,10 @@ tPQ
 tPQ
 tPQ
 tPQ
+gIL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -72503,15 +68187,14 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -72656,119 +68339,119 @@ hRl
 "}
 (110,1,1) = {"
 hRl
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-wVC
-wVC
-gIm
-gIm
-gIm
-gIm
-wVC
-gIm
-wVC
-gIm
-gIm
-gIm
-gDe
-nRM
-rHb
-rce
-mdh
-xOu
-wmG
-jfA
-fFk
-wxa
-uAH
-hUc
-uAH
-jfA
-lZC
-hcp
-fPh
-vyX
-vyX
-vyX
-aha
-fNr
-fNr
-fNr
-fNr
-fNr
-vxh
-rpU
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+iLF
+tot
+vXl
+tcf
+iLF
+kzY
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+kzY
+iLF
+iLF
+iLF
+aPu
+iLF
+kUY
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
+tPQ
+tPQ
+tPQ
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
 gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-orL
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -72913,97 +68596,85 @@ hRl
 "}
 (111,1,1) = {"
 hRl
-utH
-lCk
-pll
-pll
-pll
-fVx
-pll
-dpV
-pll
-pll
-mdK
-pll
-pll
-kMK
-pxB
-gao
-ndt
-pll
-wmG
-vOY
-vOY
-vOY
-vOY
-vOY
-vOY
-vOY
-vOY
-qOI
-xow
-pll
-dpV
-mdh
-etn
-aqT
-rce
-mdh
-cxU
-wmG
-jfA
-beC
-jfA
-tlW
-jfA
-jfA
-jfA
-ndt
-kJF
-lZC
-wKw
-gfa
-hAh
-xMx
-kKR
-iLC
-iLC
-vyX
-fNr
-cFi
-rpU
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+hId
+tot
+kyR
+iLF
+iLF
+iLF
+jhX
+hId
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+mdD
+swG
+kUY
+vvT
+qFL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 gIL
 gIL
-tPQ
 gIL
 gIL
+gIL
 tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
+gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-orL
 tPQ
-orL
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -73012,11 +68683,15 @@ tPQ
 tPQ
 orL
 tPQ
-orL
 tPQ
-orL
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -73026,6 +68701,14 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -73170,119 +68853,119 @@ hRl
 "}
 (112,1,1) = {"
 hRl
-wmG
-ndt
-mdK
-pll
-fgh
-kIY
-kgw
-kgw
-kgw
-kgw
-kgw
-kgw
-kgw
-kIY
-pxB
-gao
-fKF
-aiU
-utH
-vOY
-hNT
-frB
-pSy
-qjB
-wuq
-wuq
-ceh
-vOY
-qSa
-pll
-pll
-mdh
-nRM
-rHb
-rJa
-mdh
-etn
-wmG
-nMc
-nMc
-jfA
-uAH
-hUc
-wvd
-jfA
-ssY
-mrr
-qez
-wKw
-qXh
-eYu
-ozY
-vyX
-iLC
-iLC
-vyX
-fNr
-rDY
-rpU
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+tot
+tot
+iLF
+kyR
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+vXl
+jQj
+iLF
+iLF
+kBz
+iLF
+iLF
+kyR
+iLF
+iLF
+swG
+liz
+swG
+tot
+iLF
+uUn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+uIn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 gIL
 gIL
+gIL
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 gIL
-gIL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 orL
@@ -73427,73 +69110,73 @@ hRl
 "}
 (113,1,1) = {"
 hRl
-vSN
-tru
-yfs
-tru
-lQM
-kIY
-kIY
-kIY
-kIY
-wZe
-tru
-tru
-wuZ
-dqa
-olP
-pll
-hMT
-tdE
-wmG
-vOY
-xBn
-qxf
-wmH
-ueL
-ueL
-ueL
-tlo
-vOY
-wmG
-pll
-ojx
-mdh
-klQ
-aqT
-rJa
-mdh
-klQ
-qSa
-nMc
-eHl
-hvb
-uAH
-jfA
-jfA
-jfA
-crV
-hcp
-pxj
-vyX
-vyX
-vyX
-vyX
-vyX
-iLC
-iLC
-vyX
-fNr
-rDY
-qHI
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+iLF
+kyR
+iLF
+tot
+iLF
+vhs
+tPQ
+tPQ
+tPQ
+tPQ
+vdY
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+uIn
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 xTy
 tPQ
 gIL
 gIL
 gIL
-tPQ
 gIL
 gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -73531,15 +69214,15 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 tPQ
 tPQ
@@ -73684,71 +69367,71 @@ hRl
 "}
 (114,1,1) = {"
 hRl
-hVc
-xgZ
-xgZ
-hVc
-tHs
-qfR
-pwx
-hVc
-xgZ
-xgZ
-hVc
-tru
-haJ
-iYx
-gje
-wmG
-tru
-tru
-qIG
-vOY
-rmI
-xPV
-fft
-ueL
-vfd
-wuq
-vqW
-vOY
-wmG
-ndt
-pll
-mdh
-klQ
-aqT
-rJa
-mdh
-klQ
-wmG
-nMc
-qKJ
-uAH
-uAH
-uAH
-tvw
-jfA
-lZC
-gTr
-dcU
-wKw
-nEI
-xzN
-xlV
-gpx
-iLC
-iLC
-vyX
-fNr
-ngx
-bci
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+kyR
+iLF
+iLF
+tot
+tot
+aQm
+dLV
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+tot
+tot
+tot
+qLB
+iLF
+gzw
+cmv
+bUp
+iLF
+iLF
+kyR
+iLF
+tot
+tot
+vhs
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+vdY
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 gIL
 gIL
 gIL
-tPQ
+gIL
 gIL
 gIL
 tPQ
@@ -73941,64 +69624,64 @@ hRl
 "}
 (115,1,1) = {"
 hRl
-hVc
-lje
-ybW
-tRA
-ybW
-ybW
-ybW
-gTE
-mzj
-oKm
-hVc
-hVc
-xow
-iXY
-gje
-sgl
-vOY
-vOY
-vOY
-vOY
-fft
-jeH
-ueL
-ueL
-vOY
-hdy
-fft
-vOY
-lxX
-pll
-exd
-wbp
-klQ
-aqT
-rce
-mdh
-nRM
-utH
-nMc
-thJ
-uAH
-uAH
-uAH
-tvw
-jfA
-dAg
-hcp
-dcU
-wKw
-jJj
-hjk
-bcf
-iLC
-xqu
-iLC
-vyX
-fNr
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+kzY
+iLF
+kyR
+kBz
+iLF
+hId
+tot
+vXl
+tcf
+iLF
+iLF
+kyR
+iLF
+iLF
+iLF
+iLF
+iLF
+kzY
+tot
+tot
+iLF
+iLF
+bmC
+iLF
+viS
+iLF
+iLF
+bXm
+cmv
+jQj
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -74198,64 +69881,64 @@ hRl
 "}
 (116,1,1) = {"
 hRl
-hVc
-bHK
-ybW
-ybW
-ybW
-ybW
-hmh
-ybW
-ybW
-ybW
-bQl
-xgZ
-lCU
-iXY
-gje
-wmG
-ogc
-maY
-cNZ
-qlE
-vOY
-vOY
-kQs
-vOY
-vOY
-rtz
-rpW
-vOY
-hKg
-uLU
-cAt
-aHM
-cwC
-aqT
-rJa
-mdh
-rEv
-suy
-jfA
-jfA
-aUg
-aUg
-jfA
-jfA
-jfA
-lZC
-qWI
-mQX
-wKw
-lCl
-kkM
-iLC
-iLC
-iLC
-gKS
-vyX
-fNr
-gIL
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+iLF
+iLF
+kyR
+iLF
+tot
+tot
+tot
+tot
+tot
+tot
+gqz
+iLF
+iLF
+iLF
+iLF
+tot
+tot
+tot
+tot
+tot
+tot
+xHQ
+iLF
+iLF
+iLF
+iLF
+vXl
+tcf
+tot
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -74455,64 +70138,64 @@ hRl
 "}
 (117,1,1) = {"
 hRl
-hVc
-jfc
-ybW
-ybW
-hmh
-hmh
-hmh
-ybW
-ybW
-ybW
-qBj
-xgZ
-iQJ
-rGC
-dAH
-utH
-ogc
-dJE
-mTe
-mTe
-vOY
-nLi
-ueL
-cgZ
-vOY
-vuQ
-sMp
-vOY
-suy
-pll
-pll
-yde
-lUl
-rpa
-rJa
-mdh
-twx
-oQS
-aUg
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tot
+tot
+tot
+tot
+tot
+kXC
+kXC
+cvh
+tHN
+tHN
 rVG
-rVG
-rVG
-rVG
-pUR
-jfA
-vyX
-vyX
-sPE
-vyX
-vyX
-vyX
-gaA
-iLC
-iLC
-iLC
-vyX
-fNr
-gIL
+tHN
+tHN
+tHN
+tHN
+tHN
+tHN
+qez
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -74712,67 +70395,67 @@ hRl
 "}
 (118,1,1) = {"
 hRl
-hVc
-iyT
-ybW
-ybW
-hmh
-hmh
-ybW
-ybW
-ybW
-ybW
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
 bQl
-xgZ
+kOC
 lCU
 bgN
-dlN
-dlN
-byb
-mTe
-mTe
-mTe
-byb
-ueL
-ueL
-wuq
-vOY
-vOY
-fft
-vOY
-fKF
-tCf
-rzn
-yde
-ygf
-rHb
-rJa
-mdh
-bgu
-oII
-ied
-rVG
-rVG
-rVG
-rVG
-pUR
-jfA
-vyX
-jhh
-iLq
-lna
-xVN
-vyX
-gaA
-iLC
-iLC
-iLC
-vyX
-fNr
-gIL
-gIL
-vdY
-uIn
+hRl
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+kXC
+kXC
+gTr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+dcU
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 gIL
@@ -74969,65 +70652,65 @@ hRl
 "}
 (119,1,1) = {"
 hRl
-hVc
-jUA
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-mzj
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 oKm
-hVc
-hVc
+nEI
+kzV
 uGn
 oZJ
-gje
-iQJ
-vOY
-afZ
-mTe
-jzg
-vOY
-weC
-frB
-wuq
-vFa
-ueL
-wRR
-vOY
-oiX
-mRh
-jed
+tUj
+hRl
+hRl
+hRl
+hRl
 yde
-ygf
-aqT
-rJa
-mdh
-ccQ
-itb
-jfA
-qGQ
-rVG
-rVG
-aRi
-aRi
-jfA
-vyX
-fTO
-ihO
-bzc
-rtp
-vyX
-mHx
-iLC
-iLC
-iLC
-vyX
-fNr
-gIL
-gIL
+mdK
+weC
+hBU
+fXH
+fXH
+yde
+yde
+yde
+yde
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+kXC
+kXC
+gTr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+dcU
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 gIL
@@ -75226,64 +70909,64 @@ hRl
 "}
 (120,1,1) = {"
 hRl
-hVc
-tKS
-ybW
-ybW
-ahq
-egn
-iOa
-ybW
-rBV
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 uyW
 nOU
 hVc
-lCU
+jiy
 uYT
 cgk
-oRJ
-vOY
-rDQ
-mTe
-jzg
-vOY
-pdv
-ueL
-frB
-jLW
-ueL
-wuq
-vOY
-qWI
-mzO
-uVl
+hRl
+hRl
+hRl
+hRl
 yde
-ghS
+wcp
+jEY
+mYB
+jEY
+jLW
+ygM
+xoK
+qBj
+yde
+yde
+yde
+yde
+yde
 rHb
-rce
-mdh
-cxU
-utH
+yde
+yde
+kXC
+kXC
 tPe
-atg
-atg
-atg
-atg
-atg
-jfA
-vyX
-mdo
-ihO
-sXy
-ihO
-aha
-iLC
-iLC
-iLC
-iLC
-vyX
-fNr
-gIL
+crV
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+mrr
+dcU
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 gIL
 tPQ
@@ -75483,64 +71166,64 @@ hRl
 "}
 (121,1,1) = {"
 hRl
-ppc
-nKa
-ybW
-ybW
-vNr
-pAP
-quI
-ybW
-hUu
-hUu
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+qjn
 iUQ
-xgZ
-lCU
+xlV
+lbD
 xOW
-wmG
-qSa
-vOY
-cWl
-asT
-bjJ
-vOY
+oFe
+hRl
+hRl
+hRl
+hRl
+yde
+aHM
 mYB
-ueL
-frB
-rBg
+jEY
+jEY
+jEY
 kIc
 xoK
-vOY
-vOY
-vOY
-vOY
+pQh
 yde
-kFU
+nku
+wmG
+wmG
+vFW
 bFG
-rce
-mdh
-xOu
-rWf
+vFW
+nwr
+pll
+pll
+pll
+pll
 tPe
-atg
-atg
-atg
+mrr
 mWc
 atg
-jfA
-vyX
-gJk
-sXy
+mrr
+mrr
+crV
+crV
 gBt
-flc
-vyX
-gpx
-iLC
-iLC
-gKS
-vyX
-fNr
-fDY
+kXC
+kXC
+pll
+pll
+pll
+pll
+iir
+iir
+pll
 pll
 fDY
 pll
@@ -75740,65 +71423,65 @@ hRl
 "}
 (122,1,1) = {"
 hRl
-hVc
-cLc
-ybW
-ybW
-jOM
-oms
-moZ
-ybW
-hUu
-hUu
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+gdU
 lNX
-xgZ
+rbr
 iQJ
 nZa
-wmG
-vOY
-vOY
-vOY
-fft
-fft
-vOY
-qRl
-frB
+vVb
+hRl
+hRl
+hRl
+hRl
+yde
+hUc
+jEY
+jEY
 ueL
-drL
+jEY
+jEY
 kIc
-wuq
-jtS
-nDn
+gKS
+yde
 wze
 wmG
-his
+wmG
 vFW
-rHb
-rce
-mdh
-klQ
-vSN
-tPe
-vAD
-atg
-atg
-atg
-atg
-jfA
-vyX
-gJk
-sXy
-gOj
-ecy
-vyX
-pIg
-iLC
-iLC
-iLC
-vyX
-fNr
-fDY
+aqT
+vFW
+nwr
 pll
+pll
+pll
+pll
+pll
+tPe
+uQt
+bKo
+crV
+tdE
+pll
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+iir
+pll
+iir
+fDY
+fDY
 fDY
 pll
 fDY
@@ -75997,65 +71680,65 @@ hRl
 "}
 (123,1,1) = {"
 hRl
-hVc
-jiy
-ybW
-ybW
-jOM
-oms
-moZ
-ybW
-hUu
-hUu
-hps
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+xOW
 xgZ
-lCU
+wZe
 gCf
-wmG
-vOY
-rLL
-msP
-xtY
-eRs
-vOY
+hRl
+hRl
+hRl
+hRl
+hRl
+yde
+qgh
 jEY
-jMH
-mHJ
+jEY
+jEY
 xGF
-kIc
-ueL
-abR
-cLp
-wze
-utH
-mdh
-klQ
-rHb
-rce
-mdh
-klQ
-wmS
-jfA
-atg
-atg
-xXJ
-atg
-atg
-jfA
-vyX
-vyX
-vyX
-vyX
-qjn
-vyX
-hng
+jEY
+jEY
+jEY
+yde
+gah
+wmG
+wmG
+aBY
+aqT
+vFW
+nwr
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+kXC
+kXC
+ndt
 iLC
-iLC
-iLC
-vyX
-fNr
+pll
 fDY
-fDY
+pll
+pll
+pll
+pll
 fDY
 pll
 fDY
@@ -76254,64 +71937,64 @@ hRl
 "}
 (124,1,1) = {"
 hRl
-hVc
-rJd
-xju
-ybW
-lxW
-ryH
-rHz
-ybW
-hUu
-hUu
-hUu
-hVc
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+rGC
+gcp
 gcp
 ogq
+tEZ
+hRl
+hRl
+hRl
+hRl
+yde
+yde
+wse
+wse
+wse
+yde
+wXv
+yde
+yde
+yde
+puy
 wmG
-vOY
-gyr
-gyr
-fpl
-fpl
-vOY
-kIc
-kIc
-kIc
-kIc
-ueL
-ueL
-dgU
-eVf
-wze
-iQJ
-mdh
-klQ
-rHb
-rce
-mdh
-klQ
-wmS
-jfA
-jfA
-jfA
-jfA
-jfA
-jfA
-jfA
-fNr
-fNr
-fNr
-vyX
-vyX
-vyX
-vyX
-vyX
-vyX
-vyX
-vyX
-fNr
+wmG
+vFW
+aqT
+vFW
+nwr
+pll
+pll
+iir
+iir
+pll
+pll
+pll
+pll
+pll
 fDY
+fDY
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+fDY
+pll
+pll
+pll
 pll
 fDY
 fDY
@@ -76511,66 +72194,66 @@ hRl
 "}
 (125,1,1) = {"
 hRl
-hVc
-aSe
-aSe
-ybW
-lbD
-whm
-lbD
-ybW
-woy
-cqF
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
 ylm
-hVc
-hVc
-giQ
-wmG
-vOY
+lQh
+lQh
+lQh
+vIQ
+hRl
 rLL
-msP
-ctu
+hRl
+hRl
 fpl
 xpO
-ueL
-wuq
-ueL
-ueL
-ueL
-bGM
-wuq
-xuF
-vOY
-jnu
-mdh
-klQ
-rHb
-rce
-mdh
-klQ
-rbC
-kse
-kse
-eir
-kse
-fNr
-fNr
-fNr
-cnK
-cnK
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-fNr
-ndt
-mXo
+jmQ
+jmQ
+jmQ
+tDR
+lQh
+fft
+boV
+yde
+kMz
+wmG
+wmG
+aBY
+bFG
+vFW
+nwr
+pll
+pll
+pll
+iir
+fDY
+fDY
+fDY
+fDY
+iir
+iir
+fDY
+iir
+pll
+kXC
+kXC
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+fDY
 pll
 fDY
 fDY
@@ -76768,65 +72451,65 @@ hRl
 "}
 (126,1,1) = {"
 hRl
-hVc
-mvw
-tzX
-ybW
-ybW
-ybW
-ybW
-ybW
-hmh
-ybW
-ybW
-ybW
-qfR
-xDs
-gcp
-vOY
-vOY
-vOY
-xPV
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+rzn
+lQh
+lQh
+lQh
+lQh
+nVE
+lQh
+pwc
+hRl
 fft
-fft
+lQh
 snD
-ueL
-kIc
-kIc
-frB
-ueL
-wuq
+snD
+snD
+lQh
+lQh
+lQh
+lQh
 jjT
-vOY
-aFQ
-mdh
-klQ
-rHb
-rce
-mdh
-lVZ
-avK
-avK
-avK
-rUy
-rUy
-fNr
-oor
-avK
-avK
-iRT
-avK
-avK
-avK
-avK
-avK
-avK
-pKj
-iRT
-avK
-avK
-avK
-avK
+wmG
+wmG
+wmG
+vFW
+aqT
+vFW
+nwr
+pll
+pll
+pll
+iir
+iir
+fDY
+fDY
+pll
+fDY
+pll
+fDY
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+pll
+iir
+pll
+pll
+iir
 avK
 avK
 avK
@@ -77025,65 +72708,65 @@ gcX
 "}
 (127,1,1) = {"
 hRl
-hVc
-bPn
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
 ybW
 hmh
-qfR
-lQM
-nOT
-vOY
-byj
-cZU
-koP
-bqx
-vOY
+hmh
+hmh
+lQh
+lQh
+lQh
+mDl
+hRl
+lQh
+vyo
 tuk
 mnA
-mnA
+gPx
 lsj
-elX
-ueL
+lQh
+lQh
 jtS
-nDn
-wze
-lCU
-mdh
-klQ
-rHb
-rce
+yde
+vsv
+wmG
+wmG
+aBY
+aqT
+vFW
 nwr
-gIm
-gIm
-bKF
-bKF
-gIm
-gIm
-nVE
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-bKF
-qnf
-gIm
-gIm
-gIm
-gIm
-gIm
+pll
+pll
+pll
+pll
+iir
+fDY
+fDY
+pll
+fDY
+fDY
+fDY
+fDY
+pll
+kXC
+kXC
+pll
+pll
+pll
+iir
+pll
+pll
+iir
+iir
 gIm
 gIm
 gIm
@@ -77282,65 +72965,65 @@ vqy
 "}
 (128,1,1) = {"
 hRl
-hVc
-lQN
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
-ybW
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
 azm
 vaO
 fKN
-wZe
-vOY
-pwc
-cZU
+hRl
+mHP
+lQh
+qQQ
 koP
-epk
+lon
 nBt
 fef
-oIz
-toG
+nPS
+nPS
 sHE
 elX
-frB
+lQh
 abR
-cLp
-wze
-rKs
-mdh
-klQ
+yde
+iUe
+wmG
+wmG
+vFW
 aqT
-mLI
-mLI
-tLM
-mLI
-uWY
-mLI
-uWY
-tLM
-uWY
-uWY
-uWY
-uWY
-mLI
-uWY
-uWY
-kfv
-nDh
-mLI
-mLI
-uWY
-kfv
-kfv
-uWY
-uWY
-uWY
+vFW
+nwr
+pll
+pll
+pll
+pll
+iir
+fDY
+fDY
+pll
+pll
+fDY
+pll
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+pll
+fDY
+iir
+fDY
+fDY
 uWY
 uWY
 uWY
@@ -77538,66 +73221,66 @@ xMS
 vqy
 "}
 (129,1,1) = {"
-wHT
-mzT
-aul
-jAP
-rvE
-eGh
-aul
-dyo
-rvE
-jAP
-aul
-jAP
-aul
-wHT
-lQM
-wZe
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
 vOY
-eXe
-hNR
-cZU
+lQh
+qQQ
+koP
 lon
-vOY
+hMT
 gLd
-gLd
-gLd
+nPS
+oMQ
 okY
-elX
-ueL
+dmP
+lQh
 thp
-kwu
-vOY
-xGp
-mdh
-klQ
-rHb
-uWY
-mLI
-hkV
-mLI
-mLI
-cNK
-mLI
-tLM
-uWY
-uWY
-uWY
-uWY
-uWY
-cNK
-uWY
-mLI
-tLM
-kfv
-lxk
-uWY
-mLI
-mLI
-mLI
-mLI
-mLI
+yde
+vAD
+wmG
+wmG
+vFW
+wIP
+vFW
+nwr
+pll
+pll
+pll
+pll
+iir
+pll
+fDY
+pll
+pll
+fDY
+pll
+pll
+pll
+kXC
+kXC
+pll
+iir
+iir
+pll
+iir
+iir
+fDY
+fDY
 mLI
 uWY
 uWY
@@ -77795,66 +73478,66 @@ xMS
 vqy
 "}
 (130,1,1) = {"
-qps
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-wHT
-lah
-wZe
-vOY
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+mTe
 eXe
 hNR
+hRl
 cZU
-cZU
-vOY
-xyl
-ueL
-kIc
-kIc
-frB
-wuq
-ueL
-wuq
-mlo
-nHr
-dsp
-klQ
-rHb
-uWY
-kTZ
-tLM
-mLI
-mLI
-mLI
-kfv
-nDh
-fNr
-wdM
-uMA
-kfv
-uWY
-kfv
-uWY
-mLI
-nDh
-kfv
-cQs
-iVQ
-gbc
-gbc
-iVQ
-iVQ
-iVQ
+hRl
+hRl
+dlN
+hRl
+hRl
+icf
+lQh
+yde
+yde
+yde
+yde
+yde
+yde
+fhn
+yde
+yde
+eHl
+pll
+pll
+pll
+iir
+iir
+pll
+pll
+pll
+fDY
+iir
+pll
+pll
+kXC
+kXC
+fDY
+iir
+pll
+iir
+pll
+pll
+fDY
+pll
 udg
 uyU
 cQs
@@ -78052,66 +73735,66 @@ sCx
 blS
 "}
 (131,1,1) = {"
-qps
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-wHT
-lQM
-wZe
-vOY
-uHp
-cZU
-cZU
-cZU
-bBH
-wuq
-ueL
-frB
-frB
-ueL
-ueL
-ueL
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+lQh
+yde
 wuq
 vFa
 nHr
-gDe
-klQ
-rHb
-mLI
-uWY
-cNK
-kfv
-uWY
-kfv
-hrr
-tLM
-wse
-mLI
-mLI
-mLI
-uWY
-mLI
-uWY
-uWY
-nDh
-kfv
-uWY
-uWY
-ulJ
-hrr
-uWY
-uWY
-uWY
+yde
+tot
+tZD
+tot
+tot
+mnq
+pll
+pll
+pll
+pll
+pll
+fDY
+pll
+iir
+fDY
+iir
+pll
+pll
+kXC
+kXC
+pll
+iir
+pll
+pll
+pll
+pll
+pll
+pll
 lxk
 kfv
 mLI
@@ -78309,66 +73992,66 @@ xMS
 vqy
 "}
 (132,1,1) = {"
-qps
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-wHT
-lQM
-xLY
-vOY
-bqx
-udy
-eKM
-bqx
-fft
-cUd
-mln
-pTm
-izz
-pBs
-ueL
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+qNK
+kcx
+qNK
+qNK
+qNK
+qNK
+qNK
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hZf
+hRl
+lQh
 jZR
-qFz
-vOY
+jVv
+jVv
 qvh
-mdh
-klQ
-rHb
-mLI
-vDt
-tLM
-iIp
-vDt
-vDt
-iIp
-vDt
-vDt
-iIp
-vDt
-vDt
-iIp
-cNK
-iIp
-iIp
-iIp
-iIp
-iIp
-iIp
-iIp
-vDt
-vDt
-iIp
-vDt
+yde
+tot
+tot
+tot
+tot
+qye
+eHl
+pll
+pll
+iir
+pll
+fDY
+pll
+iir
+fDY
+iir
+pll
+pll
+kXC
+kXC
+iir
+pll
+fDY
+pll
+pll
+pll
+pll
+pll
 iIp
 iIp
 pLg
@@ -78566,66 +74249,66 @@ ucK
 vqy
 "}
 (133,1,1) = {"
-qps
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-wHT
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+kcx
+tZM
 lQM
-wZe
-vOY
-vOY
-vOY
-vOY
-vOY
-vOY
-fft
-fft
-qZI
-qZI
-qZI
-qZI
-vOY
-vOY
-vOY
+wHT
+fsE
+eVF
+qNK
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hZf
+hRl
+lQh
+yde
+lzG
+jVv
 fTf
-mdh
-klQ
-rHb
-rLl
-vlD
-avK
-avK
-avK
-avK
-avK
-avK
-spU
-iRT
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
+yde
+yde
+yde
+yde
+tot
+qye
+eHl
+pll
+pll
+iir
+pll
+fDY
+pll
+fDY
+fDY
+iir
+pll
+pll
+kXC
+kXC
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+pll
+pll
 avK
 avK
 avK
@@ -78823,67 +74506,67 @@ nrf
 vqy
 "}
 (134,1,1) = {"
-qps
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-peg
-wHT
-tiJ
-nOT
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+kcx
+bJk
+jRP
+tBH
+tBH
+jRP
+kcx
+qNK
+qNK
+uKk
+uKk
+uKk
+kcx
+uKk
+qNK
+hRl
+hRl
+lQh
 yde
-qQB
-nWC
-sYT
-sri
 yde
-tru
-cNI
-tru
-bVc
-tru
-tru
-tru
-yfs
-tru
-tru
-mdh
-klQ
-rHb
-rLl
-mdh
-isS
-bKF
-bKF
-bKF
-bKF
-bKF
+jZR
+yde
+yde
+wdM
+haJ
+yde
+yde
+yde
+yde
+pll
+pll
+iir
+pll
+fDY
+pll
+iir
+pll
+iir
+pll
+fDY
 kXC
-xZl
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
+kXC
+ndt
+iLC
+iir
+iir
+iir
+iir
+iir
+iir
+iir
 gIm
 gIm
 gIm
@@ -79080,74 +74763,109 @@ gcX
 gcX
 "}
 (135,1,1) = {"
-qps
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-iaR
-wHT
-jxi
-wZe
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+uKk
+eip
+tBH
+tBH
+tBH
+lsq
+eYt
+kGP
+sKy
+jkD
+jkD
+iIr
+cnN
+aBX
+qNK
+hRl
+hRl
+lQh
 yde
-qCp
-aMU
-aMU
-aMU
-hBy
-dlN
-wcp
-pll
-pll
-hcp
-rWC
-tHN
-tHN
+vfa
 jVv
-pll
-mdh
-klQ
-rHb
+lUl
+vad
+jVv
+jVv
 rJa
-mdh
-klQ
+ute
+hTc
 eay
-aiU
-pGm
-lXA
-hDS
-nqx
-ePP
-fNr
-cnK
-fNr
-mbZ
-mbZ
-rPR
-acd
-uJe
-acd
-mFU
-mbZ
-mbZ
-mbZ
-mbZ
-tJq
-mXo
+pll
+pll
+iir
+pll
+fDY
+pll
+iir
+pll
+iir
+fDY
+fDY
+fDY
+pll
+pll
+iir
+fDY
+fDY
+fDY
+pll
 pll
 pll
 fDY
 pll
 pll
 fDY
-fDY
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 pll
 pll
 pll
@@ -79158,41 +74876,6 @@ pll
 pll
 pll
 iir
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
 pll
 pll
 pll
@@ -79337,90 +75020,90 @@ mDA
 hRl
 "}
 (136,1,1) = {"
-qps
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+qNK
 peg
-peg
-peg
-peg
-peg
-peg
-lzy
-peg
-peg
-peg
-peg
-peg
-wHT
-fhn
-lqr
+tBH
+tBH
+tBH
+tBH
+pIl
+jkD
+jkD
+sKy
+jkD
+sHQ
+oMM
+tRQ
+qNK
+hRl
+hRl
+lQh
 yde
-jas
-aMU
-aMU
-tXS
-yde
-lCU
-xOW
-tlI
-qzf
-xRq
-mrr
-jMc
 tAT
-tdE
-kSI
-mdh
-klQ
-rHb
-rJa
-mdh
-klQ
+jVv
+jVv
+jVv
+jVv
+uRH
+yde
+kxa
+tfB
 jeE
-nLy
-dcU
-gla
-kMK
-sfS
-obh
-fNr
-fNr
-fNr
-mbZ
-pgU
-qbQ
-afY
-czD
-xlf
-xlf
-xlf
-lvG
-aST
-rPR
-pll
-fDY
-fDY
-fDY
-fDY
-pll
-fDY
-fDY
-pll
-pll
 pll
 pll
 iir
 pll
-pll
-pll
-pll
+fDY
 pll
 iir
-iir
-pll
-pll
-pll
 pll
 iir
+fDY
+fDY
+pll
+pll
+pll
+fDY
+pll
+pll
+pll
+fDY
+fDY
+pll
+fDY
+fDY
+fDY
+fDY
+pll
+fDY
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 pll
 pll
 pll
@@ -79594,69 +75277,60 @@ aGs
 hRl
 "}
 (137,1,1) = {"
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-bpm
-ciA
-wZe
-yde
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+kcx
+ykZ
+emo
+stz
+stz
+stz
+qNK
 def
-uIt
-bKo
-ptC
-uQa
-wfv
-xOW
-pll
-njY
-tAT
-aiR
-xRq
+umG
+sKy
+qrG
+sHQ
+oMM
+waI
+qNK
+hRl
+hRl
+lQh
+yde
 hcp
-tlI
+jVv
+fUk
+jVv
+jVv
+tiJ
+yde
+yde
+yde
+yde
 pll
-mdh
-klQ
-rHb
-rLl
-mdh
-klQ
-vRH
-thg
-eHy
-rTM
-xnv
-inV
-eRa
-fNr
-fNr
-fNr
-mbZ
-bIG
-hUu
-afY
-czD
-xlf
-aST
-xlf
-xlf
-xlf
-rPR
+pll
 pll
 pll
 fDY
+pll
+iir
 fDY
+fDY
+fDY
+fDY
+pll
+pll
+fDY
+pll
 pll
 fDY
 fDY
@@ -79664,48 +75338,57 @@ fDY
 fDY
 pll
 pll
+fDY
+fDY
+pll
+fDY
+fDY
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 pll
 iir
-pll
-pll
-pll
-pll
-iir
-pll
-iir
-pll
-pll
-pll
-pll
-iir
-iir
-iir
-pll
-iir
-pll
-iir
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
-pll
 pll
 pll
 pll
@@ -79852,64 +75535,64 @@ hRl
 "}
 (138,1,1) = {"
 hRl
-apm
-kcx
-hTd
-hTd
-hTd
-hTd
-hTd
-hTd
-hTd
-opB
-hTd
-soW
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 qNK
-tGZ
-gmg
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+phB
+sKy
+sKy
+wDu
+sHQ
+oMM
+egN
+qNK
+hRl
+hRl
+snD
 yde
 yde
+jVv
+eam
+jVv
+jVv
+auL
 yde
+xzN
+qjB
 yde
-yde
-yde
-lCU
-xOW
 pll
-gXv
-hcp
-crV
-gws
-nwh
 pll
 pll
-mdh
-klQ
-rHb
-rJa
-mdh
-klQ
-xZc
-wla
-xZc
-kMX
-exu
-kMX
-dOt
-fNr
-fNr
-fNr
-acd
-hUu
-hUu
-afY
-xlf
-xlf
-xlf
-xlf
-xlf
-rpz
-uJe
+pll
+fDY
+pll
+fDY
+fDY
+fDY
+pll
+fDY
+pll
+fDY
+pll
+pll
+pll
+iir
+iir
+fDY
+fDY
 pll
 pll
 fDY
@@ -79917,42 +75600,42 @@ pll
 pll
 fDY
 pll
-fDY
-fDY
-pll
-pll
-pll
-iir
-pll
-pll
-pll
-pll
-iir
-pll
-iir
-pll
-pll
-pll
-pll
-iir
-pll
-pll
-pll
-pll
-pll
-iir
-iir
-pll
-iir
-pll
-iir
 pll
 pll
 pll
 pll
 pll
 pll
-iir
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 pll
 pll
 pll
@@ -80109,64 +75792,64 @@ hRl
 "}
 (139,1,1) = {"
 hRl
-apm
-kcx
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+qNK
+fil
+gTF
+kVi
+kLP
+qhp
+wKw
+izY
+umG
+sKy
+jkD
+qHc
+rGP
+xGQ
 qNK
 qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-kcx
-uKk
-qNK
-qNK
-ute
-bGv
-vSN
-tru
-kwQ
-tru
-tru
-wJl
-bgW
-xOW
+tuf
 kSI
-ndt
-pll
-kSI
-pll
-pll
-pll
+tuf
+yde
+jVv
 cbv
-mdh
-klQ
-rHb
-rJa
-mdh
-klQ
-dpV
+jVv
+vyJ
+jMc
+yde
+eVf
+bqx
+yde
 pll
 pll
-dOt
-ckH
-gyo
-jOD
-fNr
-fNr
-fNr
-acd
-xxT
-eLM
-xxT
-aST
-aST
-uIY
-cVq
-oCc
-cVq
-acd
+pll
+pll
+fDY
+fDY
+fDY
+fDY
+iir
+fDY
+fDY
+pll
+pll
+fDY
+pll
+fDY
+pll
+pll
+iir
+pll
 pll
 fDY
 fDY
@@ -80175,34 +75858,21 @@ pll
 fDY
 fDY
 pll
-fDY
-pll
-pll
-pll
-iir
 pll
 pll
 pll
 pll
 pll
 pll
-iir
-pll
-pll
-pll
-pll
-iir
 pll
 pll
 pll
 pll
 pll
-iir
 pll
 pll
 pll
 pll
-iir
 pll
 pll
 pll
@@ -80211,7 +75881,20 @@ pll
 pll
 iir
 pll
+iir
+iir
+iir
+iir
+iir
 pll
+pll
+iir
+pll
+iir
+pll
+iir
+pll
+iir
 pll
 pll
 pll
@@ -80366,76 +76049,73 @@ hRl
 "}
 (140,1,1) = {"
 hRl
-apm
-kcx
-tBH
-tBH
-jIg
-tBH
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 qNK
-jSc
-xCx
-abe
+qyu
+kYI
+bvr
+kYI
+rKj
+wKw
+rxO
+jkD
 sKy
-kcx
-qNK
-tuf
-lVZ
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-rUy
-rUy
-avK
-avK
-avK
-avK
-avK
-avK
-dsp
-klQ
-rHb
-rJa
-mdh
-nRM
+kwv
+lnC
+jkD
+jkD
+jkD
+swF
+fDY
+fDY
+fDY
+sZG
+lln
+uBw
+vlD
+rmI
+fgh
+yde
+yde
+rHz
+yde
 pll
 pll
 pll
-wuh
-bgq
-icf
-ooY
-fNr
-fNr
-fNr
-acd
-xlf
-xlf
-xlf
-xlf
-xlf
-fww
-mNp
-jvy
-mNp
-acd
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-orL
+pll
+fDY
+fDY
+fDY
+pll
+fDY
+fDY
+pll
+fDY
+pll
+pll
+pll
+pll
+pll
+fDY
+iir
+iir
+pll
+fDY
+fDY
+pll
+pll
+fDY
+pll
+pll
+pll
 tPQ
 tPQ
 tPQ
@@ -80443,7 +76123,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -80455,6 +76135,17 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -80466,14 +76157,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -80624,103 +76307,103 @@ hRl
 (141,1,1) = {"
 hRl
 tot
-kcx
-uJT
-jRP
-jRP
-fRA
-uKk
-nMD
-kBW
-kBW
-umG
-uKk
-ovp
-fdm
-gIm
-nZK
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+qNK
+hHN
+tzl
+hTD
+kYI
+kYI
+nsA
+sKy
+sKy
+sKy
+vyX
+vyX
+vyX
+vyX
+vyX
+vyX
+fDY
+fDY
+fDY
+pJc
+hDS
+ajs
+ezN
 tpM
-rHb
-gFJ
-mdh
-nRM
-kIY
-kMK
-kIY
-sPf
-ckH
+myf
+ajs
+nxO
+nxO
+xhQ
 pll
-ppD
-fNr
-fNr
-fNr
-acd
-afY
-mQA
-xxT
-aST
-hBx
-txX
-cVq
-sfd
-cVq
-acd
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
+pll
+pll
+pll
+fDY
+fDY
+pll
+fDY
+fDY
+pll
+fDY
+pll
+pll
+pll
+pll
+pll
+fDY
+pll
+iir
+pll
+pll
+fDY
+fDY
+pll
+fDY
+fDY
+pll
+pll
+pll
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -80881,106 +76564,82 @@ hRl
 (142,1,1) = {"
 hRl
 tot
-kcx
-tZM
-tBH
-tBH
-sJj
-bLR
-fHm
-sXH
-sXH
-sKy
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 qNK
-qnW
-qex
-tHB
-rPr
+atZ
+kYI
+kYI
+kYI
+kYI
+kcx
+qNK
+vyX
+jeh
+vyX
+jed
+tPm
+kTZ
+vSn
+wKw
+fDY
+fDY
+fDY
+pJc
+hDS
 nxO
 nxO
+hnQ
 nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-nxO
-uWY
 gFJ
-mdh
-xOu
+hnQ
+ccQ
+xhQ
 pll
-jgs
-kZb
-gyo
-vEa
 pll
-vEa
-fNr
-fNr
-fNr
-mbZ
-pgU
-hUu
-xxT
-aST
-xlf
-xlf
-xlf
-aST
-aST
-acd
-tPQ
+pll
+fDY
+fDY
+iir
+pll
+fDY
+iir
+fDY
+fDY
+kXC
+kXC
+ndt
+iLC
+pll
+iir
+iir
+pll
+pll
+pll
+fDY
+fDY
+pll
+pll
+fDY
 gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -80991,6 +76650,30 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -81138,94 +76821,77 @@ hRl
 (143,1,1) = {"
 hRl
 tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 qNK
-bJk
-jRP
-tBH
-fsE
-bLR
-nku
-tPm
-tPm
-fjt
-swF
-szu
+eZy
+ivR
+jut
 nbV
-tkO
-mLI
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
-uWY
+bzu
+qNK
+qNK
+rbN
+qlE
+qlE
+bcf
+mHJ
+bVc
+mHJ
+wKw
+mxP
+fDY
+drL
+yde
+tkh
+hnQ
+nxO
+nxO
+hnQ
 gFJ
-mdh
+rbC
 xOu
-cbv
+yde
 pll
-kIY
-wuh
-tjz
 pll
-wuh
-fNr
-fNr
-fNr
-mbZ
-bIG
-hUu
-afY
-xlf
-naQ
-oCc
-lvG
-tLm
-eDY
-mbZ
-tPQ
+fDY
+fDY
+pll
+iir
+fDY
+pll
+fDY
+pll
+pll
+kXC
+kXC
+pll
+pll
+fDY
+iir
+iir
+iir
+pll
+pll
+fDY
+fDY
 gIL
 gIL
 gIL
 gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -81237,19 +76903,36 @@ tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
@@ -81395,73 +77078,109 @@ hRl
 (144,1,1) = {"
 hRl
 tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
 qNK
-eip
-jRP
-tBH
-eVF
-bLR
-jQt
-umG
-jkD
-jkD
 qNK
-hHP
-kEZ
-cIE
-rYw
-rYw
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+aiR
+qlE
+qlE
 brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
-brC
+bcf
+bcf
+mOl
+wKw
+vYz
+xYV
+aVF
+oUB
+gfa
+nxO
 kAz
-mdh
-klQ
+aiU
+wfp
+kAz
+lCP
+wfp
+xhQ
 pll
-jgs
-kMK
 pll
-wuh
+fDY
+fDY
 pll
-oYs
-fNr
-fNr
-fNr
-mbZ
-lLd
-qSd
-afY
-akR
-gqb
-rTE
-vlZ
-acd
-uJe
-mbZ
-tPQ
-gIL
-gIL
-gIL
-tPQ
-gIL
+fDY
+fDY
+fDY
+fDY
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+fDY
 gIL
 gIL
 tPQ
+gIL
+gIL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+orL
+orL
+tPQ
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+orL
+orL
+orL
+tPQ
+orL
 tPQ
 orL
 tPQ
@@ -81471,42 +77190,6 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
@@ -81652,65 +77335,64 @@ hRl
 (145,1,1) = {"
 hRl
 tot
-qNK
-awl
-gah
-jRP
-lsq
-eYt
-kGP
-sKy
-jkD
-jkD
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+edm
+vbG
+qXh
 ovp
-ovp
+qXh
 qum
-avK
-eam
-aoQ
-avK
-avK
-avK
-avK
-avK
-avK
-lel
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
-avK
+moZ
+gje
+qNK
+vyX
+vyX
+kZb
+vyX
+fKF
+jJj
+vyX
+vyX
+cty
+xYV
+vEa
+oUB
+pIo
+isE
+tHs
+rDQ
+ahq
+tHs
 gnZ
-klQ
+ahq
+xhQ
+pll
+fDY
+fDY
+pll
+fDY
+fDY
+fDY
+fDY
+iir
 pll
 pll
-kIY
+kXC
+kXC
 pll
-dtH
-ckH
-tjz
-fNr
-fNr
-fNr
-rPR
-rPR
-acd
-acd
-uJe
-uJe
-uJe
-acd
-mbZ
-rPR
-mbZ
-vdY
-hsD
+pll
+iir
+pll
+pll
+pll
+pll
+tPQ
 gIL
 gIL
 gIL
@@ -81720,14 +77402,6 @@ gIL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -81735,25 +77409,34 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -81909,95 +77592,70 @@ hRl
 (146,1,1) = {"
 hRl
 tot
-qNK
-ykZ
-tBH
-tBH
-tBH
-pIl
-umG
-jkD
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+tNI
 uJn
-jkD
-jkD
-bLR
+uJn
+sgl
+eGh
 lfa
-jqA
-gIm
-bKF
-bKF
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
-gIm
+qlL
+gje
+iir
+pll
+vyX
+vyX
+vyX
+vyX
+vyX
+vyX
+pll
+oQS
+qlL
+ppD
+yde
 wVC
-wVC
-gIm
-gIm
-gIm
-wVC
-wVC
-gIm
-cwC
-sKD
-sKD
-nAu
-sKD
-sKD
-sKD
-sKD
-fNr
-fNr
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
+apm
+apm
+apm
+apm
+yde
+yde
+yde
+yde
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+pll
+iir
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+pll
+pll
+pll
+pll
 tPQ
 gIL
 gIL
+gIL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
+gIL
+gIL
 tPQ
 tPQ
 tPQ
@@ -82011,24 +77669,49 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 mdh
@@ -82166,52 +77849,64 @@ hRl
 (147,1,1) = {"
 hRl
 tot
-kcx
-dzT
-miw
-stz
-emo
-tDR
-qam
-umG
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+qnW
+hng
 uJn
-jkD
-jkD
-bLR
-kAR
-gIm
-qNK
+ads
+miw
+lfa
+qlL
+pjg
 diM
 diM
-dha
-diM
-diM
-gZh
-dts
-qNK
-sfC
-vYz
-lCU
-sXy
-yde
-yde
-yde
-yde
-yde
-yde
-yde
+syK
+syK
+syK
+syK
+syK
+cty
+oQS
+fDY
+fDY
+kma
+kma
+kma
+eoV
+eoV
+eoV
+eoV
+eoV
 qSy
-qSy
-sKD
-lDW
-ihO
-gwL
-nWz
-lsg
-sKD
-fNr
-fNr
-gIL
+vqR
+vqR
+fDY
+fDY
+fDY
+pll
+pll
+fDY
+pll
+pll
+iir
+pll
+pll
+kXC
+kXC
+pll
+pll
+pll
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
 gIL
@@ -82222,25 +77917,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -82248,36 +77924,6 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -82285,7 +77931,44 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 mdh
@@ -82422,67 +78105,67 @@ hRl
 "}
 (148,1,1) = {"
 hRl
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-obz
-sKy
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+qnW
 ddB
-uKk
-kcx
-kcx
-kcx
-uKk
-qNK
-cyg
-fOb
+ads
+ads
+lah
+lfa
+fDY
+etC
+etC
+etC
+etC
 etC
 fOb
-fOb
-tPo
 vUF
-qNK
-rKs
-mpY
+vUF
+vUF
+fDY
+fDY
 wfv
-fJF
-akj
-sXy
-sXy
-sXy
-yde
-uVF
-sXy
+fDY
+fDY
+fDY
+gIL
+gIL
+gIL
+gIL
+gIL
 gOj
-ecy
-sKD
-niY
-ihO
-uMI
-sXy
-sXy
-sKD
+vqR
+vqR
+fDY
+fDY
+fDY
+fDY
+fDY
+iir
+pll
+pll
+iir
+pll
+pll
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
 gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-tPQ
-gIL
 gIL
 gIL
 gIL
@@ -82490,32 +78173,7 @@ gIL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -82529,9 +78187,21 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
 orL
+orL
+tPQ
+orL
+orL
+orL
+orL
+tPQ
+orL
+orL
 tPQ
 tPQ
 tPQ
@@ -82541,6 +78211,19 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -82679,80 +78362,57 @@ hRl
 "}
 (149,1,1) = {"
 hRl
-qNK
-fil
-gTF
-kVi
-kLP
-qhp
-bLR
-jXT
-umG
-jkD
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+aul
+awl
 bYl
-jkD
-iIr
-jkD
-jkD
-qNK
-lFc
-tPo
-tPo
-tPo
-tPo
-tPo
-iAG
-puy
-lCU
+lUi
+sXH
+lfa
+qeY
+xJm
+xZc
+xZc
+xZc
 vYz
-lCU
+xYV
+aVF
+xZc
+vYz
+oII
+fDY
+fDY
 sXy
-kMz
+sXy
 sXy
 bgz
-sXy
-gOj
-sXy
-sXy
-yde
-ivc
-sKD
-ckz
-sXy
-sXy
-ihO
-mzS
-sKD
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
+bgz
+bgz
+bgz
+bgz
+pAY
+vqR
+vqR
+fDY
+fDY
+fDY
+fDY
+pll
+pll
+iir
+pll
+pll
+pll
+pll
+kXC
+kXC
 tPQ
 tPQ
 tPQ
@@ -82760,8 +78420,17 @@ tPQ
 tPQ
 tPQ
 tPQ
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
+gIL
 tPQ
-orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -82774,9 +78443,23 @@ orL
 orL
 orL
 tPQ
+orL
+orL
+orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 orL
 tPQ
@@ -82786,20 +78469,20 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+mQz
 tPQ
 tPQ
 mdh
@@ -82936,70 +78619,75 @@ hRl
 "}
 (150,1,1) = {"
 hRl
-qNK
-qyu
-kYI
-tzl
-kYI
-rKj
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+qnW
+hng
 bLR
-izY
-umG
-uJn
-bLR
-jkD
+bgq
 cBK
 rpE
-jkD
-lzG
-tPo
-ygM
-tPo
-hCq
-tPo
-tPo
-tPo
-puy
-iQJ
+aVF
+pll
+pll
+pll
+qHI
+vJk
+xYV
+gje
+iir
+pll
 vYz
-lCU
+oII
+qlL
 gFj
-yde
-dbn
-hCz
+jOV
+tdl
+tdl
+tdl
 tdl
 yde
-isr
-sxA
+yde
 yde
 vqR
-sKD
-rbr
-sXy
-ihO
-pjg
-bNY
-sKD
+vqR
+fDY
+fDY
+fDY
+pll
+iir
+pll
+iir
+iir
+iir
+pll
+pll
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 gIL
-gIL
-gIL
+tPQ
 gIL
 gIL
 gIL
 gIL
 gIL
 tPQ
-gIL
-gIL
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -83023,19 +78711,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-orL
-orL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -83048,15 +78733,13 @@ tPQ
 tPQ
 orL
 orL
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+mQz
 tPQ
 tPQ
 mdh
@@ -83193,53 +78876,61 @@ hRl
 "}
 (151,1,1) = {"
 hRl
-qNK
-hHN
-kYI
-hTD
-bvr
-sLZ
-bLR
-rxO
-sKy
-sHQ
-bLR
-qrG
-sHQ
-oMM
-aBX
-qNK
-qNK
-qNK
-qNK
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+qnW
+hng
+tZu
+tZu
+eGh
+rpE
+dkt
+pBB
+pll
+pll
+lFc
 lIo
-dWA
-tPo
-xBd
-puy
-lCU
+xYV
+gje
+fXS
+iir
+wRR
 vYz
 stq
 hAU
-yde
-yde
-qSy
-yde
-yde
-yde
+nwr
+hdy
+sLZ
+sLZ
+jOa
+fFk
 bzO
 yde
-yde
-sKD
-wXv
-sXy
-ihO
-sXy
-qFt
-sKD
-gIL
-gIL
-gIL
+vqR
+vqR
+fDY
+fDY
+pll
+pll
+iir
+pll
+iir
+pll
+iir
+iir
+pll
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
 tPQ
 tPQ
@@ -83248,14 +78939,12 @@ gIL
 gIL
 gIL
 gIL
-gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -83274,7 +78963,16 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -83288,21 +78986,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -83312,8 +78995,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
 orL
+tPQ
 tPQ
 tPQ
 mdh
@@ -83450,88 +79133,71 @@ hRl
 "}
 (152,1,1) = {"
 hRl
-qNK
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+edm
+edm
+srI
 bNb
-kYI
-kYI
-kYI
-kYI
-nsA
-oMM
-sXH
-uJn
-bLR
-cnN
-sHQ
-oMM
-tRQ
-qNK
-wMH
-glQ
-pOK
-pcM
-bLR
-tPo
-tPo
-puy
-vsv
-lQM
-kIY
-kIY
-eYo
-kIY
-kIY
-kIY
+bNb
+rUy
+rpE
 gje
-aDw
+iir
+wMH
+iir
 pll
+vJk
+xYV
+gje
+pll
+iir
+pll
+vJk
+iql
+nLi
+yde
+kIY
+edk
+edk
+kse
+aDw
+mJp
 yde
 wYj
-sZG
-yde
-sZG
-gOj
-yde
-sZG
-sKD
-gIL
+vqR
+fDY
+pll
+pll
+iir
+pll
+pll
+iir
+pll
+pll
+iir
+pll
+kXC
+kXC
 tPQ
-gIL
-tPQ
-gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
 gIL
 tPQ
 tPQ
+gIL
+gIL
+gIL
+tPQ
+gIL
+gIL
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -83548,6 +79214,38 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 tPQ
 tPQ
@@ -83556,21 +79254,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 mdh
@@ -83707,104 +79390,81 @@ hRl
 "}
 (153,1,1) = {"
 hRl
-qNK
-eZy
-ivR
-jut
-tEZ
-atZ
-qNK
-qNK
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+edm
 ipD
-sHQ
-bLR
-wDu
-sHQ
-oMM
-waI
-qNK
-pde
-glQ
-glQ
-cty
-bLR
-tPo
-tPo
-puy
+cnK
+cnK
+rUy
+rUy
+aAs
+uNE
+iir
+pll
 fXS
+syK
+cty
 xYV
+jSc
+syK
+iir
+fXS
+vJk
 iql
-jMc
+fDY
 rnN
-xML
-xML
 edk
-iqN
-eCM
-yde
+edk
+edk
+edk
+wQA
+edk
 yde
 gie
+mfY
 gie
-sZG
-boV
-uMI
-lna
-qgh
-sKD
+yde
+iir
+pll
+pll
+pll
+iir
+iir
+iir
+pll
+pll
+kXC
+kXC
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 gIL
+tPQ
 tPQ
 gIL
 gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-owE
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
+orL
+orL
+orL
+orL
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 orL
 orL
@@ -83823,8 +79483,31 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 tPQ
@@ -83964,72 +79647,87 @@ hRl
 "}
 (154,1,1) = {"
 hRl
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-nnK
-sHQ
-bLR
-lnC
-qHc
-rGP
-egN
-qNK
-vyo
-glQ
-glQ
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+edm
+edm
+gCD
+gCD
+gCD
+gCD
+wJl
+gje
+pll
+iir
+lIo
+tXS
 gwe
-qkq
+mxP
+gwe
 tPo
-tPo
-puy
-rKs
-lQM
-wcp
-eCS
-qlL
-xML
-aXY
-sfn
-kJS
-sZG
-fRz
+gje
+iir
+vJk
+iql
+mxP
 yde
-qru
+kOh
+aXY
+edk
+fdm
+edk
+edk
+xyl
+edk
 vDh
-gOj
-sXy
-ihO
-ihO
-sXy
-sKD
-gIL
-gIL
-gIL
+lvH
+yde
+pll
+pll
+pll
+pll
+pll
+pll
+fDN
+pll
+pll
+kXC
+kXC
 tPQ
 tPQ
-tPQ
-gIL
-gIL
-gIL
-tPQ
-hsD
 gIL
 tPQ
 tPQ
 gIL
+tPQ
+tPQ
 gIL
 gIL
 tPQ
 tPQ
 tPQ
+orL
+orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
 tPQ
 orL
 tPQ
@@ -84043,31 +79741,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -84083,6 +79760,12 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -84221,88 +79904,78 @@ hRl
 "}
 (155,1,1) = {"
 hRl
-edm
-oMQ
-oMQ
-oMQ
-oMQ
-edm
-edm
-qNK
-nnK
-qQQ
-kcx
-rXx
-cKt
-jkD
-xGQ
-qNK
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+pBB
+iir
 nPr
-aCU
+vJk
 glQ
 wkh
-bLR
-tPo
-tPo
-qNK
-lCU
-lQM
-kIY
+wkh
+wkh
+byb
+gje
+pll
+vJk
+stq
 aVF
-pCI
-trM
-ezN
-uXJ
-aHs
-wfp
-tqo
-sZG
-hIT
-rzu
 yde
-psq
-nHE
+yde
+yde
+uXJ
+yde
+yde
+yde
+yde
+hIT
+edk
+cxU
+yde
+yde
 ihO
-iop
-sKD
-gIL
-gIL
-gIL
-gIL
-tPQ
-fNr
-fNr
-gIL
-tPQ
-gIL
-gIL
-gIL
+ihO
+ihO
+yde
+pll
+pll
+pll
+pll
+kXC
+kXC
 tPQ
 tPQ
 gIL
 tPQ
 gIL
+gIL
 tPQ
 tPQ
+gIL
 tPQ
-tPQ
-tPQ
+orL
 tPQ
 orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -84316,14 +79989,7 @@ orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 orL
 orL
@@ -84340,7 +80006,24 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -84480,75 +80163,65 @@ hRl
 hRl
 tot
 tot
-tYQ
-tYQ
-lao
-tYQ
-edm
-qNK
-qNK
-qNK
-qNK
-qNK
-kcx
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-kcx
-qNK
-qNK
-qNK
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+mzO
+bjV
+vJk
+glQ
+wkh
+abe
+wkh
+byb
+gje
 vSN
 fmt
+stq
 koc
-koc
-liW
+yde
 qJY
 upz
-uXJ
-lyW
+sIw
+yde
 vIt
 kbr
-sZG
 yde
+aRn
+edk
+sfC
 yde
-sZG
-sZG
+sri
+vMp
+vMp
+lZC
 yde
-yde
-yde
-sKD
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-fNr
-fNr
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
+eRs
+pll
+pll
+mvq
+kXC
+kXC
 tPQ
 tPQ
+tPQ
+tPQ
+gIL
+orL
+orL
+gIL
 tPQ
 orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -84558,18 +80231,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -84585,6 +80252,15 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -84599,6 +80275,13 @@ tPQ
 tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
 tPQ
 tPQ
 mdh
@@ -84740,87 +80423,63 @@ tot
 tot
 tot
 tot
-tot
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-edm
-tAh
-iLF
-iLF
-iLF
+mbZ
+mbZ
+rPR
+acd
+uJe
+acd
+acd
+mbZ
+mbZ
+mbZ
+mbZ
+pll
+oVe
+glQ
+wkh
+wkh
+wkh
+byb
+cKP
+iir
+vJk
+iql
+qxf
 yde
+hAh
+sIw
 sIw
 uXJ
-oFe
-sZG
-sZG
+edk
+edk
+qfR
+edk
+edk
+fSq
 yde
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-tPQ
-tPQ
+iqN
+vMp
+vMp
+tAh
+yde
+pll
+uIt
+pll
+pll
+kXC
+kXC
 tPQ
 tPQ
 gIL
 gIL
-gIL
-gIL
-gIL
 tPQ
 gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
 tPQ
 orL
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -84832,6 +80491,28 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
 orL
 tPQ
 tPQ
@@ -84841,20 +80522,22 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
+tPQ
 tPQ
 tPQ
 tPQ
 orL
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
 tPQ
@@ -84997,89 +80680,61 @@ tot
 tot
 tot
 tot
-tot
-tot
-tot
-tot
-tot
-tot
-tot
-tot
-iLF
-iLF
-iLF
-iLF
-iLF
-tot
-tot
-tot
-tot
-tot
-xrX
-edm
+mbZ
+pgU
+qbQ
+afY
+czD
+xlf
+xlf
+xlf
+lvG
+qGt
+rPR
+hAU
+vJk
+uJK
+ckH
+fOb
+ckH
+pOK
+gje
+pll
+vJk
+iql
 jVq
-jVq
-jVq
-jVq
-xML
+yde
+ybd
 uUl
 rRs
-xJn
+yde
 poD
 mXK
 yde
+spd
+sPf
+hBy
+yde
+xBn
+vMp
+vMp
+fUC
+yde
+pll
+mSJ
+pll
+rBg
+kXC
+kXC
 gIL
 gIL
-tPQ
-tPQ
-tPQ
 gIL
 gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 orL
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -85100,19 +80755,47 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 mdh
@@ -85252,75 +80935,65 @@ hRl
 tot
 tot
 tot
-aQm
-cmv
-qxB
 tot
 tot
-tot
-tot
-tot
-tot
-tot
-tot
-iLF
-iLF
-iLF
-iLF
-iLF
-tot
-tot
-tot
-iFp
-nJw
-qGl
-iLF
-iLF
-iLF
-iLF
-xML
-xML
-eCM
+mbZ
+bIG
+hUu
+afY
+czD
+xlf
+aST
+xlf
+xlf
+xlf
+mFU
+moZ
+hAU
+hgB
+fJF
+qlL
+aVF
+xZc
+lFc
+iir
+lIo
+iql
+dqa
 yde
 yde
 yde
 yde
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+cFi
+vMp
+vMp
+tAh
+yde
+pll
+pll
+pll
+pll
+kXC
+kXC
 gIL
 gIL
 gIL
 gIL
 tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
+orL
 tPQ
 tPQ
 tPQ
 orL
 orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -85335,12 +81008,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -85358,18 +81033,26 @@ tPQ
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
-tPQ
 tPQ
 tPQ
 mdh
@@ -85509,91 +81192,56 @@ hRl
 tot
 tot
 tot
-vXl
-nJw
-uII
-iLF
-iLF
-iLF
-iLF
-hId
 tot
 tot
-tot
-tot
-iLF
-iLF
-iLF
-iLF
-tot
-iLF
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
+acd
+hUu
+hUu
+afY
+xlf
+xlf
+xlf
+xlf
+xlf
+rpz
+uJe
+iql
+vUF
+vUF
+vUF
+qlL
+gje
+qHI
+iir
+iir
+lIo
+iql
+fDY
+fDY
+qHX
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+yde
+wLd
+vMp
+vMp
+hsR
+yde
+pll
+pll
+pll
+pll
+kXC
+kXC
+owE
 gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-vdY
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -85611,6 +81259,50 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
 orL
 tPQ
 tPQ
@@ -85618,15 +81310,6 @@ tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 mdh
@@ -85766,88 +81449,60 @@ hRl
 tot
 tot
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kzY
-iLF
-iLF
-iLF
-hId
 tot
-iLF
-iLF
-iLF
-iLF
-sOM
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-iLF
-kUY
-tny
-tPQ
-tPQ
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
+tot
+acd
+xxT
+eLM
+xxT
+aST
+aST
+uIY
+cVq
+oCc
+cVq
+acd
+xYV
+aVF
+mlo
+iir
+pll
+iir
+iir
+iir
+iir
+dzT
+iql
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+fDY
+prE
+mxP
+mxP
+mxP
+fDY
+yde
+yde
+sZG
+qzf
+yde
+yde
+pll
+pll
+qCp
+pll
+kXC
+kXC
 gIL
 uIn
 gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -85859,7 +81514,32 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
 orL
+orL
+orL
+tPQ
+orL
+orL
+tPQ
+orL
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -85874,16 +81554,19 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 orL
 tPQ
+orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 mdh
@@ -86023,59 +81706,93 @@ hRl
 tot
 tot
 tot
-iLF
-hId
 tot
-iLF
-kyR
-iLF
-iLF
-kyR
-iLF
-bXm
-dLV
-iLF
-iLF
-hId
-xwY
-kFl
-tcf
-iLF
 tot
-iLF
-iLF
-tot
-kyR
-iLF
-iLF
-kUY
+acd
+xlf
+xlf
+xlf
+xlf
+xlf
+fww
+mNp
+jvy
+mNp
+acd
+cEd
+kMK
+pll
+lFc
+iir
+pll
+pll
+iir
+iir
+xBd
+iql
+fDY
+fDY
+omT
+omT
+omT
+omT
+omT
+omT
+ulP
+mdo
+hBh
+iql
+qlL
+gje
+byj
+stq
+cIE
+pll
+syK
+syK
+syK
+syK
+kXC
+kXC
+gIL
+gIL
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
+orL
 tPQ
 tPQ
-gIL
-gIL
+orL
 tPQ
-gIL
-gIL
-gIL
+orL
+orL
 tPQ
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
-gIL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86088,21 +81805,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -86113,8 +81815,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
+orL
 tPQ
 orL
 tPQ
@@ -86122,25 +81823,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 mdh
@@ -86280,61 +81963,60 @@ hRl
 tot
 tot
 tot
-iLF
 tot
 tot
-iLF
-iLF
-iLF
-qLB
-iLF
-bXm
-hUq
-bVX
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-tot
-iLF
-iLF
-tot
-tot
-qLB
-iLF
-vhs
+acd
+afY
+mQA
+xxT
+aST
+hBx
+txX
+cVq
+sfd
+cVq
+acd
+lQh
+omT
+rzu
+rzu
+rzu
+omT
+kFU
+kFU
+kFU
+sYT
+tRA
+izz
+tRA
+omT
+thJ
+vbR
+thJ
+reb
+omT
+cAt
+umm
+cAt
+iql
+qlL
+gje
+vJk
+stq
+dts
+cty
+wkh
+fRz
+wkh
+wkh
+kXC
+kXC
 tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
 tPQ
 gIL
 tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -86345,44 +82027,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -86395,7 +82039,46 @@ orL
 orL
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86537,62 +82220,57 @@ hRl
 tot
 tot
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-vXl
-nJw
-tcf
-iLF
-iLF
-kyR
-iLF
-iLF
 tot
 tot
-tot
-iLF
-kyR
-kzY
-tot
-tot
-tot
-vhs
+mbZ
+pgU
+hUu
+xxT
+aST
+xlf
+xlf
+xlf
+aST
+aST
+acd
+lQh
+omT
+jfc
+cQD
+wjp
+omT
+hkV
+thJ
+jQt
+omT
+wzP
+thJ
+thJ
+cFY
+rPM
+omT
+thJ
+reb
+omT
+hKg
+umm
+dOt
+iql
+qlL
+gje
+dWA
+stq
+jOD
+wkh
+xXi
+wkh
+afZ
+pAP
+kXC
+kXC
+gIL
 tPQ
 gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-vdY
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -86600,24 +82278,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -86627,10 +82288,6 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -86644,6 +82301,36 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -86651,10 +82338,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 mdh
@@ -86794,80 +82477,63 @@ hRl
 tot
 tot
 tot
-iLF
-iLF
-iLF
-iLF
 tot
-jhX
-iLF
-kBz
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-kzY
-iLF
-iLF
-kyR
-iLF
-kBz
-iLF
-iLF
-iLF
-vhs
-tny
+tot
+mbZ
+bIG
+hUu
+afY
+xlf
+naQ
+oCc
+lvG
+tLm
+eDY
+mbZ
+ooY
+sYT
+nOT
+qGQ
+bpA
+omT
+ftw
+qam
+xZl
+omT
+eRa
+thJ
+thJ
+kZm
+tvO
+omT
+vNr
+reb
+omT
+kAR
+umm
+umm
+iql
+qlL
+hAU
+cty
+cEd
+fjo
+wkh
+wkh
+tKS
+lAl
+dpV
+kXC
+kXC
+gIL
+gIL
 gIL
 tPQ
-tny
-tPQ
-gIL
-tPQ
-gIL
-gIL
-hsD
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
@@ -86886,16 +82552,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -86908,9 +82572,28 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87050,74 +82733,67 @@ hRl
 hRl
 tot
 tot
-jhX
-iLF
-iLF
-iLF
-iLF
-iLF
-vXl
-jQj
-iLF
-iLF
 tot
 tot
-iLF
-iLF
-jhX
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kzY
-oGF
-tny
-tPQ
-tny
+tot
+mbZ
+lLd
+qSd
+afY
+akR
+gqb
+rTE
+vlZ
+acd
+uJe
+mbZ
+lQh
+omT
+qGQ
+ojx
+nWz
+omT
+thJ
+ckz
+pML
+omT
+qOI
+thJ
+thJ
+cFY
+akj
+omT
+thJ
 reb
-reb
-gIL
-gIL
+omT
+hCz
+umm
+umm
+iql
+qlL
+wkh
+wkh
+wkh
+wkh
+pBs
+qQB
+lAl
+lAl
+awt
+kXC
+kXC
 tPQ
 gIL
 gIL
 tPQ
-tPQ
-gIL
-fNr
-fNr
-tPQ
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
+orL
 orL
 tPQ
 tPQ
 orL
-tPQ
 orL
 tPQ
-tPQ
 orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -87130,8 +82806,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87148,17 +82824,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-orL
-orL
 orL
 orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -87168,7 +82838,20 @@ tPQ
 tPQ
 tPQ
 orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 mdh
@@ -87307,73 +82990,80 @@ hRl
 hRl
 tot
 tot
-pHG
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
 tot
 tot
-iLF
-viS
 tot
-tot
-iLF
-vXl
-jQj
-iLF
-iLF
-iFp
-qxB
-iLF
-kyR
-iLF
-kyR
-kyR
-qGd
-tPQ
-tPQ
-tPQ
-tPQ
-tny
+rPR
+rPR
+acd
+acd
+uJe
+uJe
+uJe
+acd
+mbZ
+rPR
+mbZ
+lQh
+omT
+qGQ
+eYu
+quI
+omT
+thJ
+omT
+omT
+omT
+sfn
+thJ
+thJ
+omT
+omT
+omT
+vbR
+quI
+omT
+cAt
+umm
+cAt
+iql
+qlL
+wkh
+wkh
+wkh
+wkh
+wkh
+wkh
+suy
+lAl
+qkq
+kXC
+kXC
 gIL
 gIL
 gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-fNr
-fNr
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 orL
 orL
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87388,19 +83078,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -87408,13 +83085,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-orL
-orL
-orL
-orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87423,6 +83098,14 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -87564,58 +83247,95 @@ hRl
 hRl
 tot
 tot
-pHG
 tot
-hId
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kzY
-iLF
-iLF
-iLF
-iLF
-bmC
-kyR
-kyR
-iLF
-iLF
-iLF
-qGd
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+lQh
+omT
+nOT
+oYs
+vuQ
+omT
+ftw
+ebe
+itb
+omT
+wzP
+thJ
+thJ
+kWU
+xnv
+gws
+izc
+spU
+omT
+soW
+umm
+jIg
+iql
+qlL
+wkh
+wvd
+wkh
+wkh
+wkh
+fjo
+wkh
+ecy
+awt
+kXC
+kXC
+gIL
+tPQ
+gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
+orL
+orL
+orL
+orL
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
 tPQ
-gIL
-gIL
+orL
 tPQ
-gIL
+orL
 tPQ
-gIL
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87629,48 +83349,11 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 orL
 orL
 tPQ
@@ -87820,79 +83503,59 @@ hRl
 (169,1,1) = {"
 hRl
 tot
-iFp
-tcf
 tot
 tot
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-kyR
-iLF
-iLF
-kyR
-iLF
-iLF
-kyR
-iLF
-xHQ
-iLF
-iLF
-iLF
-iLF
-aQm
-dLV
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+mzS
+bpm
+egn
+lQh
+lQh
+hvb
+lQh
+omT
+qGQ
+omT
+aPO
+omT
+thJ
+omT
+bgW
+quI
+mAu
+thJ
+thJ
+bGc
+bGc
+bGc
+izc
+udy
+omT
+lbs
+umm
+yiG
+iql
+qlL
+aVF
+xZc
+vYz
+wkh
+wkh
+wkh
+wkh
+suy
+jri
+kXC
+kXC
 tPQ
 gIL
 gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -87908,16 +83571,36 @@ tPQ
 tPQ
 orL
 orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
 tPQ
 tPQ
 tPQ
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -87935,7 +83618,7 @@ orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88077,58 +83760,97 @@ hRl
 (170,1,1) = {"
 hRl
 tot
-iLF
-iLF
 tot
-iLF
-iLF
-iLF
-hId
 tot
-sjN
-iLF
-iLF
-kyR
-iLF
-kBz
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-vXl
-tcf
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+pCI
+oor
+vOc
+lQh
+hRl
+omT
+omT
+omT
+aiy
+omT
+omT
+omT
+jas
+omT
+omT
+quI
+pSy
+thJ
+thJ
+bGc
+bGc
+bGc
+izc
+izc
+wKt
+umm
+umm
+aCU
+iql
+qlL
+gje
+pwx
+pll
+vYz
+lXh
+wkh
+wkh
+wkh
+eAc
+kXC
+kXC
+gIL
+gIL
+gIL
 tPQ
-gIL
-gIL
-gIL
-gIL
+tPQ
+orL
 tPQ
 tPQ
-gIL
-gIL
-gIL
+orL
+orL
 tPQ
 tPQ
 tPQ
-gIL
+tPQ
+orL
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
+orL
 tPQ
-gIL
-gIL
+orL
+orL
+orL
+orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
 tPQ
 tPQ
 tPQ
@@ -88144,47 +83866,8 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -88334,91 +84017,59 @@ hRl
 (171,1,1) = {"
 hRl
 tot
-kBz
-iLF
-iLF
-iLF
-kBz
-iLF
 tot
 tot
-iLF
-uJD
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-uJD
-iLF
-iLF
 tot
 tot
-iLF
-kyR
-kyR
-iLF
-iLF
-kUY
-tPQ
-tPQ
-vKu
+hRl
+hRl
+hRl
+hRl
+hRl
+jhh
+qAj
+pIg
+pmh
+hRl
+omT
+pdv
+kqO
+lmZ
+thJ
+kqO
+thJ
+thJ
+thJ
+kqO
+kqO
+thJ
+thJ
+thJ
+bGc
+bGc
+bGc
+izc
+udy
+omT
+cAt
+uVl
+cAt
+iql
+qlL
+gje
+veJ
+pll
+mcE
+ngm
+wpb
+wla
+wkh
+wkh
+kXC
+kXC
 tPQ
 gIL
 gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-tPQ
-jxT
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -88433,6 +84084,20 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+orL
+orL
+tPQ
+tPQ
+tPQ
 orL
 orL
 tPQ
@@ -88440,7 +84105,25 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88591,60 +84274,100 @@ hRl
 (172,1,1) = {"
 hRl
 tot
-uxV
-kyR
-iOs
-iLF
-iLF
-iLF
 tot
-hId
-aQm
-bVX
-kzY
-iLF
-iLF
-iLF
-iLF
 tot
-vXl
-qxB
-iLF
-viS
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-jhG
-tPQ
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+tFZ
+pyV
+aHr
+sfS
+hRl
+omT
+iyZ
+thJ
+thJ
+thJ
+kqO
+ctp
+lmZ
+thJ
+kqO
+liW
+thJ
+thJ
+thJ
+eHy
+izc
+izc
+izc
+spU
+omT
+opB
+umm
+jsL
+tlW
+tlW
+pll
+pll
+pll
+pll
+pll
+sUQ
+sUQ
+xZc
+vxh
+kXC
+kXC
+gIL
+gIL
 gIL
 gIL
 tPQ
 tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
 tPQ
 tPQ
-tPQ
-tPQ
-jxT
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
+orL
+orL
 tPQ
 tPQ
 tPQ
 tPQ
-gIL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
+tPQ
+orL
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -88657,46 +84380,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -88848,59 +84531,59 @@ hRl
 (173,1,1) = {"
 hRl
 tot
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
 tot
 tot
-vXl
-bVX
-iLF
-pJw
-iLF
-kyR
-iLF
 tot
 tot
-xSl
-iLF
-kyR
-tot
-jhX
-iLF
-kyR
-iLF
-iLF
-jhG
-tPQ
-tPQ
-tPQ
-tPQ
+hRl
+hRl
+hRl
+hRl
+hRl
+vQW
+aRr
+pMb
+aEh
+hRl
+omT
+tgK
+thJ
+lmZ
+thJ
+omT
+omT
+omT
+rce
+omT
+omT
+omT
+rce
+omT
+omT
+srN
+gws
+izc
+omT
+omT
+umm
+umm
+bHK
+pTm
+tlW
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+pll
+kXC
+kXC
 gIL
 gIL
 gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -88909,6 +84592,18 @@ tPQ
 orL
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88922,14 +84617,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
 tPQ
 orL
 tPQ
-orL
-orL
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -88939,15 +84630,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
 orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -89105,65 +84788,71 @@ hRl
 (174,1,1) = {"
 hRl
 tot
-qLB
-kyR
-jhX
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-pDU
-qLB
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-pHG
-iLF
-iLF
-kyR
-iLF
-jhG
-nza
-tPQ
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+omT
+iXY
+bKI
+uwV
+lKL
+omT
+rOW
+qFz
+exd
+ujm
+omT
+exd
+exd
+exd
+omT
+omT
+omT
+omT
+omT
+omT
+yde
+yde
+yde
+yde
+gJk
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+kXC
+kXC
+kXC
+owE
 tPQ
 gIL
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89177,7 +84866,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -89185,18 +84873,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
 tPQ
 tPQ
 tPQ
 orL
+orL
+orL
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -89209,8 +84893,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89363,58 +85046,58 @@ hRl
 hRl
 tot
 tot
-iLF
-pHG
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-kyR
-iLF
-iLF
-kyR
-iLF
-iLF
-uFd
-jQj
-iLF
-iLF
-iLF
-iLF
-vhs
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+omT
+jOM
+omT
+omT
+omT
+omT
+exd
+exd
+exd
+yfs
+omT
+aUg
+sxA
+gZh
+omT
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+yde
+lkQ
+nwh
+rvE
+wbp
 jxT
-tPQ
+nQu
+jUx
+pxj
+cLc
+yde
+kXC
+kXC
+kXC
 gIL
-gIL
-gIL
-gIL
+hsD
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
 tPQ
 tPQ
 tPQ
@@ -89427,6 +85110,30 @@ tPQ
 tPQ
 orL
 tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89437,36 +85144,12 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
 orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -89620,58 +85303,58 @@ hRl
 hRl
 tot
 tot
-iLF
-pDU
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
 tot
-aQm
-dLV
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-hDw
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+omT
+thJ
+thJ
+thJ
+lmZ
+omT
+iCP
+exd
+exd
+oeO
+omT
+omT
+omT
+omT
+omT
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tot
+tot
+yde
+iEm
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+xCx
+yde
+kXC
+kXC
+kXC
 tPQ
 gIL
 tPQ
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
 tPQ
 tPQ
 tPQ
@@ -89686,7 +85369,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89703,10 +85391,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
-tPQ
 tPQ
 tPQ
 tPQ
@@ -89715,14 +85399,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
 tPQ
 orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -89877,37 +85560,56 @@ hRl
 hRl
 tot
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-iLF
 tot
-vXl
-tcf
-iLF
-kzY
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-kzY
-iLF
-iLF
-iLF
-aPu
-iLF
-kUY
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+tot
+tot
+tot
+hRl
+omT
+thJ
+thJ
+thJ
+thJ
+omT
+eis
+exd
+wmS
+omT
+omT
+tot
+tot
+tot
+tot
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tot
+tot
+yde
+soG
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+eKD
+yde
+kXC
+kXC
+kXC
 tPQ
-tPQ
-vKu
 gIL
 tPQ
 tPQ
@@ -89915,25 +85617,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-gIL
-tPQ
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -89948,37 +85631,37 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 orL
 orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -90134,61 +85817,61 @@ hRl
 hRl
 tot
 tot
-iLF
 tot
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-hId
 tot
-kyR
-iLF
-iLF
-iLF
-jhX
-hId
+hRl
+hRl
+hRl
+hRl
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-mdD
-swG
-kUY
-vvT
-qFL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
+tot
+tot
+tot
+tot
+hRl
+omT
+thJ
+thJ
+thJ
+thJ
+omT
+iCP
+exd
+eCS
+omT
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tot
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+yde
+cqF
+nwh
+nwh
+pde
+frB
+iJo
+iJo
+nwh
+cyg
+yde
+kXC
+kXC
+kXC
 tPQ
 gIL
 tPQ
 gIL
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -90199,13 +85882,9 @@ tPQ
 orL
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -90222,22 +85901,26 @@ orL
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
 orL
 orL
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -90391,72 +86074,63 @@ hRl
 hRl
 tot
 tot
-iLF
 tot
 tot
-iLF
-kyR
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-vXl
-jQj
-iLF
-iLF
-kBz
-iLF
-iLF
-kyR
-iLF
-iLF
-swG
-liz
-swG
 tot
-iLF
-uUn
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+tot
+tot
+hRl
+omT
+thJ
+thJ
+thJ
+thJ
+omT
+quI
+kKO
+quI
+omT
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+yde
+yde
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+nwh
+xVN
+yde
+kXC
+kXC
+kXC
+tPQ
+tPQ
 tPQ
 gIL
 gIL
 tPQ
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -90469,22 +86143,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
-tPQ
-orL
-orL
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -90494,7 +86159,25 @@ tPQ
 tPQ
 orL
 tPQ
+orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 tPQ
 tPQ
@@ -90648,60 +86331,60 @@ hRl
 hRl
 tot
 tot
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-iLF
-kyR
-iLF
 tot
-iLF
-vhs
-tPQ
+tot
+tot
+tot
+tot
+tYQ
+tYQ
+tot
+tYQ
+tot
+hRl
+hRl
+hRl
+omT
+omT
+omT
+omT
+omT
+omT
+qdr
+hov
+wuh
+omT
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+xVz
+yde
+sQo
+eir
+nwh
+nwh
+nwh
+nwh
+nwh
+tvw
+yde
+kXC
+kXC
+kXC
 tPQ
 gIL
 gIL
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
 gIL
 tPQ
 tPQ
@@ -90712,14 +86395,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -90736,12 +86411,7 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -90750,8 +86420,21 @@ tPQ
 tPQ
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -90905,36 +86588,62 @@ hRl
 hRl
 tot
 tot
-iLF
-kyR
-iLF
-iLF
-tot
-tot
-aQm
-dLV
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
 tot
 tot
 tot
-qLB
-iLF
-gzw
-cmv
-bUp
-iLF
-iLF
-kyR
-iLF
 tot
 tot
-vhs
+tot
+tot
+tot
+tot
+tYQ
+tYQ
+tYQ
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+omT
+omT
+omT
+omT
+omT
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+tYQ
+xVz
+yde
+cHJ
+rQH
+nwh
+nwh
+nwh
+nwh
+nwh
+iOa
+yde
+kXC
+kXC
+kXC
+tPQ
+gIL
+gIL
+tPQ
+tPQ
+tPQ
+gIL
 tPQ
 gIL
 tPQ
@@ -90947,22 +86656,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-gIL
-tPQ
-gIL
 tPQ
 tPQ
 tPQ
@@ -90970,7 +86663,17 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -90982,34 +86685,14 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -91161,66 +86844,72 @@ hRl
 (182,1,1) = {"
 hRl
 tot
-kzY
-iLF
-kyR
-kBz
-iLF
-hId
-tot
-vXl
-tcf
-iLF
-iLF
-kyR
-iLF
-iLF
-iLF
-iLF
-iLF
-kzY
 tot
 tot
-iLF
-iLF
-bmC
-iLF
-viS
-iLF
-iLF
-bXm
-cmv
-jQj
 tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hRl
+hZf
+hZf
+hZf
+hZf
+hZf
+hZf
+hZf
+lYs
+hZf
+hZf
+tYQ
+tYQ
+xVz
+yde
+njY
+btb
+nwh
+nwh
+cLp
+ssY
+dAH
+gyr
+yde
+kXC
+kXC
+kXC
 tPQ
-mlN
+gIL
+gIL
+gIL
+tPQ
+gIL
+tPQ
+tPQ
+orL
 gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-mQz
-mQz
 tPQ
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-orL
-gIL
 tPQ
 tPQ
 tPQ
@@ -91229,10 +86918,12 @@ tPQ
 tPQ
 tPQ
 orL
-orL
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91249,26 +86940,18 @@ orL
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 orL
@@ -91419,62 +87102,62 @@ hRl
 hRl
 tot
 tot
-iLF
-iLF
-kyR
-iLF
 tot
 tot
 tot
 tot
 tot
 tot
-gqz
-iLF
-iLF
-iLF
-iLF
 tot
 tot
 tot
 tot
 tot
 tot
-xHQ
-iLF
-iLF
-iLF
-iLF
-vXl
-tcf
 tot
 tot
-mQz
-mQz
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tYQ
+tot
+tot
+tot
+tYQ
+tot
+tYQ
+hRl
+tot
+tot
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+yde
+upt
+kXC
+kXC
+kXC
+tPQ
+gIL
+gIL
+gIL
 gIL
 tPQ
 tPQ
-tPQ
-tPQ
-mQz
-mQz
-tPQ
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
 gIL
 orL
 orL
@@ -91484,18 +87167,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-tPQ
-orL
-orL
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -91510,15 +87185,9 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
@@ -91526,6 +87195,20 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
 tPQ
@@ -91677,56 +87360,56 @@ hRl
 tot
 tot
 tot
-gqz
-iLF
-tot
-tot
-tot
-txY
-tot
-tot
-tot
-tot
-iLF
-iLF
-gqz
 tot
 tot
 tot
 tot
 tot
 tot
-tot
-tot
-siU
-iLF
-lQh
 tot
 tot
 tot
 tot
 txY
 tot
-mQz
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-mQz
-mQz
-tPQ
-tPQ
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+tot
+nqx
+kXC
+kXC
+kXC
+kXC
+kXC
+kXC
+nqx
+nqx
+kXC
+kXC
+kXC
+kXC
 gIL
 gIL
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
 gIL
 tPQ
 gIL
@@ -91739,28 +87422,6 @@ gIL
 tPQ
 gIL
 gIL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -91776,12 +87437,34 @@ tPQ
 tPQ
 orL
 tPQ
+orL
+tPQ
+orL
+orL
+orL
+tPQ
+tPQ
+orL
+orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 tPQ
 orL
 orL
@@ -91939,15 +87622,6 @@ tot
 tot
 tot
 tot
-txY
-tot
-tot
-tot
-tot
-tot
-tot
-tot
-tot
 tot
 tot
 tot
@@ -91955,9 +87629,6 @@ tot
 tot
 txY
 tot
-iLF
-lQh
-iLF
 tot
 tot
 tot
@@ -91966,24 +87637,36 @@ tot
 tot
 tot
 tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+tot
+hRl
+hRl
+tot
+tot
+kXC
+kXC
+kXC
+kXC
+kXC
+nqx
+nqx
+kXC
+kXC
+kXC
+kXC
 tPQ
 tPQ
-tPQ
-tPQ
-tPQ
-mQz
-mQz
-tPQ
-tPQ
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-gIL
-gIL
 tPQ
 gIL
 gIL
@@ -91996,17 +87679,12 @@ tPQ
 gIL
 gIL
 orL
-gIL
-orL
-orL
 tPQ
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
+orL
+orL
 tPQ
 tPQ
 orL
@@ -92015,17 +87693,12 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-tPQ
-orL
 tPQ
 tPQ
 orL
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -92033,6 +87706,16 @@ tPQ
 tPQ
 orL
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92214,7 +87897,7 @@ tot
 tot
 tot
 lQh
-biq
+lQh
 txY
 tot
 tot
@@ -92224,7 +87907,7 @@ tot
 tot
 tot
 tot
-tot
+hRl
 tPQ
 tPQ
 tPQ
@@ -92250,37 +87933,20 @@ tPQ
 gIL
 gIL
 gIL
+orL
+tPQ
 gIL
 tPQ
-gIL
-tPQ
-orL
-orL
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -92291,12 +87957,29 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92508,34 +88191,14 @@ orL
 tPQ
 gIL
 gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
+orL
+orL
+orL
 tPQ
 orL
 orL
 tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
 orL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
 orL
 tPQ
 tPQ
@@ -92544,15 +88207,35 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 orL
 orL
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -92767,16 +88450,6 @@ tPQ
 gIL
 gIL
 gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 tPQ
@@ -92786,14 +88459,12 @@ tPQ
 tPQ
 orL
 tPQ
-tPQ
-tPQ
-tPQ
+orL
+orL
+orL
 orL
 tPQ
-orL
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -92807,9 +88478,21 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
 orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -93025,23 +88708,10 @@ tPQ
 gIL
 gIL
 tPQ
-gIL
-gIL
-gIL
-gIL
-orL
-tPQ
-tPQ
-orL
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -93050,12 +88720,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 orL
 tPQ
@@ -93065,8 +88729,27 @@ tPQ
 tPQ
 tPQ
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -93281,24 +88964,18 @@ gIL
 tPQ
 orL
 tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -93307,13 +88984,6 @@ orL
 tPQ
 tPQ
 orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-orL
-orL
 orL
 tPQ
 tPQ
@@ -93321,10 +88991,23 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 orL
@@ -93539,22 +89222,6 @@ gIL
 orL
 tPQ
 tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -93563,7 +89230,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -93572,6 +89245,7 @@ tPQ
 tPQ
 orL
 orL
+tPQ
 orL
 tPQ
 tPQ
@@ -93582,6 +89256,15 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -93795,13 +89478,6 @@ tPQ
 orL
 gIL
 gIL
-orL
-tPQ
-gIL
-orL
-tPQ
-gIL
-gIL
 tPQ
 tPQ
 tPQ
@@ -93810,17 +89486,18 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -93830,15 +89507,21 @@ tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+orL
+orL
+orL
+tPQ
 orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
 orL
 tPQ
 tPQ
@@ -94052,31 +89735,24 @@ gIL
 tPQ
 tPQ
 gIL
-gIL
-gIL
-orL
-gIL
-gIL
-tPQ
-gIL
-gIL
-gIL
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -94087,14 +89763,21 @@ tPQ
 orL
 tPQ
 tPQ
-orL
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 orL
 orL
@@ -94311,36 +89994,13 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-gIL
-gIL
-orL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -94349,11 +90009,34 @@ orL
 orL
 tPQ
 tPQ
-tPQ
 orL
 tPQ
+tPQ
+orL
 orL
 tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+orL
+orL
+tPQ
+tPQ
+tPQ
+tPQ
+orL
 orL
 orL
 tPQ
@@ -94566,21 +90249,8 @@ tPQ
 gIL
 gIL
 gIL
-gIL
-orL
 tPQ
-gIL
-gIL
 tPQ
-gIL
-gIL
-gIL
-orL
-gIL
-gIL
-gIL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -94588,12 +90258,6 @@ tPQ
 tPQ
 tPQ
 orL
-orL
-orL
-orL
-tPQ
-tPQ
-tPQ
 tPQ
 tPQ
 orL
@@ -94602,9 +90266,28 @@ tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 orL
@@ -94823,32 +90506,6 @@ tPQ
 tPQ
 tPQ
 gIL
-gIL
-gIL
-gIL
-gIL
-tPQ
-gIL
-tPQ
-gIL
-gIL
-gIL
-gIL
-orL
-gIL
-gIL
-tPQ
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-orL
 tPQ
 tPQ
 tPQ
@@ -94860,11 +90517,37 @@ tPQ
 tPQ
 orL
 orL
+orL
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
 orL
+tPQ
+tPQ
+tPQ
 orL
+tPQ
+orL
+orL
+tPQ
+orL
+orL
+tPQ
+orL
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+orL
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95080,21 +90763,10 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
 tPQ
 tPQ
-gIL
 tPQ
-gIL
-orL
-gIL
-gIL
-gIL
-gIL
-orL
-gIL
-gIL
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95104,18 +90776,29 @@ tPQ
 tPQ
 tPQ
 orL
+orL
+orL
 tPQ
 orL
 orL
 tPQ
 tPQ
 tPQ
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95338,41 +91021,41 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-gIL
-gIL
-tPQ
-orL
-gIL
-gIL
-tPQ
-tPQ
-gIL
-orL
-gIL
-gIL
-orL
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-tPQ
-tPQ
-orL
-tPQ
-tPQ
-orL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95598,40 +91281,40 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-gIL
-orL
 tPQ
 tPQ
 tPQ
 tPQ
-jzb
-tPQ
-gIL
-gIL
-gIL
-tEr
-tEr
 tPQ
 tPQ
 tPQ
 tPQ
-orL
-mQz
 tPQ
 tPQ
 tPQ
-dVq
-qgr
-tEr
-mQz
 tPQ
 tPQ
-orL
-orL
 tPQ
-mQz
-mQz
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95856,7 +91539,6 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
 tPQ
 tPQ
 tPQ
@@ -95864,27 +91546,28 @@ tPQ
 tPQ
 tPQ
 tPQ
-gIL
-tPQ
-gIL
-tPQ
-tPQ
-orL
-orL
-tPQ
-tPQ
-tPQ
-mQz
 tPQ
 tPQ
 tPQ
 tPQ
 tPQ
-tEr
-orL
 tPQ
-orL
-orL
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
+tPQ
 tPQ
 tPQ
 tPQ
@@ -95893,7 +91576,7 @@ tPQ
 yde
 yde
 yde
-sZG
+yde
 yde
 yde
 yde
@@ -96135,7 +91818,7 @@ mQz
 dVq
 dVq
 abd
-tEr
+mQz
 tPQ
 mQz
 orL


### PR DESCRIPTION
This pull request replaces all instances of the phrase "New Boston" with "The Den" in the codebase. This change was made in response to user feedback and to align with the desired naming convention. Please note that this pull request is not ready for testing or merging yet, and further communication will be provided to inform stakeholders about the progress and potential impact of this change.