### PR TITLE
Reclaimers botanical and west wing alterations

### DIFF
--- a/_maps/map_files/coyote_bayou/Newboston.dmm
+++ b/_maps/map_files/coyote_bayou/Newboston.dmm
@@ -34,8 +34,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "abe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "abn" = (
@@ -782,9 +784,11 @@
 	},
 /area/f13/wasteland)
 "apm" = (
-/obj/structure/barricade/bars,
-/turf/closed/wall/f13/tunnel,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
+	dir = 5
+	},
+/area/f13/building)
 "apw" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood)
@@ -1043,10 +1047,11 @@
 	},
 /area/f13/building)
 "awl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side,
-/area/f13/building)
+/turf/open/floor/f13{
+	dir = 5;
+	icon_state = "yellowsiding"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "awt" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3";
@@ -2491,8 +2496,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bpm" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/building/workshop/nash)
+/turf/open/floor/f13{
+	dir = 9;
+	icon_state = "yellowsiding"
+	},
+/area/f13/wasteland/city/newboston/outdoors)
 "bpA" = (
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/outside/dirt,
@@ -3138,8 +3146,8 @@
 	},
 /area/f13/wasteland)
 "bJk" = (
+/obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/biogenerator,
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "bJz" = (
@@ -6329,11 +6337,8 @@
 	},
 /area/f13/building)
 "dzT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/corner{
-	dir = 8
-	},
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "dzW" = (
 /obj/structure/chair/wood{
@@ -7234,7 +7239,8 @@
 /obj/item/beacon{
 	mouse_opacity = 0;
 	alpha = 0;
-	name = "RTN Teleporter Beacon"
+	name = "RTN Teleporter Beacon";
+	anchored = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -7550,12 +7556,8 @@
 	},
 /area/f13/wasteland)
 "eip" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/seed_extractor,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "eir" = (
 /obj/structure/flora/chomp/bush2{
@@ -7673,10 +7675,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "emo" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/corner{
-	dir = 1
-	},
+/obj/machinery/aug_manipulator,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "emp" = (
 /obj/machinery/chem_master/advanced,
@@ -8867,13 +8867,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/wasteland/city/newboston/bar)
 "eVF" = (
+/obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "eVX" = (
 /obj/structure/table/wood/settler,
@@ -8982,8 +8979,11 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "eYt" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall/rust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "eYu" = (
 /obj/structure/table/wasteland,
@@ -9399,6 +9399,12 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/weather/dirtcorner,
+/obj/machinery/vending/cola/space_up{
+	pixel_x = 2;
+	pixel_y = 21;
+	density = 0;
+	layer = 3
+	},
 /turf/open/indestructible/ground/outside/ruins{
 	name = "stepping stones";
 	color = "#bfbfbf"
@@ -10793,13 +10799,8 @@
 /area/f13/building)
 "fRA" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wasteland,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "fRS" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -14085,19 +14086,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/building)
 "hHP" = (
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = 32;
-	pixel_x = 1
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/f13{
-	dir = 5;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/area/f13/building)
 "hHS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -14507,7 +14502,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/workshop/nash)
 "hTd" = (
-/turf/closed/mineral/random/low_chance,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
+	dir = 4
+	},
 /area/f13/building)
 "hTe" = (
 /obj/structure/spacevine{
@@ -17406,6 +17404,12 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
+/obj/machinery/vending/cola/starkist{
+	pixel_x = 6;
+	pixel_y = 21;
+	density = 0;
+	layer = 3
+	},
 /turf/open/indestructible/ground/outside/ruins{
 	name = "stepping stones";
 	color = "#bfbfbf"
@@ -17744,9 +17748,7 @@
 /turf/open/floor/wood_fancy/wood_fancy_light,
 /area/f13/caves)
 "jIg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "jIx" = (
@@ -18181,11 +18183,12 @@
 	},
 /area/f13/building)
 "jSc" = (
-/obj/machinery/light/small{
-	dir = 8;
-	plane = -5
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/smartfridge/food,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "jSC" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19482,12 +19485,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "kBW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/caution{
-	pixel_x = -6
+/obj/machinery/door/airlock/science/glass{
+	req_one_access_txt = "136";
+	name = "Botany"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "kCb" = (
 /obj/effect/decal/cleanable/glass,
@@ -19688,9 +19690,12 @@
 	},
 /area/f13/building)
 "kGP" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowtop";
+	color = "#999999"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "kHh" = (
 /obj/structure/table/wasteland,
@@ -20961,12 +20966,6 @@
 /area/f13/brotherhood)
 "lnC" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 10
-	},
-/obj/item/mmi,
-/obj/item/mmi,
-/obj/item/mmi,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "lnT" = (
@@ -21137,8 +21136,17 @@
 	},
 /area/f13/wasteland/city/newboston/outdoors)
 "lsq" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/item/mmi,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "lsT" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -22627,10 +22635,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned)
 "miw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "miK" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
@@ -26623,7 +26632,15 @@
 /area/f13/wasteland/city/newboston/outdoors)
 "opB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wasteland,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
+	dir = 4
+	},
 /area/f13/building)
 "opN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28983,12 +29000,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "pIl" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/airlock/science/glass{
 	req_one_access_txt = "136";
-	name = "Botany"
+	name = "Mechanics Lab"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "pIo" = (
 /obj/structure/flora/chomp/potplant2,
@@ -30051,19 +30067,9 @@
 	},
 /area/f13/wasteland/city/newboston/library)
 "qnW" = (
-/obj/machinery/light/small{
-	dir = 8;
-	plane = -5
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/f13{
-	dir = 9;
-	icon_state = "yellowsiding"
-	},
-/area/f13/wasteland/city/newboston/outdoors)
+/obj/machinery/computer/rdconsole/robotics,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building)
 "qnZ" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical"
