### PR TITLE
Lets things talk again, also other stuff

### DIFF
--- a/code/controllers/subsystem/datumrentals.dm
+++ b/code/controllers/subsystem/datumrentals.dm
@@ -170,6 +170,7 @@ SUBSYSTEM_DEF(rentaldatums)
 	var/pulse_verb
 	var/langtreated
 	var/cant_language
+	var/is_thing
 
 /datum/rental_mommy/chat/copy_mommy(datum/rental_mommy/chat/mommy)
 	if(!..())
@@ -240,6 +241,7 @@ SUBSYSTEM_DEF(rentaldatums)
 	pulse_verb                         = mommy.pulse_verb
 	langtreated                        = mommy.langtreated
 	cant_language                      = mommy.cant_language
+	is_thing                           = mommy.is_thing
 
 /datum/rental_mommy/chat/wipe()
 	original_message                   = ""
@@ -308,6 +310,7 @@ SUBSYSTEM_DEF(rentaldatums)
 	pulse_verb                         = null
 	langtreated                        = null
 	cant_language                      = null
+	is_thing                           = null
 
 // /// Know what, know what? screw it, I'm compiling all the chat procs into this datum
 // /datum/rental_mommy/chat/proc/handle_say(

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -11,13 +11,12 @@
 	var/finished = 0
 	var/turf/target_oldloc
 	var/turf/origin_oldloc
-	var/list/showing_to = list()
 	var/static_beam = 0
 	var/beam_type = /obj/effect/ebeam //must be subtype
 	var/timing_id = null
 	var/recalculating = FALSE
 
-/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam,beam_sleep_time=3,list/show_to)
+/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam,beam_sleep_time=3)
 	origin = beam_origin
 	origin_oldloc =	get_turf(origin)
 	target = beam_target
@@ -30,12 +29,6 @@
 	icon = beam_icon
 	icon_state = beam_icon_state
 	beam_type = btype
-	if(!isnull(show_to))
-		var/list/to_show = islist(show_to) ? show_to : list(show_to)
-		for(var/thing in to_show)
-			var/client/C = extract_client(thing)
-			if(C)
-				showing_to += C
 	if(time < INFINITY) 
 		addtimer(CALLBACK(src,PROC_REF(End)), time)
 
@@ -90,11 +83,6 @@
 
 /datum/beam/proc/Reset()
 	for(var/obj/effect/ebeam/B in elements)
-		if(B.mypic && LAZYLEN(showing_to))
-			for(var/client/C in showing_to)
-				if(!C)
-					continue
-				C.images -= B.mypic
 		qdel(B)
 	elements.Cut()
 
@@ -121,7 +109,7 @@
 	for(N in 0 to length-1 step 32)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
 		if(finished)
 			break
-		var/obj/effect/ebeam/X = new beam_type(origin_oldloc, showing_to)
+		var/obj/effect/ebeam/X = new beam_type(origin_oldloc)
 		X.owner = src
 		elements += X
 
@@ -160,14 +148,6 @@
 
 		X.pixel_x = Pixel_x
 		X.pixel_y = Pixel_y
-		if(showing_to)
-			// snapshot no jutsu
-			var/image/II = image(X.icon, X.loc, X.icon_state, X.layer, X.dir, X.pixel_x, X.pixel_y)
-			II.transform = X.transform
-			X.mypic = II
-			for(var/client/C in showing_to)
-				if(C)
-					C.images += II
 		CHECK_TICK
 	afterDraw()
 
@@ -175,12 +155,6 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
 	var/datum/beam/owner
-	var/image/mypic
-
-/obj/effect/ebeam/Initialize(mapload, shows)
-	. = ..()
-	if(shows)
-		invisibility = INVISIBILITY_ABSTRACT
 
 /obj/effect/ebeam/Destroy()
 	owner = null
@@ -191,16 +165,7 @@
 /obj/effect/ebeam/singularity_act()
 	return
 
-/atom/proc/Beam(
-	atom/BeamTarget,
-	icon_state="b_beam",
-	icon='icons/effects/beam.dmi',
-	time=50, 
-	maxdistance=10,
-	beam_type=/obj/effect/ebeam,
-	beam_sleep_time = 3,
-	list/show_to = list()
-)
-	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type,beam_sleep_time,show_to)
+/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=50, maxdistance=10,beam_type=/obj/effect/ebeam,beam_sleep_time = 3)
+	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type,beam_sleep_time)
 	INVOKE_ASYNC(newbeam, TYPE_PROC_REF(/datum/beam/,Start))
 	return newbeam

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -33,6 +33,8 @@
 	var/eavesdrop
 	/// an alternative turf to display the message at
 	var/turf/alt_display
