### PR TITLE
Removes storage restrictions on several items

### DIFF
--- a/code/datums/components/storage/concrete/belts.dm
+++ b/code/datums/components/storage/concrete/belts.dm
@@ -15,18 +15,15 @@
 /// Utility Belt
 /datum/component/storage/concrete/belt/specialized/utility/Initialize()
 	. = ..()
-	can_hold = GLOB.toolbelt_allowed
 
 /// Medibelt
 /datum/component/storage/concrete/belt/specialized/medical/Initialize()
 	. = ..()
-	can_hold = GLOB.medibelt_allowed
 	max_w_class = WEIGHT_CLASS_NORMAL
 
 /// Bandolier
 /datum/component/storage/concrete/belt/specialized/bandolier/Initialize()
 	. = ..()
-	can_hold = GLOB.ammobelt_allowed
 
 /// Holster
 /datum/component/storage/concrete/belt/specialized/gun
@@ -37,7 +34,6 @@
 
 /datum/component/storage/concrete/belt/specialized/gun/Initialize()
 	. = ..()
-	can_hold = GLOB.gunbelt_allowed
 	quickdraw = TRUE //will see if this works!
 
 /datum/component/storage/concrete/belt/specialized/plush
@@ -48,4 +44,3 @@
 
 /datum/component/storage/concrete/belt/specialized/plush/Initialize()
 	. = ..()
-	can_hold = GLOB.plushbelt_allowed	

--- a/code/datums/components/storage/concrete/necks.dm
+++ b/code/datums/components/storage/concrete/necks.dm
@@ -15,17 +15,15 @@
 /// Utility Belt
 /datum/component/storage/concrete/neckpron/specialized/utility/Initialize()
 	. = ..()
-	can_hold = GLOB.toolbelt_allowed
 
 /// Medineckpron
 /datum/component/storage/concrete/neckpron/specialized/medical/Initialize()
 	. = ..()
-	can_hold = GLOB.medibelt_allowed
 
 /// Bandolier
+
 /datum/component/storage/concrete/neckpron/specialized/bandolier/Initialize()
 	. = ..()
-	can_hold = GLOB.ammobelt_allowed
 
 /// Holster
 /datum/component/storage/concrete/neckpron/specialized/gun
@@ -36,6 +34,5 @@
 
 /datum/component/storage/concrete/neckpron/specialized/gun/Initialize()
 	. = ..()
-	can_hold = GLOB.gunbelt_allowed
 	quickdraw = TRUE
 

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -38,7 +38,6 @@
 
 /datum/component/storage/concrete/pockets/massive/swords/Initialize()
 	. = ..()
-	can_hold = GLOB.knifebelt_allowed
 
 /// One smol pocket
 /datum/component/storage/concrete/pockets/small
@@ -56,16 +55,9 @@
 
 /datum/component/storage/concrete/pockets/small/collar/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(
-	/obj/item/reagent_containers/food/snacks/cookie,
-	/obj/item/reagent_containers/food/snacks/sugarcookie))
 
 /datum/component/storage/concrete/pockets/small/collar/locked/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(
-	/obj/item/reagent_containers/food/snacks/cookie,
-	/obj/item/reagent_containers/food/snacks/sugarcookie,
-	/obj/item/key/collar))
 
 /// 4 small pockets
 /datum/component/storage/concrete/pockets/small/four
@@ -83,7 +75,6 @@
 
 /datum/component/storage/concrete/pockets/binocular/Initialize()
 	. = ..()
-	can_hold = GLOB.storage_binocular_can_hold
 
 /// Treasurer bag
 /datum/component/storage/concrete/pockets/treasurer
@@ -94,7 +85,6 @@
 
 /datum/component/storage/concrete/pockets/treasurer/Initialize()
 	. = ..()
-	can_hold = GLOB.storage_treasurer_can_hold
 
 /datum/component/storage/concrete/pockets/tiny
 	max_items = 1
@@ -114,7 +104,6 @@
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
 	cant_hold = typecacheof(list(/obj/item/screwdriver/power))
-	can_hold = GLOB.storage_shoes_can_hold + GLOB.storage_holdout_can_hold
 
 
 /datum/component/storage/concrete/pockets/pocketprotector
@@ -127,13 +116,6 @@
 /datum/component/storage/concrete/pockets/pocketprotector/Initialize()
 	original_parent = parent
 	. = ..()
