### PR TITLE
buffed the shit out of chemical cartridges

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_cartridge.dm
@@ -16,7 +16,7 @@
 
 	rating = 1
 	var/charge = 0 //set on init
-	var/maxCharge = 10000
+	var/maxCharge = 1000000000
 
 /obj/item/stock_parts/chem_cartridge/Initialize()
 	. = ..()
@@ -42,7 +42,7 @@
 	icon_state = "salvaged"
 	item_state = "salvaged"
 	custom_price = PRICE_ALMOST_EXPENSIVE
-	maxCharge = 2500
+	maxCharge = 250000000
 	custom_materials = list(/datum/material/iron=500, /datum/material/glass=500)
 
 /obj/item/stock_parts/chem_cartridge/crafted
@@ -51,13 +51,13 @@
 	icon_state = "crafted"
 	item_state = "crafted"
 	custom_price = PRICE_ABOVE_EXPENSIVE
-	maxCharge = 7000
+	maxCharge = 700000000
 	custom_materials = list(/datum/material/iron=1000, /datum/material/glass=500)
 
 /obj/item/stock_parts/chem_cartridge/simple
 	name = "Knock-off chemical cartridge"
 	desc = "A casing holding a mix of raw material for use in chem dispensors. It looks like a mass produced knock-off."
-	maxCharge = 5000
+	maxCharge = 500000000
 	custom_price = PRICE_ABOVE_EXPENSIVE
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=500, /datum/material/plasma = 100)
 
@@ -67,5 +67,5 @@
 	icon_state = "pristine"
 	item_state = "pristine"
 	custom_price = PRICE_REALLY_EXPENSIVE
-	maxCharge = 10000
+	maxCharge = 1000000000
 	custom_materials = list(/datum/material/iron=2000, /datum/material/glass=1000, /datum/material/plasma = 500)


### PR DESCRIPTION
## About The Pull Request
see title
## Pre-Merge Checklist
- [NOPE] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

basically
tl;dr
we have made it where you can grow 1750hp healing healing powders per broc and xander plant
you can easily scale this up to 7000 with just four of each in a 2x4 area
for every eight tiles you can get 7000 hp healing resources

chemistry cannot even remotely compare

there's also more fun uses of chemistry that isn't healing, and generally people who want to play doctor who also want to play chemist don't want to deal with the system, so I soft removed it

