### PR TITLE
pile resets

### DIFF
--- a/code/controllers/subsystem/lootmanager.dm
+++ b/code/controllers/subsystem/lootmanager.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(lootmanager)
 /datum/controller/subsystem/lootmanager/Initialize(timeofday)
 	for(var/obj/item/storage/trash_stack/pile in world)
 		pile_list.Add(pile)
+	addtimer(CALLBACK(src,PROC_REF(reset_all_piles)),20 MINUTES)
 	. = ..()
 
 /datum/controller/subsystem/lootmanager/proc/add_pile(obj/item/storage/trash_stack/pile)
@@ -17,9 +18,15 @@ SUBSYSTEM_DEF(lootmanager)
 
 /datum/controller/subsystem/lootmanager/proc/send_to_all_players(obj/item/storage/trash_stack/pile)
 	for(var/mob/M in GLOB.player_list)
-		if(M.stat != DEAD)
-			pile.show(M.client)
+		if(M.ckey in pile.loot_players)
+			return
+		pile.show(M.client)
 
 /datum/controller/subsystem/lootmanager/proc/send_all_to_player(client/C)
 	for(var/obj/item/storage/trash_stack/pile in pile_list)
 		pile.show(C)
+
+/datum/controller/subsystem/lootmanager/proc/reset_all_piles()
+	for(var/obj/item/storage/trash_stack/pile in pile_list)
+		pile.loot_players = list()
+		send_to_all_players(pile)


### PR DESCRIPTION
## About The Pull Request
Resets piles every 20 minutes

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Loot piles now reset every 20 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
