### PR TITLE
Hivebot cost and power adjustments

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -139,9 +139,11 @@
 /datum/crafting_recipe/hivebotmelee
 	name = "Cheap Melee Hivebot"
 	result = /mob/living/simple_animal/hostile/eyebot/playable/hivebot/melee
-	reqs = list(/obj/item/stack/crafting/electronicparts = 4,
+	reqs = list(/obj/item/stack/crafting/electronicparts = 6,
 				/obj/item/stack/rods = 8,
-				/obj/item/stack/sheet/metal = 6)
+				/obj/item/stack/sheet/metal = 6,
+				/obj/item/assembly/prox_sensor = 1,
+				/obj/item/stack/sheet/mineral/titanium = 2)
 	tools = list()
 	time = 30
 	subcategory = CAT_SCAVENGING
@@ -153,7 +155,9 @@
 	reqs = list(/obj/item/stack/crafting/electronicparts = 8,
 				/obj/item/stack/crafting/metalparts = 4,
 				/obj/item/stack/crafting/goodparts = 3,
-				/obj/item/stack/sheet/metal = 15)
+				/obj/item/stock_parts/scanning_module/adv = 1,
+				/obj/item/stack/sheet/metal = 15,
+				/obj/item/stack/sheet/mineral/titanium = 5)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING
@@ -166,7 +170,9 @@
 				/obj/item/stack/crafting/metalparts = 16,
 				/obj/item/stack/crafting/goodparts = 12,
 				/obj/item/stack/sheet/metal = 15,
-				/obj/item/stack/sheet/plasteel = 20)
+				/obj/item/stack/sheet/plasteel = 20,
+				/obj/item/advanced_crafting_components/alloys = 1,
+				/obj/item/stack/sheet/mineral/titanium = 5)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING
@@ -179,7 +185,9 @@
 				/obj/item/stack/crafting/metalparts = 3,
 				/obj/item/stack/crafting/goodparts = 1,
 				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/plasteel = 1)
+				/obj/item/assembly/prox_sensor = 1,
+				/obj/item/stock_parts/cell = 1,
+				/obj/item/stack/sheet/mineral/titanium = 5)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING
@@ -189,10 +197,13 @@
 	name = "Regular Ranged Hivebot"
 	result = /mob/living/simple_animal/hostile/eyebot/playable/hivebot/tier2
 	reqs = list(/obj/item/stack/crafting/electronicparts = 12,
-				/obj/item/stack/crafting/metalparts = 8,
-				/obj/item/stack/crafting/goodparts = 6,
-				/obj/item/stack/sheet/metal = 12,
-				/obj/item/stack/sheet/plasteel = 8)
+				/obj/item/stack/crafting/metalparts = 6,
+				/obj/item/stack/crafting/goodparts = 4,
+				/obj/item/stack/sheet/metal = 15,
+				/obj/item/stock_parts/capacitor/adv = 1,
+				/obj/item/stock_parts/cell/high = 1,
+				/obj/item/advanced_crafting_components/lenses = 1,
+				/obj/item/stack/sheet/mineral/titanium = 8)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING
@@ -201,11 +212,16 @@
 /datum/crafting_recipe/rangedhivebot3
 	name = "Advanced Ranged Hivebot"
 	result = /mob/living/simple_animal/hostile/eyebot/playable/hivebot/tier3
-	reqs = list(/obj/item/stack/crafting/electronicparts = 16,
-				/obj/item/stack/crafting/metalparts = 10,
-				/obj/item/stack/crafting/goodparts = 12,
-				/obj/item/stack/sheet/metal = 35,
-				/obj/item/stack/sheet/plasteel = 20)
+	reqs = list(/obj/item/stack/crafting/electronicparts = 15,
+				/obj/item/stack/crafting/metalparts = 15,
+				/obj/item/stack/crafting/goodparts = 10,
+				/obj/item/stack/sheet/metal = 25,
+				/obj/item/stack/sheet/plasteel = 10,
+				/obj/item/stock_parts/cell/super = 1,
+				/obj/item/stock_parts/capacitor/super = 1,
+				/obj/item/advanced_crafting_components/conductors = 1,
+				/obj/item/advanced_crafting_components/lenses = 1,
+				/obj/item/stack/sheet/mineral/titanium = 15)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING
@@ -217,7 +233,8 @@
 	reqs = list(/obj/item/stack/crafting/electronicparts = 12,
 				/obj/item/stack/crafting/metalparts = 8,
 				/obj/item/stack/crafting/goodparts = 6,
-				/obj/item/stack/sheet/metal = 12,)
+				/obj/item/stack/sheet/metal = 12,
+				/obj/item/stock_parts/cell/high = 1,)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	subcategory = CAT_SCAVENGING

--- a/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/eyebot.dm
@@ -220,16 +220,17 @@
 	can_ghost_into = TRUE
 	projectiletype = /obj/item/projectile/beam/cranklasergun/tg/spamlaser/shocker
 	projectilesound = 'sound/weapons/taser2.ogg'
-	auto_fire_delay = GUN_AUTOFIRE_DELAY_FAST
-	ranged_cooldown_time = 15
-	extra_projectiles = 5
-	ranged_extra_spread_per_shot = 5
-	ranged_max_spread = 20
+	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOW
+	ranged_cooldown_time = 30
+	extra_projectiles = 2
+	ranged_extra_spread_per_shot = 2
+	ranged_max_spread = 21
 	ranged_base_spread = 0
+	decompose = FALSE
 	despawns_when_lonely = FALSE
