### PR TITLE
Fix broken quests and projectile damage rounding

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -236,7 +236,7 @@
 /obj/item/projectile/proc/create_statblock()
 	var/list/my_block = list()
 	my_block["projectile_name"] = name || "Unnamed Projectile"
-	my_block["projectile_damage"] = damage || 0
+	my_block["projectile_damage"] = round(damage, 0.5) || 0
 	my_block["projectile_damage_type"] = damage_type || "brute"
 	my_block["projectile_flag"] = flag || "bullet"
 	my_block["projectile_stamina"] = stamina || 0


### PR DESCRIPTION
This pull request fixes an issue with broken quests and improves the rounding of projectile damage.

The broken quests were caused by an invalid save chunk encountered during quest loading. This PR removes the invalid save chunks and prevents the generation of new quests that could cause further issues.

Additionally, the rounding of projectile damage has been improved to round to the nearest 0.5 instead of rounding down to the nearest whole number. This ensures more accurate and precise damage calculations for projectiles.