@@ -30274,6 +30280,11 @@
 /area/f13/building)
 "qum" = (
 /obj/machinery/teleport/hub,
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 32;
+	pixel_x = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder - N"
 	},
@@ -33450,7 +33461,7 @@
 /obj/structure/decoration/clock/active{
 	pixel_y = 24
 	},
-/obj/machinery/mecha_part_fabricator,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "rYc" = (
@@ -33988,8 +33999,10 @@
 /area/f13/brotherhood)
 "soW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/mineral/random/low_chance,
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
+	dir = 6
+	},
 /area/f13/building)
 "spd" = (
 /obj/effect/landmark/start/f13/wastelander,
@@ -34137,10 +34150,8 @@
 	},
 /area/f13/wasteland)
 "stz" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
-	dir = 8
-	},
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "suq" = (
 /turf/open/indestructible/ground/inside/dirt,
@@ -34678,14 +34689,10 @@
 	},
 /area/f13/wasteland)
 "sJj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wasteland,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/grenade/clusterbuster/cleaner,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/building)
 "sJr" = (
 /obj/structure/simple_door/room,
@@ -35230,6 +35237,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
+/area/f13/building)
+"sYe" = (
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "sYA" = (
@@ -36341,18 +36352,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/building)
 "tDR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowright";
-	color = "#999999"
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/closed/wall/r_wall/f13vault{
+	icon_state = "2-i"
 	},
-/obj/structure/decoration/hatch{
-	icon_state = "vault_botany";
-	plane = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/building/hospital/clinic/nash)
 "tDV" = (
 /obj/structure/spacevine,
 /turf/closed/wall/f13/wood/house,
@@ -36489,14 +36493,20 @@
 	},
 /area/f13/building/workshop/nash)
 "tHB" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wasteland,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/grenade/clusterbuster/cleaner,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/road{
-	color = "#999999";
-	icon_state = "horizontaltopborderbottom0"
+/turf/open/floor/plasteel/f13/vault_floor/green/white/side{
+	dir = 4
 	},
-/area/f13/wasteland/city/newboston/outdoors)
+/area/f13/building)
 "tHN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -37030,10 +37040,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "tZM" = (
+/obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "tZP" = (
 /mob/living/simple_animal/hostile/raider/baseball,
@@ -38260,10 +38269,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/city/newboston/outdoors)
 "uJT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16
+/obj/machinery/vending/hydroseeds{
+	force_free = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
@@ -39353,6 +39360,10 @@
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
+/area/f13/building)
+"vpD" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/building)
 "vpE" = (
 /obj/item/reagent_containers/glass/bucket/wood,
@@ -44755,8 +44766,10 @@
 	},
 /area/f13/building)
 "ykZ" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white/side,