-	can_hold = typecacheof(list( //Same items as a PDA
-		/obj/item/pen,
-		/obj/item/toy/crayon,
-		/obj/item/lipstick,
-		/obj/item/flashlight/pen,
-		/obj/item/clothing/mask/cigarette))
-	can_hold |= GLOB.storage_wallet_can_hold
 
 /datum/component/storage/concrete/pockets/pocketprotector/real_location()
 	// if the component is reparented to a jumpsuit, the items still go in the protector
@@ -152,7 +134,6 @@
 
 /datum/component/storage/concrete/pockets/bos/paladin/Initialize()
 	. = ..()
-	can_hold = GLOB.gunbelt_allowed
 
 /// Holdout
 /datum/component/storage/concrete/pockets/small/holdout
@@ -165,7 +146,6 @@
 
 /datum/component/storage/concrete/pockets/small/holdout/Initialize()
 	. = ..()
-	can_hold = GLOB.storage_holdout_can_hold
 
 /// Unarmored dusters
 /datum/component/storage/concrete/pockets/duster
@@ -246,7 +226,6 @@
 
 /datum/component/storage/concrete/pockets/service/Initialize()
 	. = ..()
-	can_hold = GLOB.toolbelt_allowed
 
 /// medi-apron
 /datum/component/storage/concrete/pockets/medical
@@ -265,7 +244,6 @@
 
 /datum/component/storage/concrete/pockets/medical/Initialize()
 	. = ..()
-	can_hold = GLOB.medibelt_allowed
 
 /// suit bandolier
 /datum/component/storage/concrete/pockets/bulletbelt
@@ -276,8 +254,6 @@
 
 /datum/component/storage/concrete/pockets/bulletbelt/Initialize()
 	. = ..()
-	can_hold = GLOB.ammobelt_allowed
-	can_hold |= GLOB.gunbelt_allowed
 
 /// Combat armor bandolier / holster
 /datum/component/storage/concrete/pockets/magpouch
@@ -288,8 +264,6 @@
 
 /datum/component/storage/concrete/pockets/magpouch/Initialize()
 	. = ..()
-	can_hold = GLOB.ammobelt_allowed
-	can_hold |= GLOB.gunbelt_allowed
 
 /// Saddle-bags
 /datum/component/storage/concrete/pockets/saddlebag

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -539,7 +539,6 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 7
-	STR.can_hold = typecacheof(list(/obj/item/toy/crayon))
 
 /obj/item/storage/crayons/PopulateContents()
 	new /obj/item/toy/crayon/red(src)

--- a/code/game/objects/items/devices/battery_box.dm
+++ b/code/game/objects/items/devices/battery_box.dm
@@ -324,7 +324,6 @@
 
 /datum/component/storage/concrete/charger_internals/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(/obj/item/stock_parts/cell, /obj/item/stock_parts/capacitor, /obj/item/persona_core/charger))
 
 /obj/item/storage/box/charger_internals
 	name = "Internal component compartment"

--- a/code/game/objects/items/devices/portable_chem_blenderbelt.dm
+++ b/code/game/objects/items/devices/portable_chem_blenderbelt.dm
@@ -801,7 +801,6 @@
 
 /datum/component/storage/concrete/blender_machinery/Initialize()
 	. = ..()
-	can_hold = typecacheof(list(/obj/item/stock_parts/cell, /obj/item/stock_parts/manipulator, /obj/item/persona_core))
 
 /obj/item/storage/box/blender_batbox
 	name = "Internal component compartment"

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -762,7 +762,6 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 
 /datum/component/storage/concrete/box/huge/foxpocket/Initialize()
 	. = ..()
-	can_hold = /obj/item/toy/plush/mammal/fox/squishfox
 
 /obj/item/toy/plush/catgirl/fermis
 	name = "medcat plushie"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -594,9 +594,6 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 1
-	STR.can_hold = list(
-		/obj/item/clothing/mask/luchador
-		)
 
 ///grenade belt
 /obj/item/storage/belt/grenade
