### PR TITLE
Fix condition for checking QR type in economy subsystem

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -1875,7 +1875,7 @@ SUBSYSTEM_DEF(economy)
 		playsound(user, 'sound/machines/dash.ogg', 75, TRUE)
 		to_chat(user, span_alert("That's not a ticket!"))
 		return FALSE
-	if(!istype(QR, /obj/item/card/id))
+	if(istype(QR, /obj/item/card/id))
 		playsound(user, 'sound/machines/dash.ogg', 75, TRUE)
 		to_chat(user, span_alert("Nobody wants your worthless ID!"))
 		return FALSE


### PR DESCRIPTION
This pull request fixes the condition for checking the QR type in the economy subsystem. Previously, the condition was incorrect and resulted in incorrect behavior. This fix ensures that the correct condition is used, allowing the system to function as intended.