### PR TITLE
soup is for sick people (which is you)

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -231,9 +231,9 @@
 ////////////////////////////////
 
 /mob/living/proc/handle_healreservoir()
-	var/heal_max = 5
+	var/heal_max = 10
 	if(HAS_TRAIT(src, TRAIT_IMPROVED_HEALING))
-		heal_max = 25
+		heal_max = 30
 	if(heal_reservoir < heal_max)
 		if(iscarbon(src)) //Humans and stuff with stinky reagents
 			if(src.reagents.has_reagent(/datum/reagent/water))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -237,9 +237,11 @@
 	if(heal_reservoir < heal_max)
 		if(iscarbon(src)) //Humans and stuff with stinky reagents
 			if(src.reagents.has_reagent(/datum/reagent/water))
-				heal_reservoir += 0.5
+				heal_reservoir += 0.75
+			if(src.reagents.has_reagent(/datum/reagent/consumable/nutriment))
+				heal_reservoir += 0.75
 			else
-				heal_reservoir += 0.25
+				heal_reservoir += 0.05
 		else //Everything else
 			heal_reservoir += (rand(10,50)/100)//0.1 to 0.5
 			heal_reservoir = min(heal_reservoir,heal_max)


### PR DESCRIPTION
## About The Pull Request
SEE title
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->


For my GitHub divers,
This PR makes it where you (basically) cannot regenerate your triage without food OR water
It also ups the reservoir by five points, bringing the total amount of healing from `25 -> 50`  for basic, and `125 -> 150` for advanced triage

Additionally, it removes the ability to find medicinal wasteland plants.