### PR TITLE
Implement bworp delay in respawner blocker

### DIFF
--- a/code/controllers/subsystem/monster_wave.dm
+++ b/code/controllers/subsystem/monster_wave.dm
@@ -304,6 +304,8 @@ SUBSYSTEM_DEF(monster_wave)
 	var/show_range_cooldown = 0
 	var/mob/living/simple_animal/nest_spawn_hole_guy/killing_something
 	var/datum/beam/my_bean
+	var/next_bworp = 0
+	var/bworp_delay = (5 MINUTES)
 
 /obj/structure/respawner_blocker/Initialize()
 	. = ..()
@@ -322,8 +324,12 @@ SUBSYSTEM_DEF(monster_wave)
 	. = ..()
 
 /obj/structure/respawner_blocker/proc/blocked_something()
+	if (next_bworp > world.time)
+		if(prob(95))
+			return
+	next_bworp = world.time + bworp_delay
 	playsound(src, 'sound/machines/respawn_blocker_blocked.ogg', 75, TRUE)
-	do_sparks(1, FALSE, src, /datum/effect_system/spark_spread/quantum)
+	do_fake_sparks(1, FALSE, src, /datum/effect_system/spark_spread/quantum)
 
 /// we're bout to ruin this guy's day
 /obj/structure/respawner_blocker/proc/killmeplease(mob/living/simple_animal/nest_spawn_hole_guy/NSHG)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -72,7 +72,6 @@
 /obj/effect/particle_effect/fake_sparks/Initialize()
 	. = ..()
 	flick(icon_state, src) // replay the animation
-	playsound(src, "sparks", 100, TRUE)
 	QDEL_IN(src, 20)
 
 /datum/effect_system/fake_spark_spread


### PR DESCRIPTION
Added bworp delay functionality to respawner blocker.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
