### PR TITLE
Makes hydroponics self sustaining easier to achieve

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -545,7 +545,7 @@
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia))
 		if(!self_sustaining)
 			adjustSelfSuff(1)
-			to_chat(user, "You spread the gaia through the soil. ([self_sustainingprog] out of 7)")
+			to_chat(user, "You spread the gaia through the soil.")
 			qdel(O)
 			return
 		else
@@ -788,7 +788,7 @@
 	weedlevel = clamp(weedlevel + adjustamt, 0, 10)
 
 /obj/machinery/hydroponics/proc/adjustSelfSuff(adjustamt)
-	if(self_sustainingprog>=6)
+	if(self_sustainingprog>=0)
 		become_self_sufficient()
 	else
 		self_sustainingprog += adjustamt

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -545,7 +545,7 @@
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia))
 		if(!self_sustaining)
 			adjustSelfSuff(1)
-			to_chat(user, "You spread the gaia through the soil.")
+			to_chat(user, "You spread the gaia through the soil. ([self_sustainingprog] out of 3)")
 			qdel(O)
 			return
 		else
@@ -788,7 +788,7 @@
 	weedlevel = clamp(weedlevel + adjustamt, 0, 10)
 
 /obj/machinery/hydroponics/proc/adjustSelfSuff(adjustamt)
-	if(self_sustainingprog>=0)
+	if(self_sustainingprog>=2)
 		become_self_sufficient()
 	else
 		self_sustainingprog += adjustamt


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Reduces the amount of ambrosia gaia needed to achieve self sufficient hydroponics to 1 instead of 7, because I'll be honest, if you have ambrosia gaia, you already have a supply of it. Having 7 just delays and makes tedious the process of getting like 15 soilbeds to be self sufficient. (105 branches of ambrosia gaia to make 15 trays self sufficient)

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
