### PR TITLE
Update ammo count overlay for guns

### DIFF
--- a/code/datums/traits/clams.dm
+++ b/code/datums/traits/clams.dm
@@ -84,6 +84,7 @@
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
 	inedible = TRUE // sorta
 	tastes = list("seafood" = 4, "dirt" = 1, "shrapnel" = 1)
+	w_class = WEIGHT_CLASS_TINY
 	list_reagents = list(
 		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/water = 2,
@@ -207,7 +208,10 @@
 	if(!guts)
 		to_chat(likcer, span_alert(oysterclam("You fish your tongue around in there for a bit, but aw man, there's no meat!", likcer)))
 		return // no guts no glory
-	likcer.visible_message(oysterclam("Wizh a deft flick of your tongue, you dart in between a gap in the shell and lap out the meat!", likcer))
+	likcer.visible_message(
+		self_message = oysterclam("Wizh a deft flick of your tongue, you dart in between a gap in the shell and lap out the meat!", likcer),
+		message = oysterclam("[likcer] licks the clam!", likcer),
+	)
 	eviscerate_clam(likcer, TRUE, tongue)
 
 /obj/item/reagent_containers/food/snacks/clam/proc/screw_clam(mob/living/carbon/likcer, obj/item/screwer)
@@ -363,6 +367,7 @@
 	icon = 'icons/mob/clothing/clam.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
 	tastes = list("seafood" = 4, "dirt" = 1, "weh" = 1)
+	w_class = WEIGHT_CLASS_TINY
 	list_reagents = list(
 		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/water = 2,
@@ -391,6 +396,7 @@
 	icon_state = "clam_shell"
 	slot_flags = INV_SLOTBIT_HEAD // as a tiny dorky hat
 	tastes = list("shell" = 4, "dirt" = 1, "weh" = 1)
+	w_class = WEIGHT_CLASS_TINY
 	list_reagents = list(
 		/datum/reagent/shell_shrapnel = 5,
 		/datum/reagent/calciumcarbonate = 2,
@@ -420,6 +426,7 @@
 	icon_state = "pearl"
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
 	tastes = list("pearl" = 4, "dirt" = 1)
+	w_class = WEIGHT_CLASS_TINY
 	grind_results = list(
 		/datum/reagent/medicine/bicaridine = 4,
 		/datum/reagent/medicine/kelotane = 4,
@@ -444,6 +451,7 @@
 	desc = "A dainty little necklace made from pearls strung up on some kind of string. \
 		It is very pretty and clearly someone put a lot of effort into making it. \
 		Some say you can get one for free, granted you have the right assets."
+	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/mob/clothing/clam.dmi'
 	icon_state = "pearl_necklace"
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
@@ -455,6 +463,7 @@
 	name = "seashell bra"
 	desc = "A cute tropical bra made from seashells and string. It's as cute as it is impractical and utterly lacking in support, \
 		which is saying something cus this bra is really really cute! Perfect for flat chested weird rats on stilts to pretend they have boobs."
+	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/mob/clothing/clam.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
 	icon_state = "clam_bra"
@@ -473,6 +482,7 @@
 	name = "seashell codpiece"
 	desc = "A cute tropical codpiece made from a seashell and string. It's as cute as it is impractical for anyone even remotely hung, \
 		which is saying something cus this codpiece is really really cute! Perfect for weird rats on stilts to pretend they have a bulge."
+	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/mob/clothing/clam.dmi'
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'
 	icon_state = "clam_codpiece"
@@ -491,6 +501,7 @@
 	name = "seashell bikini"
 	desc = "A cute tropical bikini made from seashells and string. It's as cute as it is impractical and utterly lacking in support, \
 		which is saying something cus this bikini is really really cute! Perfect for flat chested weird rats on stilts to pretend they have boobs and or a bulge."
+	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/mob/clothing/clam.dmi'
 	icon_state = "clam_bikini"
 	mob_overlay_icon = 'icons/mob/clothing/clam_onmob.dmi'

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -190,6 +190,9 @@ ATTACHMENTS
 	var/reloading = FALSE
 	/// This is the base reload speed, which is modified by things like the size of the magazine in use.
 	var/reloading_time = 1 SECONDS
+	maptext_width = 48 //prevents ammo count from wrapping down into two lines
+	maptext_x = 4
+	maptext_y = 2
 
 /obj/item/gun/Initialize()
 	recoil_tag = SSrecoil.give_recoil_tag(init_recoil)
@@ -377,6 +380,7 @@ ATTACHMENTS
 	if(!(. & EMP_PROTECT_CONTENTS))
 		for(var/obj/O in contents)
 			O.emp_act(severity)
+	update_icon()
 
 /obj/item/gun/attack(mob/living/M, mob/user)
 	if(bayonet && user.a_intent == INTENT_HARM)
@@ -385,6 +389,7 @@ ATTACHMENTS
 	. = ..()
 	if(!(. & DISCARD_LAST_ACTION))
 		user.DelayNextAction(attack_speed)
+	update_icon()
 
 /obj/item/gun/attack_obj(obj/O, mob/user)
 	if(bayonet && user.a_intent == INTENT_HARM) // Must run BEFORE parent call, so we don't smack them with the gun body too.
@@ -393,6 +398,7 @@ ATTACHMENTS
 	. = ..()
 	if(!(. & DISCARD_LAST_ACTION))
 		user.DelayNextAction(attack_speed)
+	update_icon()
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	. = ..()
@@ -1067,6 +1073,18 @@ ATTACHMENTS
 			toggle_safety(user)
 		if("Weapon Info")
 			ui_interact(user)
+
+/// Updates the ammo count number that renders on top of the icon
+/obj/item/gun/proc/UpdateAmmoCountOverlay()
+	return
+
+/obj/item/gun/doMove(atom/destination)
+	. = ..()
+	UpdateAmmoCountOverlay()
+
+/obj/item/gun/update_icon()
+	. = ..()
+	UpdateAmmoCountOverlay()
 
 /obj/item/gun/proc/toggle_scope(mob/living/user)
 	//looking through a scope limits your periphereal vision

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -54,6 +54,34 @@ GLOBAL_LIST_EMPTY(gun_accepted_magazines)
 		return
 	return SEND_SIGNAL(magazine, COMSIG_GUN_MAG_ADMIN_RELOAD) // get relayed, noob
 
+/obj/item/gun/ballistic/UpdateAmmoCountOverlay()
+	if(isturf(loc))//Only show th ammo count if the magazine is, like, in an inventory or something. Mags on the ground don't need a big number on them, that's ugly.
+		maptext = ""
+	else 
+		var/ammos = get_ammo()
+		var/ammomax = get_max_ammo()
+		var/textt = ""
+		var/culur = "#FF0000"
+		if(ammomax == 0)
+			culur = "#FFFFFF"
+		else if(ammos == ammomax)
+			culur = "#00FFFF"
+		else if(ammos > ammomax * 0.75)
+			culur = "#00FF00"
+		else if(ammos > ammomax * 0.5)
+			culur = "#FFFF00"
+		else if(ammos > ammomax * 0.25)
+			culur = "#FFA500"
+		else if(ammos > 0)
+			culur = "#FF0000"
+		else
+			culur = "#FF00FF"
+		if(ammos > 0)
+			textt = "[ammos]/[get_max_ammo()]"
+		else
+			textt = "0/[get_max_ammo()]"
+		maptext = "<font color='[culur]'><b>[textt]</b></font>"
+
 /obj/item/gun/ballistic/update_icon_state()
 	if(SEND_SIGNAL(src, COMSIG_ITEM_UPDATE_RESKIN))
 		return // all done!

--- a/code/modules/projectiles/guns/ballistic/flintlock.dm
+++ b/code/modules/projectiles/guns/ballistic/flintlock.dm
@@ -44,6 +44,29 @@
 	..()
 	gun_tags |= GUN_PROJECTILE
 
+/obj/item/gun/flintlock/UpdateAmmoCountOverlay()
+	if(isturf(loc))//Only show th ammo count if the magazine is, like, in an inventory or something. Mags on the ground don't need a big number on them, that's ugly.
+		maptext = ""
+	else
+		var/txte = ""
+		var/culur = "#FF0000"
+		if(chambered)
+			if(cocked)
+				txte = "1/1 !C!"
+				culur = "#00FFFF"
+			else
+				txte = "1/1"
+				culur = "#FFFF00"
+		else
+			if(cocked)
+				txte = "0/1 !C!"
+				culur = "#FF0000"
+			else
+				txte = "0/1"
+				culur = "#FF0000"
+		maptext = "<font color='[culur]'><b>[txte]</b></font>"
+
+
 /obj/item/gun/flintlock/ui_data(mob/user)
 	var/list/data = ..()
 	data["cockable"] = TRUE
@@ -195,6 +218,13 @@
 		shoot_with_empty_chamber(user)
 		return FALSE
 	var/atom/tar_get = user?.client?.mouseObject
+	if(istype(tar_get, /atom/movable/screen)) // we clicked the ~void~, and now we need to do math
+		tar_get = null
+		if(user?.client)
+			var/angel = mouse_angle_from_client(user.client)
+			var/turf/shootat = get_turf_in_angle(angel, get_turf(src), 20) // sure
+			if(shootat)
+				tar_get = shootat
 	/// this is if they disconnect, or tossed the gun before it fired, or ceased to exist, or something
 	if(!tar_get || !user || loc != user)
 		tar_get = null

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -546,6 +546,35 @@
 	if(can_remove == 1)
 		. += span_notice("Alt-click to eject the battery.")
 
+/obj/item/gun/energy/UpdateAmmoCountOverlay()
+	if(isturf(loc))//Only show th ammo count if the magazine is, like, in an inventory or something. Mags on the ground don't need a big number on them, that's ugly.
+		maptext = ""
+	else
+		var/txte = ""
+		var/culur = "#FF0000"
+		if(!cell)
+			culur = "#FF0000"
+			txte = "-/-"
+		if(cell)
+			var/obj/item/ammo_casing/energy/shot = ammo_type[current_firemode_index]
+			var/c_mult = get_charge_cost_mult()
+			var/shots_max = round(cell.maxcharge / max(shot?.e_cost * c_mult, 0.01))
+			var/shots_remaining = round(cell.charge / max(shot?.e_cost * c_mult, 0.01))
+			if(shots_remaining >= shots_max)
+				culur = "#00FFFF"
+			else if(shots_remaining >= shots_max * 0.75)
+				culur = "#00FF00"
+			else if(shots_remaining >= shots_max * 0.5)
+				culur = "#FFFF00"
+			else if(shots_remaining >= shots_max * 0.25)
+				culur = "#FFA500"
+			else if(shots_remaining > 0)
+				culur = "#FF0000"
+			else
+				culur = "#FF00FF"
+			txte = "[shots_remaining]/[shots_max]"
+		maptext = "<font color='[culur]'><b>[txte]</b></font>"
+
 /obj/item/gun/energy/ui_data(mob/user)
 	var/list/data = ..()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[current_firemode_index]

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -82,6 +82,29 @@
 	charges++
 	charge_timer = addtimer(CALLBACK(src,PROC_REF(charge)), recharge_rate, TIMER_UNIQUE|TIMER_STOPPABLE)
 
+/obj/item/gun/magic/UpdateAmmoCountOverlay()
+	if(isturf(loc))//Only show th ammo count if the magazine is, like, in an inventory or something. Mags on the ground don't need a big number on them, that's ugly.
+		maptext = ""
+	else
+		var/txte = ""
+		var/culur = "#FF0000"
+		var/shots_max = max_charges
+		var/shots_remaining = charges
+		if(shots_remaining >= shots_max)
+			culur = "#00FFFF"
+		else if(shots_remaining >= shots_max * 0.75)
+			culur = "#00FF00"
+		else if(shots_remaining >= shots_max * 0.5)
+			culur = "#FFFF00"
+		else if(shots_remaining >= shots_max * 0.25)
+			culur = "#FFA500"
+		else if(shots_remaining > 0)
+			culur = "#FF0000"
+		else
+			culur = "#FF00FF"
+		txte = "[shots_remaining]/[shots_max]"
+		maptext = "<font color='[culur]'><b>[txte]</b></font>"
+
 /obj/item/gun/magic/vv_edit_var(var_name, var_value)
 	. = ..()
 	switch(var_name)


### PR DESCRIPTION
This pull request updates the ammo count overlay for magic, ballistic, and energy guns. The overlay now displays the remaining ammo in a more visually appealing and informative way. It uses different colors to indicate the ammo level, and the text shows the remaining ammo count out of the maximum capacity. This improvement enhances the user experience and makes it easier to track ammo usage during gameplay.

that and it makes clamparts tiny