@@ -613,14 +610,6 @@
 	STR.display_numerical_stacking = TRUE
 	STR.max_combined_w_class = 60
 	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.can_hold = typecacheof(list(
-		/obj/item/grenade,
-		/obj/item/screwdriver,
-		/obj/item/lighter,
-		/obj/item/multitool,
-		/obj/item/reagent_containers/food/drinks/bottle/molotov,
-		/obj/item/grenade/plastic/c4,
-		))
 
 /obj/item/storage/belt/grenade/full/PopulateContents()
 	new /obj/item/grenade/flashbang(src)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -473,37 +473,6 @@
 	STR.max_items = 16
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 20
-	STR.can_hold = typecacheof(list(
-	/obj/item/storage/pill_bottle,
-	/obj/item/reagent_containers/hypospray,
-	/obj/item/pinpointer/crew,
-	/obj/item/tele_iv,
-	/obj/item/sequence_scanner,
-	/obj/item/sensor_device,
-	/obj/item/bodybag,
-	/obj/item/surgicaldrill/advanced,
-	/obj/item/healthanalyzer,
-	/obj/item/reagent_containers/syringe,
-	/obj/item/clothing/glasses/hud/health,
-	/obj/item/hemostat,
-	/obj/item/scalpel,
-	/obj/item/retractor,
-	/obj/item/cautery,
-	/obj/item/surgical_drapes,
-	/obj/item/bonesetter,
-	/obj/item/autosurgeon,
-	/obj/item/organ,
-	/obj/item/implant,
-	/obj/item/implantpad,
-	/obj/item/implantcase,
-	/obj/item/implanter,
-	/obj/item/circuitboard/computer/operating,
-	/obj/item/circuitboard/computer/crew,
-	/obj/item/stack/sheet/glass,
-	/obj/item/stack/sheet/mineral/silver,
-	/obj/item/organ_storage,
-	/obj/item/reagent_containers/chem_pack
-	))
 
 //hijacking the minature first aids for hypospray boxes. <3
 /obj/item/storage/hypospraykit
@@ -523,9 +492,6 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 12
-	STR.can_hold = typecacheof(list(
-	/obj/item/hypospray/mkii,
-	/obj/item/reagent_containers/glass/bottle/vial))
 
 /obj/item/storage/hypospraykit/regular
 	icon_state = "firstaid-mini"

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -272,18 +272,6 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	STR.silent = TRUE
 	STR.max_items = 10
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
-	STR.can_hold = typecacheof(list(
-		/obj/item/clothing/head/helmet/infiltrator,
-		/obj/item/clothing/suit/armor/medium/vest/infiltrator,
-		/obj/item/clothing/under/syndicate/bloodred,
-		/obj/item/clothing/gloves/color/latex/nitrile/infiltrator,
-		/obj/item/clothing/gloves/tackler/combat/insulated/infiltrator,
-		/obj/item/clothing/mask/infiltrator,
-		/obj/item/clothing/shoes/combat/sneakboots,
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/ammo_box
-		))
 
 /obj/item/storage/toolbox/infiltrator/PopulateContents()
 	new /obj/item/clothing/head/helmet/infiltrator(src)

--- a/code/modules/fallout/obj/krotchy.dm
+++ b/code/modules/fallout/obj/krotchy.dm
@@ -37,7 +37,6 @@
 /obj/item/weapon/storage/fancy/krotchy_box/ComponentInitialize()
 	. = ..()
 	AddComponent(component_type)
-	STR.can_hold = typecacheof(list(/obj/item/weapon/krotchy))
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 14
 	STR.max_items = 1

--- a/modular_splurt/code/modules/research/xenoarch/tools.dm
+++ b/modular_splurt/code/modules/research/xenoarch/tools.dm
@@ -289,13 +289,6 @@
 /obj/item/storage/belt/xenoarch/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
-		/obj/item/xenoarch/help,
-		/obj/item/xenoarch/clean,
-		/obj/item/t_scanner/adv_mining_scanner,
-		/obj/item/gps
-		))
-	STR.can_hold = can_hold
 	STR.max_items = 12
 	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 200


### PR DESCRIPTION
## About The Pull Request
Removes storage restrictions on some items. Notable exceptions are:

- Bags and other containers that have a "gather all" option. This leaves them with their intended function and prevents annoyingly picking up everything all the time.
- Special boxes like cigarette and match boxes. Removing the restrictions gives them the same functional capacity as a normal box
- Back Sheath. The special storage is intended to allow storing a weapon without giving up your backpack inventory. Removing the restriction just makes it a backpack within a backpack.
- Sturdy Quiver. The storage capacity of the quiver is massive to accommodate the bulky spears and javelins
- Everything in the Fancy storage. These have special icon states to indicate how full they are. Unchanged to maintain clarity. The easter basket and medal box do as well, and are also unchanged.
- Sheathes. Also have special icon states and didn't make as much sense to be able to store a bottle of absinthe in them as it would a holster.
- Keys set. This made no sense to allow anything other than keys in.
- Photo albums. Also didnt' make any sense, and may lead to unintended consequences with persistence between rounds.

A couple notable changes are the portable recharger and the blender belt. These have an internal component box that allows you to change out parts for better ones. Now you can change out the parts for anything, but they won't work unless they have the right parts.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