+	var/stick_on_turf
+	var/is_thing
 
 /**
  * Constructs a chat message overlay
@@ -58,6 +60,16 @@
 			if(mommy.display_turf && mommy.display_turf != target)
 				alt_display = mommy.display_turf
 				offscreen = TRUE
+				if(mommy.is_thing)
+					is_thing = TRUE
+					if(ismob(alt_display.loc))
+						alt_display = alt_display.loc
+			else if(mommy.is_thing)
+				is_thing = TRUE
+				if(ismob(target.loc))
+					target = target.loc
+			if(mommy.runechat_mode == "hidden_pathable")
+				stick_on_turf = TRUE
 		else
 			alt_display = data["display_turf"] || null
 			if((get_dist(owner, (alt_display || target)) > 6 || data["is_far"])) // SD screens are 7 radius, but the UI covers a bit of that
@@ -104,7 +116,7 @@
 
 	// Calculate target color if not already present
 	if (!target.chat_color || target.chat_color_name != target.name)
-		if(iscarbon(target))
+		if(iscarbon(target) && !is_thing)
 			var/mob/living/carbon/C = target
 			var/chatcolor = C.dna.features["chat_color"]
 			if(chatcolor == "whoopsie")
@@ -161,6 +173,8 @@
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	var/atom/remembered_location = alt_display || target
 	message_loc = alt_display || target
+	if(stick_on_turf)
+		message_loc = get_turf(message_loc)
 	// if(offscreen && get_dist(owner, target) > 6) // SD screens are 7 radius, but the UI covers a bit of that
 	// 	var/turf/ownerturf = get_turf(owner)
 	// 	var/turf/targetturf = get_turf(message_loc)
@@ -211,7 +225,7 @@
 	message.plane = SSchat.chat_display_plane
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	var/hight = (alt_display || offscreen) ? 0 : owner.bound_height
+	var/hight = (alt_display || offscreen) ? 0 : (owner.bound_height + 7) // +7 cus progress bars
 	message.pixel_y = hight * 0.95
 
 	message.maptext_width = CHAT_MESSAGE_WIDTH

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -26,6 +26,7 @@ Dan's even bigger Say() rewrite.
 	momchat.far_message_range = SSchat.extended_say_distance
 	momchat.source_quid = extract_quid(src)
 	momchat.source_ckey = extract_ckey(src)
+	momchat.is_thing = TRUE
 	return momchat
 
 /atom/movable/proc/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null, only_overhead)
@@ -55,7 +56,8 @@ Dan's even bigger Say() rewrite.
 	var/rendered = compose_message(src, momchat.language, momchat.message, , momchat.spans, momchat.message_mode, momchat.source, list("momchat" = momchat))
 	for(var/_AM in get_hearers_in_view(momchat.close_message_range, momchat.source))
 		var/atom/movable/AM = _AM
-		AM.Hear(rendered, src, momchat.language, momchat.message, , momchat.spans, momchat.message_mode, momchat.source, momchat.only_overhead)
+		var/list/dat = list("momchat" = momchat)
+		AM.Hear(rendered, src, momchat.language, momchat.message, , momchat.spans, momchat.message_mode, momchat.source, momchat.only_overhead, dat)
 
 /atom/movable/proc/compose_message(
 	atom/movable/speaker,

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -270,7 +270,7 @@
 	if(only_overhead)
 		return
 	// Recompose message for AI hrefs, language incomprehension.
-	if(momchat.cant_language)
+	if(momchat?.cant_language)
 		var/msg = momchat ? momchat.original_message : raw_message
 		message = compose_message(speaker, message_language, msg, radio_freq, spans, message_mode, FALSE, source, data)
 	/// abject misery - replaces doubled double quotes with single double quotes


### PR DESCRIPTION
Objects that can speak can now speak.

Claire's runechat appears over your head.

Runechat is moved up a bit to make room for a progress bar.

Offscreen chat should (should) stick on the turf it should, and not move with the speaker.

Beams should work once more.