-	health = 25
-	maxHealth = 25
-	mob_armor = ARMOR_VALUE_LIGHT
+	health = 30
+	maxHealth = 30
+	mob_armor = ARMOR_VALUE_ZERO
 	speed = 2
 	icon = 'icons/mob/playerswarmer.dmi'
 	icon_state = "ranged_hivebot"
@@ -256,8 +257,8 @@
 	send_mobs = null
 	call_backup = null
 	wander = 0
-	minimum_distance = 3
-	retreat_distance = 4
+	minimum_distance = 2
+	retreat_distance = 3
 	faction = list(
 		"neutral"
 		)
@@ -346,14 +347,14 @@
 	projectiletype = /obj/item/projectile/beam/laser/cranklasergun/tg
 	projectilesound = 'sound/weapons/magpistol.ogg'
 	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOW
-	mob_armor = ARMOR_VALUE_MEDIUM
-	ranged_cooldown_time = 25
+	mob_armor = ARMOR_VALUE_LIGHT
+	ranged_cooldown_time = 30
 	extra_projectiles = 5
 	ranged_extra_spread_per_shot = 2
 	ranged_max_spread = 5
 	ranged_base_spread = 0
-	health = 30
-	maxHealth = 30
+	health = 45
+	maxHealth = 45
 	move_to_delay = 6
 
 /mob/living/simple_animal/hostile/eyebot/playable/hivebot/tier2/New()
@@ -368,14 +369,14 @@
 	projectiletype = /obj/item/projectile/beam/cranklasergun/tg/rifle/heavy
 	projectilesound = 'sound/weapons/magrifle.ogg'
 	auto_fire_delay = GUN_AUTOFIRE_DELAY_SLOWER
-	mob_armor = ARMOR_VALUE_HEAVY
-	ranged_cooldown_time = 1
+	mob_armor = ARMOR_VALUE_LIGHT
+	ranged_cooldown_time = 30
 	extra_projectiles = 2
 	ranged_extra_spread_per_shot = 1
 	ranged_max_spread = 5
 	ranged_base_spread = 0
-	health = 30
-	maxHealth = 30
+	health = 60
+	maxHealth = 60
 	speed = 2
 	move_to_delay = 8
 
@@ -396,11 +397,11 @@
 	minimum_distance = 0
 	harm_intent_damage = 7
 	rapid_melee = 2
-	health = 25
-	maxHealth = 25
-	mob_armor = ARMOR_VALUE_RAIDER_LEATHER_JACKET
-	speed = 0.2
-	melee_damage_lower = 5
+	health = 50
+	maxHealth = 50
+	mob_armor = ARMOR_VALUE_LIGHT
+	speed = 1
+	melee_damage_lower = 1
 	melee_damage_upper = 10
 	melee_attack_cooldown = 0.5 SECONDS
 
@@ -417,11 +418,12 @@
 	icon_dead = "medium_hivebot_dead"
 	retreat_distance = 0
 	minimum_distance = 0
-	health = 50
-	maxHealth = 50
-	mob_armor = ARMOR_VALUE_RAIDER_LEATHER_JACKET
-	melee_damage_lower = 15
-	melee_damage_upper = 20
+	move_to_delay = 0.2
+	speed = 1
+	health = 100
+	maxHealth = 100
+	melee_damage_lower = 5
+	melee_damage_upper = 15
 	melee_attack_cooldown = 1 SECONDS
 
 /mob/living/simple_animal/hostile/eyebot/playable/hivebot/melee/tier2/New()
@@ -437,12 +439,13 @@
 	icon_dead = "keeper_hivebot_dead"
 	retreat_distance = 0
 	minimum_distance = 0
-	health = 75
-	maxHealth = 75
-	mob_armor = ARMOR_VALUE_RAIDER_LEATHER_JACKET
-	melee_damage_lower = 20
-	melee_damage_upper = 30
-	melee_attack_cooldown = 1 SECONDS
+	move_to_delay = 0.2
+	speed = 1
+	health = 150
+	maxHealth = 150
+	melee_damage_lower = 10
+	melee_damage_upper = 20
+	melee_attack_cooldown = 2 SECONDS
 
 /mob/living/simple_animal/hostile/eyebot/playable/hivebot/melee/tier3/New()
 	..()
@@ -456,14 +459,14 @@
 	projectiletype = /obj/item/projectile/beam/laser/cranklasergun/tg
 	projectilesound = 'sound/weapons/magburst.ogg'
 	auto_fire_delay = GUN_AUTOFIRE_DELAY_NORMAL
-	ranged_cooldown_time = 0
+	ranged_cooldown_time = 30
 	extra_projectiles = 30
 	ranged_extra_spread_per_shot = 1
 	ranged_max_spread = 30
 	ranged_base_spread = 0
 	despawns_when_lonely = FALSE
-	health = 200
-	maxHealth = 200
+	health = 400
+	maxHealth = 400
 	mob_armor = ARMOR_VALUE_HEAVY
 	speed = 8
 	move_to_delay = 8


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
Hivebots have had their costs increased, especially for ranged units, to the point that reclaimers are the only ones who can feasibly produce large amounts of them. As a flipside, these bots have been generally improved in their survivability, with tier 3 ranged hivebots able to survive several shots of 9mm in one life.

Melee hivebots now have way more health to fully serve their purpose as generally aggressive hivebots that distract opponents from real threats, and so also have slightly reduced damage and DPS

tl;dr you can no longer make large amounts of ranged hivebots simply by buying components at the vendor anymore, go salvaging and looking for components, or be a reclaimer for that robot swarm fantasy!
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
