### PR TITLE
Fixes double convert bug

### DIFF
--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_EMPTY(wasteland_vendor_shop_list)
 			say("I'll give you absolutely nothing for \the [I]!", just_chat = quiet)
 		return FALSE
 	if(!silent)
-		say("I'll give you [SSeconomy.format_currency(final_price, TRUE, TRUE)] per [I]!", just_chat = quiet)
+		say("I'll give you [SSeconomy.format_currency(final_price, FALSE, TRUE)] per [I]!", just_chat = quiet)
 	return final_price
 
 /obj/machinery/mineral/wasteland_trader/proc/lock_belt(silent)

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -677,8 +677,8 @@ GLOBAL_LIST_EMPTY(wasteland_vendor_shop_list)
 
 /obj/machinery/proc/announce_sale(soldfor, totalcash, obj/item/I)
 	var/thing = I ? "\the [I]" : "something"
-	var/currencie = "[SSeconomy.format_currency(soldfor, TRUE, TRUE)]"
-	var/currencei = "[SSeconomy.format_currency(totalcash, TRUE, TRUE)]"
+	var/currencie = "[SSeconomy.format_currency(soldfor, FALSE, TRUE)]" //Second argument false because we are already receiving coppers for the proc arguments
+	var/currencei = "[SSeconomy.format_currency(totalcash, FALSE, TRUE)]"
 	say("Sold [thing] for [currencie], bringing the total to [currencei]!")
 
 /obj/item/debug_vendorsale

--- a/code/modules/WVM/wmv_buyer.dm
+++ b/code/modules/WVM/wmv_buyer.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_EMPTY(wasteland_vendor_shop_list)
 			say("I'll give you absolutely nothing for \the [I]!", just_chat = quiet)
 		return FALSE
 	if(!silent)
-		say("I'll give you [SSeconomy.format_currency(final_price, FALSE, TRUE)] per [I]!", just_chat = quiet)
+		say("I'll give you [SSeconomy.format_currency(final_price, FALSE, TRUE)] per [I]!", just_chat = quiet) //Uses false for second argument because final_price has already been converted to copper from credits during initial assignment.
 	return final_price
 
 /obj/machinery/mineral/wasteland_trader/proc/lock_belt(silent)


### PR DESCRIPTION
## About The Pull Request
Fixes a double convert oversight that makes the workshop scrapper tell you the coins in silver instead of copper

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: Workshop scrapper now tells you the correct price
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