+/obj/machinery/vending/hydronutrients{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/building)
 "ylc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -79764,19 +79777,19 @@ hRl
 "}
 (137,1,1) = {"
 wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-wHT
-bpm
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
 ciA
 wZe
 yde
@@ -80021,19 +80034,19 @@ hRl
 "}
 (138,1,1) = {"
 hRl
+qNK
+ykZ
+jRP
 apm
-kcx
-hTd
-hTd
 hTd
 hTd
 hTd
 hTd
 hTd
 opB
-hTd
+tHB
 soW
-qNK
+bLR
 tGZ
 gmg
 yde
@@ -80278,19 +80291,19 @@ hRl
 "}
 (139,1,1) = {"
 hRl
-apm
-kcx
 qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-qNK
-kcx
-uKk
-qNK
-qNK
+eYt
+jRP
+gah
+gah
+jRP
+tBH
+jRP
+jRP
+tBH
+jRP
+fsE
+bLR
 ute
 bGv
 vSN
@@ -80535,19 +80548,19 @@ hRl
 "}
 (140,1,1) = {"
 hRl
-apm
-kcx
+qNK
+uJT
+jRP
+jRP
 tBH
-tBH
+jRP
+hHP
+jRP
+jRP
+jRP
+bJk
 jIg
-tBH
-qNK
-jSc
-xCx
-abe
-sKy
-kcx
-qNK
+bLR
 tuf
 lVZ
 avK
@@ -80792,18 +80805,18 @@ hRl
 "}
 (141,1,1) = {"
 hRl
-tot
-kcx
-uJT
-jRP
-jRP
-fRA
-uKk
-nMD
+qNK
+qNK
+qNK
+qNK
+qNK
+qNK
+jSc
+kGP
 kBW
-kBW
-umG
-uKk
+kGP
+kGP
+kGP
 ovp
 fdm
 gIm
@@ -81049,21 +81062,21 @@ hRl
 "}
 (142,1,1) = {"
 hRl
-tot
-kcx
-tZM
-tBH
-tBH
-sJj
+qNK
+eip
+sKy
+abe
+xCx
+xCx
 bLR
 fHm
 sXH
 sXH
 sKy
-qNK
-qnW
+jkD
+bLR
+bpm
 qex
-tHB
 rPr
 nxO
 nxO
@@ -81306,21 +81319,21 @@ hRl
 "}
 (143,1,1) = {"
 hRl
-tot
 qNK
-bJk
-jRP
-tBH
-fsE
+sYe
+jkD
+sKy
+eVF
+tZM
 bLR
 nku
 tPm
 tPm
 fjt
+sKy
 swF
 szu
 nbV
-tkO
 mLI
 uWY
 uWY
@@ -81563,21 +81576,21 @@ hRl
 "}
 (144,1,1) = {"
 hRl
-tot
 qNK
-eip
-jRP
-tBH
-eVF
+lsq
+sKy
+umG
+sXH
+sKy
 bLR
 jQt
 umG
+sKy
+sKy
 jkD
-jkD
-qNK
-hHP
+bLR
+awl
 kEZ
-cIE
 rYw
 rYw
 brC
@@ -81820,18 +81833,18 @@ hRl
 "}
 (145,1,1) = {"
 hRl
-tot
 qNK
-awl
-gah
-jRP
-lsq
-eYt
-kGP
+qnW
+jkD
+sXH
+sKy
+sKy
+bLR
+nMD
+sKy
 sKy
 jkD
-jkD
-ovp
+fRA
 ovp
 qum
 avK
@@ -82077,12 +82090,12 @@ hRl
 "}
 (146,1,1) = {"
 hRl
-tot
 qNK
-ykZ
-tBH
-tBH
-tBH
+umG
+sKy
+sKy
+sKy
+sKy
 pIl
 umG
 jkD
@@ -82334,8 +82347,8 @@ hRl
 "}
 (147,1,1) = {"
 hRl
-tot
-kcx
+qNK
+vpD
 dzT
 miw
 stz
@@ -82345,7 +82358,7 @@ qam
 umG
 uJn
 jkD
-jkD
+sKy
 bLR
 kAR
 gIm
@@ -83883,7 +83896,7 @@ jut
 tEZ
 atZ
 qNK
-qNK
+sJj
 ipD
 sHQ
 bLR


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
![image](https://github.com/ARF-SS13/coyote-bayou/assets/75702012/a510c66b-5085-45ba-8baf-5b43dab01f2a)
 (Remade on new branch due to conflict) ; Attempts to make the reclaimers botany lab less cluttered by using the large portion of rock and empty space on the west side. It also just serves to give botanists something to look out at and socialize to when working, which was the main point of giving an outside-facing wall like all other proper servers have hydroponics. As a side affect of the new empty space of where botany previously was and now replaces the two mech chargers, a robotics lab has been thrown in due to players still using mechs. However a common area/breakroom could always be slapped in place, even if the previous was never used. Alternatively, even moving the nanite lab to get it off of the dungeon z level.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
Tweaks: Most of the west wing of the reclaimers  remodeled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
